### PR TITLE
Refactor tooltip icons and improve tooltip styles

### DIFF
--- a/src/components/ReactTooltip.scss
+++ b/src/components/ReactTooltip.scss
@@ -49,19 +49,13 @@
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.22) !important;
 }
 
-/* Highlighted tooltip style with stronger border */
-.quorum-react-tooltip-highlighted {
-  /* Border is now handled by the border prop in ReactTooltip component */
-  /* This class can be used for additional highlighted styling if needed */
-}
-
 /* Responsive width and text wrapping for showOnTouch tooltips */
 .quorum-react-tooltip-touch {
   white-space: normal !important;
   word-wrap: break-word !important;
-  width: 300px !important;
+  max-width: 300px !important;
   
   @media (min-width: 640px) {
-    width: 400px !important;
+    max-width: 400px !important;
   }
 }

--- a/src/components/channel/SpaceEditor.tsx
+++ b/src/components/channel/SpaceEditor.tsx
@@ -97,8 +97,6 @@ const SpaceEditor: React.FunctionComponent<{
   const [isRepudiable, setIsRepudiable] = React.useState<boolean>(
     space?.isRepudiable || false
   );
-  const [repudiableTooltip, setRepudiableTooltip] = React.useState(false);
-  const [publicInviteTooltip, setPublicInviteTooltip] = React.useState(false);
   const { data: spaceMembers } = useSpaceMembers({ spaceId });
   const [deleteConfirmationStep, setDeleteConfirmationStep] = React.useState(0);
   const [iconFileError, setIconFileError] = React.useState<string | null>(null);
@@ -665,14 +663,11 @@ const SpaceEditor: React.FunctionComponent<{
                               <Trans>Repudiability</Trans>
                             </div>
                             <div className="text-sm flex flex-col justify-around ml-2">
-                              <div
+                              <FontAwesomeIcon
                                 id="repudiability-tooltip-icon"
-                                className="border border-strong rounded-full w-6 h-6 text-center leading-5 text-lg"
-                                onMouseOut={() => setRepudiableTooltip(false)}
-                                onMouseOver={() => setRepudiableTooltip(true)}
-                              >
-                                ℹ
-                              </div>
+                                icon={faInfoCircle}
+                                className="info-icon-tooltip"
+                              />
                             </div>
                             <div className="absolute left-[340px]">
                               <ReactTooltip
@@ -1237,12 +1232,12 @@ const SpaceEditor: React.FunctionComponent<{
                                       <FontAwesomeIcon
                                         id="current-invite-link-tooltip-icon"
                                         icon={faInfoCircle}
-                                        className="ml-2"
+                                        className="info-icon-tooltip"
                                       />
                                       <ReactTooltip
                                         id="current-invite-link-tooltip"
                                         anchorSelect="#current-invite-link-tooltip-icon"
-                                        className="flex flex-col justify-around pt-3 pb-1 !w-[400px]"
+                                        className="flex flex-col justify-around pt-3 pb-1 !w-[400px] cursor-pointer"
                                         place="bottom"
                                         content={t`This link will not expire, but you can generate a new one at any time, which will invalidate the old link. Current Space members will not be removed from the Space.`}
                                         showOnTouch

--- a/src/components/modals/CreateSpaceModal.tsx
+++ b/src/components/modals/CreateSpaceModal.tsx
@@ -16,7 +16,7 @@ import { t } from '@lingui/core/macro';
 import { DefaultImages } from '../../utils';
 import ReactTooltip from '../ReactTooltip';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faFileImage, faTimes } from '@fortawesome/free-solid-svg-icons';
+import { faFileImage, faTimes, faInfoCircle } from '@fortawesome/free-solid-svg-icons';
 
 type CreateSpaceModalProps = {
   visible: boolean;
@@ -170,12 +170,11 @@ const CreateSpaceModal: React.FunctionComponent<CreateSpaceModalProps> = (
                   <Trans>Repudiability</Trans>
                 </div>
                 <div className="text-sm flex flex-col justify-around ml-2">
-                  <div
+                  <FontAwesomeIcon
                     id="repudiability-tooltip-icon"
-                    className="border border-[var(--surface-6)] rounded-full w-6 h-6 text-center leading-5 text-lg"
-                  >
-                    ℹ
-                  </div>
+                    icon={faInfoCircle}
+                    className="info-icon-tooltip  hover:text-main cursor-pointer"
+                  />
                 </div>
                 <div className="absolute left-[147px]">
                   <ReactTooltip
@@ -199,12 +198,11 @@ const CreateSpaceModal: React.FunctionComponent<CreateSpaceModalProps> = (
                   Directly joinable by link
                 </div>
                 <div className="text-sm flex flex-col justify-around ml-2">
-                  <div
+                  <FontAwesomeIcon
                     id="public-tooltip-icon"
-                    className="border border-[var(--surface-6)] rounded-full w-6 h-6 text-center leading-5 text-lg"
-                  >
-                    ℹ
-                  </div>
+                    icon={faInfoCircle}
+                    className="info-icon-tooltip  hover:text-main cursor-pointer"
+                  />
                 </div>
                 <div className="absolute left-[216px]">
                   <ReactTooltip

--- a/src/components/modals/UserSettingsModal.tsx
+++ b/src/components/modals/UserSettingsModal.tsx
@@ -23,7 +23,7 @@ import locales from '../../i18n/locales';
 import useForceUpdate from '../hooks/forceUpdate';
 import ReactTooltip from '../ReactTooltip';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faTimes } from '@fortawesome/free-solid-svg-icons';
+import { faTimes, faInfoCircle } from '@fortawesome/free-solid-svg-icons';
 
 const UserSettingsModal: React.FunctionComponent<{
   dismiss: () => void;
@@ -462,12 +462,11 @@ const UserSettingsModal: React.FunctionComponent<{
                               {t`Enable sync`}
                             </div>
                             <>
-                              <div
+                              <FontAwesomeIcon
                                 id="allow-sync-tooltip-anchor"
-                                className="border border-strong rounded-full w-6 h-6 text-center leading-5 text-lg mt-1 ml-2 cursor-default"
-                              >
-                                ℹ
-                              </div>
+                                icon={faInfoCircle}
+                                className="info-icon-tooltip mt-2 ml-2"
+                              />
                               <ReactTooltip
                                 id="allow-sync-tooltip"
                                 anchorSelect="#allow-sync-tooltip-anchor"
@@ -491,12 +490,11 @@ const UserSettingsModal: React.FunctionComponent<{
                               {t`Non-repudiability`}
                             </div>
                             <>
-                              <div
+                              <FontAwesomeIcon
                                 id="non-repudiable-tooltip-anchor"
-                                className="border border-strong rounded-full w-6 h-6 text-center leading-5 text-lg mt-1 ml-2 cursor-default"
-                              >
-                                ℹ
-                              </div>
+                                icon={faInfoCircle}
+                                className="info-icon-tooltip mt-2 ml-2"
+                              />
                               <ReactTooltip
                                 id="non-repudiable-tooltip"
                                 anchorSelect="#non-repudiable-tooltip-anchor"

--- a/src/components/navbar/ExpandableNavMenu.tsx
+++ b/src/components/navbar/ExpandableNavMenu.tsx
@@ -79,10 +79,9 @@ const ExpandableNavMenu: React.FunctionComponent<ExpandableNavMenuProps> = (
       )}
       <ReactTooltip
         id="create-space-tooltip"
-        content={t`Add Space`}
+        content={t`Create a new Space`}
         place="top"
         anchorSelect="[data-tooltip-id='create-space-tooltip']"
-        showOnTouch={true}
         highlighted={true}
         className="z-[10000]"
       />
@@ -91,7 +90,6 @@ const ExpandableNavMenu: React.FunctionComponent<ExpandableNavMenuProps> = (
         content={t`Account Settings`}
         place="top"
         anchorSelect="[data-tooltip-id='user-avatar-tooltip']"
-        showOnTouch={true}
         highlighted={true}
         className="z-[10000]"
       />

--- a/src/styles/_components.scss
+++ b/src/styles/_components.scss
@@ -48,6 +48,13 @@
   -webkit-app-region: no-drag;
 }
 
+/* === INFO ICON TOOLTIPS === */
+.info-icon-tooltip {
+  @apply text-subtle hover:text-main cursor-pointer;
+  outline: none !important;
+  -webkit-tap-highlight-color: transparent;
+}
+
 .titlebar {
   -webkit-app-region: drag;
 }


### PR DESCRIPTION
Replaces custom ℹ tooltip icons with FontAwesome info icons for consistency across SpaceEditor, CreateSpaceModal, and UserSettingsModal. Updates tooltip styling in SCSS for better responsiveness and introduces a reusable .info-icon-tooltip class. Also adjusts tooltip content and removes unnecessary showOnTouch props in ExpandableNavMenu.