### PR TITLE
refactor(MessageService): rename and tighten typing

### DIFF
--- a/.agents/tasks/messagedb/README.md
+++ b/.agents/tasks/messagedb/README.md
@@ -3,7 +3,7 @@ type: index
 title: "MessageDB Refactor — Master Tracker"
 status: ongoing
 created: 2026-05-19
-updated: '2026-05-19'
+updated: '2026-05-20'
 ---
 
 # MessageDB Refactor — Master Tracker
@@ -48,10 +48,10 @@ Each item lists the doc that owns its content, the risk, the rough time investme
 |---|------|------|------|------|-------|
 | 1 | Rename `processDeliveryReceiptData` → `interceptControlMessages` | [low-risk §4.1](./optimizations-low-risk.md#41-rename-processdeliveryreceiptdata--interceptcontrolmessages) | ⚠️ Low | 15 min | Method now also dispatches typing — name lies |
 | 2 | Remove `React.MutableRefObject` from services (12 spots, 5 services) | [low-risk §2.2](./optimizations-low-risk.md#22-remove-react-types-from-services) | ⚠️ Low | 30 min–1 h | Hygiene; modest expansion of shared-migration surface |
-| 3 | Normalize control-message intercept shape | [low-risk §4.3](./optimizations-low-risk.md#43-normalize-control-message-intercept-shape) | ⚠️ Low | 30 min | Removes triple-fallback reads. **Sequencing constraint**: must land BEFORE or WITH the receipts shared migration — see [cross-check](./shared-migration-cross-check.md#sequencing-constraint-on-3-intercept-normalization). |
-| 4 | Type piggybacked ack fields (after receipts shared migration) | [low-risk §4.4](./optimizations-low-risk.md#44-type-the-piggybacked-ack-fields) | ⚠️ Low | 30 min | Removes 4 `(message as any)` casts |
+| 3 | ~~Normalize control-message intercept shape~~ ✅ DONE (2026-05-20) | [low-risk §4.3](./optimizations-low-risk.md#43-normalize-control-message-intercept-shape) | — | — | Landed as cleanup commit on the receipts-shared-migration branch (PR #147). Dead `raw.content?.type` fallbacks removed; receiver now reads only the flat wire shape. |
+| 4 | Type piggybacked ack fields | [low-risk §4.4](./optimizations-low-risk.md#44-type-the-piggybacked-ack-fields) | ⚠️ Low | 30 min | Removes 4 `(message as any)` casts. **Unblocked** — receipts shared migration landed in PR #147 (2026-05-20). |
 
-**Order rationale**: all four are < 1 hour each, near-zero risk, no behavior change. Stack them in any short session. #4 depends on the receipts shared migration landing first.
+**Order rationale**: #1, #2, #4 are < 1 hour each, near-zero risk, no behavior change. Stack them in any short session. #3 is done. #4 was previously gated on the receipts shared migration; that migration shipped 2026-05-20, so #4 is now ready.
 
 ### Tier 1 — Larger but still low-risk (when you have a focused day)
 
@@ -106,10 +106,12 @@ See also [current-state.md §Cross-cutting context](./current-state.md#cross-cut
 
 ## Active state
 
-- **In progress**: none (this is a tracker; items get picked up as feature work permits).
-- **Most recent**: ThreadService extraction (April–May 2026), TypingService extraction (May 2026), audit refresh + folder reorg (2026-05-19).
+- **In progress**: branch `refactor/messageservice-rename-and-typing` — stacking Tier 0 #1, #4, #2 (started 2026-05-20).
+- **Most recent**: receipts shared migration (PR #147, 2026-05-20) — incidentally landed Tier 0 #3 as a precursor cleanup. ThreadService extraction (April–May 2026), TypingService extraction (May 2026), audit refresh + folder reorg (2026-05-19).
 - **Blockers**: none for any Tier 0/1 item. Tier 2 items unblock once someone has a focused day. Tier 3 waits on feature triggers.
 
 ---
 
-_Last updated: 2026-05-19 — folder reorganized. Files renamed: `messagedb-current-state.md` → `current-state.md`, `messageservice-analysis.md` → `messageservice-deep-dive.md`, `messagedb-optimization-1.md` → `optimizations-low-risk.md`, `messagedb-optimization-3.md` → `optimizations-high-risk.md`. New files: `handleNewMessage-reconsidered.md`, `shared-migration-cross-check.md`. This README is new and owns the safest-to-riskiest master action plan. Tier 0 #3 marked with the sequencing constraint surfaced by the cross-check; framing softened for #5 and #7._
+_Last updated: 2026-05-20 — Tier 0 #3 marked ✅ done (landed inside receipts-shared-migration PR #147); Tier 0 #4 unblocked. Branch `refactor/messageservice-rename-and-typing` opened to stack #1 + #4 + #2._
+
+_Previously 2026-05-19 — folder reorganized. Files renamed: `messagedb-current-state.md` → `current-state.md`, `messageservice-analysis.md` → `messageservice-deep-dive.md`, `messagedb-optimization-1.md` → `optimizations-low-risk.md`, `messagedb-optimization-3.md` → `optimizations-high-risk.md`. New files: `handleNewMessage-reconsidered.md`, `shared-migration-cross-check.md`. This README is new and owns the safest-to-riskiest master action plan. Tier 0 #3 marked with the sequencing constraint surfaced by the cross-check; framing softened for #5 and #7._

--- a/.agents/tasks/messagedb/optimizations-low-risk.md
+++ b/.agents/tasks/messagedb/optimizations-low-risk.md
@@ -126,10 +126,12 @@ export interface Keyset {
 
 ---
 
-#### 2.2 Remove React Types from Services
+#### 2.2 Remove React Types from Services ✅ DONE (2026-05-20)
 **Risk**: ⚠️ LOW
-**Time**: 30 minutes – 1 hour
+**Time**: ~30 min (as estimated)
 **Impact**: Better separation of concerns (services shouldn't know about React)
+
+**What was changed**: Added `src/types/ref.ts` with a platform-agnostic `Ref<T> { current: T }` interface. Replaced all 12 `React.MutableRefObject<…>` annotations across ConfigService, InvitationService, SpaceService, SyncService, MessageService with `Ref<…>`. `React.MutableRefObject<T>` is structurally compatible with `Ref<T>`, so MessageDB and other React-land callers pass their existing refs unchanged. Done as part of Tier 0 cleanup batch on branch `refactor/messageservice-rename-and-typing`.
 
 **Current usage counts (May 2026, `React.MutableRefObject`):**
 
@@ -298,20 +300,15 @@ The cross-doc master order is in [README.md](./README.md#master-action-plan-safe
 
 These were surfaced during the 2026-05-19 audit prompted by the typing/receipts shared-migration planning. They are low-risk small-scope improvements specific to the post-typing/threads state of MessageService.
 
-### 4.1 Rename `processDeliveryReceiptData` → `interceptControlMessages`
+### 4.1 Rename `processDeliveryReceiptData` → `interceptControlMessages` ✅ DONE (2026-05-20)
 
 **Risk**: ⚠️ LOW
-**Time**: ~15 min
+**Time**: ~15 min (as estimated)
 **Impact**: Method name reflects reality
 
-**Problem**: `processDeliveryReceiptData` (MessageService.ts:314) is named for receipts, but as of May 2026 it also intercepts `typing-start` / `typing-stop` (lines 357–363). The name lies, and the next ephemeral control message type added (presence? reactions-as-control?) will make this worse.
+**What was changed**: `MessageService.processDeliveryReceiptData` → `interceptControlMessages` (declaration at MessageService.ts:313 + two callers at :2680, :4225). JSDoc rewritten to describe both responsibilities (intercept + piggyback processing). The split into `interceptControlMessage()` + `processPiggybackedAcks()` was considered but deferred — the single-method form is fine until a third unrelated responsibility appears.
 
-**Proposed**:
-- Rename to `interceptControlMessages` (or split into `interceptControlMessage()` + `processPiggybackedAcks()` since the method does two unrelated things: intercepts at steps 1/1b/1c, and processes piggybacks at steps 2/3).
-- The two callers (DM decrypt paths around MessageService.ts:4220) need a one-line update.
-- Update the JSDoc to describe both responsibilities.
-
-**Why now**: ahead of any further ephemeral control-message additions; before adding presence or any new dispatch branch.
+**Why now (history)**: ahead of any further ephemeral control-message additions (presence, reactions-as-control). Done as part of Tier 0 cleanup batch on branch `refactor/messageservice-rename-and-typing`.
 
 ### 4.2 Convert NotificationService singleton to a normal class
 
@@ -344,30 +341,17 @@ These were surfaced during the 2026-05-19 audit prompted by the typing/receipts 
 
 **Why it was safe**: no external peer ever shipped the nested shape; the only producer is local code that emits flat. The nested branches were unreachable.
 
-### 4.4 Type the piggybacked ack fields
+### 4.4 Type the piggybacked ack fields ✅ DONE (2026-05-20)
 
 **Risk**: ⚠️ LOW
-**Time**: ~30 min
-**Impact**: Removes 4 `(message as any)` casts in `attachPiggybackedAcks` / `stripPiggybackedAcks`
+**Time**: ~10 min (smaller than estimated — `ReceiptEnvelopeFields` already existed in `quorum-shared`)
+**Impact**: Removed 4 `(message as any)` casts in `attachPiggybackedAcks` / `stripPiggybackedAcks`
 
-**Problem**: `attachPiggybackedAcks` (MessageService.ts:281) and `stripPiggybackedAcks` (:299) write/delete `ackMessageIds` and `readAckUpTo` on messages via `(message as any).foo = ...`. These are transient wire fields, not part of the `Message` type.
+**What was changed**: Imported `ReceiptEnvelopeFields` from `@quilibrium/quorum-shared` (already exported as part of the receipts shared migration, see `quorum-shared/src/types/receipt.ts`). The two methods now widen `message` once at the top via `const envelope = message as Message & ReceiptEnvelopeFields;` and access typed `envelope.ackMessageIds` / `envelope.readAckUpTo` afterwards. No remaining `(message as any).ackMessageIds` / `.readAckUpTo` in MessageService.
 
-**Proposed (after receipts shared migration lands)**:
+**Note**: The unrelated `(message as any)` cast at MessageService.ts:574 (for `sendStatus` / `sendError` destructuring) is out of scope for this item — it's about transient send-state fields, not piggybacked receipts.
 
-```ts
-// In quorum-shared/src/types/receipt.ts (or wherever the receipt types land)
-export interface PiggybackedReceiptFields {
-  ackMessageIds?: string[];
-  readAckUpTo?: { messageId: string; timestamp: number };
-}
-
-// In MessageService
-private attachPiggybackedAcks(address: string, message: Message & PiggybackedReceiptFields): void {
-  // no more `as any`
-}
-```
-
-**Why now**: Already flagged in [the receipts-shared-migration task](../quorum-shared-migration/2026-05-19-receipts-shared-migration.md#actionqueuehandlersts-send-paths--stays-per-app-narrows-against-shared-types) as optional cleanup. Track it here too so it doesn't get lost.
+**Why now (history)**: Unblocked by the receipts shared migration landing (PR #147, 2026-05-20). Done as part of Tier 0 cleanup batch on branch `refactor/messageservice-rename-and-typing`.
 
 ---
 

--- a/src/services/ConfigService.ts
+++ b/src/services/ConfigService.ts
@@ -13,11 +13,12 @@ import { QueryClient } from '@tanstack/react-query';
 import { buildSpacesKey, buildConfigKey } from '../hooks';
 import { validateItems } from '../utils/folderUtils';
 import { mergeDeviceNames } from './configMergeHelpers';
+import type { Ref } from '../types/ref';
 
 export class ConfigService {
   private messageDB: MessageDB;
   private apiClient: QuorumApiClient;
-  private spaceInfo: React.MutableRefObject<{ [key: string]: any }>;
+  private spaceInfo: Ref<{ [key: string]: any }>;
   private enqueueOutbound: (action: () => Promise<string[]>) => void;
   private sendHubMessage: (spaceId: string, message: string) => Promise<string>;
   private queryClient: QueryClient;
@@ -25,7 +26,7 @@ export class ConfigService {
   constructor(dependencies: {
     messageDB: MessageDB;
     apiClient: QuorumApiClient;
-    spaceInfo: React.MutableRefObject<{ [key: string]: any }>;
+    spaceInfo: Ref<{ [key: string]: any }>;
     enqueueOutbound: (action: () => Promise<string[]>) => void;
     sendHubMessage: (spaceId: string, message: string) => Promise<string>;
     queryClient: QueryClient;

--- a/src/services/InvitationService.ts
+++ b/src/services/InvitationService.ts
@@ -11,11 +11,12 @@ import { QueryClient } from '@tanstack/react-query';
 import { buildSpacesKey, buildConfigKey, buildSpaceKey } from '../hooks';
 import type { Space } from '@quilibrium/quorum-shared';
 import { isQuorumApiError } from '../api/baseTypes';
+import type { Ref } from '../types/ref';
 
 export class InvitationService {
   private messageDB: MessageDB;
   private apiClient: QuorumApiClient;
-  private spaceInfo: React.MutableRefObject<{ [key: string]: any }>;
+  private spaceInfo: Ref<{ [key: string]: any }>;
   private selfAddress: string;
   private enqueueOutbound: (action: () => Promise<string[]>) => void;
   private queryClient: QueryClient;
@@ -27,7 +28,7 @@ export class InvitationService {
   constructor(dependencies: {
     messageDB: MessageDB;
     apiClient: QuorumApiClient;
-    spaceInfo: React.MutableRefObject<{ [key: string]: any }>;
+    spaceInfo: Ref<{ [key: string]: any }>;
     selfAddress: string;
     enqueueOutbound: (action: () => Promise<string[]>) => void;
     queryClient: QueryClient;

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -56,10 +56,11 @@ import { QuorumApiClient } from '../api/baseTypes';
 import { showWarning, noteSyncActivity } from '../utils/toast';
 import { notificationService } from './NotificationService';
 import type { ActionQueueService } from './ActionQueueService';
-import type { ReceiptService } from '@quilibrium/quorum-shared';
+import type { ReceiptService, ReceiptEnvelopeFields } from '@quilibrium/quorum-shared';
 import { TypingService, type TypingMessage } from '@quilibrium/quorum-shared';
 import { ENABLE_DM_ACTION_QUEUE } from '../config/features';
 import { ThreadService } from './ThreadService';
+import type { Ref } from '../types/ref';
 
 // Type definitions for the service
 export interface MessageServiceDependencies {
@@ -81,8 +82,8 @@ export interface MessageServiceDependencies {
     apiClient: QuorumApiClient
   ) => Promise<void>;
   navigate: (path: string, options?: any) => void;
-  spaceInfo: React.MutableRefObject<{ [key: string]: any }>;
-  syncInfo: React.MutableRefObject<{ [key: string]: any }>;
+  spaceInfo: Ref<{ [key: string]: any }>;
+  syncInfo: Ref<{ [key: string]: any }>;
   synchronizeAll: (spaceId: string, inboxAddress: string) => Promise<void>;
   informSyncData: (
     spaceId: string,
@@ -121,8 +122,8 @@ export class MessageService {
     apiClient: QuorumApiClient
   ) => Promise<void>;
   private navigate: (path: string, options?: any) => void;
-  private spaceInfo: React.MutableRefObject<{ [key: string]: any }>;
-  private syncInfo: React.MutableRefObject<{ [key: string]: any }>;
+  private spaceInfo: Ref<{ [key: string]: any }>;
+  private syncInfo: Ref<{ [key: string]: any }>;
   private synchronizeAll: (
     spaceId: string,
     inboxAddress: string
@@ -280,14 +281,16 @@ export class MessageService {
   private attachPiggybackedAcks(address: string, message: Message): void {
     if (!this.receiptService) return;
 
+    const envelope = message as Message & ReceiptEnvelopeFields;
+
     const pendingAcks = this.receiptService.flushForPiggyback(address);
     if (pendingAcks.length > 0) {
-      (message as any).ackMessageIds = pendingAcks;
+      envelope.ackMessageIds = pendingAcks;
     }
 
     const pendingReadAck = this.receiptService.flushReadForPiggyback(address);
     if (pendingReadAck) {
-      (message as any).readAckUpTo = pendingReadAck;
+      envelope.readAckUpTo = pendingReadAck;
     }
   }
 
@@ -296,21 +299,29 @@ export class MessageService {
    * These fields are transient wire-format data that should not be stored locally.
    */
   private stripPiggybackedAcks(message: Message): void {
-    delete (message as any).ackMessageIds;
-    delete (message as any).readAckUpTo;
+    const envelope = message as Message & ReceiptEnvelopeFields;
+    delete envelope.ackMessageIds;
+    delete envelope.readAckUpTo;
   }
 
   /**
-   * Process delivery receipt data from a decrypted DM message.
-   * Returns true if the message is a delivery-ack control message (should be intercepted, not saved).
-   * Returns false if the message is a normal message (continue with saveMessage pipeline).
+   * Intercept ephemeral control messages and process piggybacked receipt data
+   * from a decrypted DM message.
    *
-   * Three-step logic applied at both DM decrypt paths:
-   * 1. Intercept delivery-ack type BEFORE saveMessage — return true (early exit)
-   * 2. Extract + process ackMessageIds from any message — then strip before saveMessage
-   * 3. Buffer the received message's ID for acking — after decryption succeeds
+   * Returns true if the message is a control message (delivery-ack, read-ack,
+   * typing-start, typing-stop) that should be intercepted and never saved.
+   * Returns false if it is a normal message (continue with saveMessage pipeline);
+   * any piggybacked ack fields are processed and stripped in that case.
+   *
+   * Steps applied at both DM decrypt paths:
+   * 1.  Intercept delivery-ack control messages — return true (early exit)
+   * 1b. Intercept read-ack control messages — return true (early exit)
+   * 1c. Intercept typing-start / typing-stop control messages — return true (early exit)
+   * 2.  Extract + process piggybacked ackMessageIds — then strip before saveMessage
+   * 2b. Extract + process piggybacked readAckUpTo — then strip before saveMessage
+   * 3.  Buffer the received message's ID for acking — after decryption succeeds
    */
-  private processDeliveryReceiptData(
+  private interceptControlMessages(
     decryptedContent: Message,
     senderAddress: string,
     selfAddress: string,
@@ -2670,7 +2681,7 @@ export class MessageService {
           });
           const effectiveDeliveryReceipts = conversation.conversation?.deliveryReceipts ?? !!userConfig?.deliveryReceipts;
           const effectiveReadReceipts = conversation.conversation?.readReceipts ?? !!userConfig?.readReceipts;
-          if (this.processDeliveryReceiptData(decryptedContent, session.user_address, self_address, effectiveDeliveryReceipts, effectiveReadReceipts)) {
+          if (this.interceptControlMessages(decryptedContent, session.user_address, self_address, effectiveDeliveryReceipts, effectiveReadReceipts)) {
             // delivery-ack control message — encryption state saved, but don't save/display the message
             return;
           }
@@ -4215,7 +4226,7 @@ export class MessageService {
         const senderAddress = conversationId.split('/')[0];
         const effectiveDeliveryReceipts = conversation.conversation?.deliveryReceipts ?? !!userConfig?.deliveryReceipts;
         const effectiveReadReceipts = conversation.conversation?.readReceipts ?? !!userConfig?.readReceipts;
-        if (this.processDeliveryReceiptData(decryptedContent, senderAddress, self_address, effectiveDeliveryReceipts, effectiveReadReceipts)) {
+        if (this.interceptControlMessages(decryptedContent, senderAddress, self_address, effectiveDeliveryReceipts, effectiveReadReceipts)) {
           // delivery-ack control message — encryption state saved, but don't save/display the message
           return;
         }

--- a/src/services/SpaceService.ts
+++ b/src/services/SpaceService.ts
@@ -10,6 +10,7 @@ import { buildSpacesKey, buildSpaceKey, buildSpaceMembersKey, buildConfigKey } f
 import { channel as secureChannel, channel_raw as ch } from '@quilibrium/quilibrium-js-sdk-channels';
 import { t } from '@lingui/core/macro';
 import { QuorumApiClient } from '../api/baseTypes';
+import type { Ref } from '../types/ref';
 
 // Type definitions for the service
 export interface SpaceServiceDependencies {
@@ -22,7 +23,7 @@ export interface SpaceServiceDependencies {
     deviceKeyset: secureChannel.DeviceKeyset;
     userKeyset: secureChannel.UserKeyset;
   };
-  spaceInfo: React.MutableRefObject<{ [key: string]: any }>;
+  spaceInfo: Ref<{ [key: string]: any }>;
   saveMessage: (
     message: Message,
     messageDB: MessageDB,
@@ -49,7 +50,7 @@ export class SpaceService {
     deviceKeyset: secureChannel.DeviceKeyset;
     userKeyset: secureChannel.UserKeyset;
   };
-  private spaceInfo: React.MutableRefObject<{ [key: string]: any }>;
+  private spaceInfo: Ref<{ [key: string]: any }>;
   private saveMessage: (
     message: Message,
     messageDB: MessageDB,

--- a/src/services/SyncService.ts
+++ b/src/services/SyncService.ts
@@ -22,11 +22,12 @@ import {
 import { IndexedDBAdapter } from '../adapters/indexedDbAdapter';
 import { showSyncToast } from '../utils/toast';
 import { t } from '@lingui/core/macro';
+import type { Ref } from '../types/ref';
 
 export class SyncService {
   private messageDB: MessageDB;
   private enqueueOutbound: (callback: () => Promise<string[]>) => void;
-  private syncInfo: React.MutableRefObject<{
+  private syncInfo: Ref<{
     [spaceId: string]: {
       expiry: number;
       candidates: any[];
@@ -40,7 +41,7 @@ export class SyncService {
   constructor(dependencies: {
     messageDB: MessageDB;
     enqueueOutbound: (callback: () => Promise<string[]>) => void;
-    syncInfo: React.MutableRefObject<{
+    syncInfo: Ref<{
       [spaceId: string]: {
         expiry: number;
         candidates: any[];

--- a/src/types/ref.ts
+++ b/src/types/ref.ts
@@ -1,0 +1,11 @@
+/**
+ * Platform-agnostic ref wrapper.
+ *
+ * Services should depend on this rather than `React.MutableRefObject<T>` so
+ * that they remain free of React types. `React.MutableRefObject<T>` is
+ * structurally compatible with `Ref<T>`, so MessageDB and other React-land
+ * callers can pass their existing refs directly without changes.
+ */
+export interface Ref<T> {
+  current: T;
+}


### PR DESCRIPTION
Closes Tier 0 #1, #2, #4 from the [MessageDB refactor master tracker](.agents/tasks/messagedb/README.md). All type-only / rename-only; no runtime behavior change.

- 628ecd31 refactor(MessageService): rename receipt intercept method and tighten typing
- 842156e2 docs(messagedb): mark Tier 0 #1, #2, #4 done in cleanup tracker

## What changed

1. **Rename** `processDeliveryReceiptData` → `interceptControlMessages`. The method also handles read-ack and typing-start/typing-stop control messages, so the old receipt-only name was misleading. JSDoc rewritten to describe both intercept and piggyback-processing responsibilities.
2. **Type piggybacked ack fields** — remove 4 `(message as any)` casts in `attachPiggybackedAcks` / `stripPiggybackedAcks` by importing `ReceiptEnvelopeFields` from `@quilibrium/quorum-shared` (exported by the receipts shared migration) and using `Message & ReceiptEnvelopeFields` as a typed view.
3. **Decouple services from React types** — replace 12 `React.MutableRefObject<…>` annotations across ConfigService, InvitationService, SpaceService, SyncService, MessageService with a platform-agnostic `Ref<T> { current: T }` in `src/types/ref.ts`. `React.MutableRefObject<T>` is structurally compatible, so MessageDB and other React-land callers pass their existing refs unchanged.

## Verification

- `npx tsc --noEmit` clean (one pre-existing unrelated error in `ImportKeyStep.tsx`, confirmed via `git stash`)
- `yarn lint` — 0 errors, no new warnings in touched files
- `yarn test:run` — 321/321 passing