### PR TITLE
refactor(NotificationService): drop static singleton

### DIFF
--- a/.agents/tasks/messagedb/README.md
+++ b/.agents/tasks/messagedb/README.md
@@ -58,10 +58,10 @@ Each item lists the doc that owns its content, the risk, the rough time investme
 | # | Task | Doc | Risk | Time | Value |
 |---|------|------|------|------|-------|
 | 5 | Replace `any` types (97 occurrences across 5 services) | [low-risk §2.1](./optimizations-low-risk.md#21-replace-any-types) | ⚠️ Low (per service) | **1–2 days** | Compile-time bug catching; desktop hygiene. (All 5 affected services are per-app — see [cross-check](./shared-migration-cross-check.md#issue-a-overstating-shared-migration-enablement).) |
-| 6 | NotificationService singleton → DI'd class | [low-risk §4.2](./optimizations-low-risk.md#42-convert-notificationservice-singleton-to-a-normal-class) | ⚠️ Low–Med | Half-day | Testability; consistency (only service in the folder that isn't DI'd) |
+| 6 | ~~NotificationService singleton → DI'd class~~ ✅ DONE (2026-05-20, scope reduced) | [low-risk §4.2](./optimizations-low-risk.md#42-convert-notificationservice-singleton-to-a-normal-class) | — | ~10 min | Public constructor + module-level shared instance. Full context-DI was deemed over-engineered for a tab-global service — see §4.2 for the scope-reduction note. |
 | 7 | `BaseService` extraction (common deps) | [low-risk §3.1](./optimizations-low-risk.md) | ⚠️ Low | 1 h | -50 lines per service; **must follow #5** so base class uses real types. (Cross-check confirms no migration-eligible service fits the BaseService shape, so no shared-migration risk — see [cross-check](./shared-migration-cross-check.md#issue-c-overstated-baseservice-risk-to-shared-migration).) |
 
-**Order rationale**: #5 first (it's the precondition for #7 to be done well, and unlocks IDE confidence for everything downstream). #6 is independent — slot wherever convenient. #7 last in this tier.
+**Order rationale**: #5 first (it's the precondition for #7 to be done well, and unlocks IDE confidence for everything downstream). #6 was independent; landed 2026-05-20 with reduced scope. #7 last in this tier.
 
 ### Tier 2 — Per-message-type extractions (opportunistic, follow ThreadService precedent)
 
@@ -106,12 +106,14 @@ See also [current-state.md §Cross-cutting context](./current-state.md#cross-cut
 
 ## Active state
 
-- **In progress**: branch `refactor/messageservice-rename-and-typing` — stacking Tier 0 #1, #4, #2 (started 2026-05-20).
-- **Most recent**: receipts shared migration (PR #147, 2026-05-20) — incidentally landed Tier 0 #3 as a precursor cleanup. ThreadService extraction (April–May 2026), TypingService extraction (May 2026), audit refresh + folder reorg (2026-05-19).
+- **In progress**: branch `refactor/notificationservice-dependency-injection` — Tier 1 #6 with reduced scope (started 2026-05-20).
+- **Most recent**: Tier 0 #1, #2, #4 landed in PR #150 (2026-05-20, branch `refactor/messageservice-rename-and-typing`). Receipts shared migration (PR #147, 2026-05-20) — incidentally landed Tier 0 #3 as a precursor cleanup. ThreadService extraction (April–May 2026), TypingService extraction (May 2026), audit refresh + folder reorg (2026-05-19).
 - **Blockers**: none for any Tier 0/1 item. Tier 2 items unblock once someone has a focused day. Tier 3 waits on feature triggers.
 
 ---
 
-_Last updated: 2026-05-20 — Tier 0 #3 marked ✅ done (landed inside receipts-shared-migration PR #147); Tier 0 #4 unblocked. Branch `refactor/messageservice-rename-and-typing` opened to stack #1 + #4 + #2._
+_Last updated: 2026-05-20 PM — Tier 1 #6 marked ✅ done with reduced scope on branch `refactor/notificationservice-dependency-injection`. Full context-DI was rejected as over-engineering for a tab-global service; the change is now just "drop the static singleton ceremony, keep the module-level instance" (~10 min vs. half-day estimate)._
+
+_Earlier 2026-05-20 — Tier 0 #1, #2, #4 landed in PR #150. Tier 0 #3 was already ✅ done (landed inside receipts-shared-migration PR #147); Tier 0 #4 unblocked by same. Branch `refactor/messageservice-rename-and-typing` stacked #1 + #4 + #2._
 
 _Previously 2026-05-19 — folder reorganized. Files renamed: `messagedb-current-state.md` → `current-state.md`, `messageservice-analysis.md` → `messageservice-deep-dive.md`, `messagedb-optimization-1.md` → `optimizations-low-risk.md`, `messagedb-optimization-3.md` → `optimizations-high-risk.md`. New files: `handleNewMessage-reconsidered.md`, `shared-migration-cross-check.md`. This README is new and owns the safest-to-riskiest master action plan. Tier 0 #3 marked with the sequencing constraint surfaced by the cross-check; framing softened for #5 and #7._

--- a/.agents/tasks/messagedb/optimizations-low-risk.md
+++ b/.agents/tasks/messagedb/optimizations-low-risk.md
@@ -310,24 +310,25 @@ These were surfaced during the 2026-05-19 audit prompted by the typing/receipts 
 
 **Why now (history)**: ahead of any further ephemeral control-message additions (presence, reactions-as-control). Done as part of Tier 0 cleanup batch on branch `refactor/messageservice-rename-and-typing`.
 
-### 4.2 Convert NotificationService singleton to a normal class
+### 4.2 Convert NotificationService singleton to a normal class ✅ DONE (2026-05-20, scope reduced)
 
-**Risk**: ⚠️ LOW–MEDIUM
-**Time**: ~half-day
-**Impact**: Testability; consistency with all other services
+**Risk**: ⚠️ LOW (smaller than originally rated)
+**Time**: ~10 min (vs. half-day estimate)
+**Impact**: Testability; constructor is no longer private
 
-**Problem**: NotificationService uses `private static instance` + `getInstance()` (NotificationService.ts:39, 45). Every other service in `src/services/` is a normal class instantiated by MessageDB and wired via dependency injection. NotificationService has no unit test file — directly correlated with the singleton being hard to mock.
+**What was changed** (branch `refactor/notificationservice-dependency-injection`):
+- Removed `private static instance` and `getInstance()` from NotificationService.
+- Made the constructor `public` (was `private`).
+- Kept the module-level `export const notificationService = new NotificationService()` as the canonical shared instance, with a comment explaining why this remains a per-tab singleton (it wraps `window.Notification` and `document.visibilityState`, which are themselves tab-global).
+- Zero call-site changes: 5 consumers (MessageService, useNotificationSettings, useMutedConversationsSync, WebsocketProvider, services/index re-export) keep importing `notificationService` by the same name.
 
-**Proposed**:
-- Convert to a normal class with a constructor.
-- Have MessageDB instantiate it like every other service.
-- All current callers use `notificationService` (a lowercase singleton import from `./NotificationService`) — refactor those call sites to take it through context.
+**Scope reduction vs. original plan**:
+- The original §4.2 proposed instantiating NotificationService in MessageDB and threading it through React context, matching the ReceiptService/TypingService pattern. On second look that was over-engineered: NotificationService is genuinely a per-tab singleton (it wraps tab-global browser APIs), the React-land call sites have no per-user/per-session lifecycle to track, and threading it through context would add a hook + 3 consumer-site rewrites for zero behavior or testability gain that isn't already won by dropping `private constructor`.
+- The §4.2 caveat about "module-level state (`isProcessing`, `pendingNotifications`, `mutedConversations`) needs to move onto the instance" was incorrect on inspection — all three of those were already instance fields. Nothing had to move.
+- Tests that want isolation can now `new NotificationService()` directly. That's the testability win the original §4.2 was after.
 
-**Caveats**:
-- NotificationService.ts has DOM-coupled code (`document.visibilitychange`, `Notification`, Safari sniffing). It stays per-app forever per the [services-design audit](../quorum-shared-migration/designs/2026-05-18-services-design.md), so this is purely a desktop hygiene win, not a shared-migration enabler.
-- Module-level state in this file (`isProcessing`, `pendingNotifications`, `mutedConversations`) needs to move onto the instance.
-
-**Why now**: NotificationService is the only service in the folder that isn't testable via the standard pattern. Worth one focused cleanup pass.
+**What this is NOT**:
+- Not a "per-app forever vs. shared" change — NotificationService stays per-app forever per the [services-design audit](../quorum-shared-migration/designs/2026-05-18-services-design.md). DOM coupling unchanged.
 
 ### 4.3 Normalize control-message intercept shape ✅ DONE (2026-05-20)
 

--- a/src/services/NotificationService.ts
+++ b/src/services/NotificationService.ts
@@ -28,7 +28,6 @@ export type NotificationMetadata = {
 };
 
 export class NotificationService {
-  private static instance: NotificationService;
   private isSupported: boolean;
   private permission: NotificationPermission;
   private readonly quorumIcon = '/quorum-symbol.png';
@@ -36,16 +35,9 @@ export class NotificationService {
   private latestNotification: NotificationMetadata | null = null;
   private mutedConversations: Set<string> = new Set();
 
-  private constructor() {
+  public constructor() {
     this.isSupported = 'Notification' in window;
     this.permission = this.isSupported ? Notification.permission : 'denied';
-  }
-
-  public static getInstance(): NotificationService {
-    if (!NotificationService.instance) {
-      NotificationService.instance = new NotificationService();
-    }
-    return NotificationService.instance;
   }
 
   /**
@@ -338,5 +330,16 @@ export class NotificationService {
   }
 }
 
-// Export singleton instance
-export const notificationService = NotificationService.getInstance();
+/**
+ * Shared module-level instance.
+ *
+ * NotificationService is genuinely a per-tab singleton — it wraps the
+ * browser's `window.Notification` API and `document.visibilityState`,
+ * both of which are themselves global to the tab. We expose a single
+ * instance here so call sites don't accidentally end up with multiple
+ * permission caches or pending-notification counters out of sync.
+ *
+ * Tests that need an isolated instance can `new NotificationService()`
+ * directly (the constructor is public).
+ */
+export const notificationService = new NotificationService();


### PR DESCRIPTION
Closes Tier 1 #6 from the [MessageDB refactor master tracker](.agents/tasks/messagedb/README.md), with reduced scope vs. the original §4.2 plan.

- b1f7e305 refactor(NotificationService): drop static singleton in favor of module instance
- beae21df docs(messagedb): mark Tier 1 #6 done with scope reduction

## What changed

`NotificationService` used `private static instance` + `getInstance()`, which required a private constructor and made the class awkward to instantiate in tests. The class is genuinely a per-tab singleton (it wraps `window.Notification` and `document.visibilityState`, which are themselves tab-global), so we keep a single shared instance — just exposed as a normal module-level export rather than via a static factory.

- Remove `private static instance` and `getInstance()`.
- Make the constructor `public`.
- Keep `export const notificationService = new NotificationService()` as the canonical shared instance, with a JSDoc explaining the tab-singleton rationale and pointing tests at `new NotificationService()` for isolated instances.

All 5 existing call sites (`MessageService`, `useNotificationSettings`, `useMutedConversationsSync`, `WebsocketProvider`, `services/index` re-export) keep importing `notificationService` unchanged. **No behavior change.**

## Scope reduction vs. original §4.2 plan

The original plan proposed full DI through React context, matching the `ReceiptService` / `TypingService` pattern (half-day estimate). On second look that was over-engineered for a tab-global service that has no per-user/per-session lifecycle — context-threading would add a hook + 3 consumer-site rewrites for zero behavior or testability gain that isn't already won by dropping `private constructor`. The §4.2 caveat about module-level state needing to migrate to the instance was also incorrect — those fields were already on the instance. See [`optimizations-low-risk.md §4.2`](.agents/tasks/messagedb/optimizations-low-risk.md) for the full note.

## Verification

- `npx tsc --noEmit` clean (only pre-existing unrelated error in `ImportKeyStep.tsx`)
- `yarn lint` — 0 errors, no new warnings
- `yarn test:run` — 321/321 passing