### PR TITLE
refactor(services): name spaceInfo/syncInfo ref types

### DIFF
--- a/.agents/tasks/messagedb/README.md
+++ b/.agents/tasks/messagedb/README.md
@@ -57,7 +57,7 @@ Each item lists the doc that owns its content, the risk, the rough time investme
 
 | # | Task | Doc | Risk | Time | Value |
 |---|------|------|------|------|-------|
-| 5 | Replace `any` types (97 occurrences across 5 services) | [low-risk §2.1](./optimizations-low-risk.md#21-replace-any-types) | ⚠️ Low (per service) | **1–2 days** | Compile-time bug catching; desktop hygiene. (All 5 affected services are per-app — see [cross-check](./shared-migration-cross-check.md#issue-a-overstating-shared-migration-enablement).) |
+| 5 | Replace `any` types (originally ~105 across 5 services; **93 remaining** after 2026-05-20) | [low-risk §2.1](./optimizations-low-risk.md#21-replace-any-types--partially-done-2026-05-20) | ⚠️ Low (per service) | ~1 day remaining | Compile-time bug catching; desktop hygiene. ConfigService cleared; `spaceInfo`/`syncInfo` ref types named. Remaining `any`s are mostly MessageService wire-message dispatch — naturally addressed at Tier 2 extraction time. (All 5 affected services are per-app — see [cross-check](./shared-migration-cross-check.md#issue-a-overstating-shared-migration-enablement).) |
 | 6 | ~~NotificationService singleton → DI'd class~~ ✅ DONE (2026-05-20, scope reduced) | [low-risk §4.2](./optimizations-low-risk.md#42-convert-notificationservice-singleton-to-a-normal-class) | — | ~10 min | Public constructor + module-level shared instance. Full context-DI was deemed over-engineered for a tab-global service — see §4.2 for the scope-reduction note. |
 | 7 | `BaseService` extraction (common deps) | [low-risk §3.1](./optimizations-low-risk.md) | ⚠️ Low | 1 h | -50 lines per service; **must follow #5** so base class uses real types. (Cross-check confirms no migration-eligible service fits the BaseService shape, so no shared-migration risk — see [cross-check](./shared-migration-cross-check.md#issue-c-overstated-baseservice-risk-to-shared-migration).) |
 
@@ -106,13 +106,15 @@ See also [current-state.md §Cross-cutting context](./current-state.md#cross-cut
 
 ## Active state
 
-- **In progress**: branch `refactor/notificationservice-dependency-injection` — Tier 1 #6 with reduced scope (started 2026-05-20).
-- **Most recent**: Tier 0 #1, #2, #4 landed in PR #150 (2026-05-20, branch `refactor/messageservice-rename-and-typing`). Receipts shared migration (PR #147, 2026-05-20) — incidentally landed Tier 0 #3 as a precursor cleanup. ThreadService extraction (April–May 2026), TypingService extraction (May 2026), audit refresh + folder reorg (2026-05-19).
+- **In progress**: branch `refactor/type-spaceinfo-syncinfo-refs` — partial Tier 1 #5 (the `spaceInfo`/`syncInfo` ref subset).
+- **Most recent**: Tier 1 #6 (NotificationService) landed in PR #151. Tier 0 #1, #2, #4 landed in PR #150. Receipts shared migration (PR #147) — incidentally landed Tier 0 #3 as a precursor cleanup. ThreadService extraction (April–May 2026), TypingService extraction (May 2026), audit refresh + folder reorg (2026-05-19).
 - **Blockers**: none for any Tier 0/1 item. Tier 2 items unblock once someone has a focused day. Tier 3 waits on feature triggers.
 
 ---
 
-_Last updated: 2026-05-20 PM — Tier 1 #6 marked ✅ done with reduced scope on branch `refactor/notificationservice-dependency-injection`. Full context-DI was rejected as over-engineering for a tab-global service; the change is now just "drop the static singleton ceremony, keep the module-level instance" (~10 min vs. half-day estimate)._
+_Last updated: 2026-05-20 (late) — Tier 1 #5 partial progress on branch `refactor/type-spaceinfo-syncinfo-refs`. The `spaceInfo` and `syncInfo` refs are now properly typed across all 5 services via `SpaceInfoMap` / `SyncInfoMap` aliases in `src/types/spaceRefs.ts`. ConfigService is `any`-free. 12 of 105 `any`s removed; the remaining 93 are mostly MessageService wire-message dispatch and naturally fall to Tier 2 per-message-type extractions._
+
+_Earlier 2026-05-20 PM — Tier 1 #6 marked ✅ done with reduced scope on branch `refactor/notificationservice-dependency-injection`. Full context-DI was rejected as over-engineering for a tab-global service; the change is now just "drop the static singleton ceremony, keep the module-level instance" (~10 min vs. half-day estimate)._
 
 _Earlier 2026-05-20 — Tier 0 #1, #2, #4 landed in PR #150. Tier 0 #3 was already ✅ done (landed inside receipts-shared-migration PR #147); Tier 0 #4 unblocked by same. Branch `refactor/messageservice-rename-and-typing` stacked #1 + #4 + #2._
 

--- a/.agents/tasks/messagedb/optimizations-low-risk.md
+++ b/.agents/tasks/messagedb/optimizations-low-risk.md
@@ -62,21 +62,23 @@ After completing quick wins (code cleanup, hex utilities, JSDoc), this document 
 
 ### 🟡 Category 2: Type Safety Improvements (Low Risk)
 
-#### 2.1 Replace `any` Types
+#### 2.1 Replace `any` Types — Partially Done (2026-05-20)
 **Risk**: ⚠️ LOW per service, but volume is high
 **Time**: **1–2 days** (corrected — was previously listed as "1–2 hours")
 **Impact**: Better type safety, catches bugs at compile time
 
-**Current usage counts (May 2026, includes `: any`, `<any>`, `as any`):**
+> **2026-05-20 partial progress.** The `spaceInfo` and `syncInfo` ref types — previously `Ref<{ [key: string]: any }>` across all 5 services — are now properly typed via the new `SpaceInfoMap` and `SyncInfoMap` aliases in `src/types/spaceRefs.ts`. ConfigService is now `any`-free. 12 `any` occurrences removed across the 5 services (was 105 → now 93). Done on branch `refactor/type-spaceinfo-syncinfo-refs`. The remaining ~93 `any`s are mostly in MessageService's wire-message dispatch (`handleNewMessage` and friends) and should be addressed as Tier 2 per-message-type extractions land — typing each handler at extraction time is smaller-scope than retrofitting the monolith.
 
-| Service | Count |
-|---------|-------|
-| MessageService | 67 |
-| InvitationService | 12 |
-| SpaceService | 8 |
-| SyncService | 8 |
-| ConfigService | 2 |
-| **Total (5 main services)** | **97** |
+**Current usage counts (May 2026 → 2026-05-20):**
+
+| Service | May 2026 | 2026-05-20 |
+|---------|----------|------------|
+| MessageService | 67 → 74 (grew with features) | **70** |
+| InvitationService | 12 → 13 | **11** |
+| SpaceService | 8 | **6** |
+| SyncService | 8 | **6** |
+| ConfigService | 2 | **0** ✅ |
+| **Total** | **97 → 105** | **93** |
 
 Newer services already do this right: TypingService, ReceiptService, ThreadService, SearchService, BackupService have **zero** `any` usages.
 

--- a/src/services/ConfigService.ts
+++ b/src/services/ConfigService.ts
@@ -14,11 +14,12 @@ import { buildSpacesKey, buildConfigKey } from '../hooks';
 import { validateItems } from '../utils/folderUtils';
 import { mergeDeviceNames } from './configMergeHelpers';
 import type { Ref } from '../types/ref';
+import type { SpaceInfoMap } from '../types/spaceRefs';
 
 export class ConfigService {
   private messageDB: MessageDB;
   private apiClient: QuorumApiClient;
-  private spaceInfo: Ref<{ [key: string]: any }>;
+  private spaceInfo: Ref<SpaceInfoMap>;
   private enqueueOutbound: (action: () => Promise<string[]>) => void;
   private sendHubMessage: (spaceId: string, message: string) => Promise<string>;
   private queryClient: QueryClient;
@@ -26,7 +27,7 @@ export class ConfigService {
   constructor(dependencies: {
     messageDB: MessageDB;
     apiClient: QuorumApiClient;
-    spaceInfo: Ref<{ [key: string]: any }>;
+    spaceInfo: Ref<SpaceInfoMap>;
     enqueueOutbound: (action: () => Promise<string[]>) => void;
     sendHubMessage: (spaceId: string, message: string) => Promise<string>;
     queryClient: QueryClient;

--- a/src/services/InvitationService.ts
+++ b/src/services/InvitationService.ts
@@ -12,11 +12,12 @@ import { buildSpacesKey, buildConfigKey, buildSpaceKey } from '../hooks';
 import type { Space } from '@quilibrium/quorum-shared';
 import { isQuorumApiError } from '../api/baseTypes';
 import type { Ref } from '../types/ref';
+import type { SpaceInfoMap } from '../types/spaceRefs';
 
 export class InvitationService {
   private messageDB: MessageDB;
   private apiClient: QuorumApiClient;
-  private spaceInfo: Ref<{ [key: string]: any }>;
+  private spaceInfo: Ref<SpaceInfoMap>;
   private selfAddress: string;
   private enqueueOutbound: (action: () => Promise<string[]>) => void;
   private queryClient: QueryClient;
@@ -28,7 +29,7 @@ export class InvitationService {
   constructor(dependencies: {
     messageDB: MessageDB;
     apiClient: QuorumApiClient;
-    spaceInfo: Ref<{ [key: string]: any }>;
+    spaceInfo: Ref<SpaceInfoMap>;
     selfAddress: string;
     enqueueOutbound: (action: () => Promise<string[]>) => void;
     queryClient: QueryClient;

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -61,6 +61,7 @@ import { TypingService, type TypingMessage } from '@quilibrium/quorum-shared';
 import { ENABLE_DM_ACTION_QUEUE } from '../config/features';
 import { ThreadService } from './ThreadService';
 import type { Ref } from '../types/ref';
+import type { SpaceInfoMap, SyncInfoMap } from '../types/spaceRefs';
 
 // Type definitions for the service
 export interface MessageServiceDependencies {
@@ -82,8 +83,8 @@ export interface MessageServiceDependencies {
     apiClient: QuorumApiClient
   ) => Promise<void>;
   navigate: (path: string, options?: any) => void;
-  spaceInfo: Ref<{ [key: string]: any }>;
-  syncInfo: Ref<{ [key: string]: any }>;
+  spaceInfo: Ref<SpaceInfoMap>;
+  syncInfo: Ref<SyncInfoMap>;
   synchronizeAll: (spaceId: string, inboxAddress: string) => Promise<void>;
   informSyncData: (
     spaceId: string,
@@ -122,8 +123,8 @@ export class MessageService {
     apiClient: QuorumApiClient
   ) => Promise<void>;
   private navigate: (path: string, options?: any) => void;
-  private spaceInfo: Ref<{ [key: string]: any }>;
-  private syncInfo: Ref<{ [key: string]: any }>;
+  private spaceInfo: Ref<SpaceInfoMap>;
+  private syncInfo: Ref<SyncInfoMap>;
   private synchronizeAll: (
     spaceId: string,
     inboxAddress: string

--- a/src/services/SpaceService.ts
+++ b/src/services/SpaceService.ts
@@ -11,6 +11,7 @@ import { channel as secureChannel, channel_raw as ch } from '@quilibrium/quilibr
 import { t } from '@lingui/core/macro';
 import { QuorumApiClient } from '../api/baseTypes';
 import type { Ref } from '../types/ref';
+import type { SpaceInfoMap } from '../types/spaceRefs';
 
 // Type definitions for the service
 export interface SpaceServiceDependencies {
@@ -23,7 +24,7 @@ export interface SpaceServiceDependencies {
     deviceKeyset: secureChannel.DeviceKeyset;
     userKeyset: secureChannel.UserKeyset;
   };
-  spaceInfo: Ref<{ [key: string]: any }>;
+  spaceInfo: Ref<SpaceInfoMap>;
   saveMessage: (
     message: Message,
     messageDB: MessageDB,
@@ -50,7 +51,7 @@ export class SpaceService {
     deviceKeyset: secureChannel.DeviceKeyset;
     userKeyset: secureChannel.UserKeyset;
   };
-  private spaceInfo: Ref<{ [key: string]: any }>;
+  private spaceInfo: Ref<SpaceInfoMap>;
   private saveMessage: (
     message: Message,
     messageDB: MessageDB,

--- a/src/services/SyncService.ts
+++ b/src/services/SyncService.ts
@@ -23,17 +23,12 @@ import { IndexedDBAdapter } from '../adapters/indexedDbAdapter';
 import { showSyncToast } from '../utils/toast';
 import { t } from '@lingui/core/macro';
 import type { Ref } from '../types/ref';
+import type { SyncInfoMap } from '../types/spaceRefs';
 
 export class SyncService {
   private messageDB: MessageDB;
   private enqueueOutbound: (callback: () => Promise<string[]>) => void;
-  private syncInfo: Ref<{
-    [spaceId: string]: {
-      expiry: number;
-      candidates: any[];
-      invokable: NodeJS.Timeout | undefined;
-    };
-  }>;
+  private syncInfo: Ref<SyncInfoMap>;
   private sendHubMessage: (spaceId: string, message: string) => Promise<string>;
   private storageAdapter: IndexedDBAdapter;
   private sharedSyncService: SharedSyncService;
@@ -41,13 +36,7 @@ export class SyncService {
   constructor(dependencies: {
     messageDB: MessageDB;
     enqueueOutbound: (callback: () => Promise<string[]>) => void;
-    syncInfo: Ref<{
-      [spaceId: string]: {
-        expiry: number;
-        candidates: any[];
-        invokable: NodeJS.Timeout | undefined;
-      };
-    }>;
+    syncInfo: Ref<SyncInfoMap>;
     sendHubMessage: (spaceId: string, message: string) => Promise<string>;
   }) {
     this.messageDB = dependencies.messageDB;

--- a/src/types/spaceRefs.ts
+++ b/src/types/spaceRefs.ts
@@ -1,0 +1,31 @@
+import type { channel as secureChannel } from '@quilibrium/quilibrium-js-sdk-channels';
+
+/**
+ * Per-space registration map kept on a ref in MessageDB and read by every
+ * per-app service that needs space metadata (keysets, inbox addresses, etc).
+ *
+ * Backed by `useRef` in `MessageDB.tsx`, so it always exists for the lifetime
+ * of the React tree; services receive it via the platform-agnostic `Ref<T>`
+ * wrapper in `./ref`.
+ */
+export type SpaceInfoMap = {
+  [spaceId: string]: secureChannel.SpaceRegistration;
+};
+
+/**
+ * Per-space sync session bookkeeping for the legacy sync path.
+ *
+ * `candidates` is `any[]` here because the entries are incoming hub
+ * envelopes whose shape is narrowed by property access at the consumer
+ * (see `SyncService.initiateSync` and the `sync-info` handler in
+ * `MessageService`). Tightening this to a proper hub-envelope union is a
+ * separate cleanup; the goal of this type is just to keep the *outer*
+ * shape (`expiry`, `candidates`, `invokable`) honestly typed.
+ */
+export type SyncInfoMap = {
+  [spaceId: string]: {
+    expiry: number;
+    candidates: any[];
+    invokable: NodeJS.Timeout | undefined;
+  };
+};


### PR DESCRIPTION
Partial progress on Tier 1 #5 (replace \`any\` types) from the [MessageDB refactor master tracker](.agents/tasks/messagedb/README.md). Focused subset: the \`spaceInfo\` and \`syncInfo\` ref types only.

- d58a0f10 refactor(services): name spaceInfo/syncInfo ref types
- 424f8fdb docs(messagedb): record partial Tier 1 #5 progress

## What changed

The 5 per-app services (Config, Invitation, Space, Sync, Message) all carried two refs typed as \`Ref<{ [key: string]: any }>\`. The real types have always been known — they live in [\`MessageDB.tsx\`](src/components/context/MessageDB.tsx) where the refs are created:

- \`spaceInfo\` is \`Record<spaceId, secureChannel.SpaceRegistration>\`
- \`syncInfo\` is \`Record<spaceId, { expiry, candidates, invokable }>\`

This PR hoists those into named aliases in a new file [\`src/types/spaceRefs.ts\`](src/types/spaceRefs.ts) and switches all 5 services to use them.

## Impact

| Service | \`any\` count before | after |
|---------|---------------------|-------|
| MessageService | 74 | 70 |
| InvitationService | 13 | 11 |
| SpaceService | 8 | 6 |
| SyncService | 8 | 6 |
| ConfigService | 2 | **0** |
| **Total** | **105** | **93** |

ConfigService is now \`any\`-free. 12 \`any\`s removed total.

## Scope kept tight

\`SyncInfoMap.candidates\` stays \`any[]\` — these are dynamic hub envelopes whose shape is narrowed by property access at the consumer in [\`SyncService.initiateSync\`](src/services/SyncService.ts). Tightening that is a separate cleanup tied to a hub-envelope discriminated union and was deliberately kept out of scope here.

The remaining ~93 \`any\`s are mostly MessageService wire-message dispatch and are best addressed as Tier 2 per-message-type extractions land — typing each handler at extraction time is smaller-scope than retrofitting the 5,465-line monolith.

## Verification

- \`npx tsc --noEmit\` clean (only the pre-existing unrelated error in \`ImportKeyStep.tsx\`)
- \`yarn lint\` — 0 errors, no new warnings
- \`yarn test:run\` — 321/321 passing