### PR TITLE
chore(types): mirror isProfilePublic and farcasterLink on local UserConfig

### DIFF
--- a/src/db/messages.ts
+++ b/src/db/messages.ts
@@ -1,6 +1,6 @@
 import { logger } from '@quilibrium/quorum-shared';
 import { channel } from '@quilibrium/quilibrium-js-sdk-channels';
-import type { Conversation, Message, Space, Bookmark, BroadcastSpaceTag, ChannelThread, UserNote } from '@quilibrium/quorum-shared';
+import type { Conversation, Message, Space, Bookmark, BroadcastSpaceTag, ChannelThread, UserNote, FarcasterLink } from '@quilibrium/quorum-shared';
 import { BOOKMARKS_CONFIG } from '@quilibrium/quorum-shared';
 import type { NotificationSettings } from '../types/notifications';
 import type { IconColor } from '../components/space/IconPicker/types';
@@ -57,6 +57,8 @@ export type UserConfig = {
   name?: string;                    // User's display name (synced from profile)
   profile_image?: string;           // User's profile image as data URI (synced from profile)
   bio?: string;                     // User's bio/description (local-only for now)
+  isProfilePublic?: boolean;        // Whether the user's profile is discoverable; mirror of shared UserConfig.
+  farcasterLink?: FarcasterLink;    // Bidirectional FC ↔ Quorum identity link; mirror of shared UserConfig.
   spaceKeys?: {
     spaceId: string;
     encryptionState: {


### PR DESCRIPTION
## What

Mirror two new `UserConfig` fields onto the desktop local type in `src/db/messages.ts`:
- `isProfilePublic?: boolean`
- `farcasterLink?: FarcasterLink`

Imports `FarcasterLink` from `@quilibrium/quorum-shared`.

## Why

Same drift pattern as #157 (privacy fields) and #158 (UserNote dedup). The shared `UserConfig` recently gained these two fields plus a new `FarcasterLink` type from the upstream rollup commit on `quorum-shared/master`. The local mirror in `src/db/messages.ts` is what desktop reads from IndexedDB and writes back during config sync. Any field present on the wire but absent from the local type would be silently dropped on read.

Pure additive type-level change. No existing code references these fields yet (grep confirms zero consumers anywhere in `src/`), so behavior is unchanged today — this just keeps the mirror in step for when desktop features start consuming them.

## Cross-repo migration

Single-repo PR (desktop only). The shared-side definitions already landed on `origin/master` upstream.

## Verification

- `npx tsc --noEmit --jsx react-jsx --skipLibCheck` — clean except for one pre-existing unrelated `ImportKeyStep.tsx` error not touched by this PR
- `npx eslint src/db/messages.ts` — clean (one pre-existing warning on line 361, unrelated)
- `grep -r "isProfilePublic\|farcasterLink\|FarcasterLink" src/` — zero existing consumers, confirming additive

## Test plan

Type-only change with no runtime behavior; nothing to manually test.