### PR TITLE
chore(types): dedup notification types against quorum-shared

### DIFF
--- a/.agents/docs/features/channel-space-mute-system.md
+++ b/.agents/docs/features/channel-space-mute-system.md
@@ -39,19 +39,19 @@ export type UserConfig = {
 
   // Per-space notification settings (includes space-level muting)
   notificationSettings?: {
-    [spaceId: string]: NotificationSettings;
+    [spaceId: string]: SpaceNotificationSettings;
   };
 };
 ```
 
-**Space-level muting** uses the `isMuted` field in `NotificationSettings`:
+**Space-level muting** uses the `isMuted` field in `SpaceNotificationSettings`:
 
-**File**: [notifications.ts](src/types/notifications.ts)
+**File**: [notifications.ts](src/types/notifications.ts) (re-exports from `@quilibrium/quorum-shared`)
 
 ```typescript
-export interface NotificationSettings {
+export interface SpaceNotificationSettings {
   spaceId: string;
-  enabledNotificationTypes: NotificationTypeId[];
+  enabledNotificationTypes: SpaceNotificationTypeId[];
   isMuted?: boolean;  // When true, suppresses ALL notifications for this space
 }
 ```
@@ -373,7 +373,7 @@ React Query cache is updated immediately for instant UI feedback, while the actu
 Space-level mute checks happen first (O(1)) to avoid unnecessary channel iteration when the entire space is muted. Notification hooks also use early-exit thresholds (10 items) since UI shows "9+" for counts > 9.
 
 ### Separation of Concerns
-- `isMuted` in `NotificationSettings` represents **user intent** to mute a space
+- `isMuted` in `SpaceNotificationSettings` represents **user intent** to mute a space
 - `mutedChannels` represents **individual channel preferences**
 - `showMutedChannels` is a **UI preference** for visibility
 

--- a/.agents/docs/features/mention-notification-system.md
+++ b/.agents/docs/features/mention-notification-system.md
@@ -667,7 +667,7 @@ src/
 │   ├── notificationSettingsUtils.ts       # Settings helpers
 │   └── permissions.ts                     # Role permission utilities
 ├── types/
-│   └── notifications.ts                   # NotificationTypeId, NotificationSettings
+│   └── notifications.ts                   # Re-exports SpaceNotificationTypeId, SpaceNotificationSettings, etc. from quorum-shared
 ├── hooks/
 │   ├── business/
 │   │   ├── mentions/

--- a/.agents/tasks/quorum-shared-migration/2026-05-28-cross-repo-workflow.md
+++ b/.agents/tasks/quorum-shared-migration/2026-05-28-cross-repo-workflow.md
@@ -181,7 +181,7 @@ This sounds tedious but takes ~30 seconds per update and is invaluable when the 
 
 4. **If a PR sits >2 weeks, ping specifically.** Not "any updates?" but: *"PR #X has been open 2 weeks, blocking PR #Y and #Z on my side. Can you take 10 min today?"* Make the cost visible.
 
-5. **Don't stack desktop PRs on unmerged mobile PRs.** Each cross-repo migration: ship shared first → desktop second (Kyn merges) → mobile last (lead merges). Mobile lagging is fine.
+5. **Don't stack desktop PRs on unmerged mobile PRs.** Each cross-repo migration: ship shared first → desktop second → mobile last. Shared and desktop merges happen locally; mobile merge waits on lead review. Mobile lagging is fine.
 
 6. **Accept that some mobile PRs may sit indefinitely.** Cleanup PRs (deleting dead scaffolds) are low-value to the lead. If `useNotificationSettings` deletion sits 3 months, nothing breaks — the user-visible win already shipped on shared and desktop.
 
@@ -272,31 +272,55 @@ Mobile keeps building because nothing it currently uses has changed.
 - Changing a function signature in a non-additive way (param removal, return type change)
 - Adding a **required** field to a type (consumers that construct that type now fail to compile)
 
-For breaking changes, the standard pattern is a **same-session triplet**:
+For breaking changes, **first check what mobile actually imports**:
+
+```bash
+# In quorum-mobile, grep for every symbol the shared PR will rename/remove:
+cd D:\GitHub\Quilibrium\quorum-mobile
+grep -rE "\b(OldSymbolA|OldSymbolB|OldSymbolC)\b" --include="*.ts" --include="*.tsx" .
+```
+
+The answer determines the PR pattern.
+
+### Pattern A — Mobile imports at least one affected symbol → **same-session triplet**
 
 1. Shared PR (the breaking change)
 2. Desktop PR (fixes desktop's consumers — needed immediately because desktop's `link:` symlink sees shared changes instantly, so desktop's local build will break the moment shared changes land)
-3. Mobile PR (fixes mobile's consumers — can lag, mobile keeps using the old shared version until merged)
+3. Mobile PR (renames mobile's consumers to the new symbol names)
 
-You merge 1 and 2 in quick succession. Mobile PR sits until lead reviews.
+Merge 1 and 2 in quick succession; mobile PR can sit until lead reviews. Mobile keeps using the old shared version until the bump+rename PR merges, so nothing is broken in production.
 
-### Two important sub-cases
+### Pattern B — Mobile imports none of the affected symbols → **shared + desktop only**
+
+If grep returns zero hits in mobile, there is **nothing for a mobile PR to contain**.
+
+- ✅ Ship shared PR + desktop PR.
+- 🟥 Do NOT open an "empty" mobile PR. There's nothing to put in it; the only "change" would be a `package.json` version bump, which is the lead's territory and not something to drive from a migration PR.
+- **Document the breaking change in the shared PR description** — list the renamed/removed exports under a "Breaking changes" heading so when the lead bumps shared in mobile later, they see "X was renamed to Y, mobile didn't use X, no code change needed."
+- When the lead does bump shared in mobile, the mobile build will pass first try.
+
+This pattern came up during the 2026-05-28 notifications dedup: three settings types in shared got the `Space` prefix, but grep confirmed zero references in mobile, so no mobile PR was opened.
+
+### Sub-cases that look similar but route differently
 
 **Sub-case A: Additive shared change that mobile *should* eventually adopt**
 
 Example: shared gets a new `useFarcasterFeed` hook. Mobile has its own copy. Eventually mobile should switch.
 
-- ✅ Ship shared alone.
+- ✅ Ship shared alone (additive — see "additive vs. breaking" section).
 - 🟡 Open a mobile PR to switch over. Lead reviews whenever.
 - **Mobile is not broken if the PR sits.** Mobile keeps using its own implementation. The migration is just incomplete, not broken.
 
-**Sub-case B: "Technically breaking but practically harmless"**
+**Sub-case B: Technically breaking, mobile has *dead* consumer code**
 
-Example: the notifications migration replaces placeholder `NotificationSettings = { enabled?, mentions?, replies?, all? }` with the real shape `{ spaceId, enabledNotificationTypes[], isMuted? }`. Same name, different shape — technically breaking.
+Example: a placeholder shared type gets a different shape. Mobile imports it but only in scaffolding that's never called at runtime (verified by grep — the importer hook itself has zero callers).
 
-But Phase 0 investigation confirmed mobile has **zero actual consumers** of the inner fields. The only place a TypeScript error would surface is one dead-code fallback in `useNotificationSettings()` which is never called.
+This is the edge case to be careful about. Two interpretations:
 
-For these cases, treat as breaking anyway: open shared + mobile PRs together. The mobile PR is tiny (delete the dead hook or fix the fallback). Shared and desktop ship first; mobile catches up. Don't take shortcuts even if it "would probably work" — future bumps shouldn't surface a build error from your stale work.
+- **Treat as Pattern A** (open a mobile PR even though the dead code "would probably work"): cleanest. The mobile PR is tiny (delete or fix the dead scaffold). Stops future bumps from surfacing a build error in dead code.
+- **Treat as Pattern B** (skip the mobile PR): defensible if the dead code is so dead that no one would ever look at the build error. Cheaper.
+
+**Recommendation: default to Pattern A for this sub-case.** Dead code today can become live code tomorrow; a future contributor who tries to wire up the scaffold should find it compiling against current shared, not against a six-month-old API. The mobile PR cost is small, the future-clarity cost of skipping it can be larger.
 
 ### Decision summary
 

--- a/src/components/modals/SpaceSettingsModal/Account.tsx
+++ b/src/components/modals/SpaceSettingsModal/Account.tsx
@@ -20,7 +20,7 @@ import { usePasskeysContext } from '@quilibrium/quilibrium-js-sdk-channels';
 import { useUserRoleDisplay } from '../../../hooks/business/user/useUserRoleDisplay';
 import { useChannelMute } from '../../../hooks/business/channels';
 import type { Role } from '@quilibrium/quorum-shared';
-import type { NotificationTypeId } from '../../../types/notifications';
+import type { SpaceNotificationTypeId } from '../../../types/notifications';
 import { ReactTooltip } from '../../ui';
 
 interface AccountProps {
@@ -50,8 +50,8 @@ interface AccountProps {
   onClose: () => void;
   roles?: Role[];
   // Notification settings props (passed from parent)
-  selectedMentionTypes: NotificationTypeId[];
-  setSelectedMentionTypes: (types: NotificationTypeId[]) => void;
+  selectedMentionTypes: SpaceNotificationTypeId[];
+  setSelectedMentionTypes: (types: SpaceNotificationTypeId[]) => void;
   isMentionSettingsLoading: boolean;
 }
 
@@ -235,7 +235,7 @@ const Account: React.FunctionComponent<AccountProps> = ({
             <Select
               value={selectedMentionTypes}
               onChange={(value: string | string[]) =>
-                setSelectedMentionTypes(value as NotificationTypeId[])
+                setSelectedMentionTypes(value as SpaceNotificationTypeId[])
               }
               multiple={true}
               placeholder={t`Select`}

--- a/src/components/notifications/NotificationPanel.tsx
+++ b/src/components/notifications/NotificationPanel.tsx
@@ -10,7 +10,7 @@ import { useAllMentions, useMentionNotificationSettings } from '../../hooks/busi
 import { useAllReplies } from '../../hooks/business/replies';
 import { useMessageDB } from '../context/useMessageDB';
 import { useQueryClient } from '@tanstack/react-query';
-import type { NotificationTypeId } from '../../types/notifications';
+import type { SpaceNotificationTypeId } from '../../types/notifications';
 import './NotificationPanel.scss';
 
 interface NotificationPanelProps {
@@ -45,7 +45,7 @@ export const NotificationPanel: React.FC<NotificationPanelProps> = ({
   const { selectedTypes: savedTypes, isLoading: settingsLoading } = useMentionNotificationSettings({ spaceId });
 
   // Local filter state (syncs with saved settings)
-  const [selectedTypes, setSelectedTypes] = useState<NotificationTypeId[]>(savedTypes);
+  const [selectedTypes, setSelectedTypes] = useState<SpaceNotificationTypeId[]>(savedTypes);
 
   // Sync local state when saved settings change
   useEffect(() => {
@@ -81,20 +81,20 @@ export const NotificationPanel: React.FC<NotificationPanelProps> = ({
   // Filter options for Select primitive
   const filterOptions = [
     {
-      value: 'mention-you' as NotificationTypeId,
+      value: 'mention-you' as SpaceNotificationTypeId,
       label: t`@you`,
     },
     {
-      value: 'mention-everyone' as NotificationTypeId,
+      value: 'mention-everyone' as SpaceNotificationTypeId,
       label: t`@everyone`,
     },
     {
-      value: 'mention-roles' as NotificationTypeId,
+      value: 'mention-roles' as SpaceNotificationTypeId,
       label: t`@roles`,
       disabled: false,
     },
     {
-      value: 'reply' as NotificationTypeId,
+      value: 'reply' as SpaceNotificationTypeId,
       label: t`Replies`,
     },
   ];
@@ -105,7 +105,7 @@ export const NotificationPanel: React.FC<NotificationPanelProps> = ({
       // Don't allow deselecting all
       return;
     }
-    setSelectedTypes(newValues as NotificationTypeId[]);
+    setSelectedTypes(newValues as SpaceNotificationTypeId[]);
   }, []);
 
   // Handle navigation to message - uses hash-based highlighting (cross-component communication)

--- a/src/db/messages.ts
+++ b/src/db/messages.ts
@@ -2,7 +2,7 @@ import { logger } from '@quilibrium/quorum-shared';
 import { channel } from '@quilibrium/quilibrium-js-sdk-channels';
 import type { Conversation, Message, Space, Bookmark, BroadcastSpaceTag, ChannelThread, UserNote, FarcasterLink } from '@quilibrium/quorum-shared';
 import { BOOKMARKS_CONFIG } from '@quilibrium/quorum-shared';
-import type { NotificationSettings } from '../types/notifications';
+import type { SpaceNotificationSettings } from '../types/notifications';
 import type { IconColor } from '../components/space/IconPicker/types';
 import type { IconName } from '../components/primitives';
 import type { QueueTask, TaskStatus, QueueStats } from '../types/actionQueue';
@@ -76,7 +76,7 @@ export type UserConfig = {
     }[];
   }[];
   notificationSettings?: {
-    [spaceId: string]: NotificationSettings;
+    [spaceId: string]: SpaceNotificationSettings;
   };
   bookmarks?: Bookmark[];
   deletedBookmarkIds?: string[];

--- a/src/hooks/business/mentions/useMentionNotificationSettings.ts
+++ b/src/hooks/business/mentions/useMentionNotificationSettings.ts
@@ -12,7 +12,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useMessageDB } from '../../../components/context/useMessageDB';
 import { usePasskeysContext } from '@quilibrium/quilibrium-js-sdk-channels';
-import type { NotificationSettings, NotificationTypeId } from '../../../types/notifications';
+import type { SpaceNotificationSettings, SpaceNotificationTypeId } from '../../../types/notifications';
 import { getDefaultNotificationSettings } from '@quilibrium/quorum-shared';
 
 interface UseMentionNotificationSettingsProps {
@@ -21,11 +21,11 @@ interface UseMentionNotificationSettingsProps {
 
 interface UseMentionNotificationSettingsReturn {
   /** Current settings for this space */
-  settings: NotificationSettings;
+  settings: SpaceNotificationSettings;
   /** Selected notification types (for multiselect control) */
-  selectedTypes: NotificationTypeId[];
+  selectedTypes: SpaceNotificationTypeId[];
   /** Update selected types (doesn't save until saveSettings called) */
-  setSelectedTypes: (types: NotificationTypeId[]) => void;
+  setSelectedTypes: (types: SpaceNotificationTypeId[]) => void;
   /** Whether settings are being loaded */
   isLoading: boolean;
   /** Save settings to IndexedDB */
@@ -63,10 +63,10 @@ export function useMentionNotificationSettings({
   const { currentPasskeyInfo } = usePasskeysContext();
   const userAddress = currentPasskeyInfo?.address;
 
-  const [settings, setSettings] = useState<NotificationSettings>(() =>
+  const [settings, setSettings] = useState<SpaceNotificationSettings>(() =>
     getDefaultNotificationSettings(spaceId)
   );
-  const [selectedTypes, setSelectedTypes] = useState<NotificationTypeId[]>([]);
+  const [selectedTypes, setSelectedTypes] = useState<SpaceNotificationTypeId[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
 

--- a/src/types/notifications.ts
+++ b/src/types/notifications.ts
@@ -1,56 +1,18 @@
 /**
- * Notification Settings Types
+ * Notification type re-exports from @quilibrium/quorum-shared.
  *
- * Defines types for user-configurable notification preferences (mentions and replies).
- * Part of Phase 4: Mention Notification Settings & Reply Notification System
+ * Per-space notification preferences live on UserConfig.notificationSettings
+ * and sync across devices. DM and channel mute live on separate UserConfig
+ * fields (mutedConversations, mutedChannels) and are handled outside this
+ * type set — see the channel-space-mute and mute-conversation feature docs.
  *
- * @see .agents/tasks/mention-notification-settings-phase4.md
- * @see .agents/tasks/reply-notification-system.md
  * @see .agents/docs/features/mention-notification-system.md
+ * @see .agents/docs/features/channel-space-mute-system.md
  */
 
-import type { Message } from '@quilibrium/quorum-shared';
-
-/**
- * Types of notifications that can be enabled/disabled
- * - 'mention-you': Direct @user mentions
- * - 'mention-everyone': @everyone mentions
- * - 'mention-roles': @role mentions
- * - 'reply': Replies to user's messages
- */
-export type NotificationTypeId = 'mention-you' | 'mention-everyone' | 'mention-roles' | 'reply';
-
-/**
- * Per-space notification settings
- * Stored in IndexedDB user_config.notificationSettings[spaceId]
- */
-export interface NotificationSettings {
-  /** The space ID these settings apply to */
-  spaceId: string;
-
-  /** Array of enabled notification types (e.g., ['mention-you', 'mention-everyone', 'reply']) */
-  enabledNotificationTypes: NotificationTypeId[];
-
-  /** When true, suppresses ALL notifications for this space (mutes entire space) */
-  isMuted?: boolean;
-}
-
-/**
- * Option for the notification settings multiselect dropdown
- */
-export interface NotificationSettingOption {
-  value: NotificationTypeId;
-  label: string;
-  subtitle: string;
-  disabled?: boolean;
-}
-
-/**
- * Reply notification type (for combining with mention notifications in UI)
- */
-export interface ReplyNotification {
-  message: Message;
-  channelId: string;
-  channelName: string;
-  type: 'reply';
-}
+export type {
+  SpaceNotificationTypeId,
+  SpaceNotificationSettings,
+  SpaceNotificationSettingOption,
+  ReplyNotification,
+} from '@quilibrium/quorum-shared';


### PR DESCRIPTION
## What

Replace the local notification type definitions in `src/types/notifications.ts` with a thin re-export shim from `@quilibrium/quorum-shared`. The shared package has had identical shapes since 2026-03 (commit `e9ef224`, utils migration prep) — these have been duplicated all along.

Paired with the rename in shared:

- `NotificationSettings` → `SpaceNotificationSettings` (already named that way in shared)
- `NotificationTypeId` → `SpaceNotificationTypeId`
- `NotificationSettingOption` → `SpaceNotificationSettingOption`
- `ReplyNotification` → unchanged (event-payload type, parallel with `MentionNotification`)

## Why the `Space` prefix

The settings types are exclusively about per-space preferences. They index `UserConfig.notificationSettings[spaceId]`, and the trigger types (`mention-you`, `mention-everyone`, `mention-roles`, `reply`) are all space-only concepts. DM and channel mute are handled by completely separate `UserConfig` fields (`mutedConversations`, `mutedChannels`). The unqualified name implied broader scope than the types actually cover.

Event-payload and delivery types stay unprefixed: `ReplyNotification`, `MentionNotification`, `NotificationService`, `NotificationMetadata`. They describe notification instances or the OS delivery layer, not per-space configuration. `NotificationMetadata` is explicitly multi-scope (`'dm' | 'mention' | 'reply'`).

## Cross-repo migration

- **quorum-shared**: ✅ MERGED — QuilibriumNetwork/quorum-shared#18 (version 2.1.0-17, master commit `fbbd48c`)
- **quorum-desktop** (this PR): consumer-side updates
- **quorum-mobile**: no PR — grep confirms zero references to the renamed symbols in mobile. The next time mobile bumps shared, the build will pass first try without code changes.

## Files changed

Source (5):
- `src/types/notifications.ts` — gutted into a re-export shim
- `src/db/messages.ts` — `UserConfig.notificationSettings` inner type
- `src/hooks/business/mentions/useMentionNotificationSettings.ts` — type refs only; hook name and interface names preserved
- `src/components/notifications/NotificationPanel.tsx` — `NotificationTypeId` refs
- `src/components/modals/SpaceSettingsModal/Account.tsx` — `NotificationTypeId` refs

Docs (3):
- `.agents/docs/features/channel-space-mute-system.md` — refreshed code examples
- `.agents/docs/features/mention-notification-system.md` — refreshed file-structure reference
- `.agents/tasks/quorum-shared-migration/2026-05-28-cross-repo-workflow.md` — refined the cross-repo workflow to handle the case discovered during this PR (when a breaking shared change has zero mobile consumers, no mobile PR is opened — the shared PR description documents the rename so future shared bumps in mobile are intentional)

## Verification

- `npx tsc --noEmit --jsx react-jsx --skipLibCheck` — clean except for one pre-existing unrelated `ImportKeyStep.tsx` error not touched by this PR
- Grep: zero references to old type names remain in desktop source

## Test plan

Type-only change with no runtime behavior. Nothing to manually test.