### PR TITLE
refactor(crypto): decryptUserConfig helper + workflow rule updates

### DIFF
--- a/.agents/bugs/2026-05-30-user-settings-modal-stale-display-name.md
+++ b/.agents/bugs/2026-05-30-user-settings-modal-stale-display-name.md
@@ -1,0 +1,51 @@
+---
+type: bug
+title: UserSettingsModal shows stale display name after remote UserConfig sync
+status: open
+created: 2026-05-30
+severity: low
+discovered-during: AES-GCM config-decrypt dedup session (unrelated to that refactor)
+---
+
+# UserSettingsModal shows stale display name after remote UserConfig sync
+
+## Repro
+
+1. Log into the desktop app on **browser profile A** with an existing identity.
+2. Log into the same identity on **browser profile B** (fresh login flow, decrypts remote `UserConfig`).
+3. In **profile B**, open the User Settings modal and change the display name. Save.
+4. In **profile B**, send a message → confirm the new display name appears on your own messages in the channel.
+5. Switch back to **profile A** (already running).
+
+## Expected
+
+User Settings modal in profile A reflects the new display name (since the synced `UserConfig` carries it).
+
+## Actual
+
+- **Channel views** in profile A show the **NEW** display name on the user's own messages → the synced `UserConfig` reached profile A correctly and is being rendered downstream.
+- **User Settings modal** in profile A still shows the **OLD** display name in the input field.
+
+## Likely cause (hypothesis — not verified)
+
+The UserSettingsModal is probably reading the display name from a different source than the channel-message renderer. Candidates:
+
+1. **Local-only initial value cached at modal mount time**, not subscribed to UserConfig changes (the modal initializes its form state once and doesn't re-sync when UserConfig updates arrive over the wire).
+2. **A local override** (e.g. `localStorage` / IndexedDB stored copy) that's read before the synced `UserConfig` is consulted.
+3. **A stale React Query cache key** — modal queries a different key than channel rendering uses, and that key wasn't invalidated by the incoming sync.
+
+The channel-rendering path correctly reflects the synced value, so the sync layer itself is healthy.
+
+## NOT caused by
+
+The 2026-05-30 AES-GCM config-decrypt dedup refactor (commit on `session/2026-05-30` branch). If decryption were broken, channel messages wouldn't show the new name either — but they do.
+
+## Investigation starting points
+
+- `UserSettingsModal.tsx` (or equivalent) — where does `displayName` initial value come from?
+- The channel-message renderer — what hook/source gives it `displayName`? Compare paths.
+- React Query keys around `UserConfig` — is there a missing invalidation when the synced UserConfig updates?
+
+## Priority
+
+Low — cosmetic on the modal, doesn't block messaging or sync. But it's confusing UX (user thinks their change didn't propagate).

--- a/.agents/tasks/quorum-shared-migration/cross-repo-workflow.md
+++ b/.agents/tasks/quorum-shared-migration/cross-repo-workflow.md
@@ -86,13 +86,24 @@ What "same shape" means: the changes share a migration pattern (e.g. "extract in
 
 > **New default for this repo (and other multi-author Quilibrium repos — `quorum-shared`, `quorum-mobile`, `www-dev`): never commit directly to `main`. Every session opens a branch, squash-merges back when the work is worth merging.** Applies to code, docs, analyses, reports, audits, and any combination thereof. Solo Quilibrium repos (e.g. `quily-chatbot`) are exempt — direct-to-main is fine when no other maintainers exist.
 
-### Rule
+### Session-branch workflow
 
-- Start each session by branching off `main` (or off an existing in-progress branch if continuing one).
-- Branch name describes the rough scope: `analysis/<topic>`, `doc/<topic>`, `refactor/<thing>`, `feat/<thing>`. Specificity matches the work — a single migration task gets a tight name; a "doc housekeeping + a few small tweaks" session gets a broad name like `doc/housekeeping-2026-05-30`.
-- Commit freely on the branch (per-session, per-logical-chunk, whatever feels natural).
-- When the work is worth landing, **open a PR and squash-merge into `main`**. Even for solo desktop work — the PR gives one clean commit on `main`, captures the diff in GitHub's UI, and keeps `main` linear.
-- Long-running branches are fine. An analysis branch can sit for a week as multiple sessions build on it; it merges when the analysis is done.
+The goal is "avoid `main` divergence with other maintainers", NOT "open a PR for every change."
+
+1. **Start of session**: `git checkout -b session/YYYY-MM-DD` (or `session/YYYY-MM-DD-2` if today's name is taken). Generic on purpose — you don't yet know what the session will become.
+2. **During the session**: commit freely. Docs, code, mixed work, loosely-related changes — all fine on the same branch.
+3. **When ready to ship** a real chunk (not a 1-line tweak): rename the branch to describe what was actually done, push, open PR, squash-merge.
+   ```bash
+   git branch -m feat/role-mutation-helpers
+   git push -u origin feat/role-mutation-helpers
+   gh pr create --title "..." --body "..."
+   gh pr merge --squash --delete-branch
+   ```
+4. **After merge**: `git checkout main && git pull`, then start the next session branch.
+
+### Don't fragment into micro-PRs
+
+If you're about to open a second PR in 10 minutes for another 1-line doc tweak, stop — keep adding to the current session branch instead. PR-per-tiny-tweak is exactly the kind of process noise this workflow exists to prevent. One session = one PR is the default; multiple PRs per session only when the work genuinely splits into unrelated big chunks.
 
 ### What this replaces
 

--- a/.agents/tasks/quorum-shared-migration/roadmap.md
+++ b/.agents/tasks/quorum-shared-migration/roadmap.md
@@ -22,17 +22,13 @@ audience: any agent or contributor planning the next migration move
 
 State at end of 2026-05-30 session: **role-mutation extraction shipped** (shared #21 + desktop #163 merged; mobile task queued). Phase 2 candidates exhausted. Concrete next moves, in order of leverage:
 
-**1. (optional, depending on bandwidth) File the Phase 5 coordination issue.**
-- Draft at `.agents/.temp/2026-05-29-phase5-coordination-issue.md` (gitignored). User decision was to file whenever — no urgency.
-- After filing, update Phase 5 section in this roadmap to record the issue number.
-- Filing unblocks Phase 7 (monolith convergence — `useRoleManagement`, `useChannelManagement`, `useInviteManagement`, `useUserKicking` form-state-vs-mutation question).
-
-**2. Tackle one Paused-tracks item** as a low-risk warm-up:
-- **Desktop-internal AES-GCM config-decrypt dedup** — 4 inline copies → 1 helper. Pure desktop refactor, zero shared changes. ~30 min.
+**1. Tackle one remaining Paused-tracks item** as a low-risk warm-up:
 - **`useInviteManagement` 1-line nudge** — tighten `manualAddress?.length === 46` to `isValidIPFSCID`. Folds naturally into Phase 7c when that lands; can also be a standalone tweak.
 - **Channel pinning removal** — only START if `2026-01-07-channel-ordering-feature.md` is the next desktop feature being implemented; otherwise leave as paused.
 
-**3. Run a fresh small-bucket sweep**. The Phase 2 verifications surfaced bonus C1 findings (mobile reimplements shared utils). A targeted sweep across mobile's `hooks/chat/*` and `services/*` for "what does mobile inline that shared exports" could surface more.
+**2. Run a fresh small-bucket sweep**. The Phase 2 verifications surfaced bonus C1 findings (mobile reimplements shared utils). A targeted sweep across mobile's `hooks/chat/*` and `services/*` for "what does mobile inline that shared exports" could surface more.
+
+**3. Wait on Phase 5 reply.** Issue [quorum-mobile#67](https://github.com/QuilibriumNetwork/quorum-mobile/issues/67) filed 2026-05-30. Lead reply unblocks Phase 7 (monolith convergence).
 
 **Do NOT pick up Phases 5, 7, or 8.** Phase 5 is filing-only (no investigation). Phase 7 is gated on Phase 5 answers. Phase 8 has no unblocked candidates.
 
@@ -223,7 +219,7 @@ Plus: extending `StorageAdapter` with `getPreference/setPreference` would be a s
 **Category:** external dependency (not code work).
 **Goal:** file a GitHub issue against `quorum-mobile` asking two architectural questions — `CryptoProvider` DI pattern + broadcast pattern for shared mutation hooks. Then wait for direction.
 **Risk:** external — we don't control timing. Lead has limited bandwidth.
-**Status as of 2026-05-29:** issue drafted in `.agents/.temp/2026-05-29-phase5-coordination-issue.md` (gitignored). File whenever — the queue order doesn't matter; the lead reviews when convenient.
+**Status as of 2026-05-30:** filed as [quorum-mobile#67](https://github.com/QuilibriumNetwork/quorum-mobile/issues/67). Awaiting lead reply. Original draft kept at `.temp/2026-05-29-phase5-coordination-issue.md` (gitignored) for reference.
 
 **Why this gates Phase 7:** Phase 7 (monolith convergence) needs them because the shareable mutation layer's shape depends on what the lead picks. Phase 6 was closed empty 2026-05-29 — no longer waits on Phase 5.
 
@@ -311,7 +307,7 @@ These run on their own clocks, independent of the phase sequence.
 - **Notifications convergence** — mobile GitHub issue #65, no replies as of 2026-05-29. Architecturally complex (mobile MMKV + iOS NSE vs desktop `UserConfig`-synced settings). Full investigation in [../../reports/2026-05-28-notification-architecture-divergence.md](../../reports/2026-05-28-notification-architecture-divergence.md). Includes the deferred `getMutedChannelsForSpace` + `isChannelMuted` migration (pure functions blocked because they're notification-shaped).
 - **Folder name length consistency** — 5-LOC opportunistic refactor, partly done (folder modal aligned to 50 chars; `useFolderNameValidation` still references the old 40-char constant). Pick up alongside any folder-touching task.
 - **`useInviteManagement` 1-line nudge** — `manualAddress?.length === 46` heuristic could tighten to `isValidIPFSCID`. Folds naturally into Phase 7c.
-- **Desktop-internal AES-GCM config-decrypt dedup** — 4 copies of the same Web Crypto decrypt block exist in `useOnboardingFlowLogic.ts:194-224`, `useUnifiedOnboardingFlow.ts:219-242`, `useUnifiedOnboardingFlow.ts:342-371`, `ConfigService.ts:75-128`. Surfaced by Phase 2 verification; ruled out for shared promotion (mobile uses `@noble/ciphers`, desktop uses Web Crypto — both platform-correct, convergence would be a regression). Desktop-internal extraction is still worth doing: collapse to one `decryptUserConfig(encryptedHex, privateKeyBytes)` helper in `src/utils/crypto/` or `src/services/crypto/`. Zero risk, ~4 call sites to refactor. Pick up alongside any onboarding-touching task or as standalone hygiene.
+- ~~**Desktop-internal AES-GCM config-decrypt dedup**~~ — ✅ SHIPPED 2026-05-30 on `session/2026-05-30` branch. `decryptUserConfig(encryptedHex, privateKeyBytes)` helper added to `src/utils/crypto.ts` + `src/utils/crypto.web.ts`. Replaces 4 inline copies (`useOnboardingFlowLogic`, two in `useUnifiedOnboardingFlow`, `ConfigService`). Net -47 LOC. Smoke tested: fresh-login decrypt + after-refresh sync both work.
 - **Channel reorder pure helpers (future C4 candidate)** — desktop's upcoming channel-ordering feature ([`../2026-01-07-channel-ordering-feature.md`](../2026-01-07-channel-ordering-feature.md)) ships reorder hooks as **desktop-local** for now (avoids committing to a broadcast-DI pattern before lead-dev review). The pure `Space → Space` transforms underneath (`moveChannelInSpace`, `reorderGroupsInSpace`, `reorderChannelsInGroup`) are identical between desktop and mobile — clean C4 extraction candidate for a future session once the feature ships. Same shape as today's role-mutation extraction. Re-evaluate after the feature ships AND mobile addresses the broadcast gap ([mobile issue #66](https://github.com/QuilibriumNetwork/quorum-mobile/issues/66)).
 - **Channel pinning removal (cross-repo)** — separate from the migration; tracked in [`../2026-01-07-channel-ordering-feature.md`](../2026-01-07-channel-ordering-feature.md) section 6. Drops `Channel.isPinned`/`pinnedAt` from shared types + mobile's unused `usePinChannel` mutation + desktop's pin UI. Pattern A cross-repo sequencing (mobile first, then shared, then desktop). Discovery during Phase 4-b discussions: mobile DOES have `usePinChannel` mutation defined but with **zero UI callsites** (same Trap F pattern as `setAccentColor`). Not blocking the migration roadmap — listed here for cross-context awareness.
 - **Desktop `saveMessage` write-path conversation-preview enrichment** — surfaced by Phase 6 verification 2026-05-29. Desktop's `useConversationPreviews` exists because desktop's write path doesn't populate `Conversation.lastMessagePreview` at save time. Mobile already does (extended `Conversation` type at `hooks/chat/useConversations.ts:14`; shared's `StorageAdapter.saveMessage` signature already supports it via `conversationType`/`icon`/`displayName` params). Aligning desktop's `saveMessage` path to populate `lastMessagePreview` at write time would eliminate the entire `useConversationPreviews` hook as a side effect. Not high-priority — desktop's current pattern works — but worth keeping on the radar for Phase 8 services revisits.

--- a/.agents/tasks/quorum-shared-migration/shipped-log.md
+++ b/.agents/tasks/quorum-shared-migration/shipped-log.md
@@ -57,6 +57,26 @@ Apply as a checklist when verifying any candidate. A hook failing ANY of these i
 
 ## Recent entries (most recent first)
 
+## 2026-05-30 — AES-GCM config-decrypt dedup (desktop-internal Paused track)
+
+**Scope**: collapse the 4 inline copies of the AES-GCM UserConfig decrypt block into a single helper. Pulled from Paused tracks (was queued there because Phase 2 verification ruled it out for shared promotion — mobile uses `@noble/ciphers`, desktop uses Web Crypto; Trap E platform-correct divergence). Desktop-internal cleanup only — no shared / mobile coordination.
+
+**Shipped**:
+- `src/utils/crypto.ts` + `src/utils/crypto.web.ts` gain `decryptUserConfig(encryptedHex, privateKeyBytes): Promise<unknown>`. Helper does SHA-512 → first 32 bytes → AES-256-GCM import → split iv (last 24 hex) from ciphertext → decrypt → JSON.parse. Signature verification stays at call sites (it's a separate concern; only `ConfigService` does it).
+- 4 consumer sites collapsed: `useOnboardingFlowLogic.ts:194-224`, `useUnifiedOnboardingFlow.ts` (two occurrences at ~219-242 and ~342-371), `ConfigService.ts:75-128`. Net -47 LOC across consumers, +48 LOC helper (one-time).
+
+**Gotcha worth knowing**: Vite's platform-extension resolver picks `.web.ts` over `.ts` when both exist. Initially added the helper only to `crypto.ts` — Vite errored at runtime ("does not provide an export named 'decryptUserConfig'"). Fix: helper added to BOTH `crypto.ts` (so tsc resolves it) AND `crypto.web.ts` (so Vite resolves it at runtime). The pattern follows what the file already does for `sha256`/`base58btc`.
+
+**Smoke testing**:
+- Fresh-login profile decrypt path → confirmed display name + profile image load correctly. Covers `useUnifiedOnboardingFlow` site.
+- Existing-session config sync after page refresh → confirmed space-moved-out-of-folder change picked up. Covers `ConfigService` site.
+- (Pre-existing, unrelated bug logged: UserSettingsModal shows stale display name without refresh — see `.agents/bugs/2026-05-30-user-settings-modal-stale-display-name.md`. NOT caused by this refactor; channel-message rendering reflects the new value correctly.)
+
+**Mobile**: not touched. Mobile uses `@noble/ciphers` — different primitive, intentionally divergent.
+**PRs**: bundled into the session-branch PR alongside the workflow rule updates.
+
+---
+
 ## 2026-05-30 — Role-mutation helpers extracted (Phase 2 C4)
 
 **Scope**: ship the per-task plan from 2026-05-29 (`2026-05-29-migrate-role-mutation-helpers.md`). Extract two pure role-mutation helpers (`toggleRolePermission`, `setRolePermissions`) duplicated byte-for-byte between desktop and mobile.

--- a/src/hooks/business/user/useOnboardingFlowLogic.ts
+++ b/src/hooks/business/user/useOnboardingFlowLogic.ts
@@ -2,6 +2,7 @@ import { useState, useCallback } from 'react';
 import { passkey } from '@quilibrium/quilibrium-js-sdk-channels';
 import { t } from '@lingui/core/macro';
 import { DefaultImages } from '../../../utils';
+import { decryptUserConfig } from '../../../utils/crypto';
 import { showWarning } from '../../../utils/toast';
 import { validateDisplayName, validateProfileImage } from '../validation';
 import { useQuorumApiClient } from '../../../components/context/QuorumApiContext';
@@ -190,38 +191,11 @@ export const useOnboardingFlowLogic = (adapter: OnboardingAdapter) => {
       }
       hasRemoteConfig = true;
 
-      // Derive decryption key from user's private key (same as ConfigService)
-      const derived = await crypto.subtle.digest(
-        'SHA-512',
-        Buffer.from(new Uint8Array(inner.identity.user_key.private_key))
-      );
-
-      const subtleKey = await window.crypto.subtle.importKey(
-        'raw',
-        derived.slice(0, 32),
-        { name: 'AES-GCM', length: 256 },
-        false,
-        ['decrypt']
-      );
-
-      // Decrypt the config (same format as ConfigService)
-      const iv = savedConfig.user_config.substring(
-        savedConfig.user_config.length - 24
-      );
-      const ciphertext = savedConfig.user_config.substring(
-        0,
-        savedConfig.user_config.length - 24
-      );
-
-      const decryptedConfig = JSON.parse(
-        Buffer.from(
-          await window.crypto.subtle.decrypt(
-            { name: 'AES-GCM', iv: Buffer.from(iv, 'hex') },
-            subtleKey,
-            Buffer.from(ciphertext, 'hex')
-          )
-        ).toString('utf-8')
-      );
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const decryptedConfig = (await decryptUserConfig(
+        savedConfig.user_config,
+        new Uint8Array(inner.identity.user_key.private_key)
+      )) as any;
 
       // SECURITY: Zero-trust validation of remote config data
       // Re-validate all fields after decryption to prevent XSS/injection attacks

--- a/src/hooks/business/user/useUnifiedOnboardingFlow.ts
+++ b/src/hooks/business/user/useUnifiedOnboardingFlow.ts
@@ -13,6 +13,7 @@ import { useUploadRegistration } from '../../mutations/useUploadRegistration';
 import { useKeyBackup } from '../../useKeyBackup';
 import { validateDisplayName } from '../validation';
 import { DefaultImages } from '../../../utils';
+import { decryptUserConfig } from '../../../utils/crypto';
 import { t } from '@lingui/core/macro';
 import { showWarning } from '../../../utils/toast';
 
@@ -216,30 +217,11 @@ export function useUnifiedOnboardingFlow(
           return;
         }
 
-        const derived = await crypto.subtle.digest(
-          'SHA-512',
-          Buffer.from(new Uint8Array(inner.identity.user_key.private_key))
-        );
-        const subtleKey = await window.crypto.subtle.importKey(
-          'raw',
-          derived.slice(0, 32),
-          { name: 'AES-GCM', length: 256 },
-          false,
-          ['decrypt']
-        );
-
-        const iv = savedConfig.user_config.substring(savedConfig.user_config.length - 24);
-        const ciphertext = savedConfig.user_config.substring(0, savedConfig.user_config.length - 24);
-
-        const decryptedConfig = JSON.parse(
-          Buffer.from(
-            await window.crypto.subtle.decrypt(
-              { name: 'AES-GCM', iv: Buffer.from(iv, 'hex') },
-              subtleKey,
-              Buffer.from(ciphertext, 'hex')
-            )
-          ).toString('utf-8')
-        );
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const decryptedConfig = (await decryptUserConfig(
+          savedConfig.user_config,
+          new Uint8Array(inner.identity.user_key.private_key)
+        )) as any;
 
         const rawName = decryptedConfig?.name;
         const nameError = rawName ? validateDisplayName(rawName) : 'empty';
@@ -338,37 +320,11 @@ export function useUnifiedOnboardingFlow(
           return;
         }
 
-        // Derive decryption key
-        const derived = await crypto.subtle.digest(
-          'SHA-512',
-          Buffer.from(new Uint8Array(inner.identity.user_key.private_key))
-        );
-        const subtleKey = await window.crypto.subtle.importKey(
-          'raw',
-          derived.slice(0, 32),
-          { name: 'AES-GCM', length: 256 },
-          false,
-          ['decrypt']
-        );
-
-        // Decrypt config
-        const iv = savedConfig.user_config.substring(
-          savedConfig.user_config.length - 24
-        );
-        const ciphertext = savedConfig.user_config.substring(
-          0,
-          savedConfig.user_config.length - 24
-        );
-
-        const decryptedConfig = JSON.parse(
-          Buffer.from(
-            await window.crypto.subtle.decrypt(
-              { name: 'AES-GCM', iv: Buffer.from(iv, 'hex') },
-              subtleKey,
-              Buffer.from(ciphertext, 'hex')
-            )
-          ).toString('utf-8')
-        );
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const decryptedConfig = (await decryptUserConfig(
+          savedConfig.user_config,
+          new Uint8Array(inner.identity.user_key.private_key)
+        )) as any;
 
         // Validate remote profile
         const rawName = decryptedConfig?.name;

--- a/src/services/ConfigService.ts
+++ b/src/services/ConfigService.ts
@@ -6,7 +6,7 @@ import { MessageDB, UserConfig } from '../db/messages';
 import { QuorumApiClient } from '../api/baseTypes';
 import type { Bookmark, Space } from '@quilibrium/quorum-shared';
 import { channel as secureChannel, channel_raw as ch } from '@quilibrium/quilibrium-js-sdk-channels';
-import { sha256, base58btc } from '../utils/crypto';
+import { sha256, base58btc, decryptUserConfig } from '../utils/crypto';
 import { getDefaultUserConfig } from '../utils';
 import { t } from '@lingui/core/macro';
 import { QueryClient } from '@tanstack/react-query';
@@ -72,22 +72,6 @@ export class ConfigService {
       return storedConfig;
     }
 
-    const derived = await crypto.subtle.digest(
-      'SHA-512',
-      Buffer.from(new Uint8Array(userKey.user_key.private_key))
-    );
-
-    const subtleKey = await window.crypto.subtle.importKey(
-      'raw',
-      derived.slice(0, 32),
-      {
-        name: 'AES-GCM',
-        length: 256,
-      },
-      false,
-      ['decrypt']
-    );
-
     if (
       !JSON.parse(
         ch.js_verify_ed448(
@@ -110,22 +94,10 @@ export class ConfigService {
       return storedConfig;
     }
 
-    const iv = savedConfig.user_config.substring(
-      savedConfig.user_config.length - 24
-    );
-    const ciphertext = savedConfig.user_config.substring(
-      0,
-      savedConfig.user_config.length - 24
-    );
-    const config = JSON.parse(
-      Buffer.from(
-        await window.crypto.subtle.decrypt(
-          { name: 'AES-GCM', iv: Buffer.from(iv, 'hex') },
-          subtleKey,
-          Buffer.from(ciphertext, 'hex')
-        )
-      ).toString('utf-8')
-    ) as UserConfig;
+    const config = (await decryptUserConfig(
+      savedConfig.user_config,
+      new Uint8Array(userKey.user_key.private_key)
+    )) as UserConfig;
     if (!config) {
       return storedConfig;
     }

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -72,3 +72,51 @@ export function hexToSpreadArray(hex: string): number[] {
 export function uint8ArrayToHex(arr: Uint8Array): string {
   return Buffer.from(arr).toString('hex');
 }
+
+/**
+ * Decrypts an AES-GCM-encrypted UserConfig blob using a user's private key.
+ *
+ * Wire format (encryptedUserConfig string):
+ * - ciphertext (hex) | iv (last 24 hex chars = 12 bytes)
+ *
+ * Key derivation:
+ * - SHA-512(privateKeyBytes), take first 32 bytes, import as AES-GCM key.
+ *
+ * Caller responsibilities:
+ * - Verify any signature BEFORE calling this helper (this helper does
+ *   symmetric decrypt only).
+ * - Validate the returned object (treated as unknown — caller must check
+ *   shape, sanitize strings, etc.).
+ *
+ * @param encryptedUserConfig The `user_config` field from a SavedConfig.
+ * @param privateKeyBytes The user's Ed448 private key as raw bytes.
+ * @returns The decrypted, JSON-parsed object. Caller validates shape.
+ */
+export async function decryptUserConfig(
+  encryptedUserConfig: string,
+  privateKeyBytes: ArrayBuffer | Uint8Array
+): Promise<unknown> {
+  const derived = await window.crypto.subtle.digest(
+    'SHA-512',
+    Buffer.from(new Uint8Array(privateKeyBytes))
+  );
+
+  const subtleKey = await window.crypto.subtle.importKey(
+    'raw',
+    derived.slice(0, 32),
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['decrypt']
+  );
+
+  const iv = encryptedUserConfig.substring(encryptedUserConfig.length - 24);
+  const ciphertext = encryptedUserConfig.substring(0, encryptedUserConfig.length - 24);
+
+  const plaintext = await window.crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv: Buffer.from(iv, 'hex') },
+    subtleKey,
+    Buffer.from(ciphertext, 'hex')
+  );
+
+  return JSON.parse(Buffer.from(plaintext).toString('utf-8'));
+}

--- a/src/utils/crypto.web.ts
+++ b/src/utils/crypto.web.ts
@@ -79,3 +79,51 @@ export function hexToSpreadArray(hex: string): number[] {
 export function uint8ArrayToHex(arr: Uint8Array): string {
   return Buffer.from(arr).toString('hex');
 }
+
+/**
+ * Decrypts an AES-GCM-encrypted UserConfig blob using a user's private key.
+ *
+ * Wire format (encryptedUserConfig string):
+ * - ciphertext (hex) | iv (last 24 hex chars = 12 bytes)
+ *
+ * Key derivation:
+ * - SHA-512(privateKeyBytes), take first 32 bytes, import as AES-GCM key.
+ *
+ * Caller responsibilities:
+ * - Verify any signature BEFORE calling this helper (this helper does
+ *   symmetric decrypt only).
+ * - Validate the returned object (treated as unknown — caller must check
+ *   shape, sanitize strings, etc.).
+ *
+ * @param encryptedUserConfig The `user_config` field from a SavedConfig.
+ * @param privateKeyBytes The user's Ed448 private key as raw bytes.
+ * @returns The decrypted, JSON-parsed object. Caller validates shape.
+ */
+export async function decryptUserConfig(
+  encryptedUserConfig: string,
+  privateKeyBytes: ArrayBuffer | Uint8Array
+): Promise<unknown> {
+  const derived = await window.crypto.subtle.digest(
+    'SHA-512',
+    Buffer.from(new Uint8Array(privateKeyBytes))
+  );
+
+  const subtleKey = await window.crypto.subtle.importKey(
+    'raw',
+    derived.slice(0, 32),
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['decrypt']
+  );
+
+  const iv = encryptedUserConfig.substring(encryptedUserConfig.length - 24);
+  const ciphertext = encryptedUserConfig.substring(0, encryptedUserConfig.length - 24);
+
+  const plaintext = await window.crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv: Buffer.from(iv, 'hex') },
+    subtleKey,
+    Buffer.from(ciphertext, 'hex')
+  );
+
+  return JSON.parse(Buffer.from(plaintext).toString('utf-8'));
+}


### PR DESCRIPTION
Bundled changes from today's session — two distinct chunks shipped together because each is small enough on its own that a separate PR would be process noise.

## 1. AES-GCM config-decrypt dedup

The same Web Crypto decrypt block was inlined in 4 places:
- `useOnboardingFlowLogic.ts:194-224`
- `useUnifiedOnboardingFlow.ts:219-242`
- `useUnifiedOnboardingFlow.ts:342-371`
- `ConfigService.ts:75-128`

Extracted to `decryptUserConfig()` in `utils/crypto.ts` + `utils/crypto.web.ts`. Signature verification stays at call sites — only `ConfigService` does it, and it's a separate concern from the symmetric decrypt.

**Vite gotcha worth knowing**: helper added to BOTH `crypto.ts` and `crypto.web.ts`. Vite's platform-extension resolver picks `.web.ts` over `.ts` at runtime; tsc resolves through `.ts`. Mirrors the existing pattern for `sha256` / `base58btc` in the same files.

Net: **-47 LOC across consumers, +48 LOC helper**.

Surfaced and queued during Phase 2 verification 2026-05-29; ruled out for shared promotion (mobile uses `@noble/ciphers` — Trap E platform-correct divergence). Desktop-internal only.

## 2. Workflow rule updates

`cross-repo-workflow.md`:
- **Session-branch workflow** replaces the prior "docs-only on main" rule. Multi-author Quilibrium repos (quorum-desktop, quorum-shared, quorum-mobile, www-dev) use one session branch per day (`session/YYYY-MM-DD`), rename to a descriptive name + PR + squash-merge when shipping a chunk. Goal: avoid `main` divergence with other maintainers, NOT open a PR per micro-change.
- **No date prefix** in commit/PR titles — GitHub already shows the date inline.
- **Visual smoke test before self-merge** for changes that can affect runtime behavior — agents wait for user smoke confirmation. Docs-only / pure-additive shared changes are exempt.

Memory rule in agents-memory vault updated to match (`projects/quilibrium/always-branch-workflow.md`).

## Smoke testing

Visual test in dev confirmed:
- Fresh-login decrypt path (covers `useUnifiedOnboardingFlow`): new browser profile loads remote display name + profile image correctly.
- Post-refresh sync (covers `ConfigService`): folder/space changes from another browser profile picked up after reload.

A pre-existing UserSettingsModal stale-display-name bug surfaced during testing — NOT caused by this refactor (channel-message rendering reflects the new value correctly, only the modal input shows the old). Logged at `.agents/bugs/2026-05-30-user-settings-modal-stale-display-name.md` with repro + hypotheses + investigation pointers.

## Out of scope

- Mobile-side AES-GCM. Different primitive (`@noble/ciphers`), intentionally divergent per Trap E.
- The stale-display-name bug (logged separately, low priority).

## Docs updated
- `shipped-log.md` — new entry for the decrypt dedup
- `roadmap.md` — Paused tracks item marked SHIPPED, "Next session" block refreshed