### PR TITLE
fix(nav-rail,spaces): drop DM unread dot; remember per-space last channel

### DIFF
--- a/src/components/shell/NavRail.tsx
+++ b/src/components/shell/NavRail.tsx
@@ -7,7 +7,6 @@ import { usePasskeysContext } from '@quilibrium/quilibrium-js-sdk-channels';
 import { useModalContext } from '../context/ModalProvider';
 import { UserAvatar } from '../user/UserAvatar';
 import { getAddressSuffix } from '../../utils';
-import { useDirectMessageUnreadCount } from '../../hooks/business/messages';
 import { useOptionalShellState } from './useShellState';
 import './NavRail.scss';
 
@@ -75,7 +74,6 @@ export const NavRail: React.FunctionComponent<NavRailProps> = ({ collapsed, onTo
   // an empty deps array).
   const items = buildItems();
   const user = usePasskeysContext();
-  const dmUnreadCount = useDirectMessageUnreadCount();
   const { openUserSettings } = useModalContext();
   // On phone the rail lives inside the drawer; tapping a section should swap
   // what the sidebar shows (DM list, spaces list) rather than navigate to the
@@ -128,8 +126,21 @@ export const NavRail: React.FunctionComponent<NavRailProps> = ({ collapsed, onTo
         return;
       }
       // Otherwise, restore the last visited space + channel if we have one.
-      const lastSpaceId = sessionStorage.getItem('lastSpaceId');
-      const lastChannelId = sessionStorage.getItem('lastChannelId');
+      // localStorage so it survives tab close (mobile browsers kill background tabs).
+      let lastSpaceId: string | null = null;
+      let lastChannelId: string | undefined;
+      try {
+        lastSpaceId = localStorage.getItem('lastSpaceId');
+        if (lastSpaceId) {
+          const raw = localStorage.getItem('lastChannelBySpace');
+          if (raw) {
+            const map = JSON.parse(raw) as Record<string, string>;
+            lastChannelId = map[lastSpaceId];
+          }
+        }
+      } catch {
+        // ignore
+      }
       if (lastSpaceId && lastChannelId) {
         navigate(`/spaces/${lastSpaceId}/${lastChannelId}`);
         return;
@@ -145,7 +156,6 @@ export const NavRail: React.FunctionComponent<NavRailProps> = ({ collapsed, onTo
       <div className="nav-rail__items">
         {items.map((item) => {
           const active = activeId === item.id;
-          const hasUnread = item.id === 'dm' && dmUnreadCount > 0;
           const buttonContent = (
             <button
               key={item.id}
@@ -157,9 +167,6 @@ export const NavRail: React.FunctionComponent<NavRailProps> = ({ collapsed, onTo
             >
               <span className="relative flex-shrink-0">
                 <Icon name={item.icon} size="xl" />
-                {hasUnread && (
-                  <span className="icon-unread-dot" title={t`Unread direct messages`} />
-                )}
               </span>
               {!collapsed && (
                 <span className="nav-rail__item-label">{item.label}</span>

--- a/src/components/space/ChannelGroup.tsx
+++ b/src/components/space/ChannelGroup.tsx
@@ -69,11 +69,20 @@ const ChannelGroup: React.FunctionComponent<{
   // Handle channel navigation. Closes the phone drawer (if open) so the user
   // sees the channel they just picked, even when re-tapping the current channel.
   // Also records the last-visited space + channel so the rail's Spaces button
-  // can restore the user's position next session click.
+  // and the sidebar space rows can restore the user's position next time.
+  // localStorage (not sessionStorage) so the pointer survives tab close — mobile
+  // browsers aggressively kill background tabs.
   const handleChannelNavigate = React.useCallback((channelId: string) => {
     if (spaceId) {
-      sessionStorage.setItem('lastSpaceId', spaceId);
-      sessionStorage.setItem('lastChannelId', channelId);
+      try {
+        localStorage.setItem('lastSpaceId', spaceId);
+        const raw = localStorage.getItem('lastChannelBySpace');
+        const map = raw ? JSON.parse(raw) : {};
+        map[spaceId] = channelId;
+        localStorage.setItem('lastChannelBySpace', JSON.stringify(map));
+      } catch {
+        // localStorage unavailable / quota / parse error — non-fatal.
+      }
     }
     shell?.closeDrawer();
     navigate(`/spaces/${spaceId}/${channelId}`);

--- a/src/components/space/ChannelList.tsx
+++ b/src/components/space/ChannelList.tsx
@@ -36,11 +36,16 @@ const ChannelList: React.FC<ChannelListProps> = ({ spaceId }) => {
   const user = usePasskeysContext();
   const navigate = useNavigate();
 
-  // New-shell back-to-spaces-list handler: clears the "last visited" pointers
-  // so the rail Spaces button doesn't bounce the user right back here.
+  // New-shell back-to-spaces-list handler: clears the "last visited" space
+  // pointer so the rail Spaces button doesn't bounce the user right back here.
+  // Per-space last-channel map is preserved so re-entering a space still lands
+  // on the right channel.
   const handleBackToSpaces = React.useCallback(() => {
-    sessionStorage.removeItem('lastSpaceId');
-    sessionStorage.removeItem('lastChannelId');
+    try {
+      localStorage.removeItem('lastSpaceId');
+    } catch {
+      // ignore
+    }
     navigate('/spaces');
   }, [navigate]);
 

--- a/src/components/space/SpacesSidebar.tsx
+++ b/src/components/space/SpacesSidebar.tsx
@@ -52,7 +52,7 @@ const MOCK_SPACES_COUNT = parseInt(
 );
 
 const LAST_SPACE_KEY = 'lastSpaceId';
-const LAST_CHANNEL_KEY = 'lastChannelId';
+const LAST_CHANNEL_BY_SPACE_KEY = 'lastChannelBySpace';
 
 /** Spaces sidebar — folders + standalone spaces, with DnD and right-click menus. */
 interface SpacesSidebarProps {
@@ -329,9 +329,28 @@ const SpacesSidebarInner: React.FunctionComponent<SpacesSidebarProps> = ({ onAdd
     spaceId: string,
     defaultChannelId: string | undefined
   ) => {
-    const channelId = defaultChannelId || 'general';
-    sessionStorage.setItem(LAST_SPACE_KEY, spaceId);
-    sessionStorage.setItem(LAST_CHANNEL_KEY, channelId);
+    // Prefer the channel the user was last on in this space, so re-entering a
+    // space lands them where they left off (matches mobile-app expectation).
+    let lastChannelId: string | undefined;
+    try {
+      const raw = localStorage.getItem(LAST_CHANNEL_BY_SPACE_KEY);
+      if (raw) {
+        const map = JSON.parse(raw) as Record<string, string>;
+        lastChannelId = map[spaceId];
+      }
+    } catch {
+      // ignore parse / storage errors
+    }
+    const channelId = lastChannelId || defaultChannelId || 'general';
+    try {
+      localStorage.setItem(LAST_SPACE_KEY, spaceId);
+      const raw = localStorage.getItem(LAST_CHANNEL_BY_SPACE_KEY);
+      const map = raw ? (JSON.parse(raw) as Record<string, string>) : {};
+      map[spaceId] = channelId;
+      localStorage.setItem(LAST_CHANNEL_BY_SPACE_KEY, JSON.stringify(map));
+    } catch {
+      // ignore
+    }
     navigate(`/spaces/${spaceId}/${channelId}`);
   };
 


### PR DESCRIPTION
- Remove the DM unread indicator from the NavRail Messages item.
- Persist last-visited channel per space in localStorage (lastChannelBySpace map) so re-entering a space lands on the channel the user was last on, matching the mobile-app behavior.
- Switch lastSpaceId/lastChannel pointers from sessionStorage to localStorage so they survive tab close (mobile browsers kill background tabs, which was forcing users back to the default channel).