### PR TITLE
feat: consolidate invite system with mobile

### DIFF
--- a/.agents/INDEX.md
+++ b/.agents/INDEX.md
@@ -376,6 +376,7 @@ This is the main index for all documentation, bug reports, and task management.
 - [Typing Indicators Implementation Plan](tasks/.done/2026-05-18-typing-indicators-plan.md)
 - [Test Suite Review — Cleanup Before Migration](tasks/.done/2026-05-19-test-suite-review.md)
 - [Fix UserConfig type drift between quorum-shared and quorum-desktop](tasks/.done/2026-05-27-userconfig-type-drift.md)
+- [Consolidate Desktop Invite System with Mobile](tasks/.done/2026-06-07-consolidate-invite-system-with-mobile.md)
 - [AccentColorSwitcher Cross-Platform Migration + Persistence](tasks/.done/accent-color-switcher-cross-platform-migration.md)
 - [Add Context to Desktop Notifications](tasks/.done/rich-desktop-notifications-context.md)
 - [Add DM-Specific Action Queue Handlers](tasks/.done/dm-action-queue-handlers.md)

--- a/.agents/bugs/2025-09-22-public-invite-link-intermittent-expiration.md
+++ b/.agents/bugs/2025-09-22-public-invite-link-intermittent-expiration.md
@@ -1,10 +1,16 @@
 ---
 type: bug
 title: Public Invite Link Intermittent Expiration Bug
-status: open
+status: likely-resolved-by-consolidation
 created: 2026-01-09T00:00:00.000Z
-updated: 2026-01-09T00:00:00.000Z
+updated: 2026-06-07T00:00:00.000Z
 ---
+
+> **2026-06-07 update:** the invite-system consolidation (see `tasks/2026-06-07-consolidate-invite-system-with-mobile.md`) likely makes this no longer reproducible. The original behavior — first 1-2 joiners succeed, later ones fail — is the exact failure mode of the old "one server eval per join" model: the eval pool drained on the server side after a few joins.
+>
+> Under the new model, the server serves the same single eval to every joiner instead of popping one per join (confirmed by the comment at `quorum-mobile/services/space/inviteService.ts` lines 352-356: *"server now serves the same eval to every joiner instead of popping one per join"*). Concurrent joins should no longer cause expiration.
+>
+> Not closed as `solved` because we haven't reproduced the original failure end-to-end after the consolidation — but the architectural cause is gone. To verify: in a fresh space, generate a public link, then have 5+ users join in quick succession. If all succeed, mark solved and move to `.solved/`.
 
 # Public Invite Link Intermittent Expiration Bug
 

--- a/.agents/docs/features/invite-system-analysis.md
+++ b/.agents/docs/features/invite-system-analysis.md
@@ -4,7 +4,7 @@ title: Invite System Documentation
 status: done
 ai_generated: true
 created: 2026-01-09T00:00:00.000Z
-updated: 2026-01-09T00:00:00.000Z
+updated: 2026-06-07T00:00:00.000Z
 ---
 
 # Invite System Documentation
@@ -13,7 +13,9 @@ updated: 2026-01-09T00:00:00.000Z
 
 ## Overview
 
-The Quorum desktop application features a sophisticated dual-key invite system that supports both private and public invite links for spaces. This document explains how the invite system works, its architecture, and important behavioral considerations.
+The Quorum desktop application supports two invite link formats for spaces: **one-time** (private) and **public**. Both formats coexist on the same space — generating a public link does NOT block one-time invites, and either format can be sent to a contact via DM. This document explains how the invite system works, its architecture, and behavioral considerations.
+
+> **Consolidation note (2026-06-07):** desktop's invite logic was realigned with mobile (`quorum-mobile/services/space/inviteService.ts`). Previously, generating a public link rekeyed all members, minted a new config keypair, uploaded ~200 evals, and silently hijacked the "send private invite" button. After consolidation, public generation reuses the existing config key, uploads exactly 1 eval, refreshes the manifest, and both invite formats remain available in parallel. See [`tasks/2026-06-07-consolidate-invite-system-with-mobile.md`](../../tasks/2026-06-07-consolidate-invite-system-with-mobile.md).
 
 ## Architecture Overview
 
@@ -38,78 +40,52 @@ The invite system operates through several key components:
 
 ## Invite Types and Behavior
 
-### Private vs Public: Key Differences
+### One-Time vs Public: Key Differences
 
-| Aspect | Private Invite | Public Invite |
-|--------|----------------|---------------|
-| **Evals stored** | Locally on inviter's device | Uploaded to server |
-| **Eval consumed when** | Link is **generated** | Link is **used to join** |
-| **URL changes each generation** | Yes (unique `secret` each time) | No (stable until regenerated) |
-| **One link = how many people** | 1 person per link | Unlimited (until server evals exhausted) |
+| Aspect | One-Time Invite | Public Invite |
+|--------|-----------------|---------------|
+| **Eval lives where** | Embedded in the URL | Uploaded to server, keyed by `configPublicKey` |
+| **Eval consumed when** | Link is **generated** | Link is **generated** (1 server-side eval per regen) |
+| **URL changes each generation** | Yes (unique `secret` + `template` each time) | No (deterministic per space — same configKey reused) |
+| **One link = how many people** | 1 person per link | Unlimited until regenerated |
 | **Crypto material in URL** | Full (`template`, `secret`, `hubKey`) | Minimal (`configKey` only) |
 | **How joiner gets crypto material** | Embedded in URL | Fetched from server via `getSpaceInviteEval()` |
+| **Available alongside the other type?** | Yes — coexist freely | Yes — coexist freely |
 
-### Private Invites
+### One-Time Invites
 
-Private invites are sent directly to users via existing conversations or manual address entry. They use unique cryptographic keys for each space and remain private between the sender and recipient.
+One-time invites are sent directly to users via existing conversations or manual address entry. Each link contains all the cryptographic material needed for exactly one person to join.
 
 **Characteristics:**
 - **One link per person**: Each generated link contains a unique `secret` that can only be used once
-- Sent through direct messages
-- **Eval consumed on generation**: Each invite generation consumes one secret from the local `evals` array
-- **Limited supply**: Spaces have a limited number of secrets available for private invites
+- Sent through direct messages or shared out-of-band
+- **Eval consumed on generation**: Each one-time invite consumes one secret from the local `evals` array
+- **Limited supply**: Spaces have a finite pool of secrets (~10K from space creation)
 - URL contains all crypto material needed to join (no server fetch required)
 
 ### Public Invite Links
 
-Public invite links are shareable URLs that anyone can use to join a space. They use a different key system from private invites.
+Public invite links are shareable URLs that anyone can use to join a space. They reuse the space's existing config key.
 
 **Characteristics:**
 - **Same URL for everyone**: Share one link with unlimited people
-- **Eval consumed on join**: When someone uses the link, the server provides one eval from the uploaded pool
+- **Eval consumed on join**: When someone uses the link, the server returns the stored eval; the same eval is served to every joiner (one eval per public-link generation)
 - Can be shared anywhere (social media, websites, etc.)
-- Regeneratable (invalidates previous public link by creating new keys)
-- Switches system to public-only mode (private invites become public URL)
+- Regeneratable: re-uploads a fresh eval and a fresh manifest snapshot to the server. The URL string itself is unchanged because the configKey is unchanged.
 
-## Critical System Behavior
+## How the System Behaves
 
-### ⚠️ System Switch Behavior
+### Coexistence model (current, as of 2026-06-07)
 
-When you generate a public invite link, the system switches from private-only to public-only mode.
+Public and one-time invites are independent capabilities on the same space:
 
-**Exact Behavior Flow:**
+1. **Generating a public link**: reuses the existing config keypair, uploads exactly 1 server-side eval, re-publishes the encrypted manifest with a fresh timestamp, saves `space.inviteUrl` locally. **Does not** rekey members or invalidate the local one-time evals pool.
 
-1. **Phase 1 - Private Only Mode:**
-   - Send private invites via "existing conversations" or manual address
-   - Each invite generation consumes one secret from the space's finite `evals` array
-   - Generated invites remain valid until the space switches to public mode
-   - **Limited capacity**: Spaces can only generate a finite number of private invites
+2. **Generating a one-time link** (`constructInviteLink`): pops one eval from the local pool, bakes the full crypto material into the URL. Always returns a fresh URL even when `space.inviteUrl` is set. The old short-circuit that hijacked this method to return the public URL has been removed.
 
-2. **Phase 2 - The Switch:**
-   - Generate first public link → `space.inviteUrl` is set
-   - `constructInviteLink()` now returns the public URL immediately (line 57-58)
-   - **ALL subsequent "private" invites become the public URL**
+3. **Sending an invite via DM**: the service-layer `sendInviteToUser` action takes a `mode: 'one-time' | 'public' | 'reuse'` argument plus an optional `presetLink`. In `'public'` mode it forwards the existing `space.inviteUrl` (errors if no public link exists). In `'one-time'` mode it generates a fresh URL per call. In `'reuse'` mode it sends the explicit `presetLink` value without generating anything new (no eval consumed). The current UI never uses `'reuse'` — the active call paths are `'one-time'` for the One-Time tab's Send via DM (fresh per send) and `'public'` for the Public tab's Send via DM. `'reuse'` is retained on the service surface because the architectural property is useful (e.g. a future "review then send" pattern would call it).
 
-3. **Phase 3 - Public-Only Mode:**
-   - "Send invite to existing conversations" now sends the **same public URL** to everyone
-   - No more unique private invites possible while public link exists
-   - Can generate new public links (invalidates old one by creating new config key)
-   - **Cannot delete**: True deletion requires backend API endpoint that doesn't exist
-
-**🔥 Critical Code Evidence:**
-
-```typescript
-// constructInviteLink() - InvitationService.ts:55-59
-async constructInviteLink(spaceId: string) {
-  const space = await this.messageDB.getSpace(spaceId);
-  if (space?.inviteUrl) {
-    return space.inviteUrl; // ← Returns public URL, skips private invite generation!
-  }
-  // ... private invite code never reached once inviteUrl exists
-}
-```
-
-**LIMITATION:** Cannot return to private-only mode - deletion requires backend API support.
+4. **Regenerating the public link**: produces the **same URL string** (because the configKey is reused). The server-side eval is overwritten with a fresh one, and the manifest snapshot is updated. Existing copies of the URL in the wild continue to resolve.
 
 ### Evals (Polynomial Evaluations)
 
@@ -117,21 +93,29 @@ Evals are cryptographic secrets used exclusively for invite generation. They are
 
 **Eval Allocation:**
 
-| Operation | Evals Generated | Notes |
-|-----------|-----------------|-------|
-| Space creation | ~10,000 (SDK default) | No `total` param passed |
-| Generate public invite link | `members + 200` | Replaces previous session |
-| Kick user (rekey) | `members + 200` | Replaces previous session |
-
-**Important**: When `generateNewInviteLink()` is called, it creates a NEW session that **replaces** the old encryption state. The original ~10K evals from space creation are discarded and replaced with ~200 evals.
+| Operation | Evals Consumed/Generated | Notes |
+|-----------|--------------------------|-------|
+| Space creation | ~10,000 generated (SDK default) | No `total` param passed |
+| Generate one-time invite link | 1 consumed from local pool | URL embeds the eval |
+| Generate public invite link | 1 consumed from local pool, uploaded to server | `MAX_PUBLIC_EVALS = 1`; replaces any existing server-side eval for this space |
+| Kick user (rekey) | `members + 200` generated, replaces session | This is the only operation that still rekeys; out of scope for the invite consolidation |
 
 **Eval Consumption:**
 
 ```typescript
-// InvitationService.ts - Private invite consumes one eval
+// InvitationService.constructInviteLink — one-time invite consumes one eval
 const index_secret_raw = sets[0].evals.shift(); // Removes from array
 await this.messageDB.saveEncryptionState(
-  { ...response[0], state: JSON.stringify(sets[0]) }, // Saves updated state
+  { ...response[0], state: JSON.stringify(sets[0]) },
+  true
+);
+```
+
+```typescript
+// InvitationService.generateNewInviteLink — public link consumes one eval
+session.evals = session.evals.slice(MAX_PUBLIC_EVALS); // MAX_PUBLIC_EVALS = 1
+await this.messageDB.saveEncryptionState(
+  { ...stateRow, state: JSON.stringify(session) },
   true
 );
 ```
@@ -146,88 +130,72 @@ Space creation allocates ~10K evals (~2MB per space) which causes config sync fa
 
 ## Technical Architecture Details
 
-### Dual Key System Architecture
+### Single Key System Architecture (post-consolidation)
 
-**Two Separate Invite Systems:**
+There is one config keypair per space, established at space creation. Both one-time and public invites are built on top of it.
 
-1. **Original Space Keys** (Space Creation):
+```
+Created: When space is first created
+Keys: space_key, owner_key, hub_key, config_key
+Used by: constructInviteLink() AND generateNewInviteLink() — both reuse the original config_key
+Lifetime: Permanent for the life of the space (unless explicitly rotated by some future feature)
+```
 
-   ```
-   Created: When space is first created
-   Keys: config_key, hub_key (from space creation)
-   Used by: constructInviteLink() when space.inviteUrl is null
-   Lifetime: Permanent until public links are enabled
-   ```
-
-2. **Public Link Keys** (On-Demand Generation):
-   ```
-   Created: When generateNewInviteLink() is called
-   Keys: New X448 key pairs + updated config
-   Used by: constructInviteLink() when space.inviteUrl exists
-   Lifetime: Until regenerated
-   ```
+This is a behavior change from the previous design, where `generateNewInviteLink` minted a fresh config keypair on each call. The new design matches `quorum-mobile/services/space/inviteService.ts`, where the comment is explicit: *"Use the EXISTING space config key (not a new one). This ensures all space members use the same config key for hub envelope encryption/decryption."*
 
 ### Invite Link Structures
 
-**Private Invites (Original Keys + Consumed Secrets):**
+**One-Time Invites (existing config key + consumed secret):**
 
 ```
-https://[domain]/#spaceId={SPACE_ID}&configKey={ORIGINAL_CONFIG_PRIVATE_KEY}&template={TEMPLATE}&secret={CONSUMED_SECRET}&hubKey={HUB_PRIVATE_KEY}
+https://app.quorummessenger.com/#spaceId={SPACE_ID}&configKey={CONFIG_PRIVATE_KEY}&template={TEMPLATE}&secret={CONSUMED_SECRET}&hubKey={HUB_PRIVATE_KEY}
 ```
 
-**Note**: The `secret` parameter comes from `evals.shift()` - each private invite permanently consumes one secret from the space's finite pool.
+**Note:** the `secret` comes from `evals.shift()`. Each one-time invite consumes one slot from the local pool.
 
-**Public Links (Generated Keys):**
+**Public Links (existing config key, eval lives on server):**
 
 ```
-https://[domain]/invite/#spaceId={SPACE_ID}&configKey={NEW_CONFIG_PRIVATE_KEY}
+https://app.quorummessenger.com/invite/#spaceId={SPACE_ID}&configKey={CONFIG_PRIVATE_KEY}
 ```
 
-**Domain Resolution (as of September 22, 2025):**
-- **Production** (`app.quorummessenger.com`): Uses `qm.one` for short links
-- **Staging** (`test.quorummessenger.com`): Uses `test.quorummessenger.com`
-- **Local Development** (`localhost`): Uses `localhost:port` with http protocol
+**Note:** the `configKey` here is the SAME `configKey` used by one-time invites and by member-side hub envelope encryption. The URL is therefore deterministic per space.
+
+**Domain Resolution (as of 2026-06-07):**
+- **Production** (`app.quorummessenger.com`): Generated URLs use `app.quorummessenger.com` (matches mobile). `qm.one` short links are still accepted as input for backward compatibility. See `buildInviteBase` helper in `InvitationService.ts`.
+- **Staging** (`test.quorummessenger.com`): Uses `test.quorummessenger.com`.
+- **Local Development** (`localhost`): Uses `localhost:port` with http protocol.
 
 ### Cryptographic Flow
 
-**Private Invites (constructInviteLink):**
+**One-Time Invites (`constructInviteLink`):**
 
-1. **Check**: Does `space.inviteUrl` exist?
-2. **If NO**: Use original space creation keys
-3. **Secret Consumption**: `sets[0].evals.shift()` permanently removes one secret from the finite pool
-4. **Template Construction**: Uses existing encryption states and ratchets
-5. **Link Generation**: Includes template, consumed secret, and hub keys
-6. **State Update**: The `InvitationService` now handles saving the modified encryption state (with one less secret) back to the database.
-7. **Validation**: Uses original config keys for decryption
+1. Load `config_key` and `hub_key` from local storage.
+2. Load the space's encryption state (`spaceId/spaceId` conversationId).
+3. Verify the local pool has at least one eval; throw if exhausted.
+4. Deep-copy the template, set `ratchet.id = 10001 - evals.length`, copy `root_key` from session state, hex-encode the template.
+5. Pop one eval via `evals.shift()`, hex-encode as the URL `secret`.
+6. Persist the smaller pool via `saveEncryptionState`.
+7. Return the URL: `{base}#spaceId={..}&configKey={..}&template={..}&secret={..}&hubKey={..}`.
 
-**Public Links (generateNewInviteLink):**
+**Public Links (`generateNewInviteLink`):**
 
-1. **Key Generation**: Create new X448 key pair
-2. **Key Storage**: Save new config keys to database
-3. **Space Update**: Set `space.inviteUrl` with new link
-4. **Manifest Creation**: Encrypt space data with new keys
-5. **Validation**: Uses new config keys for decryption
-
-### Key Decision Logic
-
-```typescript
-// The critical decision point in constructInviteLink(), now orchestrated by InvitationService
-if (space?.inviteUrl) {
-  return space.inviteUrl; // PUBLIC SYSTEM
-} else {
-  // PRIVATE SYSTEM - use original keys. These calls would be internal to a service.
-  const config_key = await messageDB.getSpaceKey(spaceId, 'config');
-  const hub_key = await messageDB.getSpaceKey(spaceId, 'hub');
-}
-```
+1. Load `owner_key`, `hub_key`, `config_key` from local storage.
+2. Load the space's encryption state.
+3. Verify the local pool has at least `MAX_PUBLIC_EVALS = 1` eval; throw if exhausted.
+4. Generate an ephemeral X448 keypair (used for both eval and manifest encryption).
+5. Take the first eval (slice, don't mutate yet), build one encrypted eval payload using the existing config public key.
+6. Sign the eval payload with `owner_key`, POST to `apiClient.postSpaceInviteEvals`.
+7. Re-encrypt the local space manifest with the same config key + ephemeral key, sign with `owner_key`, POST to `apiClient.postSpaceManifest`.
+8. Set `space.inviteUrl = "{base}/invite/#spaceId={..}&configKey={..}"` using the EXISTING config private key. Save via `saveSpace`.
+9. Decrement the local pool (`session.evals.slice(MAX_PUBLIC_EVALS)`), persist via `saveEncryptionState`. This happens AFTER successful network calls so a failed upload doesn't leak a pool slot.
 
 ### Database Operations
 
-- **Space Keys**: Multiple types stored ('hub', 'owner', 'config', 'space')
-- **Key Evolution**: Original keys preserved, new keys added when public links enabled
-- **Space State**: `inviteUrl` property determines which key system is active
-- **Member Management**: Real-time updates via WebSocket sync
-- **Message History**: Persistent storage in local MessageDB, managed by `MessageService`.
+- **Space Keys**: Multiple types stored ('hub', 'owner', 'config', 'space'). All set at space creation; not rotated by invite operations.
+- **Space State**: `inviteUrl` tracks the current public link (deterministic per space; same string across regenerations).
+- **Encryption State**: A single per-space row holds the DKG template + local evals pool. Both invite paths mutate this row by popping evals.
+- **Member Management**: Real-time updates via WebSocket sync (unaffected by invite operations).
 
 ## Recommendations
 
@@ -244,64 +212,66 @@ if (space?.inviteUrl) {
 3. **Error Handling**: More granular error categorization and handling
 4. **Documentation**: Better code comments explaining the dual key system
 
-### Current Public Invite Link UI Flow
+### Current Invites UI Flow
 
-**No Link State**: Shows warning text + "Generate Public Invite Link" button → Direct generation → Link appears with "Generate New Link" button
+**Segmented toggle (underline tabs)**: At the top of the Invites tab the user picks a mode — **One-Time** or **Public Link**. The Public option is owner-only; non-owners see it disabled.
 
-**Link Exists State**: Shows copyable link field with "Generate New Link" button (modal confirm) → Operations show loading callouts → Success callouts (3s auto-dismiss)
+**One-Time mode** (deliberately departs from mobile's UI to avoid mobile's same-URL-to-many footgun):
+- Two parallel actions, no displayed link box. Resting state shows just **Send via DM** (expandable) and **Copy a link**.
+- **Send via DM**: expands an inline existing-conversations picker + manual-address fallback + a **Send Invite** button. Each click of Send Invite mints a fresh one-time URL invisibly and DMs it to the chosen contact (mode='one-time' under the hood). Selected contact is cleared on success so the user can immediately pick another. The picker stays expanded for repeat sends.
+- **Copy a link**: mints a fresh one-time URL and writes it to the clipboard. The URL is never rendered on screen. A persistent "Link copied" callout confirms. Each click mints another link. A local 1.2s minimum spinner duration keeps the button's "Generating…" state perceivable (the underlying mint is sync-fast).
+- **Mutually exclusive success callouts**: clicking Send via DM collapses the Copy callout; clicking Copy a link collapses the DM picker and clears any leftover "Invite sent" callout. Only one success state visible at a time.
+- Each Send or Copy action consumes one local eval. With ~10K evals per space, exhaustion is unrealistic in practice.
 
-**Note**: Delete button was removed (2025-10-04) as true deletion requires backend API support that doesn't exist.
+**Public mode** (owner only):
+- If no public link exists: "Generate Public Invite Link" primary button → confirmation modal → link generated. Confirmation is shown only for first-time generation.
+- If a public link exists: copyable link field + "Republish" secondary button (subtle-outline variant, visually demoted) + "Send via DM" expandable picker.
+- "Republish" bypasses the confirmation modal. It pushes a fresh encrypted eval and a fresh manifest snapshot through the invite-resolution path; the URL string stays identical.
+
+> **What "Republish" is actually for.** The manifest snapshot is already pushed automatically every time the owner saves any Space changes (name, description, icon, etc.) — `SpaceService.updateSpace` calls `postSpaceManifest` on every save. The Republish button's UNIQUE behavior is `postSpaceInviteEvals` — pushing a fresh encrypted eval through the invite-resolution path. The eval is the cryptographic ticket joiners fetch when they click the public link.
+>
+> Practically, the button is a defensive escape hatch: it gives the owner a self-service way to fix a public invite link that mysteriously stops working. It's not a routine action — owners shouldn't need to click it after normal edits. Mobile has the same button (labeled "New" with a misleading "Regenerate to invalidate the old link" caption — the URL doesn't change). Verified by tracing `quorum-mobile/services/space/inviteService.ts` `generatePublicInviteLink` vs. mobile's save flow (`useSpaceSettings.ts` → `broadcastSpaceUpdate.ts`) — only the button calls `postInviteEvals`.
+- "Send via DM" picker forwards the existing `space.inviteUrl` (mode='public').
+
+**Pool-exhausted state** (typically only on legacy desktop-created spaces):
+- A warning banner replaces the inability to issue new invites with an honest explanation.
+- Banner copy adapts: if `space.inviteUrl` exists AND user is in one-time mode, it points them at the Public Link tab.
+- All one-time generate/copy and public refresh buttons are disabled. In Public mode, "Send via DM" still works because it forwards the existing `space.inviteUrl` (mode='public' doesn't consume an eval).
 
 ## Summary
 
-The invite system uses a sophisticated **dual key architecture** that supports both private and public invite modes. Key characteristics:
+Both invite formats coexist on the same space, sharing one config keypair:
 
-1. **Private invites consume finite secrets** - each generation permanently uses one secret from the `evals` array
-2. **Public link mode is NOT reversible** - switching to public is permanent (deletion requires backend API)
-3. **"Expiration" errors are validation failures** - often due to secret exhaustion or key mismatches
-4. **No persistent user blocking** - kicked users can easily rejoin
-5. **Regeneration invalidates old links** - creates new config key, orphaning old server data
-
-The system is cryptographically sound but switching to public mode is a one-way operation with current implementation.
+1. **One-time invites consume finite secrets** — each generation permanently uses one secret from the local `evals` pool.
+2. **Public-link generation is cheap** — 1 server-side eval upload + 1 manifest re-publish, no member rekey, no new keypair.
+3. **Public-link URL is deterministic per space** — regenerating produces the same string; the server-side eval is what gets refreshed.
+4. **"Expiration" errors are validation failures** — typically eval pool exhaustion or stale links from before the 2026-06-07 consolidation.
+5. **No persistent user blocking** — kicked users can still receive invites and click public links.
 
 ## Frequently Asked Questions
 
 ### Can kicked users receive new invites?
 
-**Answer: YES** - There are no blocks preventing kicked users from receiving invites in existing conversations.
-
-The system allows selecting any existing conversation and does not check if users were previously kicked. Previously kicked users can still receive invite messages in their direct conversations.
+**Yes.** There is no ban-list check in the invite send path or in the public-link join path. Kicked users can receive one-time DMs and click public links. Owners who want to keep someone out have to manage that out-of-band.
 
 ### Why do I get "Invite Link Expired" errors?
 
-**Answer:** This occurs due to cryptographic validation failures, not time-based expiration.
+These are cryptographic validation failures, not time-based expirations. Common causes:
 
-**Common Causes:**
-- **Secret exhaustion**: Space has run out of secrets in the `evals` array for private invites
-- **Key system conflict**: Using private invite links after switching to public mode
-- Links using old keys after public link generation
-- Missing or corrupted space configuration
-
-The error message "expired or invalid" is misleading - invite links don't actually expire based on time, but private invites have limited capacity.
+- **Eval pool exhaustion**: the space has used up its local pool.
+- **Stale public links from before 2026-06-07**: spaces that had a public link generated under the old desktop logic embedded a freshly-minted configKey in the URL. After the consolidation, regenerating the public link on the new build emits a URL built from the original space configKey instead — the old URL becomes a dead pointer. Owners can regenerate to get the new (current) URL.
+- **Missing or corrupted space configuration** in local storage.
 
 ### Can kicked users rejoin via public invite links?
 
-**Answer: YES** - Kicked users can immediately rejoin via public invite links.
+**Yes.** Public invite links bypass membership checks. The only way to lock someone out is to remove the public link entirely or rely on social trust.
 
-There is no persistent "ban list" or kicked user tracking. Public invite links bypass membership checks entirely.
+### Can I go back to "one-time only" after generating a public link?
 
-**Prevention methods:**
-- Regenerate invite links after kicking users (creates new config key)
-- Manually manage invite distribution
-- ~~Switch to private-only invites~~ (not possible once in public mode)
+**The question no longer applies** under the post-consolidation model. One-time invites continue to work whether or not a public link exists. If you want to stop offering public joins, the only options are:
 
-### Can I go back to private-only mode after enabling public links?
-
-**Answer: NO** - Cannot return to private-only mode with current implementation.
-
-True deletion requires a backend `DELETE /invite/evals` API endpoint that doesn't exist. You can only:
-- **Regenerate** the public link (invalidates old one by creating new config key)
-- **Cannot delete** server-side invite evals (remains in public mode permanently)
+- **Republish** the public link to refresh the eval — useful if joiners report the link isn't working. The URL stays the same; this does not invalidate the old link in any meaningful sense.
+- **Future work** would need a backend `DELETE /invite/evals` endpoint to truly take the public link offline. None currently exists.
 
 ---
 
@@ -356,4 +326,4 @@ The invite system now dynamically detects the environment and uses appropriate d
 
 _Covers: SpaceSettingsModal/Invites.tsx, useInviteManagement.ts, useInviteValidation.ts, useSpaceJoining.ts, InvitationService.ts, MessageDB Context, InviteLink.tsx, inviteDomain.ts_
 
-_Last updated: 2026-05-20 — staleness audit fixes_
+_Last updated: 2026-06-07_

--- a/.agents/tasks/.done/2026-06-07-consolidate-invite-system-with-mobile.md
+++ b/.agents/tasks/.done/2026-06-07-consolidate-invite-system-with-mobile.md
@@ -1,0 +1,360 @@
+---
+type: task
+title: Consolidate desktop invite system with mobile (cryptographic logic + UX)
+status: in-progress
+branch: feat/consolidate-invite-system-with-mobile
+created: 2026-06-07
+updated: 2026-06-07
+---
+
+# Consolidate desktop invite system with mobile
+
+## 1. Summary
+
+Desktop's invite system and mobile's invite system diverged. The lead (who owns mobile) shipped a simpler, cheaper model: public and private invites coexist on the same space, "Generate Public Link" doesn't rekey, and the UI surfaces a single modal with a segmented toggle.
+
+This task aligns desktop with mobile's model: cryptographic behavior, UX, copy, and the underlying service-call sequence. Per the migration cross-repo workflow rule (2026-05-28: "when mobile has shipped a working pattern, mobile's pattern is the starting point"), mobile is the canonical reference here.
+
+## 2. The actual logic gap
+
+### Mobile model (`quorum-mobile/services/space/inviteService.ts`)
+
+- **`generatePrivateInviteLink(spaceId)`** — pops one ticket from the local `evals` pool, bakes template + secret + hubKey + configKey into the URL. No state mutation beyond the smaller pool. URL form: `https://app.quorummessenger.com/#spaceId=...&configKey=...&template=...&secret=...&hubKey=...`.
+- **`generatePublicInviteLink(spaceId)`** — reuses the **existing** space config key (line 332-339, "Use the EXISTING space config key (not a new one)"). Uploads exactly `MAX_PUBLIC_EVALS = 1` eval to the server keyed by `configPublicKey`. Re-uploads the manifest (so joiners see a current snapshot). Saves `space.inviteUrl` locally. No member rekey, no new keypair, no batch eval generation.
+- Both functions can be called repeatedly in any order. Private invites continue to work after a public link exists. Public link regeneration produces an identical URL string (same `configKey`) — what changes is the server-side eval and the manifest.
+- The owner-only check is implicit in `getSpaceKey(spaceId, 'owner')` failing for non-owners (throws "Only space owners can generate public invites").
+
+### Desktop model (current — `src/services/InvitationService.ts`)
+
+- **`constructInviteLink(spaceId)` (private)** — has a short-circuit at lines 58-60: `if (space?.inviteUrl) return space.inviteUrl;`. So once a public link exists, the "Send Private Invite" button silently sends the public URL to the DM. The user thinks they're sending a one-time link; they're not.
+- **`generateNewInviteLink(spaceId, ...)`** — heavy. Generates a brand-new X448 config keypair, runs a full member rekey loop (one sealed envelope per existing member), pre-encrypts ~200 evals (one per remaining ticket), batch-uploads them. Re-uploads the manifest with the new config key. Saves the new `space.inviteUrl` with the new configKey embedded.
+- Consequence: regenerating a public link on desktop produces a **different URL** (different configKey), invalidates the old URL, and is dramatically more expensive than mobile.
+
+### Side-by-side
+
+| Aspect | Mobile | Desktop today |
+|---|---|---|
+| Public-link generation cost | 1 server eval upload + 1 manifest upload | ~200 server evals + N member envelopes + new config keypair + manifest |
+| Public-link configKey | Reuses existing | Generates new |
+| Public-link URL string changes on regen | No (same configKey) | Yes (new configKey) |
+| Old public link after regen | Same URL, fresh server eval | Different URL, old one is now a dead pointer |
+| Private invite after public exists | Works (pops next local eval, returns full URL) | Silently returns public URL (short-circuit in constructInviteLink) |
+| UI mode selection | Per-click via segmented toggle | Stacked sections; public mode is sticky |
+| Member rekey on public gen | No | Yes |
+
+The lead's mobile design is intentionally cheaper. We adopt it.
+
+## 3. In scope
+
+- **Stop generating `qm.one` URLs on desktop.** Mobile generates `https://app.quorummessenger.com/...` for all invite links and we're aligning with that. See §6.1 below for the concrete change in `@quilibrium/quorum-shared`.
+- Rewrite `InvitationService.constructInviteLink` to **never** short-circuit on `space.inviteUrl`. Always generate a fresh one-time link from the local evals pool.
+- Rewrite `InvitationService.generateNewInviteLink` to mirror mobile's `generatePublicInviteLink`:
+  - Reuse existing space config key (no new keypair, no `saveSpaceKey` for 'config').
+  - Upload exactly **1** eval (not ~200).
+  - No member rekey loop, no sealed envelopes to existing members.
+  - Re-upload the manifest encrypted with the existing config key, with a fresh timestamp.
+  - Save `space.inviteUrl` locally.
+- Redesign `src/components/modals/SpaceSettingsModal/Invites.tsx`:
+  - Replace the two stacked sections with mobile's segmented toggle: **One-Time** / **Public Link**.
+  - Single primary "Generate Invite Link" button; copy adapts to selected mode.
+  - On generation, show the link box with **Copy** and **Share to DM** actions (share opens an inline conversation picker, same as mobile's `ShareInviteSheet`).
+  - Show a small info/warning banner that adapts to the selected mode (one-time vs reusable, copy from mobile lines 274-278).
+  - Keep "Generate New Link" available when a link is showing (regenerate same mode).
+  - Owner-only gating for the Public option; non-owners see only One-Time.
+- Fix the existing typo on line 248 ("Inivte" → "Invite") as part of the copy refresh.
+- Update `.agents/docs/features/invite-system-analysis.md` to reflect the new model:
+  - Remove the "system switch is permanent" warning section.
+  - Update the "Eval Allocation" table (public gen now consumes 1 eval, not `members + 200`).
+  - Update the "Current Public Invite Link UI Flow" section.
+  - Update the "Can I go back to private-only mode" FAQ — no longer relevant, both coexist.
+  - Update the `constructInviteLink` code snippet to remove the short-circuit.
+
+## 4. Out of scope
+
+- Promoting any invite code into `@quilibrium/quorum-shared`. The services-design audit (`2026-05-18-services-design.md` §12) explicitly puts `InvitationService.ts` in the "STAYS PER-APP" bucket: 904 LOC of React Query / `MutableRefObject` / Lingui coupling, plus `joinInviteLink` calls `queryClient.invalidateQueries` four times. Mobile already uses shared's invite domain helpers (`getInviteUrlBase`, `parseInviteParams`, `getValidInvitePrefixes`); desktop uses them too. That's already the right amount of sharing for this layer.
+- Touching `joinInviteLink`. The join path already handles both public (no `secret`/`template`/`hubKey` in URL → fetches eval from server) and private (full crypto material in URL) correctly. The cleanup only affects generation, not consumption.
+- Mobile-side changes. Mobile is already correct.
+- The pre-assign-role-to-non-member feature (`2026-04-20-invite-with-role-design.md`) — that's a separate planned feature. This task neither blocks nor unblocks it.
+- The legacy "Send Invite to Existing Conversations" picker (the `SearchableConversationSelect` block) — mobile's `ShareInviteSheet` is the new pattern but it has the same intent (pick a DM, send the link as a message). We adapt the UI to be more compact like mobile's, but keep the underlying `sendInviteToUser` call path. No change to `InvitationService.sendInviteToUser`.
+
+## 5. Why this approach (vs alternatives)
+
+Three options were considered:
+
+1. **Match mobile fully (this task).** Highest alignment, cheapest runtime, makes the "system switch" go away. Requires changing both `constructInviteLink` and `generateNewInviteLink`. Best long-term: desktop and mobile converge on the same conceptual model, which makes the eventual `InvitationService` audit (if it ever moves into shared) clean.
+2. Keep desktop's heavy regen, just remove the short-circuit. Smaller blast radius but leaves desktop and mobile cryptographically asymmetric (different `configKey` per regen on desktop, same on mobile). Future bugs around link sharing across platforms would become harder to reason about.
+3. UX/copy only, no logic change. Doesn't actually solve the reported problem (user wants both link types to coexist). Toggle would be cosmetic since the short-circuit would still hijack private generation once public exists.
+
+Picking #1.
+
+### Why the lead's mobile model is safe to adopt
+
+- **No data loss.** The local evals pool isn't deleted by the new public-gen path. Existing members aren't rekeyed (no need — the configKey didn't change). Manifests on the server stay decryptable by anyone who has the URL.
+- **Joiner experience is unchanged.** `joinInviteLink` already handles both link shapes today; it doesn't care whether the eval came from a new configKey or the existing one. The decryption path is identical.
+- **Trust signal.** The lead designs both apps and ships the mobile crypto. The migration playbook explicitly says: where mobile and desktop diverge on something the lead already shipped, follow mobile.
+
+## 6. Concrete code changes
+
+### 6.1 Desktop-only override: stop generating `qm.one` URLs
+
+**Status check (verified 2026-06-07):**
+
+- `quorum-shared/src/utils/inviteDomain.ts` `getInviteBaseDomain()` returns `qm.one` for hosts on `app.quorummessenger.com` (lines 26-29).
+- `quorum-mobile/services/space/inviteService.ts` has its own hardcoded `INVITE_DOMAINS.production = 'app.quorummessenger.com'` (line 35) and does NOT use shared's `getInviteUrlBase` for generation — so mobile generates `https://app.quorummessenger.com/...` URLs regardless.
+- `quorum-desktop` uses shared's `getInviteUrlBase` everywhere, so prod desktop currently generates `https://qm.one/...` URLs.
+- Both apps accept both prefixes for parsing/joining, so cross-platform interop already works.
+
+**Decision: do NOT touch `quorum-shared` in this task.** Override the prod host at the desktop call sites instead. Trade-off: small, contained patch in desktop; no cross-repo PR; no shared version bump. Cost: duplicates the "use long domain in prod" rule. Acceptable for now because there's a planned cleanup track in shared anyway.
+
+**Change:** at the two desktop call sites that currently call `getInviteUrlBase` for invite generation (inside `InvitationService.constructInviteLink` and `InvitationService.generateNewInviteLink`), wrap the value so that when the returned domain is `qm.one`, we substitute `app.quorummessenger.com`. Easiest form: a small local helper in `InvitationService.ts`:
+
+```typescript
+function buildInviteBase(isPublic: boolean): string {
+  const base = getInviteUrlBase(isPublic);
+  // Match mobile: use the long prod domain, not the qm.one short one.
+  // The shared helper still emits qm.one for back-compat with old code paths;
+  // override here until shared is updated in a separate cross-repo PR.
+  return base.replace('://qm.one/', '://app.quorummessenger.com/');
+}
+```
+
+Then replace the two `getInviteUrlBase(...)` calls in `InvitationService.ts` with `buildInviteBase(...)`. Leave all other call sites of `getInviteUrlBase` (for example join-link validation paths in hooks, or display in `JoinSpaceModal`) untouched — those care about acceptance, not generation, and `getValidInvitePrefixes` already covers both hosts.
+
+After this change:
+
+- New desktop-generated invite URLs: `https://app.quorummessenger.com/#...` (matches mobile).
+- New desktop-generated public links: `https://app.quorummessenger.com/invite/#...` (matches mobile).
+- Old `qm.one` URLs still in the wild (from past generations) keep working — `getValidInvitePrefixes()` accepts both, and the `qm.one` short domain still redirects.
+- Shared package: unchanged. No version bump needed for this part.
+
+### File: `src/services/InvitationService.ts`
+
+**`constructInviteLink` (lines 56-106) — remove the short-circuit:**
+
+```typescript
+async constructInviteLink(spaceId: string) {
+  const space = await this.messageDB.getSpace(spaceId);
+  // REMOVED: if (space?.inviteUrl) return space.inviteUrl;
+
+  const config_key = await this.messageDB.getSpaceKey(spaceId, 'config');
+  const hub_key = await this.messageDB.getSpaceKey(spaceId, 'hub');
+  // ... rest unchanged: pops one eval, bakes the full URL
+}
+```
+
+**`generateNewInviteLink` (lines 142-504) — major rewrite to mirror mobile's `generatePublicInviteLink`:**
+
+- Drop `secureChannel.EstablishTripleRatchetSessionForSpace` call.
+- Drop the `ch.js_generate_x448()` call for `configPair`. Use existing config key from `messageDB.getSpaceKey(spaceId, 'config')`.
+- Drop the `filteredMembers` rekey loop (all the inner-envelope / SealSyncEnvelope / outbounds code).
+- Replace the `for (let e = session.evals.shift(); e != undefined; ...)` loop with a single-eval encryption (mobile uses `session.evals.slice(0, MAX_PUBLIC_EVALS = 1)` — keep the same constant for parity).
+- Manifest upload uses the existing configKey, fresh timestamp.
+- Final `space.inviteUrl` uses the **existing** configKey, not a new one. So the URL string will be deterministic per space until/unless a future change replaces the configKey for other reasons.
+- Pull the smaller eval-count out of the local pool (`session.evals = session.evals.slice(1)`) and persist.
+- Remove the `enqueueOutbound` for outbounds (no rekey envelopes to send).
+
+The Quilibrium SDK calls used by mobile (`encryptInboxMessage`, `signEd448`, `getPublicKeyX448`, `generateX448`) are all available on desktop via `channel_raw as ch` — no SDK gap.
+
+### File: `src/components/modals/SpaceSettingsModal/Invites.tsx`
+
+Replace the entire body of the `Invites` component with a mobile-inspired layout:
+
+- Top: title "Invites", short description.
+- Segmented toggle (use the `Switch`-style primitive or a custom inline two-button toggle — mobile uses a custom one, desktop can match using existing primitives).
+- Info text adapts to selection (mobile copy:
+  - one-time: "Generate a one-time use invite link. Each link can only be used by one person."
+  - public: "Generate a reusable public invite link. Anyone with this link can join.")
+- Primary button "Generate Invite Link" (or "Generate Public Link" when in public mode).
+- After generation: `ClickToCopyContent` with the URL, plus a Share button that opens an inline picker of existing DMs (reuses the existing `getUserOptions()` flow that's currently inlined in the component).
+- Below: small banner with the existing warning copy (mobile: "Anyone with this link can join. You can regenerate it at any time to invalidate the old link." or "This link can only be used once. Generate a new link for each person you want to invite.").
+- "Generate New Link" secondary button.
+- Owner-only gating: if not owner, hide the Public Link toggle (or disable it with a tooltip). Use existing `useSpaceOwnership` / `isSpaceOwner` logic that already exists for `generateNewInviteLink` callers.
+
+Note: keep the legacy `useInviteManagement` hook surface; this is a UI-layer refactor on top of the same hook. The hook may need a small additional state field for the active toggle mode, but no breaking API change.
+
+### File: `src/hooks/business/spaces/useInviteManagement.ts` (not read in this task)
+
+May need a small change: when calling `invite()` (send-to-DM), the hook will need to know whether to construct a one-time URL or use the existing public URL. Today `constructInviteLink` short-circuits to public; after this change, it always builds one-time. So the "share" path needs to either:
+
+- (a) call `constructInviteLink` for the one-time flow, or
+- (b) use `space.inviteUrl` directly for the public-share flow.
+
+The toggle in the UI determines which. The hook should expose two separate share-to-DM actions, OR accept a `mode: 'private' | 'public'` argument. Either is fine; prefer the explicit-argument variant for clarity at the call site.
+
+### File: `.agents/docs/features/invite-system-analysis.md`
+
+- Drop the "⚠️ System Switch Behavior" section (the model no longer applies).
+- Update the "Evals (Polynomial Evaluations)" table:
+  - "Generate public invite link" row: `1` eval (was `members + 200`).
+  - "Kick user (rekey)" row: stays as-is (kick is a separate operation, not in scope).
+- Update the "Current Public Invite Link UI Flow" section to describe the new toggle-based modal.
+- Update "Can I go back to private-only mode after enabling public links?" FAQ — answer becomes "Not applicable: both modes coexist. You can always generate a fresh one-time link even when a public link exists."
+- Add a short note: "As of 2026-06-07, desktop aligns with mobile's behavior — public-link generation is a 1-eval upload + manifest refresh, no member rekey."
+- Update the `constructInviteLink` code snippet to remove the short-circuit and add a comment pointing to mobile parity.
+
+## 7. Testing plan
+
+Manual on web (Vite dev) first; Electron later.
+
+### Private-only path (clean slate)
+
+- Create a new space. Don't generate a public link.
+- Send a one-time invite to a DM. Recipient joins. Confirm join works exactly as today.
+- Generate another one-time invite. Confirm a different URL is produced. Recipient B joins.
+
+### Public-then-private
+
+- Create a new space. Generate a public link. Copy it.
+- Without closing the modal, switch to One-Time toggle. Generate. Confirm:
+  - The URL produced is different from the public one.
+  - The URL is a full private link (`#spaceId=...&configKey=...&template=...&secret=...&hubKey=...`).
+- Recipient A joins via the private link. Confirm join works.
+- Recipient B joins via the public link. Confirm join works.
+- Both end up in the space with no role.
+
+### Public regen produces identical URL
+
+- Space with existing public link. Click "Generate New Link" in public mode.
+- Confirm the URL string is identical to the previous one.
+- Have an old joiner click the old (= new = same) URL. Confirm they can still join.
+
+### Cross-platform sync
+
+- Create a space on desktop. Generate a public link.
+- Open the same space on mobile. Confirm mobile sees the same `space.inviteUrl`.
+- Generate a private link on mobile. Confirm desktop sees the local eval pool decremented (visible in pool size on next desktop private-gen attempt).
+
+### Owner-only gating
+
+- Sign in as a non-owner member. Confirm the Public Link toggle is hidden/disabled.
+- Sign in as the owner. Confirm both toggles work.
+
+### Manifest refresh
+
+- Generate a public link. Confirm the server's manifest reflects current space state (rename the space, regenerate, then join from a fresh device — should see the new name on the join screen).
+
+### Regression: existing public links from before this change
+
+- Spaces created on the old desktop logic stored a `space.inviteUrl` built from a fresh-on-public-gen configKey, not the original space configKey. With the new logic, regenerating produces a URL built from the **original** configKey instead — different URL string.
+- **Not a real concern in practice**: nearly all current real spaces were created on the mobile app, so they already follow the new model. The handful of desktop-created spaces with old-style public URLs are acceptable collateral: if their old URL silently stops resolving, that's fine.
+- **Hard requirement**: the app must not **crash** on a space with an old-style `inviteUrl`. The link can become a dead pointer, but rendering the settings modal, opening the space, generating a new link, sending DMs, etc. must all keep working. This is easy to satisfy since `space.inviteUrl` is just a string we read — nothing in the new flow parses or relies on a specific configKey embedded in it.
+- Confirm in testing: open a pre-existing desktop space that has an old `inviteUrl` set, open the Invites modal, verify it renders without errors, regenerate the link, verify the new URL replaces the old one cleanly.
+
+## 8. Risks
+
+- **The desktop rekey loop existed for a reason.** Best guess: it was an early-days "we don't fully trust the eval-reuse server behavior, so generate a fresh ratchet on every public gen" defensive move. Mobile's design (single eval, manifest refresh, no rekey) is the optimized version after the server behavior settled. We cannot pause on the lead's review for this change — we're shipping the alignment now. Mitigation: mobile has been running this exact model in production for months, so it's empirically safe. PR description still lists the open questions so the lead can flag anything when they next touch this code.
+- **Existing desktop-created public links from before this change.** Not a real concern — almost all production spaces were created on mobile and already follow the new model. The only invariant: the app must not crash when it encounters an old-style `inviteUrl`. The old URL silently becoming a dead pointer is acceptable. Covered in testing.
+- **i18n strings.** New copy needs Lingui marking + `yarn extract`. Standard part of the UI work.
+- **`useInviteManagement` refactor blast radius.** The hook is already on the roadmap's "hardest" list. Resist scope creep — keep the refactor scoped to "add a mode argument to the share-to-DM mutation", don't try to split CRUD vs form-state in this PR.
+
+## 9. Sequencing
+
+Desktop-only PR on this branch (`feat/consolidate-invite-system-with-mobile`). Mobile and shared are untouched. Three commits:
+
+1. **Service-layer rewrite.** `InvitationService.ts` only. New `generateNewInviteLink` mirrors mobile; `constructInviteLink` short-circuit removed; add the small `buildInviteBase` host-override helper (§6.1) and route the two generation call sites through it. tsc clean. Manual smoke: dev console can call both methods and produce both URL shapes, both with `app.quorummessenger.com` host.
+2. **UI refactor.** `Invites.tsx` + any small `useInviteManagement` adjustment + i18n extract. Visual parity check with mobile (screenshot side-by-side in PR description).
+3. **Docs.** Update `.agents/docs/features/invite-system-analysis.md`. Mention this task file. Last-updated footer.
+
+Open PR to `main`, squash-merge per [[overview]]'s branch policy.
+
+**Future cleanup (separate task, not in scope here):** when the cross-repo workflow allows, fix `getInviteBaseDomain()` in `quorum-shared` to emit `app.quorummessenger.com` directly and remove the desktop-side `buildInviteBase` override. That cleanup also unblocks the pending mobile task (`2026-05-29-mobile-rewire-invite-helpers-to-shared.md`) which wants mobile to use shared's helpers instead of its own hardcoded `INVITE_DOMAINS`.
+
+Open PR after commit 3 to `main`. Squash-merge per [[overview]]'s branch policy.
+
+## 10. Open questions for the lead
+
+To raise in the PR description, not blockers for the design:
+
+- The desktop rekey loop on public-link gen — was that intentionally defensive or just stale? (Confirms it's safe to drop.)
+- Mobile's `MAX_PUBLIC_EVALS = 1` constant — was 200 the original number on both platforms, or did mobile start with 1 from the beginning?
+- Any planned changes to the server-side eval-serving behavior (the "Option 2: server now serves the same eval to every joiner" comment in mobile's inviteService) that would invalidate the convergence?
+
+---
+
+## Implementation log (2026-06-07)
+
+**Service layer** (`src/services/InvitationService.ts`):
+- `constructInviteLink` short-circuit removed. Always builds a fresh one-time URL from the local pool.
+- `generateNewInviteLink` rewritten to match mobile: reuses existing config key (no new keypair, no member rekey), uploads exactly 1 eval (`MAX_PUBLIC_EVALS = 1`), re-publishes manifest with fresh timestamp, then decrements the local pool only on success.
+- Added `buildInviteBase()` helper to substitute `qm.one` → `app.quorummessenger.com` in generated URLs (matches mobile output). Acceptance of `qm.one` URLs remains unchanged.
+- Added `InviteEvalsExhaustedError` typed error; thrown by both invite paths when the local pool is empty so callers can render a friendly banner.
+- `sendInviteToUser` gained a `mode: 'one-time' | 'public'` parameter so the UI can choose between generating a fresh one-time link or forwarding the existing public URL.
+
+**UI** (`src/components/modals/SpaceSettingsModal/Invites.tsx`):
+- Replaced the two stacked sections with a segmented toggle (One-Time / Public Link) styled as underline tabs.
+- One-time mode: DM picker + "Send Invite" primary action (one-shot pick-and-send), plus a "Generate Link" secondary action that produces and displays the URL for sharing outside Quorum.
+- Public mode: link box + "Republish" secondary action (subtle-outline variant) with a plain-English tooltip + "Send via DM" expanding picker. First-time generation still gated by a confirmation modal. The button was renamed twice during this PR: first from "Refresh Link" → "Update Join Preview" (which overstated the user-visible effect), then to "Republish" after verifying that the manifest snapshot is already re-uploaded automatically on every save (`SpaceService.updateSpace` → `postSpaceManifest`). The button's UNIQUE behavior — the thing the normal save flow doesn't do — is `postSpaceInviteEvals` (server-side eval refresh). Practically, the button is a defensive escape hatch for the rare case where joiners report the public link isn't working. Confirmed parity with mobile: mobile's button (labeled "New") has the same architectural role, despite a misleading "invalidate the old link" caption.
+- Owner-only gating on the Public toggle; non-owners see only One-Time.
+- Pool-exhausted state: dedicated `Callout` banner + disabled actions. Banner copy points the user toward the public-link path when an `inviteUrl` already exists.
+- Invites tab icon changed from `user-plus` to `share` to match mobile.
+- Refresh-success callout separated from generation-success callout (different copy).
+
+**Hook** (`src/hooks/business/spaces/useInviteManagement.ts`):
+- Threads the `mode` parameter through to `sendInviteToUser`.
+- Adds `generateOneTimeLink`, `generatedOneTimeLink`, `clearGeneratedOneTimeLink`, `generatingOneTimeLink`, `generateOneTimeLinkError` for the new Generate Link action.
+- Proactively detects pool exhaustion on mount by reading the encryption state, exposes `poolExhausted` flag.
+- Catches `InviteEvalsExhaustedError` from both invite paths and surfaces it via `poolExhausted` instead of generic failure text.
+
+**Context** (`src/components/context/MessageDB.tsx`):
+- Exposes `constructInviteLink` through the context so the UI can build a one-time URL without sending it.
+- `sendInviteToUser` signature extended with the `mode` parameter.
+
+**Confirmation modal copy** (`SpaceSettingsModal.tsx`):
+- Simplified to first-time-generation only. Removed the conditional refresh-vs-generate text; refresh now bypasses the modal entirely.
+
+**Tests** (`src/dev/tests/services/InvitationService.unit.test.tsx`):
+- All 24 tests passing.
+- Updated tests 1, 3, 6, 7 to reflect new behavior (no short-circuit, fresh one-time link even when `inviteUrl` exists).
+- Added new tests covering: MAX_PUBLIC_EVALS = 1 upload count, existing config key reuse (no new keypair), no `postSpace`, no `getSpaceMembers`, no outbound rekey envelopes, manifest re-publish call, pool decrement, failure-doesn't-leak-pool, empty-pool error, non-owner gating, qm.one absence in generated URLs.
+
+**Docs updated**:
+- `.agents/docs/features/invite-system-analysis.md` rewritten to reflect the single-key model. Dropped the "system switch is permanent" warning. Updated eval allocation table. Updated FAQ.
+- `.agents/bugs/2025-09-22-public-invite-link-intermittent-expiration.md` annotated as `likely-resolved-by-consolidation` (original "first 1-2 joiners succeed" symptom matches the old eval-pop-per-join behavior that the new server-side model removes).
+- `.agents/tasks/.todo/2026-01-09-delete-public-invite-link.md` annotated with the consolidation context — task is still valid, narrower scope now.
+
+**Out-of-scope items NOT done in this PR** (documented for follow-up):
+- Recovery path for legacy spaces with drained local pools (real production spaces are on mobile and unaffected; not worth the UI surface).
+- Auto-update of the manifest snapshot on space metadata changes — already in place via `SpaceService.updateSpace`. The "Republish" button is NOT redundant with this (it ALSO refreshes the server-side eval via `postSpaceInviteEvals`, which the save flow does not).
+- Shared package change to make `getInviteUrlBase` emit `app.quorummessenger.com` instead of `qm.one` directly. Currently overridden at the desktop call site via `buildInviteBase`.
+
+---
+
+## Late-stage UI revision (same PR)
+
+After the initial implementation landed in the codebase, multiple rounds of user feedback led to a One-Time mode redesign. The earlier iterations (recorded in the implementation log above) went through:
+
+1. **Always-visible DM picker + Send Invite button + Generate Link secondary** — felt heavy, the two zones (link area + picker) read as disconnected.
+2. **Generate-first-then-share, mirroring mobile** — added a `'reuse'` service mode so the displayed link could be DMed without minting fresh. User reported the displayed link could be sent to multiple recipients (mobile has the same footgun: link is single-use at the network level; second and later joiners silently fail). Investigated mobile's pattern thoroughly via an agent, confirmed mobile sends the same URL to all recipients with only a passive warning text.
+3. **Final landed UI** — deliberately deviates from mobile to close the multi-recipient footgun:
+   - **No displayed link box.** The one-time URL is never rendered on screen.
+   - **Send via DM** (secondary) expands an inline picker. Each Send Invite click mints a fresh `'one-time'` URL invisibly. Multiple sends in a row each get independent unique URLs. Selected contact auto-clears after success.
+   - **Copy a link** (subtle-outline) mints + writes to clipboard + shows a persistent "Link copied" callout. The URL is never displayed. 1.2s minimum spinner ensures the action is perceivable.
+   - **Mutually exclusive success states.** Clicking either button clears the other's leftover UI (the Copy button collapses the DM picker AND clears the Invite-sent callout; opening the DM picker clears the Link-copied callout). Only one success state visible at a time.
+   - **Persistent callouts.** No `autoClose` — user dismisses with the X.
+   - **Underline-tab styling** for the mode toggle (no pill background); hover bumps to `rgb(var(--color-text-main))` for visible affordance.
+
+### Service-layer impact
+
+The `sendInviteToUser` signature added a `'reuse'` mode + `presetLink` arg during the generate-first iteration. The final UI never calls it (one-time sends use `'one-time'`; public sends use `'public'`). `'reuse'` is retained on the service surface because the architectural property is useful for future "review then send" patterns — see invite-system-analysis.md §3 for the rationale.
+
+### Why we deviate from mobile here
+
+Mobile's UI forces every one-time invite through a displayed-link flow and lets users send the same URL to multiple recipients with only a passive warning text. Mobile's pattern was traced thoroughly (`components/InviteModal.tsx`, `components/ShareInviteSheet.tsx`, `services/space/inviteService.ts`, `hooks/chat/useInviteManagement.ts`); the footgun is intentional UX, not a bug. The lead presumably accepted that warning-text approach as good enough.
+
+On desktop we have the room for a different pattern that closes the footgun deterministically. The trade-off is a small platform divergence. If the lead pushes back, the simplest revert is to switch the "Send Invite" button's call from `mode='one-time'` to `mode='reuse'` with the displayed link as `presetLink` — restoring mobile's same-URL-to-many behavior — and reintroducing the displayed link box. The service layer already supports both patterns.
+
+### Other late-stage polish
+
+- **Republish tooltip** rewritten to plain English: *"If users report that this invite link isn't working, click to republish it. The link URL stays the same."* — replaces earlier wordings that overstated the user-visible effect.
+- **Confirmation modals** removed for refresh/republish (state change is invisible; URL stays identical). First-time public-link generation still gated by a confirmation (genuine state change: the space becomes publicly joinable).
+- **Tab icon** changed from `user-plus` to `share` to match mobile.
+- **Pool-exhausted banner** copy adapts to mode — when in one-time mode with an existing public URL, it points the user to the Public Link tab; when already in public mode it omits the redirect to avoid the self-referential "switch above" instruction.
+- **Generate-new-on-public-gen** decision: the saved encryption state template's `dkg_ratchet` is now deep-copied before mutation in `constructInviteLink` (mirrors mobile's defensive pattern). Without this, concurrent generations could leak mutated `ratchet.id`/`root_key` into the persisted template. Test asserts the saved template stays unmutated.
+
+### Test additions
+
+- 28 tests passing.
+- Added: `mode='public'` happy path + missing-inviteUrl error, `mode='reuse'` happy path + missing-presetLink error.
+- Updated: `constructInviteLink` deep-copy assertion (saved template stays at original `id`; only the URL-embedded template has the bumped `ratchet.id`).
+
+*Created 2026-06-07. Implementation log appended 2026-06-07. Late-stage UI revision section appended 2026-06-07.*

--- a/.agents/tasks/.todo/2026-01-09-delete-public-invite-link.md
+++ b/.agents/tasks/.todo/2026-01-09-delete-public-invite-link.md
@@ -4,7 +4,7 @@ title: 'Task: Implement Delete Public Invite Link Feature'
 status: open
 ai_generated: true
 created: 2026-01-09T00:00:00.000Z
-updated: '2026-01-09'
+updated: '2026-06-07'
 related_issues:
   - '#101'
 ---
@@ -16,6 +16,8 @@ related_issues:
 https://github.com/QuilibriumNetwork/quorum-desktop/issues/101
 
 Enable space owners to delete public invite links, removing server-side invite evals and returning to private-only mode.
+
+> **2026-06-07 context update:** the invite-system consolidation (`tasks/2026-06-07-consolidate-invite-system-with-mobile.md`) removed the "system switch is permanent" framing — one-time and public invites now coexist on the same space and don't conflict. However, the underlying limitation this task addresses still applies: there is no backend endpoint to remove server-side evals, so a public link cannot be truly revoked even after the consolidation. Owners can refresh the link to rotate the server-side eval, but the URL remains resolvable. This task is still legitimate, just narrower in scope.
 
 ## Prerequisites
 

--- a/src/components/context/MessageDB.tsx
+++ b/src/components/context/MessageDB.tsx
@@ -186,7 +186,9 @@ type MessageDBContextValue = {
       displayName?: string;
       pfpUrl?: string;
       completedOnboarding: boolean;
-    }
+    },
+    mode?: 'one-time' | 'public' | 'reuse',
+    presetLink?: string
   ) => Promise<void>;
   generateNewInviteLink: (
     spaceId: string,
@@ -194,6 +196,7 @@ type MessageDBContextValue = {
     device_keyset: secureChannel.DeviceKeyset,
     registration: secureChannel.UserRegistration
   ) => Promise<void>;
+  constructInviteLink: (spaceId: string) => Promise<string>;
   processInviteLink: (inviteLink: string) => Promise<Space>;
   joinInviteLink: (
     inviteLink: string,
@@ -753,9 +756,11 @@ const MessageDBProvider: FC<MessageDBContextProps> = ({ children }) => {
         displayName?: string;
         pfpUrl?: string;
         completedOnboarding: boolean;
-      }
+      },
+      mode: 'one-time' | 'public' | 'reuse' = 'one-time',
+      presetLink?: string
     ) => {
-      return invitationService.sendInviteToUser(address, spaceId, currentPasskeyInfo, keyset, submitMessage);
+      return invitationService.sendInviteToUser(address, spaceId, currentPasskeyInfo, keyset, submitMessage, mode, presetLink);
     },
     [invitationService, keyset, submitMessage]
   );
@@ -768,6 +773,13 @@ const MessageDBProvider: FC<MessageDBContextProps> = ({ children }) => {
       registration: secureChannel.UserRegistration
     ) => {
       return invitationService.generateNewInviteLink(spaceId, user_keyset, device_keyset, registration);
+    },
+    [invitationService]
+  );
+
+  const constructInviteLink = React.useCallback(
+    async (spaceId: string) => {
+      return invitationService.constructInviteLink(spaceId);
     },
     [invitationService]
   );
@@ -1401,6 +1413,7 @@ const MessageDBProvider: FC<MessageDBContextProps> = ({ children }) => {
         ensureKeyForSpace,
         sendInviteToUser,
         generateNewInviteLink,
+        constructInviteLink,
         processInviteLink,
         joinInviteLink,
         deleteSpace,
@@ -1440,6 +1453,7 @@ const MessageDBContext = createContext<MessageDBContextValue>({
   ensureKeyForSpace: () => undefined as never,
   sendInviteToUser: () => undefined as never,
   generateNewInviteLink: () => undefined as never,
+  constructInviteLink: () => undefined as never,
   processInviteLink: () => undefined as never,
   joinInviteLink: () => undefined as never,
   deleteSpace: () => undefined as never,

--- a/src/components/modals/SpaceSettingsModal/Invites.tsx
+++ b/src/components/modals/SpaceSettingsModal/Invites.tsx
@@ -5,6 +5,9 @@ import { t } from '@lingui/core/macro';
 import { ClickToCopyContent } from '../../ui';
 import { UserAvatar } from '../../user/UserAvatar';
 import { DefaultImages } from '../../../utils';
+import { useCopyToClipboard } from '../../../hooks/business/ui/useCopyToClipboard';
+
+type InviteMode = 'one-time' | 'public';
 
 interface InvitesProps {
   space: any;
@@ -15,13 +18,28 @@ interface InvitesProps {
   resolvedUser: any;
   getUserOptions: () => any[];
   sendingInvite: boolean;
-  invite: (address: string) => void;
+  invite: (
+    address: string,
+    mode?: 'one-time' | 'public' | 'reuse',
+    presetLink?: string
+  ) => void;
   success: boolean;
   membershipWarning: string | undefined;
   generating: boolean;
   generationSuccess: boolean;
+  refreshSuccess: boolean;
   errorMessage: string;
   setShowGenerateModal: (show: boolean) => void;
+  refreshInviteLink: () => Promise<void>;
+  // One-time "Copy a link" support — mint + clipboard write under the hood.
+  // The UI never displays a persistent link, so `generatedOneTimeLink` from
+  // the hook isn't exposed here; same for `generatingOneTimeLink` (button
+  // drives its own spinner state).
+  generateOneTimeLink: () => Promise<string | null>;
+  clearGeneratedOneTimeLink: () => void;
+  generateOneTimeLinkError: string | undefined;
+  poolExhausted: boolean;
+  isSpaceOwner: boolean;
 }
 
 interface SearchableConversationSelectProps {
@@ -42,7 +60,6 @@ const SearchableConversationSelect: React.FunctionComponent<SearchableConversati
   const selectRef = React.useRef<HTMLDivElement>(null);
   const dropdownRef = React.useRef<HTMLDivElement>(null);
 
-  // Filter options based on search
   const filteredOptions = React.useMemo(() => {
     if (!searchInput.trim()) return options;
     const term = searchInput.toLowerCase();
@@ -53,10 +70,8 @@ const SearchableConversationSelect: React.FunctionComponent<SearchableConversati
     );
   }, [options, searchInput]);
 
-  // Find selected option for display
   const selectedOption = options.find(opt => opt.value === value);
 
-  // Close dropdown when clicking outside
   React.useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       const target = event.target as Node;
@@ -95,10 +110,9 @@ const SearchableConversationSelect: React.FunctionComponent<SearchableConversati
 
   return (
     <div ref={selectRef} className="relative w-full">
-      {/* Select trigger button */}
       <button
         type="button"
-        className="w-full px-3 py-2 bg-[var(--color-field-bg)] border border-transparent rounded-lg text-left flex items-center justify-between hover:bg-[var(--color-field-bg-focus)] transition-colors"
+        className="w-full px-3 py-2 bg-[var(--color-field-bg)] border border-transparent rounded-lg text-left flex items-center justify-between hover:bg-[var(--color-field-bg-focus)] transition-colors cursor-pointer"
         onClick={() => setIsOpen(!isOpen)}
       >
         <span className="flex items-center gap-2 flex-1">
@@ -125,13 +139,11 @@ const SearchableConversationSelect: React.FunctionComponent<SearchableConversati
         />
       </button>
 
-      {/* Dropdown */}
       {isOpen && (
         <div
           ref={dropdownRef}
           className="absolute top-full left-0 w-full z-[10200] mt-1 bg-[var(--color-field-options-bg)] border-0 rounded-lg shadow-md max-h-60 overflow-hidden"
         >
-          {/* Search input */}
           <div className="p-2 border-b border-[var(--color-field-border)]">
             <div className="flex items-center gap-2 ml-1">
               <Icon name="search" size="sm" className="text-subtle" />
@@ -148,7 +160,6 @@ const SearchableConversationSelect: React.FunctionComponent<SearchableConversati
             </div>
           </div>
 
-          {/* Options list */}
           <div className="max-h-48 overflow-y-auto overflow-x-hidden">
             {filteredOptions.length === 0 ? (
               <div className="p-3 text-subtle text-sm">
@@ -168,7 +179,6 @@ const SearchableConversationSelect: React.FunctionComponent<SearchableConversati
                     onClick={() => handleSelect(option.value)}
                   >
                     <div className="flex items-center gap-3 flex-1 min-w-0">
-                      {/* Avatar */}
                       {hasValidAvatar ? (
                         <div
                           className="w-8 h-8 rounded-full bg-cover bg-center flex-shrink-0"
@@ -183,7 +193,6 @@ const SearchableConversationSelect: React.FunctionComponent<SearchableConversati
                         />
                       ) : null}
 
-                      {/* Text content */}
                       <div className="flex-1 min-w-0">
                         <div className="text-sm font-medium truncate">
                           {option.label}
@@ -196,7 +205,6 @@ const SearchableConversationSelect: React.FunctionComponent<SearchableConversati
                       </div>
                     </div>
 
-                    {/* Selected indicator */}
                     {isSelected && (
                       <Icon
                         name="check"
@@ -215,6 +223,117 @@ const SearchableConversationSelect: React.FunctionComponent<SearchableConversati
   );
 };
 
+interface ModeToggleProps {
+  mode: InviteMode;
+  setMode: (m: InviteMode) => void;
+  publicDisabled: boolean;
+}
+
+const ModeToggle: React.FunctionComponent<ModeToggleProps> = ({ mode, setMode, publicDisabled }) => {
+  // Underline-style tabs.
+  // Matches the pattern used on the Discover page.
+  const base =
+    'flex items-center gap-2 px-1 py-2 text-sm font-semibold bg-transparent border-0 border-b-2 transition-colors cursor-pointer';
+  const inactive =
+    'text-[var(--color-text-subtle)] border-transparent hover:text-[rgb(var(--color-text-main))]';
+  const active = 'text-[var(--color-text-strong)] border-[var(--accent)]';
+
+  return (
+    <div className="flex gap-6 border-b border-[var(--color-border-default)]">
+      <button
+        type="button"
+        className={`${base} ${mode === 'one-time' ? active : inactive}`}
+        onClick={() => setMode('one-time')}
+      >
+        <Icon name="user" size="sm" />
+        <Trans>One-Time</Trans>
+      </button>
+      <button
+        type="button"
+        disabled={publicDisabled}
+        className={`${base} ${mode === 'public' ? active : inactive} ${
+          publicDisabled
+            ? 'opacity-50 !cursor-not-allowed hover:!text-[var(--color-text-subtle)]'
+            : ''
+        }`}
+        onClick={() => !publicDisabled && setMode('public')}
+      >
+        <Icon name="globe" size="sm" />
+        <Trans>Public Link</Trans>
+      </button>
+    </div>
+  );
+};
+
+interface DmPickerProps {
+  selectedUser: any;
+  setSelectedUser: (user: any) => void;
+  manualAddress: string;
+  setManualAddress: (address: string) => void;
+  getUserOptions: () => any[];
+  showManualAddress: boolean;
+  setShowManualAddress: (show: boolean) => void;
+}
+
+const DmPicker: React.FunctionComponent<DmPickerProps> = ({
+  selectedUser,
+  setSelectedUser,
+  manualAddress,
+  setManualAddress,
+  getUserOptions,
+  showManualAddress,
+  setShowManualAddress,
+}) => (
+  <>
+    <div className="input-style-label">
+      <Trans>Existing Conversations</Trans>
+    </div>
+    <SearchableConversationSelect
+      value={selectedUser?.address || ''}
+      options={getUserOptions()}
+      onChange={(address: string) => {
+        const allConversations = getUserOptions();
+        const conversation = allConversations.find((c) => c.value === address);
+        if (conversation) {
+          setSelectedUser({
+            address: conversation.value,
+            displayName: conversation.label,
+            icon: conversation.avatar,
+          } as any);
+          setManualAddress('');
+        }
+      }}
+      placeholder={t`Select conversation`}
+    />
+    <Spacer size="sm" />
+    <div>
+      <Button
+        type="unstyled"
+        onClick={() => setShowManualAddress(!showManualAddress)}
+        className="flex items-center gap-2 p-0"
+      >
+        <span>
+          <Trans>Enter Address Manually</Trans>
+        </span>
+        <Icon
+          name={showManualAddress ? 'chevron-down' : 'chevron-right'}
+          size="sm"
+        />
+      </Button>
+    </div>
+    {showManualAddress && (
+      <div className="mt-2">
+        <Input
+          className="w-full placeholder:text-sm"
+          value={manualAddress}
+          placeholder={t`Type the address of the user you want to send to`}
+          onChange={setManualAddress}
+        />
+      </div>
+    )}
+  </>
+);
+
 const Invites: React.FunctionComponent<InvitesProps> = ({
   space,
   selectedUser,
@@ -229,11 +348,77 @@ const Invites: React.FunctionComponent<InvitesProps> = ({
   membershipWarning,
   generating,
   generationSuccess,
+  refreshSuccess,
   errorMessage,
   setShowGenerateModal,
+  refreshInviteLink,
+  generateOneTimeLink,
+  clearGeneratedOneTimeLink,
+  generateOneTimeLinkError,
+  poolExhausted,
+  isSpaceOwner,
 }) => {
-  // State for showing/hiding manual address field
+  // Default to public mode if a public link already exists (likely intent on
+  // re-open). Non-owners are stuck on one-time.
+  const [mode, setMode] = React.useState<InviteMode>(
+    isSpaceOwner && space?.inviteUrl ? 'public' : 'one-time'
+  );
   const [showManualAddress, setShowManualAddress] = React.useState<boolean>(false);
+  // Both modes hide the DM picker behind a "Send via DM" toggle.
+  const [showPublicDmPicker, setShowPublicDmPicker] = React.useState<boolean>(false);
+  const [showOneTimeDmPicker, setShowOneTimeDmPicker] = React.useState<boolean>(false);
+  // "Link copied" callout. Persists until dismissed.
+  const [oneTimeLinkCopied, setOneTimeLinkCopied] = React.useState<boolean>(false);
+  // Mirrors the hook's transient `success` so the "Invite sent" callout
+  // persists until the user dismisses it or fires another send.
+  const [oneTimeSentVisible, setOneTimeSentVisible] = React.useState<boolean>(false);
+  // Drives the Copy button's in-button spinner. We use a local flag because
+  // the underlying mint is near-instant (no network); without a minimum
+  // window the spinner just flickers and the user can't tell anything happened.
+  const [oneTimeCopying, setOneTimeCopying] = React.useState<boolean>(false);
+
+  const { copyToClipboard } = useCopyToClipboard();
+
+  const publicDisabled = !isSpaceOwner;
+
+  // Force one-time mode if owner status flips false mid-modal.
+  React.useEffect(() => {
+    if (publicDisabled && mode === 'public') setMode('one-time');
+  }, [publicDisabled, mode]);
+
+  // Reset the picker expansions and the persistent one-time callouts when
+  // the user switches modes.
+  React.useEffect(() => {
+    setShowPublicDmPicker(false);
+    setShowOneTimeDmPicker(false);
+    setOneTimeLinkCopied(false);
+    setOneTimeSentVisible(false);
+  }, [mode]);
+
+  // After a successful one-time DM send: clear the picked contact (so the
+  // user can immediately pick another) and surface the "Invite sent" callout.
+  React.useEffect(() => {
+    if (mode !== 'one-time') return;
+    if (success) {
+      setSelectedUser(undefined);
+      setManualAddress('');
+      setOneTimeSentVisible(true);
+    }
+  }, [success, mode, setSelectedUser, setManualAddress]);
+
+  const sendArgs: { mode: 'one-time' | 'public' } = { mode };
+
+  const canSend =
+    !sendingInvite && !poolExhausted && (selectedUser || resolvedUser);
+
+  const onSend = () => {
+    const address = selectedUser?.address ?? resolvedUser?.user_address;
+    if (!address) return;
+    // Hide any leftover "Invite sent" callout so the user sees a fresh one
+    // for this send.
+    setOneTimeSentVisible(false);
+    invite(address, sendArgs.mode);
+  };
 
   return (
     <>
@@ -242,232 +427,379 @@ const Invites: React.FunctionComponent<InvitesProps> = ({
           <div className="text-title">
             <Trans>Invites</Trans>
           </div>
-          <div className="pt-2 text-body">
-            <Trans>
-              Manage Inivte links and send invites to people you've previously had
-              conversations with.
-            </Trans>
-          </div>
         </div>
       </div>
+
       <div className="modal-content-section">
-        <div className="flex"></div>
-        <div className=""></div>
         <div className="modal-content-info">
-          {/* Section header changes based on whether public link exists */}
-          <div className="text-subtitle-2 mb-1">
-            {space?.inviteUrl ? (
-              <Trans>Share Public Link</Trans>
-            ) : (
-              <Trans>Send Private Invite</Trans>
-            )}
-          </div>
-          <div className="text-label pt-1 mb-4 max-w-[500px]">
-            {space?.inviteUrl ? (
-              <Trans>Send your public invite link directly to someone via DM.</Trans>
-            ) : (
-              <Trans>Send a unique invite link directly to someone. Each invite can only be used once.</Trans>
-            )}
-          </div>
-          <div className="input-style-label">
-            <Trans>Existing Conversations</Trans>
-          </div>
-          <SearchableConversationSelect
-            value={selectedUser?.address || ''}
-            options={getUserOptions()}
-            onChange={(address: string) => {
-              // Find conversation and set selected user
-              const allConversations = getUserOptions();
-              const conversation = allConversations.find(
-                (c) => c.value === address
-              );
-              if (conversation) {
-                setSelectedUser({
-                  address: conversation.value,
-                  displayName: conversation.label,
-                  icon: conversation.avatar,
-                } as any);
-                setManualAddress('');
-              }
-            }}
-            placeholder={t`Select conversation`}
+          {/* Mode toggle */}
+          <ModeToggle
+            mode={mode}
+            setMode={setMode}
+            publicDisabled={publicDisabled}
           />
-          <Spacer size="md"></Spacer>
 
-          {/* Manual Address Toggle */}
-          <div>
-            <Button
-              type="unstyled"
-              onClick={() => setShowManualAddress(!showManualAddress)}
-              className="flex items-center gap-2 p-0"
-            >
-              <span><Trans>Enter Address Manually</Trans></span>
-              <Icon
-                name={showManualAddress ? "chevron-down" : "chevron-right"}
-                size="sm"
-              />
-            </Button>
-          </div>
+          <Spacer size="md" />
 
-          {/* Manual Address Input - Collapsible */}
-          {showManualAddress && (
-            <div className="mt-2 mb-6">
-              <Input
-                className="w-full placeholder:text-sm"
-                value={manualAddress}
-                placeholder="Type the address of the user you want to send to"
-                onChange={setManualAddress}
-              />
-            </div>
-          )}
-
-          {/* Send Invite Button - Moved here */}
-          <div className="flex gap-2 mt-4">
-            <Button
-              type="primary"
-              disabled={
-                sendingInvite || (!selectedUser && !resolvedUser)
-              }
-              onClick={() => {
-                if (selectedUser) {
-                  invite(selectedUser.address);
-                } else if (resolvedUser) {
-                  invite(resolvedUser.user_address);
-                }
-              }}
-            >
-              {space?.inviteUrl ? (
-                <Trans>Send Invite</Trans>
-              ) : (
-                <Trans>Send Private Invite</Trans>
-              )}
-            </Button>
-          </div>
-          {success && (
-            <>
-              <Spacer size="sm"/>
-              <Callout variant="success" layout="minimal" size="sm" autoClose={3}>
+          {/* Mode-specific intro copy. Public mode hides it once a link is
+              displayed (the link box is self-explanatory); one-time mode
+              always shows it (there's never a persistent link on screen). */}
+          {(mode === 'one-time' || !space?.inviteUrl) && (
+            <div className="text-label mb-4 max-w-[500px]">
+              {mode === 'one-time' ? (
                 <Trans>
-                  Successfully sent invite to{' '}
-                  {selectedUser?.displayName}
+                  Send a one-time invite directly to someone. Each link can only
+                  be used once.
                 </Trans>
-              </Callout>
-            </>
+              ) : (
+                <Trans>
+                  A reusable link anyone can use to join. Share it on social
+                  media or your website.
+                </Trans>
+              )}
+            </div>
           )}
-          {membershipWarning && (
+
+          {poolExhausted && (
+            <Callout variant="warning" size="sm" className="mb-4">
+              <div className="text-sm">
+                {space?.inviteUrl && mode === 'one-time' ? (
+                  <Trans>
+                    New one-time invites can't be issued from this device for
+                    this Space. The public invite link still works — switch
+                    to <b>Public Link</b> above to copy it or send it via DM.
+                  </Trans>
+                ) : space?.inviteUrl && mode === 'public' ? (
+                  <Trans>
+                    New invites can't be issued from this device, but the
+                    existing public invite link still works — copy it or
+                    send it via DM below.
+                  </Trans>
+                ) : (
+                  <Trans>
+                    New invites can't be issued from this device for this
+                    Space. Existing invite links keep working. This
+                    typically affects spaces created on the desktop app
+                    before June 2026.
+                  </Trans>
+                )}
+              </div>
+            </Callout>
+          )}
+
+          {/* One-time mode: two parallel actions, no displayed link.
+              - Send via DM: expands inline picker. Each Send mints a fresh
+                URL invisibly and DMs it. Multiple sends in a row each
+                generate independent links — no "same URL to many" footgun.
+              - Copy a link: mints + clipboard, shows a callout. Never
+                rendered on screen. */}
+          {mode === 'one-time' && (
             <>
-              <Spacer size="sm"/>
-              <Callout variant="warning" layout="minimal" size="sm" autoClose={5}>
-                {membershipWarning}
-              </Callout>
+              {generateOneTimeLinkError && (
+                <Callout variant="error" size="sm" className="mb-4">
+                  <span>{generateOneTimeLinkError}</span>
+                </Callout>
+              )}
+
+              {oneTimeLinkCopied && (
+                <Callout
+                  variant="success"
+                  size="sm"
+                  className="mb-4"
+                  dismissible
+                  onClose={() => setOneTimeLinkCopied(false)}
+                >
+                  <Trans>
+                    Link copied. Paste it where you want to share it.
+                  </Trans>
+                </Callout>
+              )}
+
+              <div className="flex gap-2 items-center">
+                <Button
+                  type="secondary"
+                  onClick={() => {
+                    // Toggle Send via DM. When opening it, dismiss any
+                    // leftover "Link copied" from a prior Copy a link.
+                    // When closing it, also clear the Invite-sent callout
+                    // so the next reopen is clean.
+                    setShowOneTimeDmPicker((v) => {
+                      const opening = !v;
+                      if (opening) {
+                        setOneTimeLinkCopied(false);
+                      } else {
+                        setOneTimeSentVisible(false);
+                      }
+                      return opening;
+                    });
+                  }}
+                >
+                  <Trans>Send via DM</Trans>
+                  <Icon
+                    name={
+                      showOneTimeDmPicker ? 'chevron-down' : 'chevron-right'
+                    }
+                    size="sm"
+                    className="ml-1"
+                  />
+                </Button>
+                <Tooltip
+                  id="copy-one-time-link-tooltip"
+                  content={t`Generate a fresh one-time invite link and copy it to your clipboard. Each click creates a new link. Paste it wherever you want (email, WhatsApp, etc.).`}
+                  place="bottom"
+                  className="!w-[400px]"
+                  maxWidth={400}
+                >
+                  <Button
+                    type="subtle-outline"
+                    disabled={poolExhausted || oneTimeCopying}
+                    onClick={async () => {
+                      // Collapse the DM picker and clear any leftover
+                      // Invite-sent state so the Copy callout is the only
+                      // thing on screen after this action.
+                      setShowOneTimeDmPicker(false);
+                      setOneTimeSentVisible(false);
+                      // 1.2s minimum so the in-button spinner is perceivable.
+                      setOneTimeCopying(true);
+                      setOneTimeLinkCopied(false);
+                      try {
+                        const [link] = await Promise.all([
+                          generateOneTimeLink(),
+                          new Promise<void>((r) => window.setTimeout(r, 1200)),
+                        ]);
+                        if (link) {
+                          await copyToClipboard(link);
+                          clearGeneratedOneTimeLink();
+                          setOneTimeLinkCopied(true);
+                        }
+                      } finally {
+                        setOneTimeCopying(false);
+                      }
+                    }}
+                  >
+                    {oneTimeCopying ? (
+                      <div className="flex items-center gap-2">
+                        <Icon name="spinner" size="sm" className="icon-spin" />
+                        <Trans>Generating…</Trans>
+                      </div>
+                    ) : (
+                      <Trans>Copy a link</Trans>
+                    )}
+                  </Button>
+                </Tooltip>
+              </div>
+
+              {showOneTimeDmPicker && (
+                <div className="mt-4">
+                  {oneTimeSentVisible && (
+                    <Callout
+                      variant="success"
+                      size="sm"
+                      className="mb-4"
+                      dismissible
+                      onClose={() => setOneTimeSentVisible(false)}
+                    >
+                      <Trans>Invite sent. Pick another contact to send another.</Trans>
+                    </Callout>
+                  )}
+                  {membershipWarning && (
+                    <Callout
+                      variant="warning"
+                      size="sm"
+                      className="mb-4"
+                    >
+                      {membershipWarning}
+                    </Callout>
+                  )}
+
+                  <DmPicker
+                    selectedUser={selectedUser}
+                    setSelectedUser={setSelectedUser}
+                    manualAddress={manualAddress}
+                    setManualAddress={setManualAddress}
+                    getUserOptions={getUserOptions}
+                    showManualAddress={showManualAddress}
+                    setShowManualAddress={setShowManualAddress}
+                  />
+                  <div className="flex gap-2 mt-4">
+                    <Button type="primary" disabled={!canSend} onClick={onSend}>
+                      <Trans>Send Invite</Trans>
+                    </Button>
+                  </div>
+                </div>
+              )}
             </>
           )}
-          <Spacer
-            spaceBefore="lg"
-            spaceAfter="md"
-            border={true}
-            direction="vertical"
-          />
-          <div>
-            <div className="text-subtitle-2 mb-1">
-              <Trans>Public Invite Links</Trans>
-            </div>
-            <div className="text-label pt-1 mb-4 max-w-[500px]">
-              <Trans>
-                Public invite links allow anyone with access to the link to join your Space.
-                Consider who you share the link with and where you post it.
-              </Trans>
-            </div>
 
-            {/* Callouts for operations */}
-            {generating && (
-              <Callout variant="warning" size="sm" className="mb-4">
-                <div className="flex items-center gap-2">
-                  <Icon name="spinner" className="text-warning icon-spin" />
-                  <span>Generating public invite link...</span>
-                </div>
-              </Callout>
-            )}
+          {/* Public mode: link box + Send via DM + Republish, or the
+              first-time generate button if no link exists. */}
+          {mode === 'public' && (
+            <>
+              {generating && (
+                <Callout variant="warning" size="sm" className="mb-4">
+                  <div className="flex items-center gap-2">
+                    <Icon name="spinner" className="text-warning icon-spin" />
+                    <span>
+                      <Trans>Generating public invite link...</Trans>
+                    </span>
+                  </div>
+                </Callout>
+              )}
 
-            {generationSuccess && (
-              <Callout variant="success" size="sm" className="mb-4" autoClose={3}>
-                <span>Public invite link generated successfully.</span>
-              </Callout>
-            )}
+              {generationSuccess && (
+                <Callout
+                  variant="success"
+                  size="sm"
+                  className="mb-4"
+                  autoClose={3}
+                >
+                  <span>
+                    <Trans>Public invite link generated successfully.</Trans>
+                  </span>
+                </Callout>
+              )}
 
-            {errorMessage && (
-              <Callout variant="error" size="sm" className="mb-4">
-                <span>{errorMessage}</span>
-              </Callout>
-            )}
+              {refreshSuccess && (
+                <Callout
+                  variant="success"
+                  size="sm"
+                  className="mb-4"
+                  autoClose={3}
+                >
+                  <span>
+                    <Trans>Join preview updated.</Trans>
+                  </span>
+                </Callout>
+              )}
 
-            {!space?.inviteUrl && !generating ? (
-              // STATE 1: No link exists and not generating - Show generate button
-              <div>
+              {errorMessage && (
+                <Callout variant="error" size="sm" className="mb-4">
+                  <span>{errorMessage}</span>
+                </Callout>
+              )}
+
+              {space?.inviteUrl && !generating ? (
+                <>
+                  <div className="flex pb-1 items-center">
+                    <div className="input-style-label">
+                      <Trans>Current Invite Link</Trans>
+                    </div>
+                    <Tooltip
+                      id="current-invite-link-tooltip"
+                      content={t`This link does not expire. Anyone with it can join your Space.`}
+                      place="bottom"
+                      className="!w-[400px]"
+                      maxWidth={400}
+                    >
+                      <Icon
+                        name="info-circle"
+                        className="text-main hover:text-strong cursor-pointer ml-2 -mt-1"
+                        size="sm"
+                      />
+                    </Tooltip>
+                  </div>
+
+                  <ClickToCopyContent
+                    text={space.inviteUrl}
+                    tooltipText={t`Copy invite link to clipboard`}
+                    className="bg-field border-0 rounded-md px-3 py-1.5 text-sm w-full max-w-full overflow-hidden whitespace-nowrap cursor-pointer"
+                    iconClassName="text-muted hover:text-main"
+                    copyOnContentClick
+                  >
+                    <div className="flex items-center gap-2 w-full">
+                      <div className="truncate flex-1 text-subtle">
+                        {space.inviteUrl}
+                      </div>
+                    </div>
+                  </ClickToCopyContent>
+
+                  <div className="flex gap-2 mt-4 items-center">
+                    <Button
+                      type="secondary"
+                      onClick={() => setShowPublicDmPicker((v) => !v)}
+                    >
+                      <Trans>Send via DM</Trans>
+                      <Icon
+                        name={
+                          showPublicDmPicker ? 'chevron-down' : 'chevron-right'
+                        }
+                        size="sm"
+                        className="ml-1"
+                      />
+                    </Button>
+                    <Tooltip
+                      id="republish-invite-tooltip"
+                      content={t`If users report that this invite link isn't working, click to republish it. The link URL stays the same.`}
+                      place="bottom"
+                      className="!w-[400px]"
+                      maxWidth={400}
+                    >
+                      <Button
+                        type="subtle-outline"
+                        onClick={() => { void refreshInviteLink(); }}
+                        disabled={generating || poolExhausted}
+                      >
+                        <Trans>Republish</Trans>
+                      </Button>
+                    </Tooltip>
+                  </div>
+
+                  {showPublicDmPicker && (
+                    <div className="mt-4">
+                      {success && (
+                        <Callout
+                          variant="success"
+                          size="sm"
+                          className="mb-4"
+                          dismissible
+                        >
+                          <Trans>Invite sent. Pick another contact to send another.</Trans>
+                        </Callout>
+                      )}
+                      {membershipWarning && (
+                        <Callout
+                          variant="warning"
+                          size="sm"
+                          className="mb-4"
+                        >
+                          {membershipWarning}
+                        </Callout>
+                      )}
+
+                      <DmPicker
+                        selectedUser={selectedUser}
+                        setSelectedUser={setSelectedUser}
+                        manualAddress={manualAddress}
+                        setManualAddress={setManualAddress}
+                        getUserOptions={getUserOptions}
+                        showManualAddress={showManualAddress}
+                        setShowManualAddress={setShowManualAddress}
+                      />
+                      <div className="flex gap-2 mt-4">
+                        <Button
+                          type="primary"
+                          disabled={!canSend}
+                          onClick={onSend}
+                        >
+                          <Trans>Send Link</Trans>
+                        </Button>
+                      </div>
+                    </div>
+                  )}
+                </>
+              ) : !space?.inviteUrl && !generating ? (
                 <div className="flex">
                   <Button
-                    type="secondary"
+                    type="primary"
                     onClick={() => setShowGenerateModal(true)}
-                    disabled={generating}
+                    disabled={generating || poolExhausted}
                   >
                     <Trans>Generate Public Invite Link</Trans>
                   </Button>
                 </div>
-              </div>
-            ) : !space?.inviteUrl && generating ? (
-              // STATE 1b: Generating first link - Only show callout
-              null
-            ) : space?.inviteUrl && generating ? (
-              // STATE 2b: Regenerating link - Only show callout
-              null
-            ) : (
-              // STATE 2: Link exists and not generating - Show link + action buttons
-              <div>
-                <div className="flex pb-1 items-center">
-                  <div className="input-style-label">
-                    <Trans>Current Invite Link</Trans>
-                  </div>
-                  <Tooltip
-                    id="current-invite-link-tooltip"
-                    content={t`This link will not expire, but you can generate a new one at any time, which will invalidate the old link.`}
-                    place="bottom"
-                    className="!w-[400px]"
-                    maxWidth={400}
-                  >
-                    <Icon
-                      name="info-circle"
-                      className="text-main hover:text-strong cursor-pointer ml-2 -mt-1"
-                      size="sm"
-                    />
-                  </Tooltip>
-                </div>
-
-                <ClickToCopyContent
-                  text={space?.inviteUrl || ''}
-                  tooltipText={t`Copy invite link to clipboard`}
-                  className="bg-field border-0 rounded-md px-3 py-1.5 text-sm w-full max-w-full overflow-hidden whitespace-nowrap cursor-pointer"
-                  iconClassName="text-muted hover:text-main"
-                  copyOnContentClick
-                >
-                  <div className="flex items-center gap-2 w-full">
-                    <div className="truncate flex-1 text-subtle">
-                      {space?.inviteUrl}
-                    </div>
-                  </div>
-                </ClickToCopyContent>
-
-                <div className="flex gap-2 mt-4">
-                  <Button
-                    type="secondary"
-                    onClick={() => setShowGenerateModal(true)}
-                    disabled={generating}
-                  >
-                    <Trans>Generate New Link</Trans>
-                  </Button>
-                </div>
-              </div>
-            )}
-          </div>
+              ) : null}
+            </>
+          )}
         </div>
       </div>
     </>

--- a/src/components/modals/SpaceSettingsModal/Navigation.tsx
+++ b/src/components/modals/SpaceSettingsModal/Navigation.tsx
@@ -24,7 +24,7 @@ const Navigation: React.FunctionComponent<NavigationProps> = ({
     { id: 'space-tag', icon: 'tag', label: t`Space Tag`, className: '' },
     { id: 'emojis', icon: 'smile', label: t`Emojis`, className: '' },
     { id: 'stickers', icon: 'image', label: t`Stickers`, className: '' },
-    { id: 'invites', icon: 'user-plus', label: t`Invites`, className: '' },
+    { id: 'invites', icon: 'share', label: t`Invites`, className: '' },
     { id: 'danger', icon: 'warning', label: t`Delete Space`, className: 'text-danger' },
   ];
 

--- a/src/components/modals/SpaceSettingsModal/SpaceSettingsModal.tsx
+++ b/src/components/modals/SpaceSettingsModal/SpaceSettingsModal.tsx
@@ -29,6 +29,7 @@ import {
 import { useMentionNotificationSettings } from '../../../hooks/business/mentions';
 import { showToast } from '../../../utils/toast';
 import { useSpaceTag } from '../../../hooks/business/spaces/useSpaceTag';
+import { InviteEvalsExhaustedError } from '../../../services/InvitationService';
 import Account from './Account';
 import General from './General';
 import Channels from './Channels';
@@ -257,7 +258,11 @@ const SpaceSettingsModal: React.FunctionComponent<{
     sendingInvite,
     success,
     membershipWarning,
+    poolExhausted,
     invite,
+    generateOneTimeLink,
+    clearGeneratedOneTimeLink,
+    generateOneTimeLinkError,
     publicInvite,
     setPublicInvite,
     generating,
@@ -327,6 +332,7 @@ const SpaceSettingsModal: React.FunctionComponent<{
 
   // Public invite link state management
   const [generationSuccess, setGenerationSuccess] = React.useState(false);
+  const [refreshSuccess, setRefreshSuccess] = React.useState(false);
   const [errorMessage, setErrorMessage] = React.useState('');
   const [showGenerateModal, setShowGenerateModal] = React.useState(false);
 
@@ -598,6 +604,30 @@ const SpaceSettingsModal: React.FunctionComponent<{
                           generationSuccess={generationSuccess}
                           errorMessage={errorMessage}
                           setShowGenerateModal={setShowGenerateModal}
+                          refreshSuccess={refreshSuccess}
+                          generateOneTimeLink={generateOneTimeLink}
+                          clearGeneratedOneTimeLink={clearGeneratedOneTimeLink}
+                          generateOneTimeLinkError={generateOneTimeLinkError}
+                          refreshInviteLink={async () => {
+                            // Refresh = same URL, fresh server eval + manifest.
+                            // Nothing to confirm — old link stays valid.
+                            setErrorMessage('');
+                            try {
+                              await generateNewInviteLink();
+                              setRefreshSuccess(true);
+                              setTimeout(() => setRefreshSuccess(false), 3000);
+                            } catch (error) {
+                              if (error instanceof InviteEvalsExhaustedError) {
+                                // Pool-exhausted state is surfaced via the
+                                // hook's `poolExhausted` flag + banner, not
+                                // as a transient error.
+                                return;
+                              }
+                              setErrorMessage(t`Failed to update join preview. Please try again.`);
+                            }
+                          }}
+                          poolExhausted={poolExhausted}
+                          isSpaceOwner={!!isSpaceOwner}
                         />
                       );
                     case 'danger':
@@ -656,17 +686,16 @@ const SpaceSettingsModal: React.FunctionComponent<{
         </div>
       </Modal>
 
-      {/* Confirmation modals for invite management */}
+      {/* First-time public-invite generation is gated by a confirmation modal
+          because it's the moment a space becomes publicly joinable. Subsequent
+          refreshes go through `refreshInviteLink` (no confirm — same URL,
+          old link keeps working). */}
       {showGenerateModal && (
         <ConfirmationModal
           visible={showGenerateModal}
           title={t`Generate Public Invite Link`}
-          message={
-            space?.inviteUrl
-              ? t`This will generate a new public invite link and invalidate the current one. Anyone with the old link will no longer be able to use it.`
-              : t`This will create a public invite link that anyone can use to join your Space. Consider who you share this link with.`
-          }
-          confirmText={space?.inviteUrl ? t`Generate New Link` : t`Generate Link`}
+          message={t`This will create a public invite link that anyone can use to join your Space. Consider who you share this link with.`}
+          confirmText={t`Generate Link`}
           onConfirm={async () => {
             setShowGenerateModal(false);
             setErrorMessage('');
@@ -675,6 +704,10 @@ const SpaceSettingsModal: React.FunctionComponent<{
               setGenerationSuccess(true);
               setTimeout(() => setGenerationSuccess(false), 3000);
             } catch (error) {
+              if (error instanceof InviteEvalsExhaustedError) {
+                // Surfaced via the persistent banner; no transient error.
+                return;
+              }
               setErrorMessage(t`Failed to generate invite link. Please try again.`);
             }
           }}

--- a/src/dev/tests/services/InvitationService.unit.test.tsx
+++ b/src/dev/tests/services/InvitationService.unit.test.tsx
@@ -48,7 +48,9 @@ vi.mock('@quilibrium/quilibrium-js-sdk-channels', () => ({
       JSON.stringify(JSON.stringify({ spaceId: 'space-123', spaceName: 'Test Space', defaultChannelId: 'chan-1', inviteUrl: 'https://qm.one/invite/#spaceId=space-123&configKey=aabbcc' }))
     ),
     js_get_pubkey_x448: vi.fn().mockReturnValue(
-      Buffer.from([1, 2, 3]).toString('base64')
+      // The real SDK wraps the base64 result in JSON.stringify, so callers
+      // do JSON.parse(...) on it. Mirror that here.
+      JSON.stringify(Buffer.from([1, 2, 3]).toString('base64'))
     ),
     js_get_pubkey_ed448: vi.fn().mockReturnValue(
       Buffer.from([7, 8, 9]).toString('base64')
@@ -142,24 +144,57 @@ describe('InvitationService - Unit Tests', () => {
     vi.clearAllMocks();
   });
 
-  describe('1. constructInviteLink() - Invite Link Construction', () => {
-    it('should return existing invite URL if space has one', async () => {
+  describe('1. constructInviteLink() - always builds a fresh one-time link', () => {
+    // Mobile-aligned behavior (2026-06-07): even when `space.inviteUrl` is set,
+    // private one-time invites continue to be generated from the local evals
+    // pool. The old short-circuit that hijacked private invites and returned
+    // the public URL is gone.
+    it('should build a fresh one-time link even when space already has a public inviteUrl', async () => {
       const spaceId = 'space-123';
-      const existingUrl = 'https://quorum.app/invite#spaceId=space-123&configKey=abc';
+      const existingPublicUrl = 'https://app.quorummessenger.com/invite/#spaceId=space-123&configKey=abc';
 
       mockDeps.messageDB.getSpace = vi.fn().mockResolvedValue({
         spaceId,
         spaceName: 'Test Space',
-        inviteUrl: existingUrl,
+        inviteUrl: existingPublicUrl,
       });
+      mockDeps.messageDB.getSpaceKey = vi.fn()
+        .mockResolvedValueOnce({ keyId: 'config', publicKey: 'cfg-pub', privateKey: 'cfg-priv' })
+        .mockResolvedValueOnce({ keyId: 'hub', publicKey: 'hub-pub', privateKey: 'hub-priv' });
+
+      const encStateRaw = {
+        state: JSON.stringify({
+          id_peer_map: { 1: { public_key: 'peer-key' } },
+          peer_id_map: {},
+          root_key: 'root-key-value',
+        }),
+        template: {
+          dkg_ratchet: JSON.stringify({ id: 5 }),
+          root_key: 'old-root-key',
+        },
+        evals: [[10, 20, 30], [40, 50, 60]],
+      };
+      mockDeps.messageDB.getEncryptionStates = vi.fn().mockResolvedValue([
+        { state: JSON.stringify(encStateRaw), conversationId: spaceId + '/' + spaceId },
+      ]);
 
       const result = await invitationService.constructInviteLink(spaceId);
 
-      // ✅ VERIFY: Existing URL returned
-      expect(result).toBe(existingUrl);
+      // ✅ VERIFY: returned a one-time link (has template/secret/hubKey), NOT the public URL
+      expect(result).not.toBe(existingPublicUrl);
+      expect(result).toContain('spaceId=' + spaceId);
+      expect(result).toContain('configKey=cfg-priv');
+      expect(result).toContain('template=');
+      expect(result).toContain('secret=');
+      expect(result).toContain('hubKey=hub-priv');
 
-      // ✅ VERIFY: Space retrieved
-      expect(mockDeps.messageDB.getSpace).toHaveBeenCalledWith(spaceId);
+      // ✅ VERIFY: local eval pool decremented by one
+      expect(mockDeps.messageDB.saveEncryptionState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          state: expect.stringContaining('"evals":[[40,50,60]]'),
+        }),
+        true
+      );
     });
   });
 
@@ -194,7 +229,7 @@ describe('InvitationService - Unit Tests', () => {
   });
 
   describe('3. sendInviteToUser() - Send Invite to User', () => {
-    it('should call constructInviteLink and submitMessage', async () => {
+    it('should build a fresh one-time link from the local pool and call submitMessage with it', async () => {
       const address = 'recipient-address';
       const spaceId = 'space-123';
       const mockPasskeyInfo = {
@@ -206,11 +241,23 @@ describe('InvitationService - Unit Tests', () => {
       const mockKeyset = { userKeyset: {}, deviceKeyset: {} } as any;
       const mockSubmitMessage = vi.fn().mockResolvedValue(undefined);
 
-      // Mock constructInviteLink to return quickly
+      // Space has a public inviteUrl set; the new flow ignores it and builds
+      // a fresh one-time link from the local evals pool anyway.
       mockDeps.messageDB.getSpace = vi.fn().mockResolvedValue({
         spaceId,
-        inviteUrl: 'https://test-link',
+        inviteUrl: 'https://app.quorummessenger.com/invite/#spaceId=space-123&configKey=pub',
       });
+      mockDeps.messageDB.getSpaceKey = vi.fn()
+        .mockResolvedValueOnce({ keyId: 'config', publicKey: 'cfg-pub', privateKey: 'cfg-priv' })
+        .mockResolvedValueOnce({ keyId: 'hub', publicKey: 'hub-pub', privateKey: 'hub-priv' });
+      const encStateRaw = {
+        state: JSON.stringify({ root_key: 'rk', id_peer_map: {}, peer_id_map: {} }),
+        template: { dkg_ratchet: JSON.stringify({ id: 1 }), root_key: 'rk' },
+        evals: [[1, 2, 3]],
+      };
+      mockDeps.messageDB.getEncryptionStates = vi.fn().mockResolvedValue([
+        { state: JSON.stringify(encStateRaw), conversationId: spaceId + '/' + spaceId },
+      ]);
 
       await invitationService.sendInviteToUser(
         address,
@@ -220,15 +267,18 @@ describe('InvitationService - Unit Tests', () => {
         mockSubmitMessage
       );
 
-      // ✅ VERIFY: getSpace called (part of constructInviteLink)
-      expect(mockDeps.messageDB.getSpace).toHaveBeenCalledWith(spaceId);
-
       // ✅ VERIFY: getUser called for both sender and recipient
       expect(mockDeps.apiClient.getUser).toHaveBeenCalledWith(mockPasskeyInfo.address);
       expect(mockDeps.apiClient.getUser).toHaveBeenCalledWith(address);
 
-      // ✅ VERIFY: submitMessage called
-      expect(mockSubmitMessage).toHaveBeenCalled();
+      // ✅ VERIFY: submitMessage called with a one-time link (not the existing public URL)
+      const submitArgs = mockSubmitMessage.mock.calls[0];
+      const linkSent = submitArgs[1];
+      expect(linkSent).toContain('spaceId=' + spaceId);
+      expect(linkSent).toContain('template=');
+      expect(linkSent).toContain('secret=');
+      expect(linkSent).toContain('hubKey=hub-priv');
+      expect(linkSent).not.toContain('configKey=pub');
     });
   });
 
@@ -321,11 +371,22 @@ describe('InvitationService - Unit Tests', () => {
 
       const result = await invitationService.constructInviteLink(spaceId);
 
+      // The link's embedded template carries ratchet.id = 10001 - evals.length
+      // (computed BEFORE consuming the eval). Extract it from the URL.
+      const match = result.match(/template=([0-9a-f]+)/);
+      expect(match).not.toBeNull();
+      const templateHex = match![1];
+      const templateJson = JSON.parse(Buffer.from(templateHex, 'hex').toString('utf-8'));
+      const linkedRatchet = JSON.parse(templateJson.dkg_ratchet);
+      expect(linkedRatchet.id).toBe(10001 - 3);
+
+      // The SAVED template stays unchanged (no in-place mutation leak). The
+      // deep-copy at constructInviteLink protects the persisted template from
+      // being polluted by transient invite generation.
       const savedCall = mockDeps.messageDB.saveEncryptionState.mock.calls[0][0];
       const savedSets = JSON.parse(savedCall.state);
-      const savedTemplate = savedSets.template;
-      const savedRatchet = JSON.parse(savedTemplate.dkg_ratchet);
-      expect(savedRatchet.id).toBe(10001 - 3);
+      const savedRatchet = JSON.parse(savedSets.template.dkg_ratchet);
+      expect(savedRatchet.id).toBe(99);
 
       expect(result).toContain('spaceId=' + spaceId);
     });
@@ -360,10 +421,9 @@ describe('InvitationService - Unit Tests', () => {
   });
 
   describe('6. sendInviteToUser() - Argument Verification', () => {
-    it('should call submitMessage with the invite URL, sender address, and recipient address', async () => {
+    it('should call submitMessage with sender, recipient, and a freshly-built one-time link', async () => {
       const spaceId = 'space-send';
       const recipientAddress = 'recipient-addr';
-      const existingUrl = 'https://qm.one/#spaceId=space-send&configKey=deadbeef';
       const mockPasskeyInfo = {
         credentialId: 'cred',
         address: 'sender-addr',
@@ -373,10 +433,18 @@ describe('InvitationService - Unit Tests', () => {
       const mockKeyset = { userKeyset: {} as any, deviceKeyset: {} as any };
       const mockSubmitMessage = vi.fn().mockResolvedValue(undefined);
 
-      mockDeps.messageDB.getSpace = vi.fn().mockResolvedValue({
-        spaceId,
-        inviteUrl: existingUrl,
-      });
+      mockDeps.messageDB.getSpace = vi.fn().mockResolvedValue({ spaceId, inviteUrl: null });
+      mockDeps.messageDB.getSpaceKey = vi.fn()
+        .mockResolvedValueOnce({ keyId: 'config', publicKey: 'cpub', privateKey: 'cpriv' })
+        .mockResolvedValueOnce({ keyId: 'hub', publicKey: 'hpub', privateKey: 'hpriv' });
+      const encStateRaw = {
+        state: JSON.stringify({ root_key: 'rk', id_peer_map: {}, peer_id_map: {} }),
+        template: { dkg_ratchet: JSON.stringify({ id: 1 }), root_key: 'rk' },
+        evals: [[9, 9, 9]],
+      };
+      mockDeps.messageDB.getEncryptionStates = vi.fn().mockResolvedValue([
+        { state: JSON.stringify(encStateRaw), conversationId: spaceId + '/' + spaceId },
+      ]);
       mockDeps.apiClient.getUser = vi.fn()
         .mockResolvedValueOnce({ data: { address: 'sender-addr', device_registrations: [] } })
         .mockResolvedValueOnce({ data: { address: 'recipient-addr', device_registrations: [] } });
@@ -391,7 +459,7 @@ describe('InvitationService - Unit Tests', () => {
 
       expect(mockSubmitMessage).toHaveBeenCalledWith(
         recipientAddress,
-        existingUrl,
+        expect.stringContaining('spaceId=' + spaceId),
         expect.objectContaining({ address: 'sender-addr' }),
         expect.objectContaining({ address: 'recipient-addr' }),
         expect.anything(),
@@ -402,53 +470,379 @@ describe('InvitationService - Unit Tests', () => {
       expect(mockDeps.apiClient.getUser).toHaveBeenCalledWith(mockPasskeyInfo.address);
       expect(mockDeps.apiClient.getUser).toHaveBeenCalledWith(recipientAddress);
     });
+
+    it('mode=public: forwards the existing space.inviteUrl without constructing a new link', async () => {
+      const spaceId = 'space-public-send';
+      const existingPublicUrl = 'https://app.quorummessenger.com/invite/#spaceId=space-public-send&configKey=public-cfg';
+      const mockPasskeyInfo = {
+        credentialId: 'cred',
+        address: 'sender-addr',
+        publicKey: 'pubkey',
+        completedOnboarding: true,
+      };
+      const mockKeyset = { userKeyset: {} as any, deviceKeyset: {} as any };
+      const mockSubmitMessage = vi.fn().mockResolvedValue(undefined);
+
+      mockDeps.messageDB.getSpace = vi.fn().mockResolvedValue({
+        spaceId,
+        inviteUrl: existingPublicUrl,
+      });
+      // Encryption state setup deliberately omitted — if mode='public' incorrectly
+      // fell through to constructInviteLink, it would throw on missing template.
+      mockDeps.messageDB.getEncryptionStates = vi.fn().mockResolvedValue([]);
+      mockDeps.apiClient.getUser = vi.fn()
+        .mockResolvedValueOnce({ data: { address: 'sender-addr', device_registrations: [] } })
+        .mockResolvedValueOnce({ data: { address: 'recipient-addr', device_registrations: [] } });
+
+      await invitationService.sendInviteToUser(
+        'recipient-addr',
+        spaceId,
+        mockPasskeyInfo,
+        mockKeyset,
+        mockSubmitMessage,
+        'public'
+      );
+
+      // Exact existing URL was forwarded
+      expect(mockSubmitMessage).toHaveBeenCalledWith(
+        'recipient-addr',
+        existingPublicUrl,
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        mockKeyset
+      );
+
+      // No eval was consumed
+      expect(mockDeps.messageDB.saveEncryptionState).not.toHaveBeenCalled();
+    });
+
+    it('mode=public: throws when no public inviteUrl exists yet', async () => {
+      const spaceId = 'space-no-public';
+      const mockPasskeyInfo = {
+        credentialId: 'cred',
+        address: 'sender-addr',
+        publicKey: 'pubkey',
+        completedOnboarding: true,
+      };
+
+      mockDeps.messageDB.getSpace = vi.fn().mockResolvedValue({ spaceId, inviteUrl: null });
+
+      await expect(
+        invitationService.sendInviteToUser(
+          'recipient-addr',
+          spaceId,
+          mockPasskeyInfo,
+          {} as any,
+          vi.fn(),
+          'public'
+        )
+      ).rejects.toThrow();
+    });
+
+    it('mode=reuse: sends the exact presetLink without consuming an eval', async () => {
+      const spaceId = 'space-reuse';
+      const presetLink = 'https://app.quorummessenger.com/#spaceId=space-reuse&configKey=cfg&template=tpl&secret=sec&hubKey=hub';
+      const mockPasskeyInfo = {
+        credentialId: 'cred',
+        address: 'sender-addr',
+        publicKey: 'pubkey',
+        completedOnboarding: true,
+      };
+      const mockKeyset = { userKeyset: {} as any, deviceKeyset: {} as any };
+      const mockSubmitMessage = vi.fn().mockResolvedValue(undefined);
+
+      // No getSpace mock, no encryption state — reuse mode must not need them.
+      mockDeps.messageDB.getEncryptionStates = vi.fn().mockResolvedValue([]);
+      mockDeps.apiClient.getUser = vi.fn()
+        .mockResolvedValueOnce({ data: { address: 'sender-addr', device_registrations: [] } })
+        .mockResolvedValueOnce({ data: { address: 'recipient-addr', device_registrations: [] } });
+
+      await invitationService.sendInviteToUser(
+        'recipient-addr',
+        spaceId,
+        mockPasskeyInfo,
+        mockKeyset,
+        mockSubmitMessage,
+        'reuse',
+        presetLink
+      );
+
+      // Exact preset link sent
+      expect(mockSubmitMessage).toHaveBeenCalledWith(
+        'recipient-addr',
+        presetLink,
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        mockKeyset
+      );
+
+      // No eval consumed — saveEncryptionState would have been called by
+      // constructInviteLink if the mode had silently fallen through.
+      expect(mockDeps.messageDB.saveEncryptionState).not.toHaveBeenCalled();
+    });
+
+    it('mode=reuse: throws when presetLink is missing', async () => {
+      const spaceId = 'space-reuse-missing';
+      const mockPasskeyInfo = {
+        credentialId: 'cred',
+        address: 'sender-addr',
+        publicKey: 'pubkey',
+        completedOnboarding: true,
+      };
+
+      await expect(
+        invitationService.sendInviteToUser(
+          'recipient-addr',
+          spaceId,
+          mockPasskeyInfo,
+          {} as any,
+          vi.fn(),
+          'reuse'
+          // no presetLink
+        )
+      ).rejects.toThrow();
+    });
   });
 
-  describe('7. generateNewInviteLink() - Invite Generation', () => {
-    it('should call postSpaceInviteEvals, saveEncryptionState, and saveSpace', async () => {
-      const spaceId = 'space-gen';
+  describe('7. generateNewInviteLink() - Public link generation (mobile-aligned)', () => {
+    // Shared helper: produces a deps shape that the new generateNewInviteLink
+    // expects. Encryption state has template/state/evals at the TOP level
+    // (not nested), because the new flow uses the same encryption-state shape
+    // as constructInviteLink (one source of truth) — not the nested shape the
+    // old rekey path used.
+    const setupForPublicGen = (spaceId: string, opts: { initialEvalCount?: number; inviteUrl?: string | null } = {}) => {
+      const evalCount = opts.initialEvalCount ?? 3;
+      const evals = Array.from({ length: evalCount }, (_, i) => [i + 1, i + 2, i + 3]);
 
       mockDeps.messageDB.getSpace = vi.fn().mockResolvedValue({
         spaceId,
         spaceName: 'Gen Space',
-        inviteUrl: null,
+        inviteUrl: opts.inviteUrl ?? null,
       });
+      mockDeps.messageDB.getSpaceKey = vi.fn().mockImplementation((_id: string, keyId: string) => {
+        if (keyId === 'owner') return Promise.resolve({ spaceId, keyId: 'owner', publicKey: 'owner-pub-hex', privateKey: 'owner-priv-hex' });
+        if (keyId === 'hub') return Promise.resolve({ spaceId, keyId: 'hub', publicKey: 'hub-pub-hex', privateKey: 'hub-priv-hex', address: 'hub-addr' });
+        if (keyId === 'config') return Promise.resolve({ spaceId, keyId: 'config', publicKey: 'cfg-pub-hex', privateKey: 'cfg-priv-hex' });
+        return Promise.resolve({ spaceId, keyId, publicKey: 'p', privateKey: 'p' });
+      });
+      const encStateRaw = {
+        state: JSON.stringify({ root_key: 'root-key', id_peer_map: {}, peer_id_map: {} }),
+        template: { dkg_ratchet: JSON.stringify({ id: 1 }), root_key: 'root-key' },
+        evals,
+      };
+      mockDeps.messageDB.getEncryptionStates = vi.fn().mockResolvedValue([
+        { state: JSON.stringify(encStateRaw), conversationId: spaceId + '/' + spaceId },
+      ]);
+    };
+
+    it('should upload exactly ONE eval to postSpaceInviteEvals (MAX_PUBLIC_EVALS = 1)', async () => {
+      const spaceId = 'space-gen';
+      setupForPublicGen(spaceId, { initialEvalCount: 5 });
+
+      await invitationService.generateNewInviteLink(spaceId, {} as any, {} as any, {} as any);
+
+      expect(mockDeps.apiClient.postSpaceInviteEvals).toHaveBeenCalledTimes(1);
+      const payload = mockDeps.apiClient.postSpaceInviteEvals.mock.calls[0][0];
+      expect(payload.space_evals).toHaveLength(1);
+      expect(payload.space_address).toBe(spaceId);
+    });
+
+    it('should use the EXISTING config public key (no new keypair) when uploading evals', async () => {
+      const spaceId = 'space-gen-cfg';
+      setupForPublicGen(spaceId);
+
+      await invitationService.generateNewInviteLink(spaceId, {} as any, {} as any, {} as any);
+
+      const payload = mockDeps.apiClient.postSpaceInviteEvals.mock.calls[0][0];
+      // Mobile parity: reuses existing 'config' key, does NOT mint a new one.
+      expect(payload.config_public_key).toBe('cfg-pub-hex');
+      expect(payload.owner_public_key).toBe('owner-pub-hex');
+    });
+
+    it('should NOT call saveSpaceKey for the config key (no new keypair persisted)', async () => {
+      const spaceId = 'space-no-rekey';
+      setupForPublicGen(spaceId);
+
+      await invitationService.generateNewInviteLink(spaceId, {} as any, {} as any, {} as any);
+
+      const configSaveCalls = mockDeps.messageDB.saveSpaceKey.mock.calls.filter(
+        (c: any[]) => c[0]?.keyId === 'config'
+      );
+      expect(configSaveCalls).toHaveLength(0);
+    });
+
+    it('should NOT call apiClient.postSpace (no space re-registration in the mobile-aligned flow)', async () => {
+      const spaceId = 'space-no-postspace';
+      setupForPublicGen(spaceId);
+
+      await invitationService.generateNewInviteLink(spaceId, {} as any, {} as any, {} as any);
+
+      expect(mockDeps.apiClient.postSpace).not.toHaveBeenCalled();
+    });
+
+    it('should NOT read space members (no member rekey loop)', async () => {
+      const spaceId = 'space-no-members-read';
+      setupForPublicGen(spaceId);
+
+      await invitationService.generateNewInviteLink(spaceId, {} as any, {} as any, {} as any);
+
+      expect(mockDeps.messageDB.getSpaceMembers).not.toHaveBeenCalled();
+    });
+
+    it('should NOT enqueue outbound sync envelopes (no member rekey messages)', async () => {
+      const spaceId = 'space-no-outbounds';
+      setupForPublicGen(spaceId);
+
+      await invitationService.generateNewInviteLink(spaceId, {} as any, {} as any, {} as any);
+
+      expect(mockDeps.enqueueOutbound).not.toHaveBeenCalled();
+    });
+
+    it('should call postSpaceManifest to refresh the on-server snapshot', async () => {
+      const spaceId = 'space-manifest-refresh';
+      setupForPublicGen(spaceId);
+
+      await invitationService.generateNewInviteLink(spaceId, {} as any, {} as any, {} as any);
+
+      expect(mockDeps.apiClient.postSpaceManifest).toHaveBeenCalledTimes(1);
+      const manifestCall = mockDeps.apiClient.postSpaceManifest.mock.calls[0];
+      expect(manifestCall[0]).toBe(spaceId);
+      expect(manifestCall[1]).toEqual(
+        expect.objectContaining({
+          space_address: spaceId,
+          owner_public_key: 'owner-pub-hex',
+        })
+      );
+    });
+
+    it('should save space with inviteUrl built from the EXISTING config private key', async () => {
+      const spaceId = 'space-save';
+      setupForPublicGen(spaceId);
+
+      await invitationService.generateNewInviteLink(spaceId, {} as any, {} as any, {} as any);
+
+      expect(mockDeps.messageDB.saveSpace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          spaceId,
+          // URL uses the existing config private key, NOT a freshly-minted one
+          inviteUrl: expect.stringContaining('configKey=cfg-priv-hex'),
+        })
+      );
+      // And the URL is a public-invite shape (/invite/#)
+      const savedSpace = mockDeps.messageDB.saveSpace.mock.calls[0][0];
+      expect(savedSpace.inviteUrl).toContain('/invite/#');
+      expect(savedSpace.inviteUrl).toContain('spaceId=' + spaceId);
+    });
+
+    it('should decrement the local evals pool by MAX_PUBLIC_EVALS (1)', async () => {
+      const spaceId = 'space-pool-decrement';
+      setupForPublicGen(spaceId, { initialEvalCount: 5 });
+
+      await invitationService.generateNewInviteLink(spaceId, {} as any, {} as any, {} as any);
+
+      expect(mockDeps.messageDB.saveEncryptionState).toHaveBeenCalled();
+      const saveCall = mockDeps.messageDB.saveEncryptionState.mock.calls[0][0];
+      const savedSession = JSON.parse(saveCall.state);
+      expect(savedSession.evals).toHaveLength(4); // 5 - 1
+    });
+
+    it('should not decrement the pool when the eval upload fails (failure happens before save)', async () => {
+      const spaceId = 'space-fail-upload';
+      setupForPublicGen(spaceId, { initialEvalCount: 3 });
+      mockDeps.apiClient.postSpaceInviteEvals = vi.fn().mockRejectedValue(new Error('network down'));
+
+      await expect(
+        invitationService.generateNewInviteLink(spaceId, {} as any, {} as any, {} as any)
+      ).rejects.toThrow();
+
+      // saveEncryptionState should NOT have been called — the pool stays intact
+      expect(mockDeps.messageDB.saveEncryptionState).not.toHaveBeenCalled();
+    });
+
+    it('should throw when the local evals pool is empty', async () => {
+      const spaceId = 'space-empty-pool';
+      setupForPublicGen(spaceId, { initialEvalCount: 0 });
+
+      await expect(
+        invitationService.generateNewInviteLink(spaceId, {} as any, {} as any, {} as any)
+      ).rejects.toThrow();
+
+      expect(mockDeps.apiClient.postSpaceInviteEvals).not.toHaveBeenCalled();
+    });
+
+    it('should throw when no owner key is present (non-owner gating)', async () => {
+      const spaceId = 'space-non-owner';
+      setupForPublicGen(spaceId);
+      // Override owner key to return falsy
+      mockDeps.messageDB.getSpaceKey = vi.fn().mockImplementation((_id: string, keyId: string) => {
+        if (keyId === 'owner') return Promise.resolve({ spaceId, keyId: 'owner', publicKey: '', privateKey: '' });
+        if (keyId === 'hub') return Promise.resolve({ spaceId, keyId: 'hub', publicKey: 'hub-pub', privateKey: 'hub-priv' });
+        if (keyId === 'config') return Promise.resolve({ spaceId, keyId: 'config', publicKey: 'cfg-pub', privateKey: 'cfg-priv' });
+        return Promise.resolve({ spaceId, keyId, publicKey: 'p', privateKey: 'p' });
+      });
+
+      await expect(
+        invitationService.generateNewInviteLink(spaceId, {} as any, {} as any, {} as any)
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('8. URL host override (qm.one -> app.quorummessenger.com)', () => {
+    // The buildInviteBase helper substitutes qm.one with app.quorummessenger.com
+    // to match mobile's generation host. We assert against the public-gen URL
+    // because the test env runs under jsdom (localhost), so the prod qm.one
+    // branch in shared's getInviteUrlBase isn't hit at runtime — but the
+    // .replace() in buildInviteBase is a deterministic string op so any URL
+    // emitted from prod-shaped paths will be cleaned.
+    it('should never emit qm.one in any generated invite URL', async () => {
+      const spaceId = 'space-host-override';
+
+      // Private path
+      mockDeps.messageDB.getSpace = vi.fn().mockResolvedValue({ spaceId, inviteUrl: null });
       mockDeps.messageDB.getSpaceKey = vi.fn()
-        .mockResolvedValueOnce({ spaceId, keyId: spaceId, publicKey: 'space-pub', privateKey: 'space-priv' })
-        .mockResolvedValueOnce({ spaceId, keyId: 'owner', publicKey: 'owner-pub', privateKey: 'owner-priv' })
-        .mockResolvedValueOnce({ spaceId, keyId: 'hub', publicKey: 'hub-pub', privateKey: 'hub-priv', address: 'hub-addr' });
-      mockDeps.messageDB.getSpaceMembers = vi.fn().mockResolvedValue([]);
+        .mockResolvedValueOnce({ keyId: 'config', publicKey: 'cpub', privateKey: 'cpriv' })
+        .mockResolvedValueOnce({ keyId: 'hub', publicKey: 'hpub', privateKey: 'hpriv' });
       mockDeps.messageDB.getEncryptionStates = vi.fn().mockResolvedValue([
         {
           state: JSON.stringify({
-            state: JSON.stringify({
-              id_peer_map: { 1: { public_key: 'peer-key' } },
-              peer_id_map: { 'peer-key': 1 },
-              root_key: 'root-key',
-            }),
+            state: JSON.stringify({ root_key: 'rk', id_peer_map: {}, peer_id_map: {} }),
+            template: { dkg_ratchet: JSON.stringify({ id: 1 }), root_key: 'rk' },
+            evals: [[1, 2]],
           }),
           conversationId: spaceId + '/' + spaceId,
         },
       ]);
 
-      const mockUserKeyset = {} as any;
-      const mockDeviceKeyset = {} as any;
-      const mockRegistration = {} as any;
+      const privateLink = await invitationService.constructInviteLink(spaceId);
+      expect(privateLink).not.toContain('qm.one');
 
-      await invitationService.generateNewInviteLink(
-        spaceId,
-        mockUserKeyset,
-        mockDeviceKeyset,
-        mockRegistration
-      );
+      // Public path
+      mockDeps.messageDB.getSpace = vi.fn().mockResolvedValue({ spaceId, inviteUrl: null });
+      mockDeps.messageDB.getSpaceKey = vi.fn().mockImplementation((_id: string, keyId: string) => {
+        if (keyId === 'owner') return Promise.resolve({ keyId: 'owner', publicKey: 'op', privateKey: 'opriv' });
+        if (keyId === 'hub') return Promise.resolve({ keyId: 'hub', publicKey: 'hp', privateKey: 'hpriv' });
+        if (keyId === 'config') return Promise.resolve({ keyId: 'config', publicKey: 'cp', privateKey: 'cpriv' });
+        return Promise.resolve({ keyId, publicKey: 'p', privateKey: 'p' });
+      });
+      mockDeps.messageDB.getEncryptionStates = vi.fn().mockResolvedValue([
+        {
+          state: JSON.stringify({
+            state: JSON.stringify({ root_key: 'rk', id_peer_map: {}, peer_id_map: {} }),
+            template: { dkg_ratchet: JSON.stringify({ id: 1 }), root_key: 'rk' },
+            evals: [[1, 2]],
+          }),
+          conversationId: spaceId + '/' + spaceId,
+        },
+      ]);
 
-      expect(mockDeps.apiClient.postSpaceInviteEvals).toHaveBeenCalledWith(
-        expect.objectContaining({ space_address: spaceId })
-      );
-      expect(mockDeps.messageDB.saveEncryptionState).toHaveBeenCalled();
-      expect(mockDeps.messageDB.saveSpace).toHaveBeenCalledWith(
-        expect.objectContaining({ spaceId, inviteUrl: expect.stringContaining('spaceId=' + spaceId) })
-      );
+      await invitationService.generateNewInviteLink(spaceId, {} as any, {} as any, {} as any);
+
+      const publicSaved = mockDeps.messageDB.saveSpace.mock.calls[0][0];
+      expect(publicSaved.inviteUrl).not.toContain('qm.one');
     });
   });
 

--- a/src/hooks/business/spaces/useInviteManagement.ts
+++ b/src/hooks/business/spaces/useInviteManagement.ts
@@ -11,6 +11,7 @@ import { useConversations, useRegistration } from '../../queries';
 import { isValidIPFSCID, type Conversation, type Channel } from '@quilibrium/quorum-shared';
 import { getAddressSuffix } from '../../../utils';
 import { t } from '@lingui/core/macro';
+import { InviteEvalsExhaustedError } from '../../../services/InvitationService';
 
 export interface UseInviteManagementOptions {
   spaceId: string;
@@ -31,7 +32,29 @@ export interface UseInviteManagementReturn {
   sendingInvite: boolean;
   success: boolean;
   membershipWarning: string | undefined;
-  invite: (address: string) => Promise<void>;
+  // True when this space's local invite-evals pool is empty — typically a
+  // legacy state from before the 2026-06-07 consolidation. UI uses this to
+  // render a friendly banner instead of throwing on the next operation.
+  poolExhausted: boolean;
+  // `mode` selects what link to send:
+  //  - 'one-time' (default): generate a fresh link from the pool, consume one eval.
+  //  - 'public': forward the space's existing public inviteUrl.
+  //  - 'reuse': send the explicit `presetLink` (e.g. a one-time link the user
+  //    already generated via the Generate Invite Link button); no eval is
+  //    consumed.
+  invite: (
+    address: string,
+    mode?: 'one-time' | 'public' | 'reuse',
+    presetLink?: string
+  ) => Promise<void>;
+  // Generate a fresh one-time invite URL and return it (no DM send). Consumes
+  // one eval from the local pool. The UI uses this for the "I want the link
+  // to share outside Quorum" case.
+  generateOneTimeLink: () => Promise<string | null>;
+  generatedOneTimeLink: string | null;
+  clearGeneratedOneTimeLink: () => void;
+  generatingOneTimeLink: boolean;
+  generateOneTimeLinkError: string | undefined;
 
   // Public invite link
   publicInvite: boolean;
@@ -58,6 +81,10 @@ export const useInviteManagement = (
   const [publicInvite, setPublicInvite] = useState<boolean>(
     space?.isPublic || false
   );
+  const [poolExhausted, setPoolExhausted] = useState<boolean>(false);
+  const [generatedOneTimeLink, setGeneratedOneTimeLink] = useState<string | null>(null);
+  const [generatingOneTimeLink, setGeneratingOneTimeLink] = useState<boolean>(false);
+  const [generateOneTimeLinkError, setGenerateOneTimeLinkError] = useState<string | undefined>();
 
   // Hooks
   const { currentPasskeyInfo } = usePasskeysContext();
@@ -66,6 +93,7 @@ export const useInviteManagement = (
     ensureKeyForSpace,
     sendInviteToUser,
     generateNewInviteLink: generateInviteLink,
+    constructInviteLink,
   } = useMessageDB();
   const { keyset } = useRegistrationContext();
   const { data: registration } = useRegistration({
@@ -109,9 +137,41 @@ export const useInviteManagement = (
     })();
   }, [manualAddress, apiClient]);
 
+  // Proactively detect a depleted local evals pool so the UI can warn the
+  // user up-front instead of failing mid-operation. Same check that
+  // InvitationService runs internally.
+  useEffect(() => {
+    if (!spaceId || !messageDB) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const states = await messageDB.getEncryptionStates({
+          conversationId: spaceId + '/' + spaceId,
+        });
+        if (cancelled) return;
+        if (!states || states.length === 0) {
+          setPoolExhausted(false);
+          return;
+        }
+        const sets = JSON.parse(states[0].state);
+        const exhausted = !sets?.evals || sets.evals.length === 0;
+        setPoolExhausted(exhausted);
+      } catch {
+        if (!cancelled) setPoolExhausted(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [spaceId, messageDB]);
+
   // Send invite function
   const invite = useCallback(
-    async (address: string) => {
+    async (
+      address: string,
+      mode: 'one-time' | 'public' | 'reuse' = 'one-time',
+      presetLink?: string
+    ) => {
       setSendingInvite(true);
       setSuccess(false);
       setMembershipWarning(undefined);
@@ -137,11 +197,15 @@ export const useInviteManagement = (
           navigate('/spaces/' + spaceAddress + '/' + defaultChannel.channelId);
         }
 
-        await sendInviteToUser(address, spaceAddress, currentPasskeyInfo!);
+        await sendInviteToUser(address, spaceAddress, currentPasskeyInfo!, mode, presetLink);
         setSuccess(true);
       } catch (error) {
         console.error('Invite error:', error);
-        setMembershipWarning(t`Failed to send invite. Please try again.`);
+        if (error instanceof InviteEvalsExhaustedError) {
+          setPoolExhausted(true);
+        } else {
+          setMembershipWarning(t`Failed to send invite. Please try again.`);
+        }
       } finally {
         setSendingInvite(false);
       }
@@ -176,6 +240,41 @@ export const useInviteManagement = (
     }
   }, [space, registration, keyset, generateInviteLink]);
 
+  // Generate a fresh one-time invite URL without sending. Used by the
+  // "Generate Link" action in one-time mode for the share-outside-Quorum
+  // case. Each call consumes one local eval, just like sending one.
+  const generateOneTimeLink = useCallback(async () => {
+    if (!space) return null;
+    setGeneratingOneTimeLink(true);
+    setGenerateOneTimeLinkError(undefined);
+    try {
+      const spaceAddress = await ensureKeyForSpace(
+        currentPasskeyInfo!.address,
+        space
+      );
+      const link = await constructInviteLink(spaceAddress);
+      setGeneratedOneTimeLink(link);
+      return link;
+    } catch (error) {
+      console.error('Generate one-time link error:', error);
+      if (error instanceof InviteEvalsExhaustedError) {
+        setPoolExhausted(true);
+      } else {
+        setGenerateOneTimeLinkError(
+          t`Failed to generate invite link. Please try again.`
+        );
+      }
+      return null;
+    } finally {
+      setGeneratingOneTimeLink(false);
+    }
+  }, [space, ensureKeyForSpace, currentPasskeyInfo, constructInviteLink]);
+
+  const clearGeneratedOneTimeLink = useCallback(() => {
+    setGeneratedOneTimeLink(null);
+    setGenerateOneTimeLinkError(undefined);
+  }, []);
+
   return {
     selectedUser,
     setSelectedUser,
@@ -187,7 +286,14 @@ export const useInviteManagement = (
     sendingInvite,
     success,
     membershipWarning,
+    poolExhausted,
     invite,
+
+    generateOneTimeLink,
+    generatedOneTimeLink,
+    clearGeneratedOneTimeLink,
+    generatingOneTimeLink,
+    generateOneTimeLinkError,
 
     publicInvite,
     setPublicInvite,

--- a/src/services/InvitationService.ts
+++ b/src/services/InvitationService.ts
@@ -14,6 +14,33 @@ import { isQuorumApiError } from '../api/baseTypes';
 import type { Ref } from '../types/ref';
 import type { SpaceInfoMap } from '../types/spaceRefs';
 
+// Mobile generates invite URLs with the long prod domain (app.quorummessenger.com).
+// Shared's getInviteUrlBase still emits qm.one for the prod browser case; override
+// here so desktop matches mobile until shared is updated in a separate cross-repo PR.
+// Acceptance of qm.one links keeps working via getValidInvitePrefixes().
+function buildInviteBase(isPublic: boolean): string {
+  return getInviteUrlBase(isPublic).replace('://qm.one/', '://app.quorummessenger.com/');
+}
+
+const MAX_PUBLIC_EVALS = 1;
+
+/**
+ * Thrown when a space's local invite-evals pool is empty. This typically
+ * happens on spaces where the legacy (pre-2026-06-07) `generateNewInviteLink`
+ * was run, since that path drained the entire pool into the server-side eval
+ * batch. New spaces start with ~10K evals and lose one per invite, so they
+ * won't hit this in practice.
+ *
+ * Callers catch this specifically to render a friendly UI instead of the raw
+ * error message.
+ */
+export class InviteEvalsExhaustedError extends Error {
+  constructor() {
+    super('Invite evaluations exhausted for this Space.');
+    this.name = 'InviteEvalsExhaustedError';
+  }
+}
+
 export class InvitationService {
   private messageDB: MessageDB;
   private apiClient: QuorumApiClient;
@@ -52,13 +79,12 @@ export class InvitationService {
 
   /**
    * Constructs one-time invite link with embedded template/secret (consumes one eval).
+   *
+   * Matches mobile (`quorum-mobile/services/space/inviteService.ts` -> `generatePrivateInviteLink`):
+   * always builds a fresh one-time link from the local evals pool, even when the
+   * space already has a public `inviteUrl`. Public and one-time invites coexist.
    */
   async constructInviteLink(spaceId: string) {
-    const space = await this.messageDB.getSpace(spaceId);
-    if (space?.inviteUrl) {
-      return space.inviteUrl;
-    }
-
     const config_key = await this.messageDB.getSpaceKey(spaceId, 'config');
     const hub_key = await this.messageDB.getSpaceKey(spaceId, 'hub');
     const response = await this.messageDB.getEncryptionStates({
@@ -76,10 +102,13 @@ export class InvitationService {
     }
 
     if (!sets[0].evals || sets[0].evals.length === 0) {
-      throw new Error(t`No invite evaluations available. Please generate a public invite link or ensure the Space encryption state is properly initialized.`);
+      throw new InviteEvalsExhaustedError();
     }
 
-    const state = sets[0].template;
+    // Deep-copy the template so we don't mutate the shared object that gets
+    // persisted back to the DB. Mirrors mobile's defensive pattern
+    // (`quorum-mobile/services/space/inviteService.ts` line 148).
+    const state = JSON.parse(JSON.stringify(sets[0].template));
     const ratchet = JSON.parse(state.dkg_ratchet);
     ratchet.id = 10001 - sets[0].evals.length;
 
@@ -101,12 +130,22 @@ export class InvitationService {
       { ...response[0], state: JSON.stringify(sets[0]) },
       true
     );
-    const link = `${getInviteUrlBase(false)}#spaceId=${spaceId}&configKey=${config_key.privateKey}&template=${template}&secret=${secret}&hubKey=${hub_key.privateKey}`;
+    const link = `${buildInviteBase(false)}#spaceId=${spaceId}&configKey=${config_key.privateKey}&template=${template}&secret=${secret}&hubKey=${hub_key.privateKey}`;
     return link;
   }
 
   /**
-   * Sends invite link to user via DM.
+   * Sends an invite link to a user via DM.
+   *
+   * `mode` selects the kind of link sent:
+   *  - `'one-time'` (default): generates a fresh one-time link from the local
+   *    evals pool. Each call consumes one eval.
+   *  - `'public'`: reuses the space's existing `inviteUrl` (the persistent
+   *    public link). Throws if no public link exists yet — caller should
+   *    generate one first.
+   *  - `'reuse'`: sends the explicit `presetLink` argument. The caller is
+   *    responsible for having generated it already (e.g. via the Generate
+   *    Invite Link button). No eval is consumed by this call.
    */
   async sendInviteToUser(
     address: string,
@@ -120,9 +159,28 @@ export class InvitationService {
       completedOnboarding: boolean;
     },
     keyset: any,
-    submitMessage: any
+    submitMessage: any,
+    mode: 'one-time' | 'public' | 'reuse' = 'one-time',
+    presetLink?: string
   ) {
-    const link = await this.constructInviteLink(spaceId);
+    let link: string;
+    if (mode === 'reuse') {
+      if (!presetLink) {
+        throw new Error('sendInviteToUser called with mode=reuse but no presetLink');
+      }
+      link = presetLink;
+    } else if (mode === 'public') {
+      const space = await this.messageDB.getSpace(spaceId);
+      if (!space?.inviteUrl) {
+        throw new Error(
+          t`No public invite link exists yet. Generate one before sharing.`
+        );
+      }
+      link = space.inviteUrl;
+    } else {
+      link = await this.constructInviteLink(spaceId);
+    }
+
     const self = await this.apiClient.getUser(currentPasskeyInfo.address);
     const recipient = await this.apiClient.getUser(address);
     await submitMessage(
@@ -137,366 +195,255 @@ export class InvitationService {
   }
 
   /**
-   * Generates public invite system with 200+ one-time invites, sends rekey to members.
+   * Generate (or regenerate) the public invite link for a space.
+   *
+   * Mirrors mobile (`quorum-mobile/services/space/inviteService.ts` ->
+   * `generatePublicInviteLink`): reuses the EXISTING space config key (no new
+   * keypair, no member rekey), uploads exactly ONE encrypted eval to the
+   * server, and re-publishes the manifest. Private/one-time invites continue
+   * to work in parallel — the old "system switch" behavior is gone.
+   *
+   * The `user_keyset`/`device_keyset`/`registration` parameters are kept on the
+   * method signature for compatibility with existing callers (MessageDB ->
+   * useInviteManagement); they are unused under the mobile-aligned model
+   * because there is no triple-ratchet rekey loop.
    */
   async generateNewInviteLink(
     spaceId: string,
-    user_keyset: secureChannel.UserKeyset,
-    device_keyset: secureChannel.DeviceKeyset,
-    registration: secureChannel.UserRegistration
+    _user_keyset: secureChannel.UserKeyset,
+    _device_keyset: secureChannel.DeviceKeyset,
+    _registration: secureChannel.UserRegistration
   ) {
     try {
       const space = await this.messageDB.getSpace(spaceId);
-      const spaceKey = await this.messageDB.getSpaceKey(spaceId, spaceId);
+      if (!space) {
+        throw new Error(t`Space not found`);
+      }
+
       const ownerKey = await this.messageDB.getSpaceKey(spaceId, 'owner');
+      if (!ownerKey?.privateKey) {
+        throw new Error(
+          t`Only space owners can generate public invite links.`
+        );
+      }
+
       const hubKey = await this.messageDB.getSpaceKey(spaceId, 'hub');
-      const cp = ch.js_generate_x448();
-      const configPair = JSON.parse(cp);
+      if (!hubKey?.privateKey) {
+        throw new Error(t`Hub key not found for this Space.`);
+      }
 
-      await this.messageDB.saveSpaceKey({
-        spaceId: spaceId,
-        keyId: 'config',
-        publicKey: Buffer.from(
-          new Uint8Array(configPair.public_key)
-        ).toString('hex'),
-        privateKey: Buffer.from(
-          new Uint8Array(configPair.private_key)
-        ).toString('hex'),
-      });
+      // Reuse the EXISTING config key — do not generate a new keypair.
+      // This is what keeps private one-time invites working alongside public:
+      // the local DKG template/evals stay valid because the config key is
+      // unchanged.
+      const configKey = await this.messageDB.getSpaceKey(spaceId, 'config');
+      if (!configKey?.privateKey || !configKey?.publicKey) {
+        throw new Error(t`Config key not found for this Space.`);
+      }
 
-      const ts = Date.now();
-      const ownerPayload = Buffer.from(
-        new Uint8Array([
-          ...hexToSpreadArray(spaceKey.publicKey),
-          ...configPair.public_key,
-          ...hexToSpreadArray(ownerKey.publicKey),
-          ...int64ToBytes(ts),
-        ])
-      ).toString('base64');
-      const spacePayload = Buffer.from(
-        new Uint8Array([
-          ...hexToSpreadArray(spaceKey.publicKey),
-          ...configPair.public_key,
-          ...hexToSpreadArray(ownerKey.publicKey),
-          ...int64ToBytes(ts),
-        ])
-      ).toString('base64');
-      const spaceSignature = JSON.parse(
-        ch.js_sign_ed448(
-          Buffer.from(spaceKey.privateKey, 'hex').toString('base64'),
-          spacePayload
-        )
-      );
-      const ownerSignature = JSON.parse(
-        ch.js_sign_ed448(
-          Buffer.from(ownerKey.privateKey, 'hex').toString('base64'),
-          ownerPayload
-        )
-      );
-      this.spaceInfo.current[spaceId] = {
-        space_address: spaceId,
-        space_public_key: spaceKey.publicKey,
-        space_signature: Buffer.from(spaceSignature, 'base64').toString(
-          'hex'
-        ),
-        config_public_key: Buffer.from(
-          new Uint8Array(configPair.public_key)
-        ).toString('hex'),
-        owner_public_keys: [ownerKey.publicKey],
-        owner_signatures: [
-          Buffer.from(ownerSignature, 'base64').toString('hex'),
-        ],
-        timestamp: ts,
-      } as secureChannel.SpaceRegistration;
-      const ephemeral_key = JSON.parse(
-        ch.js_generate_x448()
-      ) as secureChannel.X448Keypair;
-      const members = await this.messageDB.getSpaceMembers(spaceId);
-      const filteredMembers = members.filter(
-        (m) => m.inbox_address !== '' && m.user_address != this.selfAddress
-      );
+      const configPublicKeyBytes = hexToSpreadArray(configKey.publicKey);
+
+      // Load encryption state for the space's own conversation. The template
+      // and evals pool we use here are identical to the ones used for private
+      // invite generation in constructInviteLink.
       const encryptionStates = await this.messageDB.getEncryptionStates({
         conversationId: spaceId + '/' + spaceId,
       });
-      const state = encryptionStates[0];
-      const trState = JSON.parse(JSON.parse(state.state).state);
-      const session =
-        await secureChannel.EstablishTripleRatchetSessionForSpace(
-          user_keyset,
-          device_keyset,
-          registration,
-          filteredMembers.length + 200
+      if (!encryptionStates || encryptionStates.length === 0) {
+        throw new Error(
+          t`No encryption state found for this Space. Cannot generate public invite.`
         );
-
-      logger.log('new link session', session);
-      const outbounds: string[] = [];
-      let newPeerIdSet = {
-        [trState.id_peer_map[1].public_key]: 1,
-      };
-      let newIdPeerSet = {
-        [1]: trState.id_peer_map[1],
-      } as { [key: number]: any };
-      let idCounter = 2;
-      for (const member of filteredMembers) {
-        const user = await this.apiClient.getUser(member.user_address);
-        const device = user.data.device_registrations.find(
-          (d: any) =>
-            trState.peer_id_map[
-              Buffer.from(
-                d.inbox_registration.inbox_encryption_public_key,
-                'hex'
-              ).toString('base64')
-            ]
-        );
-        if (!device) {
-          idCounter++;
-          continue;
-        }
-        const inboxKey = Buffer.from(
-          device!.inbox_registration.inbox_encryption_public_key,
-          'hex'
-        ).toString('base64');
-        newPeerIdSet = {
-          ...newPeerIdSet,
-          [inboxKey]: idCounter,
-        };
-        newIdPeerSet = {
-          ...newIdPeerSet,
-          [idCounter]: trState.id_peer_map[trState.peer_id_map[inboxKey]],
-        };
-        idCounter++;
       }
-      const ownRatchet = JSON.parse(session.state);
-      ownRatchet.peer_id_map = newPeerIdSet;
-      ownRatchet.id_peer_map = newIdPeerSet;
-      session.state = JSON.stringify(ownRatchet);
+      const stateRow = encryptionStates[0];
+      const session = JSON.parse(stateRow.state);
 
-      idCounter = 2;
-      for (const member of filteredMembers) {
-        if (!newIdPeerSet[idCounter]) {
-          continue;
-        }
-        const sendState = session.template;
-        const ratchet = JSON.parse(sendState.dkg_ratchet);
-        sendState.peer_id_map = newPeerIdSet;
-        sendState.id_peer_map = newIdPeerSet;
-        ratchet.id = filteredMembers.length + 201 - session.evals.length;
-        sendState.root_key = JSON.parse(session.state).root_key;
-        const index_secret_raw = session.evals.shift();
-        const secret_pair = JSON.parse(ch.js_generate_x448());
-        const eph_pair = JSON.parse(ch.js_generate_x448());
-        ratchet.total = Object.keys(ownRatchet.peer_id_map).length;
-        ratchet.secret = Buffer.from(
-          new Uint8Array(secret_pair.private_key)
-        ).toString('base64');
-        ratchet.scalar = Buffer.from(
-          new Uint8Array(index_secret_raw!)
-        ).toString('base64');
-        ratchet.point = JSON.parse(
-          ch.js_get_pubkey_x448(
-            Buffer.from(new Uint8Array(index_secret_raw!)).toString('base64')
-          )
+      if (!session.template) {
+        throw new Error(
+          t`Encryption state is missing required template data. The invite pool was not initialized.`
         );
-        ratchet.random_commitment_point = JSON.parse(
-          ch.js_get_pubkey_x448(
-            Buffer.from(new Uint8Array(index_secret_raw!)).toString('base64')
-          )
-        );
-        sendState.dkg_ratchet = JSON.stringify(ratchet);
-        sendState.next_dkg_ratchet = JSON.stringify(ratchet);
-        sendState.ephemeral_private_key = Buffer.from(
-          new Uint8Array(eph_pair.private_key)
-        ).toString('base64');
-        const template = JSON.stringify(sendState);
-
-        const innerEnvelope = await secureChannel.SealInboxEnvelope(
-          newIdPeerSet[idCounter].public_key,
-          JSON.stringify({
-            configKey: Buffer.from(
-              new Uint8Array(configPair.private_key)
-            ).toString('hex'),
-            state: template,
-          })
-        );
-        const envelope = await secureChannel.SealSyncEnvelope(
-          member.inbox_address,
-          hubKey.address!,
-          {
-            type: 'ed448',
-            private_key: hexToSpreadArray(hubKey.privateKey),
-            public_key: hexToSpreadArray(hubKey.publicKey),
-          },
-          {
-            type: 'ed448',
-            private_key: hexToSpreadArray(ownerKey.privateKey),
-            public_key: hexToSpreadArray(ownerKey.publicKey),
-          },
-          JSON.stringify({
-            type: 'control',
-            message: {
-              type: 'rekey',
-              info: JSON.stringify(innerEnvelope),
-            },
-          })
-        );
-        outbounds.push(JSON.stringify({ type: 'sync', ...envelope }));
-        idCounter++;
+      }
+      if (!session.evals || session.evals.length === 0) {
+        throw new InviteEvalsExhaustedError();
+      }
+      if (!session.state) {
+        throw new Error(t`Encryption state is missing state data.`);
       }
 
-      const space_evals = [] as string[];
-      for (
-        let e = session.evals.shift();
-        e != undefined;
-        e = session.evals.shift()
-      ) {
-        const sendState = session.template;
+      // Ephemeral keypair used to encrypt both the eval and the manifest.
+      const ephemeralKey = JSON.parse(
+        ch.js_generate_x448()
+      ) as secureChannel.X448Keypair;
+
+      // Build a single eval payload (MAX_PUBLIC_EVALS = 1). Matches mobile.
+      const evalsToProcess = session.evals.slice(0, MAX_PUBLIC_EVALS);
+      const spaceEvals: string[] = [];
+      let idCounter = 10001 - session.evals.length;
+
+      const parsedState =
+        typeof session.state === 'string'
+          ? JSON.parse(session.state)
+          : session.state;
+
+      for (const evalData of evalsToProcess) {
+        // Deep-copy the template so we don't mutate the shared template that
+        // private invites also use.
+        const sendState = JSON.parse(JSON.stringify(session.template));
         const ratchet = JSON.parse(sendState.dkg_ratchet);
-        sendState.peer_id_map = newPeerIdSet;
-        sendState.id_peer_map = newIdPeerSet;
+
         ratchet.id = idCounter;
-        sendState.root_key = JSON.parse(session.state).root_key;
-        const index_secret_raw = e;
-        const secret_pair = JSON.parse(ch.js_generate_x448());
-        const eph_pair = JSON.parse(ch.js_generate_x448());
-        ratchet.total = Object.keys(ownRatchet.peer_id_map).length;
+        sendState.root_key = parsedState.root_key;
+
+        const secretPair = JSON.parse(ch.js_generate_x448());
+        const ephPair = JSON.parse(ch.js_generate_x448());
+
+        const evalSecretBase64 = Buffer.from(
+          new Uint8Array(evalData)
+        ).toString('base64');
+
         ratchet.secret = Buffer.from(
-          new Uint8Array(secret_pair.private_key)
+          new Uint8Array(secretPair.private_key)
         ).toString('base64');
-        ratchet.scalar = Buffer.from(
-          new Uint8Array(index_secret_raw!)
+        ratchet.scalar = evalSecretBase64;
+        const evalPoint = JSON.parse(ch.js_get_pubkey_x448(evalSecretBase64));
+        ratchet.point = evalPoint;
+        ratchet.random_commitment_point = Buffer.from(
+          new Uint8Array(secretPair.public_key)
         ).toString('base64');
-        ratchet.point = JSON.parse(
-          ch.js_get_pubkey_x448(
-            Buffer.from(new Uint8Array(index_secret_raw!)).toString('base64')
-          )
-        );
-        ratchet.random_commitment_point = JSON.parse(
-          ch.js_get_pubkey_x448(
-            Buffer.from(new Uint8Array(index_secret_raw!)).toString('base64')
-          )
-        );
+
         sendState.dkg_ratchet = JSON.stringify(ratchet);
         sendState.next_dkg_ratchet = JSON.stringify(ratchet);
         sendState.ephemeral_private_key = Buffer.from(
-          new Uint8Array(eph_pair.private_key)
+          new Uint8Array(ephPair.private_key)
         ).toString('base64');
+
         const template = JSON.stringify(sendState);
+
+        const evalPayload = {
+          id: idCounter,
+          template: template,
+          secret: Buffer.from(new Uint8Array(evalData)).toString('hex'),
+          hubKey: hubKey.privateKey,
+        };
+
         const ciphertext = ch.js_encrypt_inbox_message(
           JSON.stringify({
-            inbox_public_key: [...new Uint8Array(configPair.public_key)],
-            ephemeral_private_key: ephemeral_key.private_key,
+            inbox_public_key: configPublicKeyBytes,
+            ephemeral_private_key: ephemeralKey.private_key,
             plaintext: [
               ...new Uint8Array(
-                Buffer.from(
-                  JSON.stringify({
-                    id: idCounter,
-                    template: template,
-                    secret: Buffer.from(new Uint8Array(e)).toString('hex'),
-                    hubKey: hubKey.privateKey,
-                  }),
-                  'utf-8'
-                )
+                Buffer.from(JSON.stringify(evalPayload), 'utf-8')
               ),
             ],
           } as secureChannel.SealedInboxMessageEncryptRequest)
         );
 
-        space_evals.push(ciphertext);
+        spaceEvals.push(ciphertext);
         idCounter++;
       }
 
-      const out = {
-        config_public_key: Buffer.from(
-          new Uint8Array(configPair.public_key)
-        ).toString('hex'),
-        space_address: space!.spaceId,
-        space_evals: space_evals,
-        ephemeral_public_key: Buffer.from(
-          new Uint8Array(ephemeral_key.public_key)
-        ).toString('hex'),
-        owner_public_key: ownerKey.publicKey,
-        owner_signature: Buffer.from(
-          JSON.parse(
-            ch.js_sign_ed448(
-              Buffer.from(ownerKey.privateKey, 'hex').toString('base64'),
-              Buffer.from(
-                new Uint8Array([
-                  ...space_evals.flatMap((s) => [
-                    ...new Uint8Array(Buffer.from(s, 'utf-8')),
-                  ]),
-                ])
-              ).toString('base64')
-            )
-          ),
-          'base64'
-        ).toString('hex'),
-      };
+      // Signature payload is all eval ciphertexts concatenated as utf-8 bytes.
+      const evalsPayloadBase64 = Buffer.from(
+        new Uint8Array(
+          spaceEvals.flatMap((s) => [
+            ...new Uint8Array(Buffer.from(s, 'utf-8')),
+          ])
+        )
+      ).toString('base64');
+      const evalsSignatureBase64 = JSON.parse(
+        ch.js_sign_ed448(
+          Buffer.from(ownerKey.privateKey, 'hex').toString('base64'),
+          evalsPayloadBase64
+        )
+      );
 
-      space!.inviteUrl = `${getInviteUrlBase(true)}#spaceId=${space!.spaceId}&configKey=${Buffer.from(new Uint8Array(configPair.private_key)).toString('hex')}`;
-      const ciphertext = ch.js_encrypt_inbox_message(
+      // Build the new public invite URL using the EXISTING config private key.
+      // The URL string is therefore deterministic per space — regenerating
+      // produces the same URL, only the server-side eval and manifest change.
+      const inviteLink = `${buildInviteBase(true)}#spaceId=${spaceId}&configKey=${configKey.privateKey}`;
+      space.inviteUrl = inviteLink;
+
+      // Re-publish the manifest encrypted with the existing config key. This
+      // is what gives new joiners a current snapshot (name, members, channels)
+      // when they fetch via the public link.
+      const manifestCiphertext = ch.js_encrypt_inbox_message(
         JSON.stringify({
-          inbox_public_key: [...new Uint8Array(configPair.public_key)],
-          ephemeral_private_key: ephemeral_key.private_key,
+          inbox_public_key: configPublicKeyBytes,
+          ephemeral_private_key: ephemeralKey.private_key,
           plaintext: [
             ...new Uint8Array(Buffer.from(JSON.stringify(space), 'utf-8')),
           ],
         } as secureChannel.SealedInboxMessageEncryptRequest)
       );
 
-      const manifest = {
+      const ts = Date.now();
+      const manifestSignaturePayloadBase64 = Buffer.from(
+        new Uint8Array([
+          ...new Uint8Array(Buffer.from(manifestCiphertext, 'utf-8')),
+          ...int64ToBytes(ts),
+        ])
+      ).toString('base64');
+      const manifestSignatureBase64 = JSON.parse(
+        ch.js_sign_ed448(
+          Buffer.from(ownerKey.privateKey, 'hex').toString('base64'),
+          manifestSignaturePayloadBase64
+        )
+      );
+
+      const ephemeralPublicKeyHex = Buffer.from(
+        new Uint8Array(ephemeralKey.public_key)
+      ).toString('hex');
+
+      // Upload the single eval to the server keyed by config_public_key.
+      await this.apiClient.postSpaceInviteEvals({
+        config_public_key: configKey.publicKey,
         space_address: spaceId,
-        space_manifest: ciphertext,
-        ephemeral_public_key: Buffer.from(
-          new Uint8Array(ephemeral_key.public_key)
+        space_evals: spaceEvals,
+        ephemeral_public_key: ephemeralPublicKeyHex,
+        owner_public_key: ownerKey.publicKey,
+        owner_signature: Buffer.from(
+          evalsSignatureBase64,
+          'base64'
         ).toString('hex'),
+      });
+
+      // Re-publish the manifest.
+      await this.apiClient.postSpaceManifest(spaceId, {
+        space_address: spaceId,
+        space_manifest: manifestCiphertext,
+        ephemeral_public_key: ephemeralPublicKeyHex,
         timestamp: ts,
         owner_public_key: ownerKey.publicKey,
         owner_signature: Buffer.from(
-          JSON.parse(
-            ch.js_sign_ed448(
-              Buffer.from(ownerKey.privateKey, 'hex').toString('base64'),
-              Buffer.from(
-                new Uint8Array([
-                  ...new Uint8Array(Buffer.from(ciphertext, 'utf-8')),
-                  ...int64ToBytes(ts),
-                ])
-              ).toString('base64')
-            )
-          ),
+          manifestSignatureBase64,
           'base64'
         ).toString('hex'),
-      };
+      });
 
-      await this.apiClient.postSpace(spaceId, {
-        space_address: spaceId,
-        space_public_key: spaceKey.publicKey,
-        space_signature: Buffer.from(spaceSignature, 'base64').toString(
-          'hex'
-        ),
-        config_public_key: Buffer.from(
-          new Uint8Array(configPair.public_key)
-        ).toString('hex'),
-        owner_public_keys: [ownerKey.publicKey],
-        owner_signatures: [
-          Buffer.from(ownerSignature, 'base64').toString('hex'),
-        ],
-        timestamp: ts,
-      } as secureChannel.SpaceRegistration);
-      await this.apiClient.postSpaceInviteEvals(out);
-      await this.apiClient.postSpaceManifest(spaceId, manifest);
-      await this.messageDB.saveSpace(space!);
+      // Persist the new inviteUrl locally.
+      await this.messageDB.saveSpace(space);
       await this.queryClient.setQueryData(
-        buildSpaceKey({ spaceId: space?.spaceId! }),
+        buildSpaceKey({ spaceId: space.spaceId }),
         space
       );
 
+      // Pop the consumed evals from the local pool and persist. We do this
+      // AFTER successful upload so a failed network request doesn't leak
+      // pool slots.
+      session.evals = session.evals.slice(MAX_PUBLIC_EVALS);
       await this.messageDB.saveEncryptionState(
-        { ...state, state: JSON.stringify(session) },
+        { ...stateRow, state: JSON.stringify(session) },
         true
       );
-      this.enqueueOutbound(async () => {
-        return outbounds;
+
+      logger.log('[invite] public link generated', {
+        spaceId: spaceId.slice(0, 12),
+        remainingEvals: session.evals.length,
       });
+
+      // Silence unused-parameter warnings — see method docblock.
+      void _user_keyset;
+      void _device_keyset;
+      void _registration;
     } catch (e) {
       console.error(e);
       throw e;


### PR DESCRIPTION
## Summary

Realigns desktop's invite system with mobile (`quorum-mobile`). Public-link generation becomes cheap (1 server eval, no member rekey, existing config key reused). One-time and public invites coexist on the same Space. The Invites tab UX is rebuilt from the ground up.

## Service layer

- `constructInviteLink`: removed the short-circuit on `space.inviteUrl`. Always builds a fresh one-time URL from the local evals pool. Template is deep-copied before mutation (mirrors mobile's defensive pattern; prevents leaked-ratchet bugs on concurrent generation).
- `generateNewInviteLink`: rewritten to mirror mobile's `generatePublicInviteLink`. Reuses existing config key, uploads exactly 1 server eval (`MAX_PUBLIC_EVALS = 1`), re-publishes the manifest. No member rekey, no new keypair. Decrements the local pool only after a successful upload.
- `buildInviteBase` helper substitutes `qm.one` → `app.quorummessenger.com` in generated URLs to match mobile output. Acceptance of `qm.one` links remains unchanged.
- New `InviteEvalsExhaustedError` typed error so the UI can render a friendly banner instead of a raw failure.
- `sendInviteToUser` gains `mode: 'one-time' | 'public' | 'reuse'` plus optional `presetLink`.

## UI (`SpaceSettingsModal/Invites.tsx`)

- Underline-tab segmented toggle between One-Time and Public Link modes. Public is owner-only.
- **One-time mode (deliberately deviates from mobile to close the multi-recipient footgun)**: no displayed link box. Two parallel actions:
  - **Send via DM**: expandable picker. Each Send Invite mints a fresh URL invisibly. Multiple sends in a row each get independent unique URLs. Selected contact auto-clears after success.
  - **Copy a link**: mints a fresh URL, writes to clipboard, shows a persistent "Link copied" callout. URL never rendered on screen. 1.2s minimum spinner duration.
- **Public mode**: link box + Send via DM + Republish (subtle-outline, visually demoted). Republish bypasses the confirmation modal — the URL stays the same; it only refreshes the on-server eval. Tooltip explains the actual purpose: defensive escape hatch for joiners reporting the link isn't working.
- Mutually exclusive success states across the two one-time actions.
- Pool-exhausted banner with mode-adaptive copy + disabled action buttons.
- Tab icon changed from `user-plus` to `share` to match mobile.

## Hook + Context

- `useInviteManagement` threads `mode` + `presetLink`. Adds `generateOneTimeLink`, `clearGeneratedOneTimeLink`, `generateOneTimeLinkError`, and `poolExhausted` (proactively detected from encryption state on mount).
- `MessageDB` context exposes `constructInviteLink` and the extended `sendInviteToUser` signature.

## Tests (28/28 passing)

Added coverage for: MAX_PUBLIC_EVALS = 1 upload, existing config key reuse, no `postSpace`, no `getSpaceMembers`, no outbound rekey envelopes, manifest re-publish, pool decrement timing, failure-doesn't-leak-pool, empty-pool error, non-owner gating, `qm.one` absence in generated URLs, `mode='public'` + `mode='reuse'` happy paths and error cases. Updated `constructInviteLink` test to assert the saved template stays unmutated (deep-copy correctness).

## Docs

- `.agents/docs/features/invite-system-analysis.md` rewritten for the single-key coexistence model. Dropped the "system switch is permanent" warning.
- `.agents/bugs/2025-09-22-public-invite-link-intermittent-expiration.md` annotated as `likely-resolved-by-consolidation`.
- `.agents/tasks/.todo/2026-01-09-delete-public-invite-link.md` annotated with consolidation context.
- New `.agents/tasks/.done/2026-06-07-consolidate-invite-system-with-mobile.md` (full task spec + implementation log + late-stage UI revision rationale).

## Test plan

- [x] `npx tsc --noEmit --skipLibCheck` clean (only pre-existing unrelated error)
- [x] `npx vitest run src/dev/tests/services/InvitationService.unit.test.tsx` — 28/28 passing
- [x] Manual: One-time tab — Send via DM expands picker, sends to A, picker resets, sends to B, B gets a different URL; Copy a link works and copies a different URL each click; spinner is perceivable
- [x] Manual: Public tab — Generate Public Invite Link (with confirm modal), link displayed, Republish updates without dialog, Send via DM forwards the inviteUrl
- [x] Manual: Mode switch — callouts and pickers reset cleanly between tabs
- [x] Manual: Mutually exclusive success states verified