### PR TITLE
feat(sidebar): unified width across modes with channels 144px floor

### DIFF
--- a/.agents/INDEX.md
+++ b/.agents/INDEX.md
@@ -44,6 +44,7 @@ This is the main index for all documentation, bug reports, and task management.
 - [ReactTooltip Mobile Support Documentation](docs/features/reacttooltip-mobile.md)
 - [Responsive Layout System Documentation](docs/features/responsive-layout.md)
 - [Security Architecture](docs/features/security.md)
+- [Sidebar Drag & Minimize UX](docs/features/sidebar-drag-ux.md)
 - [Space Folders](docs/features/space-folders.md)
 - [Space Settings Modal - Fixes Section](docs/features/space-settings-fixes-section.md)
 - [Space Tags](docs/features/space-tags.md)

--- a/.agents/docs/features/responsive-layout.md
+++ b/.agents/docs/features/responsive-layout.md
@@ -59,7 +59,7 @@ The shell renders three slots — `app-shell__rail`, `app-shell__sidebar`, `app-
 ## Layout Behavior
 
 - **Desktop**: rail and sidebar are inline. Sidebar is user-resizable via a drag handle on its right edge (hover-arms after 500ms; arrow keys nudge by 16px). Releasing below `SIDEBAR_SNAP_THRESHOLD` snaps to the collapsed strip.
-- **Channels mode** (route `/spaces/:spaceId/:channelId`): the sidebar has a 300px floor (`CHANNELS_SIDEBAR_WIDTH`). Drag handle stays available but cannot shrink below the floor and snap-to-collapsed is disabled.
+- **Channels mode** (route `/spaces/:spaceId/:channelId`): floor is 144px (`CHANNELS_SIDEBAR_FLOOR`); channels never fully collapses to the 72px strip. Channels shares the same persisted `sidebarWidth` as DM/Spaces. The full spec — including cross-mode minimize propagation rules and a scenario table — lives in [`sidebar-drag-ux.md`](./sidebar-drag-ux.md).
 - **Tablet**: rail and sidebar are forced collapsed (72px). Drag handle not rendered.
 - **Phone**: rail and sidebar are removed from the inline flow. A focus-trapped off-canvas drawer mounts them on demand; the drawer trigger lives in each view's chat header. The drawer auto-closes when the route lands on a leaf (DM conversation, channel, Public Spaces).
 
@@ -77,7 +77,7 @@ The rail does not have its own breakpoint logic — its width follows the shell'
 ### Sidebar width (`_variables.scss` + `useShellState.ts`)
 
 ```scss
-$sidebar-width: 300px;          // default expanded width
+$sidebar-width: 280px;          // default expanded width
 $sidebar-width-collapsed: 72px; // strip layout
 ```
 
@@ -86,9 +86,10 @@ export const SIDEBAR_COLLAPSED_WIDTH = 72;
 export const SIDEBAR_MIN_WIDTH = 240;
 export const SIDEBAR_MAX_WIDTH = 480;
 export const SIDEBAR_SNAP_THRESHOLD = 200;
+export const CHANNELS_SIDEBAR_FLOOR = 144;
 ```
 
-`shell.sidebarWidth` in localStorage holds the user's last free-drag width. The legacy `shell.sidebarCollapsed` boolean is read once on first load for migration and kept mirrored on write so a rollback still picks up a sensible state.
+`shell.sidebarWidth` holds the user's "free width" (the width when not minimized). `shell.sidebarCollapsed` holds whether DM/Spaces is currently in the collapsed (72px) state. `shell.channelsFloored` holds whether channels is currently at the 144px floor. These flags are independent per mode but cross-coupled: setting `channelsFloored=true` also sets `sidebarCollapsed=true`. `shell.lastFreeWidth` mirrors `shell.sidebarWidth` for backwards compatibility.
 
 ### Chat Content Width Fix (`src/styles/_chat.scss`)
 
@@ -190,9 +191,10 @@ The shell exposes the current sidebar width as a CSS variable on the AppShell ro
 
 ```scss
 .app-shell {
-  // --shell-sidebar-width is set inline in AppShell.tsx (defaults to the
-  // user's persisted shell.sidebarWidth, or CHANNELS_SIDEBAR_WIDTH when
-  // the channels sidebar is mounted).
+  // --shell-sidebar-width is set inline in AppShell.tsx. Value is the live
+  // drag-tracked width while dragging, otherwise the "resting" width:
+  //   channels mode: channelsFloored ? 144 : max(sidebarWidth, 144)
+  //   DM/Spaces:     sidebarCollapsed ? 72 : sidebarWidth
 }
 ```
 
@@ -234,7 +236,7 @@ Downstream features can read `var(--shell-sidebar-width)` if they need to size r
 1. Test at 1024px boundary (tablet ↔ desktop) — rail/sidebar should switch from forced-collapsed to user-controlled width.
 2. Test at 768px boundary (phone ↔ tablet) — drawer should disappear from the layout in favour of the inline collapsed strip.
 3. Verify the drag handle is present on desktop and absent on tablet/phone.
-4. Verify channels mode pins the sidebar at 300px on desktop regardless of the user's persisted width.
+4. Verify width is unified across modes when expanded (drag wider in channels → DM/Spaces is also wider when you switch), and minimize-intent propagates one-way (channels at 144 → DM/Spaces collapsed to 72; collapsing DM/Spaces does NOT floor channels).
 
 ### Interaction Testing
 
@@ -322,4 +324,4 @@ A comprehensive modal system has been implemented with consistent responsive beh
 
 ---
 
-*Last updated: 2026-06-04*
+*Last updated: 2026-06-08*

--- a/.agents/docs/features/sidebar-drag-ux.md
+++ b/.agents/docs/features/sidebar-drag-ux.md
@@ -1,0 +1,113 @@
+# Sidebar Drag & Minimize UX
+
+How the section sidebar (DMs / Spaces / Channels / Discover) behaves when the user resizes or minimizes it. This is the spec — the source of truth for "what should happen when..." questions about sidebar width. Implementation lives in [`src/components/shell/useShellState.ts`](../../../src/components/shell/useShellState.ts) and [`src/components/shell/AppShell.tsx`](../../../src/components/shell/AppShell.tsx).
+
+For broader responsive-layout context (rail, drawer, breakpoints), see [responsive-layout.md](./responsive-layout.md).
+
+## Mental model
+
+There is **one sidebar** that shows different content depending on route. Width is a property of the sidebar (like a window), not of each content mode. The user sized it; it should stay sized as they navigate.
+
+**Two minimize states exist**, because the two content categories have different minimum-usable widths:
+- **DM / Spaces / Discover** can collapse to a 72px icon strip (still functional — you can see avatars / space icons / section icons).
+- **Channels** has a 144px floor (channel names truncate heavily but the list is still navigable). Channels cannot fully collapse to 72 — that would defeat the purpose of being in a channel.
+
+## State (persisted in localStorage)
+
+| Key | Type | Meaning |
+|---|---|---|
+| `shell.sidebarWidth` | number (240–480) | The user's "free width" — what the sidebar shows when not minimized. Same value used by all modes. |
+| `shell.sidebarCollapsed` | boolean | True when DM/Spaces/Discover is currently in its 72px collapsed strip. |
+| `shell.channelsFloored` | boolean | True when channels is currently at the 144px floor. |
+| `shell.lastFreeWidth` | number | Mirror of `sidebarWidth` for backwards compatibility. |
+
+## State (ephemeral, in `ShellState` context only)
+
+| Field | Meaning |
+|---|---|
+| `dragWidth` | The live cursor-tracked width during an active drag (`null` when not dragging). |
+| `sidebarLiveCollapsed` | Derived: `dragWidth !== null ? dragWidth <= 72 : sidebarCollapsed`. Sidebar content components (`DirectMessageContactsList`, `SpacesSidebar`, `DiscoverSidebar`) read THIS — not `sidebarCollapsed` — so the expanded layout appears as soon as the user starts pulling. If the user releases in the snap zone (< 200), `sidebarCollapsed` flips back true and content returns to the collapsed strip. |
+
+## Resting (non-drag) effective width
+
+```
+channels mode:
+  channelsFloored          → 144
+  otherwise                → max(sidebarWidth, 144)
+
+DM / Spaces / Discover:
+  sidebarCollapsed         → 72
+  otherwise                → sidebarWidth
+```
+
+## Drag behaviour
+
+**Channels mode:**
+- Dragging clamps the live width to `[144, 480]`.
+- On release at exactly 144 → set `channelsFloored = true` (also sets `sidebarCollapsed = true`, see propagation rule below).
+- On release above 144 → set `channelsFloored = false`, persist new width to `sidebarWidth`.
+
+**DM / Spaces / Discover:**
+- Dragging clamps live width to `[72, 480]`; below the 200px snap threshold the visible width follows the cursor down to the 72 collapsed strip.
+- On release ≤ 200 → set `sidebarCollapsed = true`. `sidebarWidth` is preserved (so the next expand restores the prior free width).
+- On release > 200 → set `sidebarCollapsed = false`, persist new width to `sidebarWidth`.
+
+**Keyboard (arrow keys, Home, End on the drag handle):**
+- Channels: clamp to `[144, 480]`. Pressing into the floor sets `channelsFloored = true`.
+- DM/Spaces: clamp to `[240, 480]`. Keyboard never snap-to-collapses (only mouse drag does).
+
+## Cross-mode propagation (the asymmetric rule)
+
+**One propagation only:** setting `channelsFloored = true` also sets `sidebarCollapsed = true`.
+
+Everything else is independent:
+- Setting `channelsFloored = false` does NOT auto-clear `sidebarCollapsed`.
+- Setting `sidebarCollapsed` (true or false) does NOT change `channelsFloored`.
+- Setting `sidebarWidth` (drag above the floor in either mode) is purely shared — both modes will pick up the new width when next expanded.
+
+### Why asymmetric?
+
+- **Minimize is a global mood.** When the user shrinks one mode to its floor, they're usually saying "I want more room for content right now" — that intent applies broadly. Propagating minimize matches it.
+- **Maximize is local.** Expanding channels usually has a channel-specific reason (long channel names); it's not a statement about DM/Spaces. Don't propagate.
+- **Collapse-from-DM/Spaces shouldn't floor channels** because entering a channel from a collapsed-Spaces state almost always means the user wants to see the channel list. Forcing 144px there would surprise.
+- **Collapse intent has a canonical destination** (72 or 144); width intent is a continuum — propagating "expand" would force a width choice on the other mode.
+
+## Scenario table
+
+The model resolved against the scenarios that drove the design:
+
+| # | Start state | User action | Expected outcome | Why |
+|---|---|---|---|---|
+| 1 | Spaces at 280 | Switch to channels | Channels at 280 | Same `sidebarWidth`, `channelsFloored=false`. |
+| 2 | Channels at 280, user drags to 400 | Switch to Spaces | Spaces at 400 | Width is shared; drag persisted to `sidebarWidth`. |
+| 3 | Channels at 400, user drags to 144 | Switch to Spaces | Spaces collapsed at 72 | Floor → both flags set. |
+| 4 | Spaces collapsed (72), user clicks a space icon → enters channel | Channels opens at 280 (or whatever last `sidebarWidth` was) | Collapsing Spaces doesn't floor channels. |
+| 5 | Channels at 400, user drags to 144 (collapses Spaces), user drags back to 400 | Channels at 400; Spaces stays collapsed | Asymmetric un-collapse: dragging channels back up is one action; user didn't ask to un-collapse Spaces. |
+| 6 | Spaces collapsed (72), user drags handle out to 350 | Spaces at 350 (`sidebarCollapsed=false`, `sidebarWidth=350`) | Standard expand. If now switching to channels, channels at 350. |
+| 7 | Channels at 400, switch to Spaces (also 400), drag Spaces to 72 (collapse) | Spaces collapsed; switch back to channels → channels still at 400 | Collapsing Spaces does NOT floor channels. |
+| 8 | First-time user | — | `sidebarWidth=280`, both flags false. Every mode renders at 280. | Clean defaults. |
+
+## Constants (in [`useShellState.ts`](../../../src/components/shell/useShellState.ts))
+
+```typescript
+export const SIDEBAR_COLLAPSED_WIDTH = 72;   // DM/Spaces collapsed-strip width
+export const SIDEBAR_MIN_WIDTH = 240;        // DM/Spaces minimum free width
+export const SIDEBAR_MAX_WIDTH = 480;        // shared max
+export const SIDEBAR_SNAP_THRESHOLD = 200;   // mouse drag below this → snap to collapsed
+export const CHANNELS_SIDEBAR_FLOOR = 144;   // channels mode minimum
+const DEFAULT_SIDEBAR_WIDTH = 280;           // first-time-user default
+```
+
+Mirror in [`_variables.scss`](../../../src/styles/_variables.scss): `$sidebar-width: 280px`, `$sidebar-width-collapsed: 72px`.
+
+## Touch / phone
+
+Phone collapses both the rail and the sidebar into a focus-trapped off-canvas drawer (see [responsive-layout.md](./responsive-layout.md)). The drag handle is suppressed on touch (`@media (hover: none)` in [`AppShell.scss`](../../../src/components/shell/AppShell.scss)). All width/minimize state is desktop-only — tablet and phone force `sidebarCollapsed = true` for visual layout, but the underlying desktop preferences are preserved untouched.
+
+## Migration
+
+Pre-existing users may have `shell.sidebarWidth = 72` from the old model that wrote the collapsed-strip width directly into the width key. On first load with the new model, `resolveInitialState` detects width ≤ 72 and treats the user as collapsed: it restores their prior free width from `lastFreeWidth` (or falls back to the 280 default) and sets `sidebarCollapsed = true`. Old `shell.channelsWidth` keys from an interim model are simply ignored — the new model doesn't read them.
+
+---
+
+*Last updated: 2026-06-08*

--- a/src/components/direct/DirectMessageContactsList.tsx
+++ b/src/components/direct/DirectMessageContactsList.tsx
@@ -76,8 +76,10 @@ const DirectMessageContactsList: React.FC<DirectMessageContactsListProps> = ({ f
   const { markAllReadTimestamp } = useDmReadState();
 
   // Shell state — null when rendered outside the AppShell tree (legacy fallback).
+  // sidebarLiveCollapsed follows the on-screen width during drag so the layout
+  // re-renders as the user crosses the snap threshold.
   const shell = useOptionalShellState();
-  const sidebarCollapsed = shell?.sidebarCollapsed ?? false;
+  const sidebarCollapsed = shell?.sidebarLiveCollapsed ?? false;
   const renderCollapsed = sidebarCollapsed && !forceExpanded;
 
   // Load mock utilities dynamically in development only

--- a/src/components/shell/AppShell.tsx
+++ b/src/components/shell/AppShell.tsx
@@ -8,6 +8,7 @@ import {
   SIDEBAR_MIN_WIDTH,
   SIDEBAR_MAX_WIDTH,
   SIDEBAR_SNAP_THRESHOLD,
+  CHANNELS_SIDEBAR_FLOOR,
 } from './useShellState';
 import { useSidebarMode } from './useSidebarMode';
 import { NavRail } from './NavRail';
@@ -16,13 +17,6 @@ import './AppShell.scss';
 
 const HOVER_ARM_DELAY_MS = 500;
 const KEYBOARD_RESIZE_STEP = 16;
-
-// Channels mode pins the sidebar at a fixed width regardless of the user's
-// persisted collapse/resize preference for the other modes. Channel names
-// need a predictable amount of horizontal space to stay readable, and the
-// sidebar isn't user-resizable here (drag handle is suppressed below).
-// Mirrors $sidebar-width in _variables.scss.
-const CHANNELS_SIDEBAR_WIDTH = 300;
 
 const FOCUSABLE_SELECTOR = [
   'a[href]',
@@ -137,7 +131,12 @@ const AppShellInner: React.FunctionComponent<AppShellProps> = ({ children, onAdd
     railCollapsed,
     sidebarCollapsed,
     sidebarWidth,
+    channelsFloored,
+    dragWidth,
     setSidebarWidth,
+    setChannelsFloored,
+    setSidebarCollapsed,
+    setDragWidth,
     toggleRailCollapsed,
     viewport,
     drawerOpen,
@@ -149,94 +148,97 @@ const AppShellInner: React.FunctionComponent<AppShellProps> = ({ children, onAdd
   const location = useLocation();
   const drawerRef = React.useRef<HTMLDivElement>(null);
   const dragHandleRef = React.useRef<HTMLDivElement>(null);
-  const [isDragging, setIsDragging] = React.useState(false);
+  const isDragging = dragWidth !== null;
   useDrawerFocusTrap(drawerRef, isPhone && drawerOpen, closeDrawer);
   useHoverArm(dragHandleRef, isDragging);
 
-  // Channels mode never collapses — channel names need a readable floor width.
-  // The collapse preference still persists in the background for DM/Spaces modes.
-  const effectiveCollapsed = sidebarMode === 'channels' ? false : sidebarCollapsed;
-  // Effective floor for the sidebar in the current mode. Channels mode raises
-  // the floor to CHANNELS_SIDEBAR_WIDTH; everything else uses SIDEBAR_MIN_WIDTH.
-  // Used for drag clamping AND for the rendered width (via effectiveSidebarWidth
-  // below) so a previously-shrunk sidebar grows up to the floor on entry.
-  const minSidebarWidth =
-    sidebarMode === 'channels' ? CHANNELS_SIDEBAR_WIDTH : SIDEBAR_MIN_WIDTH;
+  const isChannels = sidebarMode === 'channels';
   const railToggleHandler = viewport === 'desktop' ? toggleRailCollapsed : null;
-  // Drag handle is rendered on desktop whenever the sidebar is visible. In
-  // channels mode the drag is clamped to the channels floor so the user can
-  // expand the channels sidebar but never shrink it below the floor; the
-  // snap-to-collapsed behaviour is also disabled in channels mode.
-  const showDragHandle =
-    viewport === 'desktop' && !sidebarHidden;
+  const showDragHandle = viewport === 'desktop' && !sidebarHidden;
+
+  // Resting (non-drag) effective width: channels uses CHANNELS_SIDEBAR_FLOOR
+  // when floored and sidebarWidth (lifted to the channels floor) otherwise.
+  // DM/Spaces uses SIDEBAR_COLLAPSED_WIDTH when collapsed and sidebarWidth otherwise.
+  const restingSidebarWidth = isChannels
+    ? channelsFloored
+      ? CHANNELS_SIDEBAR_FLOOR
+      : Math.max(sidebarWidth, CHANNELS_SIDEBAR_FLOOR)
+    : sidebarCollapsed
+      ? SIDEBAR_COLLAPSED_WIDTH
+      : sidebarWidth;
+  // While dragging, the on-screen width follows the cursor (via dragWidth);
+  // otherwise it's the resting width from the model.
+  const effectiveSidebarWidth = dragWidth ?? restingSidebarWidth;
+  // Floor for the drag handle ARIA attributes (the lowest width this mode can render).
+  const minSidebarWidth = isChannels ? CHANNELS_SIDEBAR_FLOOR : SIDEBAR_COLLAPSED_WIDTH;
 
   const onDragHandleMouseDown = React.useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
       if (e.button !== 0) return;
       e.preventDefault();
-      const isChannels = sidebarMode === 'channels';
       const startX = e.clientX;
-      // In channels mode the drag starts from the visible (floor-clamped)
-      // width, not from the persisted sidebarWidth. Otherwise a user landing
-      // in channels at the 300 floor with a saved 72 would have their first
-      // drag pixel jump straight back to 72.
-      const startWidth = isChannels
-        ? Math.max(sidebarWidth, CHANNELS_SIDEBAR_WIDTH)
-        : sidebarWidth;
-      const minFloor = isChannels ? CHANNELS_SIDEBAR_WIDTH : SIDEBAR_MIN_WIDTH;
-      setIsDragging(true);
+      const startWidth = restingSidebarWidth;
+      setDragWidth(startWidth);
       document.body.style.cursor = 'col-resize';
       document.body.style.userSelect = 'none';
 
+      // During drag we maintain dragWidth (local state) so the sidebar tracks
+      // the cursor in real time. We don't touch sidebarWidth / flags during
+      // drag — those get committed on release based on where the user lands.
       const onMove = (ev: MouseEvent) => {
         const candidate = startWidth + (ev.clientX - startX);
-        let next: number;
         if (isChannels) {
-          // Channels: no snap-to-collapsed; clamp at the channels floor.
-          next = clampWidth(candidate, CHANNELS_SIDEBAR_WIDTH);
+          // Channels: clamp at the channels floor for visual feedback.
+          setDragWidth(clampWidth(candidate, CHANNELS_SIDEBAR_FLOOR));
         } else {
-          // Non-channels: existing snap-zone feedback below SIDEBAR_MIN_WIDTH.
-          next =
-            candidate <= SIDEBAR_SNAP_THRESHOLD
-              ? Math.max(SIDEBAR_COLLAPSED_WIDTH, candidate)
-              : clampWidth(candidate);
+          // DM/Spaces: below the snap threshold, visual width follows down to
+          // the collapsed strip (clamped to >= SIDEBAR_COLLAPSED_WIDTH).
+          // Above the threshold, clamp to [SIDEBAR_MIN_WIDTH, MAX].
+          if (candidate <= SIDEBAR_SNAP_THRESHOLD) {
+            setDragWidth(Math.max(SIDEBAR_COLLAPSED_WIDTH, candidate));
+          } else {
+            setDragWidth(clampWidth(candidate));
+          }
         }
-        setSidebarWidth(next);
       };
       const onUp = (ev: MouseEvent) => {
         const finalCandidate = startWidth + (ev.clientX - startX);
-        let final: number;
         if (isChannels) {
-          final = clampWidth(finalCandidate, CHANNELS_SIDEBAR_WIDTH);
+          const clamped = clampWidth(finalCandidate, CHANNELS_SIDEBAR_FLOOR);
+          if (clamped <= CHANNELS_SIDEBAR_FLOOR) {
+            // Landed at the floor — flip the floor flag (which also collapses DM/Spaces).
+            setChannelsFloored(true);
+          } else {
+            // Landed above the floor — clear floor flag and persist as free width.
+            setChannelsFloored(false);
+            setSidebarWidth(clamped);
+          }
         } else {
-          final =
-            finalCandidate <= SIDEBAR_SNAP_THRESHOLD
-              ? SIDEBAR_COLLAPSED_WIDTH
-              : clampWidth(finalCandidate);
+          if (finalCandidate <= SIDEBAR_SNAP_THRESHOLD) {
+            // Snap to collapsed; preserve the persisted "free width" untouched.
+            setSidebarCollapsed(true);
+          } else {
+            setSidebarCollapsed(false);
+            setSidebarWidth(clampWidth(finalCandidate));
+          }
         }
-        setSidebarWidth(final);
         document.body.style.cursor = '';
         document.body.style.userSelect = '';
         window.removeEventListener('mousemove', onMove);
         window.removeEventListener('mouseup', onUp);
-        setIsDragging(false);
+        setDragWidth(null);
       };
       window.addEventListener('mousemove', onMove);
       window.addEventListener('mouseup', onUp);
     },
-    [sidebarWidth, setSidebarWidth, sidebarMode]
+    [restingSidebarWidth, isChannels, setSidebarWidth, setChannelsFloored, setSidebarCollapsed, setDragWidth]
   );
 
   const onDragHandleKeyDown = React.useCallback(
     (e: React.KeyboardEvent<HTMLDivElement>) => {
-      const isChannels = sidebarMode === 'channels';
-      const floor = isChannels ? CHANNELS_SIDEBAR_WIDTH : SIDEBAR_MIN_WIDTH;
-      // Operate on the visible width so the first keypress matches what the
-      // user sees, even when the persisted sidebarWidth sits below the floor.
-      const baseWidth = isChannels
-        ? Math.max(sidebarWidth, CHANNELS_SIDEBAR_WIDTH)
-        : sidebarWidth;
-      let next: number | null = null;
+      const floor = isChannels ? CHANNELS_SIDEBAR_FLOOR : SIDEBAR_MIN_WIDTH;
+      const baseWidth = effectiveSidebarWidth;
+      let next: number;
       switch (e.key) {
         case 'ArrowLeft':
           next = clampWidth(baseWidth - KEYBOARD_RESIZE_STEP, floor);
@@ -254,9 +256,21 @@ const AppShellInner: React.FunctionComponent<AppShellProps> = ({ children, onAdd
           return;
       }
       e.preventDefault();
-      setSidebarWidth(next);
+      if (isChannels) {
+        if (next <= CHANNELS_SIDEBAR_FLOOR) {
+          setChannelsFloored(true);
+        } else {
+          setChannelsFloored(false);
+          setSidebarWidth(next);
+        }
+      } else {
+        // Keyboard never snap-to-collapses (no SIDEBAR_SNAP_THRESHOLD logic);
+        // SIDEBAR_MIN_WIDTH is the keyboard floor for DM/Spaces.
+        setSidebarCollapsed(false);
+        setSidebarWidth(next);
+      }
     },
-    [sidebarWidth, setSidebarWidth, sidebarMode]
+    [effectiveSidebarWidth, isChannels, setSidebarWidth, setChannelsFloored, setSidebarCollapsed]
   );
 
   // Phone: rail + sidebar are hidden inline; their content lives in the drawer.
@@ -266,9 +280,13 @@ const AppShellInner: React.FunctionComponent<AppShellProps> = ({ children, onAdd
       ? 'app-shell__rail--collapsed'
       : 'app-shell__rail--expanded';
 
+  // --collapsed class is only used by DM/Spaces (it locks width to 72px in CSS).
+  // Channels mode renders via --expanded with --shell-sidebar-width = CHANNELS_SIDEBAR_FLOOR
+  // when floored, so the slot picks up the floor width from the CSS variable.
+  // During drag we always use --expanded so the live dragWidth drives the slot.
   const sidebarSlotClass = (isPhone || sidebarHidden)
     ? 'app-shell__sidebar--hidden'
-    : effectiveCollapsed
+    : (!isChannels && sidebarCollapsed && !isDragging)
       ? 'app-shell__sidebar--collapsed'
       : 'app-shell__sidebar--expanded';
 
@@ -285,16 +303,6 @@ const AppShellInner: React.FunctionComponent<AppShellProps> = ({ children, onAdd
     if (isDmLeaf || isSpaceLeaf || isDiscoverLeaf || isHiddenSidebar) closeDrawer();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [location.pathname, location.search]);
-
-  // Channels sidebar has a hard *floor* but no hard ceiling vs other modes:
-  // if the user already has the sidebar dragged wider than the channels floor,
-  // we keep that width when they enter a channel (no jump). If it's narrower
-  // or collapsed, we float it up to the floor so channel names stay readable.
-  // Drag below the floor is blocked while in channels (see onDragHandleMouseDown).
-  const effectiveSidebarWidth =
-    sidebarMode === 'channels'
-      ? Math.max(sidebarWidth, CHANNELS_SIDEBAR_WIDTH)
-      : sidebarWidth;
 
   const shellStyle = React.useMemo(
     () => ({ ['--shell-sidebar-width' as string]: `${effectiveSidebarWidth}px` }),

--- a/src/components/shell/DiscoverSidebar.tsx
+++ b/src/components/shell/DiscoverSidebar.tsx
@@ -45,8 +45,10 @@ interface DiscoverSidebarProps {
 export const DiscoverSidebar: React.FC<DiscoverSidebarProps> = ({ forceExpanded }) => {
   const navigate = useNavigate();
   const location = useLocation();
-  const { sidebarCollapsed } = useShellState();
-  const renderCollapsed = sidebarCollapsed && !forceExpanded;
+  // sidebarLiveCollapsed reflects the on-screen width during drag so the
+  // expanded layout appears as soon as the user crosses the snap threshold.
+  const { sidebarLiveCollapsed } = useShellState();
+  const renderCollapsed = sidebarLiveCollapsed && !forceExpanded;
   const sections = buildSections();
 
   const activeId: DiscoverSectionId = location.pathname.startsWith('/discover/people')

--- a/src/components/shell/useShellState.ts
+++ b/src/components/shell/useShellState.ts
@@ -6,6 +6,7 @@ const STORAGE_KEY_RAIL = 'shell.railCollapsed';
 const STORAGE_KEY_SIDEBAR = 'shell.sidebarCollapsed';
 const STORAGE_KEY_SIDEBAR_WIDTH = 'shell.sidebarWidth';
 const STORAGE_KEY_LAST_FREE_WIDTH = 'shell.lastFreeWidth';
+const STORAGE_KEY_CHANNELS_FLOORED = 'shell.channelsFloored';
 
 const DEFAULT_RAIL_COLLAPSED = true;
 const DEFAULT_SIDEBAR_COLLAPSED = false;
@@ -16,7 +17,12 @@ export const SIDEBAR_COLLAPSED_WIDTH = 72;
 export const SIDEBAR_MIN_WIDTH = 240;
 export const SIDEBAR_MAX_WIDTH = 480;
 export const SIDEBAR_SNAP_THRESHOLD = 200;
-const DEFAULT_SIDEBAR_WIDTH = 300;
+const DEFAULT_SIDEBAR_WIDTH = 280;
+
+// Channels mode has a narrower minimum than DM/Spaces — at this width channel
+// names truncate heavily but the list is still navigable. Channels cannot
+// fully collapse (would defeat the purpose of being in a channel).
+export const CHANNELS_SIDEBAR_FLOOR = 144;
 
 // Viewport breakpoints — mirror $screen-md / $screen-lg in _variables.scss.
 const PHONE_MAX = 767;
@@ -26,16 +32,32 @@ export type ShellViewport = 'phone' | 'tablet' | 'desktop';
 
 export interface ShellState {
   railCollapsed: boolean;
-  /** Derived: true when sidebarWidth <= SIDEBAR_COLLAPSED_WIDTH. */
+  /** Persisted: true when DM/Spaces sidebar is in its collapsed (72px) state. */
   sidebarCollapsed: boolean;
-  /** Effective sidebar width in px. SIDEBAR_COLLAPSED_WIDTH (72) means collapsed strip. */
+  /** Persisted "free width" — what the sidebar shows when not minimized.
+   *  Range: [SIDEBAR_MIN_WIDTH, SIDEBAR_MAX_WIDTH]. Same value used by all modes. */
   sidebarWidth: number;
+  /** Persisted: true when the user has dragged the channels sidebar down to the
+   *  floor (CHANNELS_SIDEBAR_FLOOR). Setting true also collapses DM/Spaces. */
+  channelsFloored: boolean;
+  /** Live drag width (null when not dragging). Sidebar consumers should derive
+   *  their layout from `sidebarLiveCollapsed` instead of `sidebarCollapsed` so
+   *  they re-render the expanded layout as the user drags past the threshold. */
+  dragWidth: number | null;
+  /** Live "should I render the collapsed (icons-only) layout?" — during drag,
+   *  this follows the on-screen width; at rest, it equals `sidebarCollapsed`. */
+  sidebarLiveCollapsed: boolean;
   setRailCollapsed: (v: boolean) => void;
   toggleRailCollapsed: () => void;
   setSidebarCollapsed: (v: boolean) => void;
   toggleSidebarCollapsed: () => void;
-  /** Set sidebar width directly (used by the drag handle). Caller clamps; this persists. */
+  /** Set the shared "free width". Caller clamps. Persists across all modes. */
   setSidebarWidth: (px: number) => void;
+  /** Set the channels-floored flag. true also collapses DM/Spaces; false does
+   *  NOT auto-expand DM/Spaces (asymmetric — see docs/responsive-layout.md). */
+  setChannelsFloored: (v: boolean) => void;
+  /** Set the live drag width. AppShell calls this from its drag handlers. */
+  setDragWidth: (px: number | null) => void;
 
   /** Derived viewport bucket — recomputed on resize. */
   viewport: ShellViewport;
@@ -88,15 +110,34 @@ const writeNumber = (key: string, value: number) => {
   }
 };
 
-// Resolve initial sidebar width: prefer the new shell.sidebarWidth key; fall
-// back to migrating the legacy shell.sidebarCollapsed boolean; default to
-// DEFAULT_SIDEBAR_WIDTH. Legacy key is left in place for one release so a
-// rollback still finds a valid value.
-const resolveInitialSidebarWidth = (): number => {
+// Resolve initial state from storage. The model used to write SIDEBAR_COLLAPSED_WIDTH (72)
+// into shell.sidebarWidth when collapsed; the new model keeps shell.sidebarWidth as the
+// "free width" (>= SIDEBAR_MIN_WIDTH) and tracks collapse separately via STORAGE_KEY_SIDEBAR.
+// So if we read a value <= SIDEBAR_COLLAPSED_WIDTH (or below the min), we treat the user
+// as collapsed, lift the width to lastFreeWidth (or default), and mark them collapsed.
+interface InitialState {
+  width: number;
+  othersCollapsed: boolean;
+}
+const resolveInitialState = (): InitialState => {
   const direct = readNumber(STORAGE_KEY_SIDEBAR_WIDTH);
-  if (direct !== null) return direct;
+  if (direct !== null) {
+    if (direct <= SIDEBAR_COLLAPSED_WIDTH) {
+      // Old format: width was being set to 72 to represent collapsed. Restore
+      // the user's prior free width from STORAGE_KEY_LAST_FREE_WIDTH.
+      const lastFree = readNumber(STORAGE_KEY_LAST_FREE_WIDTH);
+      const restored = lastFree && lastFree >= SIDEBAR_MIN_WIDTH ? lastFree : DEFAULT_SIDEBAR_WIDTH;
+      return { width: restored, othersCollapsed: true };
+    }
+    if (direct < SIDEBAR_MIN_WIDTH) {
+      // Stale value between the snap threshold and the min — bring it to the floor.
+      return { width: SIDEBAR_MIN_WIDTH, othersCollapsed: false };
+    }
+    return { width: direct, othersCollapsed: false };
+  }
+  // No persisted width — migrate from legacy boolean.
   const legacyCollapsed = readBool(STORAGE_KEY_SIDEBAR, DEFAULT_SIDEBAR_COLLAPSED);
-  return legacyCollapsed ? SIDEBAR_COLLAPSED_WIDTH : DEFAULT_SIDEBAR_WIDTH;
+  return { width: DEFAULT_SIDEBAR_WIDTH, othersCollapsed: legacyCollapsed };
 };
 
 const computeViewport = (width: number): ShellViewport => {
@@ -123,22 +164,27 @@ const useViewport = (): ShellViewport => {
 const useShellStateInternal = (): ShellState => {
   // Initialize synchronously from localStorage so we don't paint the default
   // width and then jump to the saved one on first render.
+  const initial = React.useMemo(() => resolveInitialState(), []);
   const [railCollapsedPref, setRailCollapsedState] = useState<boolean>(() =>
     readBool(STORAGE_KEY_RAIL, DEFAULT_RAIL_COLLAPSED)
   );
-  const [sidebarWidthPref, setSidebarWidthState] = useState<number>(() => resolveInitialSidebarWidth());
+  const [sidebarWidthPref, setSidebarWidthState] = useState<number>(initial.width);
+  const [othersCollapsedPref, setOthersCollapsedState] = useState<boolean>(initial.othersCollapsed);
+  const [channelsFlooredPref, setChannelsFlooredState] = useState<boolean>(
+    () => readBool(STORAGE_KEY_CHANNELS_FLOORED, false)
+  );
+  // Live drag width (not persisted). null = not dragging. AppShell sets this.
+  const [dragWidth, setDragWidthState] = useState<number | null>(null);
   const [drawerOpen, setDrawerOpen] = useState<boolean>(false);
   // Element focused before the drawer opened — restored on close so keyboard
   // and AT users return to the hamburger that triggered the drawer.
   const drawerTriggerRef = React.useRef<HTMLElement | null>(null);
   const viewport = useViewport();
 
-  // Persist the migrated value so the legacy boolean can be retired safely.
+  // Persist the resolved initial state so subsequent loads find a clean shape.
   useEffect(() => {
-    if (readNumber(STORAGE_KEY_SIDEBAR_WIDTH) === null) {
-      writeNumber(STORAGE_KEY_SIDEBAR_WIDTH, sidebarWidthPref);
-    }
-    // Run once on mount.
+    writeNumber(STORAGE_KEY_SIDEBAR_WIDTH, initial.width);
+    writeBool(STORAGE_KEY_SIDEBAR, initial.othersCollapsed);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -160,40 +206,45 @@ const useShellStateInternal = (): ShellState => {
     });
   }, []);
 
+  // setSidebarWidth: update the shared "free width." This is what every mode
+  // uses when not minimized. Caller is responsible for clamping to a sensible
+  // range; this just persists.
   const setSidebarWidth = useCallback((px: number) => {
     setSidebarWidthState(px);
     writeNumber(STORAGE_KEY_SIDEBAR_WIDTH, px);
-    // Mirror to the legacy boolean so a rollback still picks the right state.
-    writeBool(STORAGE_KEY_SIDEBAR, px <= SIDEBAR_COLLAPSED_WIDTH);
+    writeNumber(STORAGE_KEY_LAST_FREE_WIDTH, px);
+  }, []);
+
+  const setOthersCollapsed = useCallback((v: boolean) => {
+    setOthersCollapsedState(v);
+    writeBool(STORAGE_KEY_SIDEBAR, v);
+  }, []);
+
+  // setChannelsFloored: toggle the channels-mode minimize flag. Setting it true
+  // also collapses DM/Spaces (cross-mode "minimize" intent). Setting it false
+  // does NOT auto-expand DM/Spaces — each "expand" action is local to its mode.
+  // See docs/features/responsive-layout.md for the full rationale.
+  const setDragWidth = useCallback((px: number | null) => {
+    setDragWidthState(px);
+  }, []);
+
+  const setChannelsFloored = useCallback((v: boolean) => {
+    setChannelsFlooredState(v);
+    writeBool(STORAGE_KEY_CHANNELS_FLOORED, v);
+    if (v) {
+      setOthersCollapsedState(true);
+      writeBool(STORAGE_KEY_SIDEBAR, true);
+    }
   }, []);
 
   const setSidebarCollapsed = useCallback((v: boolean) => {
-    if (v) {
-      // Going collapsed: stash the current width as lastFreeWidth so the next
-      // expand restores it, then snap to the collapsed strip.
-      const current = readNumber(STORAGE_KEY_SIDEBAR_WIDTH) ?? DEFAULT_SIDEBAR_WIDTH;
-      if (current > SIDEBAR_COLLAPSED_WIDTH) {
-        writeNumber(STORAGE_KEY_LAST_FREE_WIDTH, current);
-      }
-      setSidebarWidth(SIDEBAR_COLLAPSED_WIDTH);
-    } else {
-      const restored = readNumber(STORAGE_KEY_LAST_FREE_WIDTH) ?? DEFAULT_SIDEBAR_WIDTH;
-      setSidebarWidth(restored);
-    }
-  }, [setSidebarWidth]);
+    setOthersCollapsed(v);
+  }, [setOthersCollapsed]);
 
   const toggleSidebarCollapsed = useCallback(() => {
-    setSidebarWidthState((prev) => {
-      const isCollapsed = prev <= SIDEBAR_COLLAPSED_WIDTH;
-      let next: number;
-      if (isCollapsed) {
-        next = readNumber(STORAGE_KEY_LAST_FREE_WIDTH) ?? DEFAULT_SIDEBAR_WIDTH;
-      } else {
-        writeNumber(STORAGE_KEY_LAST_FREE_WIDTH, prev);
-        next = SIDEBAR_COLLAPSED_WIDTH;
-      }
-      writeNumber(STORAGE_KEY_SIDEBAR_WIDTH, next);
-      writeBool(STORAGE_KEY_SIDEBAR, next <= SIDEBAR_COLLAPSED_WIDTH);
+    setOthersCollapsedState((prev) => {
+      const next = !prev;
+      writeBool(STORAGE_KEY_SIDEBAR, next);
       return next;
     });
   }, []);
@@ -216,13 +267,21 @@ const useShellStateInternal = (): ShellState => {
     }
   }, []);
 
-  // Effective collapse state: tablet forces sidebar to collapsed visual state
-  // regardless of the user's persisted desktop preference. Desktop honours the
-  // user pref. Phone collapses both into the drawer (handled by AppShell using
-  // the `viewport === 'phone'` flag, not these booleans).
+  // Effective state: tablet forces collapsed visual state regardless of
+  // persisted desktop preference. Desktop honours the user prefs. Phone
+  // collapses both into the drawer (handled by AppShell using `viewport`).
   const railCollapsed = viewport === 'desktop' ? railCollapsedPref : true;
-  const sidebarWidth = viewport === 'desktop' ? sidebarWidthPref : SIDEBAR_COLLAPSED_WIDTH;
-  const sidebarCollapsed = sidebarWidth <= SIDEBAR_COLLAPSED_WIDTH;
+  const sidebarCollapsed = viewport === 'desktop' ? othersCollapsedPref : true;
+  const sidebarWidth = sidebarWidthPref;
+  const channelsFloored = viewport === 'desktop' ? channelsFlooredPref : false;
+  // Live collapsed flag for sidebar content. While dragging, content switches
+  // to the expanded layout as soon as the sidebar is wider than the collapsed
+  // strip — the user expects to see the expanded list the moment they start
+  // pulling. At rest, this equals sidebarCollapsed. (On release, if the user
+  // landed in the snap zone, sidebarCollapsed flips back to true and the
+  // content returns to the collapsed strip.)
+  const sidebarLiveCollapsed =
+    dragWidth !== null ? dragWidth <= SIDEBAR_COLLAPSED_WIDTH : sidebarCollapsed;
 
   // Memoize so context consumers (NavRail, Sidebar, etc.) don't re-render on
   // every parent render. Setters/togglers are stable via useCallback([]); only
@@ -232,11 +291,16 @@ const useShellStateInternal = (): ShellState => {
       railCollapsed,
       sidebarCollapsed,
       sidebarWidth,
+      channelsFloored,
+      dragWidth,
+      sidebarLiveCollapsed,
       setRailCollapsed,
       toggleRailCollapsed,
       setSidebarCollapsed,
       toggleSidebarCollapsed,
       setSidebarWidth,
+      setChannelsFloored,
+      setDragWidth,
       viewport,
       drawerOpen,
       openDrawer,
@@ -246,6 +310,9 @@ const useShellStateInternal = (): ShellState => {
       railCollapsed,
       sidebarCollapsed,
       sidebarWidth,
+      channelsFloored,
+      dragWidth,
+      sidebarLiveCollapsed,
       viewport,
       drawerOpen,
       setRailCollapsed,
@@ -253,6 +320,8 @@ const useShellStateInternal = (): ShellState => {
       setSidebarCollapsed,
       toggleSidebarCollapsed,
       setSidebarWidth,
+      setChannelsFloored,
+      setDragWidth,
       openDrawer,
       closeDrawer,
     ]

--- a/src/components/space/SpacesSidebar.tsx
+++ b/src/components/space/SpacesSidebar.tsx
@@ -171,8 +171,10 @@ const SpacesSidebarInner: React.FunctionComponent<SpacesSidebarProps> = ({ onAdd
     }
     return overlay;
   }, [realSpaceUnreadCounts, mockSpaces, mockFolderSpaces, mockFolderCounts]);
-  const { sidebarCollapsed } = useShellState();
-  const renderCollapsed = sidebarCollapsed && !forceExpanded;
+  // sidebarLiveCollapsed reflects the on-screen width during drag so the
+  // expanded layout appears as soon as the user crosses the snap threshold.
+  const { sidebarLiveCollapsed } = useShellState();
+  const renderCollapsed = sidebarLiveCollapsed && !forceExpanded;
   const { mutedSpacesSet } = useMutedSpacesSet();
   const { openContextMenu: openRowContextMenu, contextMenu: rowContextMenu } = useSpaceContextMenu();
 

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -324,7 +324,7 @@ $message-avatar-size-mobile: $s-9;        /* 36px - mobile avatar size (≤480px
 /* Used across src/components/shell/ and its child components. */
 $rail-width-collapsed:    72px;
 $rail-width-expanded:    236px;
-$sidebar-width:          300px;
+$sidebar-width:          280px;
 $sidebar-width-collapsed: 72px;
 $sidebar-header-height:   56px;
 $rail-item-height:        46px;


### PR DESCRIPTION
## Summary

- Lower default sidebar width 300px → 280px.
- Channels sidebar is now user-resizable with a 144px floor; full collapse is suppressed (entering a channel with no channel list would defeat the purpose).
- Width is shared across modes: dragging wider in channels carries into DM/Spaces (and vice versa). Cross-mode "minimize" intent propagates one way only — channels at the floor also collapses DM/Spaces; the reverse does not.
- Sidebar content (DM list, Spaces list, Discover) switches to its expanded layout the moment a drag starts, instead of waiting for release.

## UX spec

Full state model, scenario table, and rationale for the asymmetric minimize-propagation rule live in [.agents/docs/features/sidebar-drag-ux.md](.agents/docs/features/sidebar-drag-ux.md).

## Migration

Pre-existing users whose ``shell.sidebarWidth`` was set to 72 (old collapsed-state representation) are migrated on first load: width is restored from ``shell.lastFreeWidth`` (or default 280) and ``shell.sidebarCollapsed`` is set true. No data loss.

## Test plan

- [ ] Drag channels sidebar wider → switch to Spaces → Spaces shows same width.
- [ ] Drag channels to 144 floor → Spaces also collapses to 72.
- [ ] Drag channels back above 144 → Spaces stays collapsed (asymmetric).
- [ ] Spaces collapsed → click space icon → channels opens at last expanded width (not 144).
- [ ] Drag DM/Spaces sidebar from collapsed → content flips to expanded layout immediately, not on release.
- [ ] Release drag in snap zone (< 200) → snaps to collapsed strip; persisted width preserved.
- [ ] Tablet/phone viewport: sidebar still forced collapsed; desktop prefs untouched.