### PR TITLE
fix(action-queue): roll back optimistic state and surface error toasts on enqueue failure

### DIFF
--- a/src/hooks/business/channels/useChannelMute.ts
+++ b/src/hooks/business/channels/useChannelMute.ts
@@ -12,11 +12,13 @@
 
 import { useCallback } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
+import { t } from '@lingui/core/macro';
 import { useMessageDB } from '../../../components/context/useMessageDB';
 import { usePasskeysContext } from '@quilibrium/quilibrium-js-sdk-channels';
 import { isChannelMuted, getMutedChannelsForSpace } from '../../../utils/channelUtils';
-import { getDefaultNotificationSettings } from '@quilibrium/quorum-shared';
+import { getDefaultNotificationSettings, logger } from '@quilibrium/quorum-shared';
 import { useConfig, buildConfigKey } from '../../queries/config';
+import { showError } from '../../../utils/toast';
 
 interface UseChannelMuteProps {
   spaceId: string;
@@ -163,11 +165,18 @@ export function useChannelMute({
         // Fire-and-forget: the optimistic cache update already gave the UI
         // its instant feedback. Awaiting would block the next toggle's read
         // and widen the race window.
-        void actionQueueService.enqueue(
-          'save-user-config',
-          { config: updatedConfig },
-          `config:${userAddress}` // Dedup key - collapses rapid toggles
-        );
+        actionQueueService
+          .enqueue(
+            'save-user-config',
+            { config: updatedConfig },
+            `config:${userAddress}` // Dedup key - collapses rapid toggles
+          )
+          .catch((err) => {
+            logger.error('[ChannelMute] enqueue failed for muteChannel, rolling back', err);
+            queryClient.setQueryData(buildConfigKey({ userAddress }), currentConfig);
+            invalidateNotificationQueries();
+            showError(t`Failed to save notification setting`);
+          });
       } catch (error) {
         console.error('[ChannelMute] Error muting channel:', error);
         throw error;
@@ -216,11 +225,18 @@ export function useChannelMute({
         // Fire-and-forget: the optimistic cache update already gave the UI
         // its instant feedback. Awaiting would block the next toggle's read
         // and widen the race window.
-        void actionQueueService.enqueue(
-          'save-user-config',
-          { config: updatedConfig },
-          `config:${userAddress}` // Dedup key - collapses rapid toggles
-        );
+        actionQueueService
+          .enqueue(
+            'save-user-config',
+            { config: updatedConfig },
+            `config:${userAddress}` // Dedup key - collapses rapid toggles
+          )
+          .catch((err) => {
+            logger.error('[ChannelMute] enqueue failed for unmuteChannel, rolling back', err);
+            queryClient.setQueryData(buildConfigKey({ userAddress }), currentConfig);
+            invalidateNotificationQueries();
+            showError(t`Failed to save notification setting`);
+          });
       } catch (error) {
         console.error('[ChannelMute] Error unmuting channel:', error);
         throw error;
@@ -270,11 +286,17 @@ export function useChannelMute({
       // Fire-and-forget: the optimistic cache update already gave the UI
       // its instant feedback. Awaiting would block the next toggle's read
       // and widen the race window.
-      void actionQueueService.enqueue(
-        'save-user-config',
-        { config: updatedConfig },
-        `config:${userAddress}` // Dedup key
-      );
+      actionQueueService
+        .enqueue(
+          'save-user-config',
+          { config: updatedConfig },
+          `config:${userAddress}` // Dedup key
+        )
+        .catch((err) => {
+          logger.error('[ChannelMute] enqueue failed for toggleShowMutedChannels, rolling back', err);
+          queryClient.setQueryData(buildConfigKey({ userAddress }), currentConfig);
+          showError(t`Failed to save notification setting`);
+        });
     } catch (error) {
       console.error('[ChannelMute] Error toggling showMutedChannels:', error);
       throw error;
@@ -326,11 +348,18 @@ export function useChannelMute({
       // Fire-and-forget: the optimistic cache update already gave the UI
       // its instant feedback. Awaiting would block the next toggle's read
       // and widen the race window.
-      void actionQueueService.enqueue(
-        'save-user-config',
-        { config: updatedConfig },
-        `config:${userAddress}` // Dedup key
-      );
+      actionQueueService
+        .enqueue(
+          'save-user-config',
+          { config: updatedConfig },
+          `config:${userAddress}` // Dedup key
+        )
+        .catch((err) => {
+          logger.error('[ChannelMute] enqueue failed for muteSpace, rolling back', err);
+          queryClient.setQueryData(buildConfigKey({ userAddress }), currentConfig);
+          invalidateNotificationQueries();
+          showError(t`Failed to save notification setting`);
+        });
     } catch (error) {
       console.error('[ChannelMute] Error muting space:', error);
       throw error;
@@ -379,11 +408,18 @@ export function useChannelMute({
       // Fire-and-forget: the optimistic cache update already gave the UI
       // its instant feedback. Awaiting would block the next toggle's read
       // and widen the race window.
-      void actionQueueService.enqueue(
-        'save-user-config',
-        { config: updatedConfig },
-        `config:${userAddress}` // Dedup key
-      );
+      actionQueueService
+        .enqueue(
+          'save-user-config',
+          { config: updatedConfig },
+          `config:${userAddress}` // Dedup key
+        )
+        .catch((err) => {
+          logger.error('[ChannelMute] enqueue failed for unmuteSpace, rolling back', err);
+          queryClient.setQueryData(buildConfigKey({ userAddress }), currentConfig);
+          invalidateNotificationQueries();
+          showError(t`Failed to save notification setting`);
+        });
     } catch (error) {
       console.error('[ChannelMute] Error unmuting space:', error);
       throw error;

--- a/src/hooks/business/dm/useDMFavorites.ts
+++ b/src/hooks/business/dm/useDMFavorites.ts
@@ -8,9 +8,12 @@
 
 import { useCallback, useMemo } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
+import { t } from '@lingui/core/macro';
+import { logger } from '@quilibrium/quorum-shared';
 import { useMessageDB } from '../../../components/context/useMessageDB';
 import { usePasskeysContext } from '@quilibrium/quilibrium-js-sdk-channels';
 import { useConfig, buildConfigKey } from '../../queries/config';
+import { showError } from '../../../utils/toast';
 
 interface UseDMFavoritesReturn {
   /** Array of favorite conversation IDs */
@@ -97,11 +100,17 @@ export function useDMFavorites(): UseDMFavoritesReturn {
         // Fire-and-forget: the optimistic cache update already gave the UI
         // its instant feedback. Awaiting would block the next toggle's read
         // and widen the race window.
-        void actionQueueService.enqueue(
-          'save-user-config',
-          { config: updatedConfig },
-          `config:${userAddress}` // Dedup key - collapses rapid toggles
-        );
+        actionQueueService
+          .enqueue(
+            'save-user-config',
+            { config: updatedConfig },
+            `config:${userAddress}` // Dedup key - collapses rapid toggles
+          )
+          .catch((err) => {
+            logger.error('[DMFavorites] enqueue failed for addFavorite, rolling back', err);
+            queryClient.setQueryData(buildConfigKey({ userAddress }), currentConfig);
+            showError(t`Failed to save favorite`);
+          });
       } catch (error) {
         console.error('[DMFavorites] Error adding favorite:', error);
         throw error;
@@ -145,11 +154,17 @@ export function useDMFavorites(): UseDMFavoritesReturn {
         // Fire-and-forget: the optimistic cache update already gave the UI
         // its instant feedback. Awaiting would block the next toggle's read
         // and widen the race window.
-        void actionQueueService.enqueue(
-          'save-user-config',
-          { config: updatedConfig },
-          `config:${userAddress}` // Dedup key - collapses rapid toggles
-        );
+        actionQueueService
+          .enqueue(
+            'save-user-config',
+            { config: updatedConfig },
+            `config:${userAddress}` // Dedup key - collapses rapid toggles
+          )
+          .catch((err) => {
+            logger.error('[DMFavorites] enqueue failed for removeFavorite, rolling back', err);
+            queryClient.setQueryData(buildConfigKey({ userAddress }), currentConfig);
+            showError(t`Failed to save favorite`);
+          });
       } catch (error) {
         console.error('[DMFavorites] Error removing favorite:', error);
         throw error;

--- a/src/hooks/business/dm/useDMMute.ts
+++ b/src/hooks/business/dm/useDMMute.ts
@@ -8,9 +8,12 @@
 
 import { useCallback, useMemo } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
+import { t } from '@lingui/core/macro';
+import { logger } from '@quilibrium/quorum-shared';
 import { useMessageDB } from '../../../components/context/useMessageDB';
 import { usePasskeysContext } from '@quilibrium/quilibrium-js-sdk-channels';
 import { useConfig, buildConfigKey } from '../../queries/config';
+import { showError } from '../../../utils/toast';
 
 interface UseDMMuteReturn {
   /** Array of muted conversation IDs */
@@ -102,11 +105,20 @@ export function useDMMute(): UseDMMuteReturn {
         // Fire-and-forget: the optimistic cache update already gave the UI
         // its instant feedback. Awaiting would block the next toggle's read
         // and widen the race window.
-        void actionQueueService.enqueue(
-          'save-user-config',
-          { config: updatedConfig },
-          `config:${userAddress}` // Dedup key - collapses rapid toggles
-        );
+        actionQueueService
+          .enqueue(
+            'save-user-config',
+            { config: updatedConfig },
+            `config:${userAddress}` // Dedup key - collapses rapid toggles
+          )
+          .catch((err) => {
+            logger.error('[DMMute] enqueue failed for muteConversation, rolling back', err);
+            queryClient.setQueryData(buildConfigKey({ userAddress }), currentConfig);
+            queryClient.invalidateQueries({
+              queryKey: ['unread-counts', 'direct-messages', userAddress],
+            });
+            showError(t`Failed to save mute setting`);
+          });
       } catch (error) {
         console.error('[DMMute] Error muting conversation:', error);
         throw error;
@@ -155,11 +167,20 @@ export function useDMMute(): UseDMMuteReturn {
         // Fire-and-forget: the optimistic cache update already gave the UI
         // its instant feedback. Awaiting would block the next toggle's read
         // and widen the race window.
-        void actionQueueService.enqueue(
-          'save-user-config',
-          { config: updatedConfig },
-          `config:${userAddress}` // Dedup key - collapses rapid toggles
-        );
+        actionQueueService
+          .enqueue(
+            'save-user-config',
+            { config: updatedConfig },
+            `config:${userAddress}` // Dedup key - collapses rapid toggles
+          )
+          .catch((err) => {
+            logger.error('[DMMute] enqueue failed for unmuteConversation, rolling back', err);
+            queryClient.setQueryData(buildConfigKey({ userAddress }), currentConfig);
+            queryClient.invalidateQueries({
+              queryKey: ['unread-counts', 'direct-messages', userAddress],
+            });
+            showError(t`Failed to save mute setting`);
+          });
       } catch (error) {
         console.error('[DMMute] Error unmuting conversation:', error);
         throw error;

--- a/src/hooks/business/folders/useDeleteFolder.ts
+++ b/src/hooks/business/folders/useDeleteFolder.ts
@@ -1,10 +1,13 @@
 import { useCallback } from 'react';
 import { usePasskeysContext } from '@quilibrium/quilibrium-js-sdk-channels';
 import { useQueryClient } from '@tanstack/react-query';
+import { t } from '@lingui/core/macro';
+import { logger } from '@quilibrium/quorum-shared';
 import { useConfig, buildConfigKey } from '../../queries';
 import { useMessageDB } from '../../../components/context/useMessageDB';
 import { NavItem, UserConfig } from '../../../db/messages';
 import { deriveSpaceIds } from '../../../utils/folderUtils';
+import { showError } from '../../../utils/toast';
 
 /**
  * Hook for deleting a folder and "spilling out" its spaces to standalone.
@@ -56,12 +59,26 @@ export const useDeleteFolder = () => {
         );
       }
 
-      // Queue config save in background - no more UI blocking!
-      await actionQueueService.enqueue(
-        'save-user-config',
-        { config: newConfig },
-        `config:${config.address}` // Dedup key
-      );
+      // Queue config save in background. Fire-and-forget with rollback: if
+      // enqueue rejects, restore the pre-delete config (which still contains
+      // the folder) and toast. SpacesSidebar's await on this resolves either
+      // way; the toast + rollback handle the user-facing contract.
+      actionQueueService
+        .enqueue(
+          'save-user-config',
+          { config: newConfig },
+          `config:${config.address}` // Dedup key
+        )
+        .catch((err) => {
+          logger.error('[DeleteFolder] enqueue failed, rolling back', err);
+          if (config.address) {
+            queryClient.setQueryData(
+              buildConfigKey({ userAddress: config.address }),
+              config
+            );
+          }
+          showError(t`Failed to delete folder`);
+        });
     },
     [config, queryClient, actionQueueService]
   );

--- a/src/hooks/business/folders/useFolderDragAndDrop.ts
+++ b/src/hooks/business/folders/useFolderDragAndDrop.ts
@@ -26,8 +26,10 @@ import {
   DROP_ZONE_BOTTOM_THRESHOLD,
 } from '../../../utils/folderUtils';
 import { isTouchDevice } from '../../../utils/platform';
-import { showWarning } from '../../../utils/toast';
+import { showError, showWarning } from '../../../utils/toast';
 import { buildConfigKey } from '../../queries';
+import { t } from '@lingui/core/macro';
+import { logger } from '@quilibrium/quorum-shared';
 
 /**
  * Drag scenario types for folder operations
@@ -593,6 +595,9 @@ export const useFolderDragAndDrop = ({
       }
 
       // Queue config save in background - no more UI blocking!
+      // If enqueue rejects, roll the cache back to the pre-drop snapshot
+      // (latestConfig) and toast — otherwise the sidebar would visually
+      // reflect a drag that didn't persist and silently revert on next sync.
       actionQueueService
         .enqueue(
           'save-user-config',
@@ -600,7 +605,14 @@ export const useFolderDragAndDrop = ({
           `config:${newConfig.address}` // Dedup key - only latest config matters
         )
         .catch((err) => {
-          console.error('[FolderDragAndDrop] Failed to queue config save:', err);
+          logger.error('[FolderDragAndDrop] enqueue failed, rolling back', err);
+          if (config.address) {
+            queryClient.setQueryData(
+              buildConfigKey({ userAddress: config.address }),
+              latestConfig
+            );
+          }
+          showError(t`Failed to save layout`);
         });
     },
     [config, actionQueueService, setIsDragging, setActiveItem, dropTarget, setDropTarget, queryClient, onFolderCreated]

--- a/src/hooks/business/folders/useFolderManagement.ts
+++ b/src/hooks/business/folders/useFolderManagement.ts
@@ -8,8 +8,9 @@ import { NavItem, UserConfig } from '../../../db/messages';
 import type { IconName, IconVariant } from '../../../components/primitives';
 import { IconColor } from '../../../components/space/IconPicker/types';
 import { createFolder, deriveSpaceIds } from '../../../utils/folderUtils';
-import { validateNameForXSS, MAX_NAME_LENGTH } from '@quilibrium/quorum-shared';
+import { validateNameForXSS, MAX_NAME_LENGTH, logger } from '@quilibrium/quorum-shared';
 import { useDeleteFolder } from './useDeleteFolder';
+import { showError } from '../../../utils/toast';
 
 interface UseFolderManagementProps {
   folderId?: string;
@@ -142,12 +143,26 @@ export const useFolderManagement = ({
       );
     }
 
-    // Queue config save in background
-    await actionQueueService.enqueue(
-      'save-user-config',
-      { config: newConfig },
-      `config:${config.address}` // Dedup key
-    );
+    // Queue config save in background. Fire-and-forget: if enqueue rejects,
+    // roll the cache back to the pre-update snapshot (config) and toast.
+    // The modal's saveUntilComplete wrapper won't see the failure but the
+    // toast + rollback satisfy the user-facing contract.
+    actionQueueService
+      .enqueue(
+        'save-user-config',
+        { config: newConfig },
+        `config:${config.address}` // Dedup key
+      )
+      .catch((err) => {
+        logger.error('[FolderManagement] enqueue failed for saveChanges, rolling back', err);
+        if (config.address) {
+          queryClient.setQueryData(
+            buildConfigKey({ userAddress: config.address }),
+            config
+          );
+        }
+        showError(t`Failed to save folder`);
+      });
   }, [
     config,
     keyset,

--- a/src/hooks/business/mentions/useMentionNotificationSettings.ts
+++ b/src/hooks/business/mentions/useMentionNotificationSettings.ts
@@ -11,11 +11,13 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
+import { t } from '@lingui/core/macro';
 import { useMessageDB } from '../../../components/context/useMessageDB';
 import { usePasskeysContext } from '@quilibrium/quilibrium-js-sdk-channels';
 import type { SpaceNotificationSettings, SpaceNotificationTypeId } from '../../../types/notifications';
-import { getDefaultNotificationSettings } from '@quilibrium/quorum-shared';
+import { getDefaultNotificationSettings, logger } from '@quilibrium/quorum-shared';
 import { buildConfigKey } from '../../queries/config';
+import { showError } from '../../../utils/toast';
 
 interface UseMentionNotificationSettingsProps {
   spaceId: string;
@@ -144,6 +146,9 @@ export function useMentionNotificationSettings({
         },
       };
 
+      // Capture pre-update snapshots for rollback before mutating either.
+      const previousSettings = settings;
+
       // Optimistically update React Query cache for instant UI feedback
       queryClient.setQueryData(
         buildConfigKey({ userAddress }),
@@ -159,12 +164,20 @@ export function useMentionNotificationSettings({
 
       // Queue config save in background (encrypt + sign + post + IndexedDB).
       // Fire-and-forget keeps the modal responsive; the optimistic cache update
-      // already gave the UI its instant feedback.
-      void actionQueueService.enqueue(
-        'save-user-config',
-        { config: updatedConfig },
-        `config:${userAddress}` // Dedup key - collapses with other config writes
-      );
+      // already gave the UI its instant feedback. On failure, restore both the
+      // cache and the local hook state so the UI matches what actually persisted.
+      actionQueueService
+        .enqueue(
+          'save-user-config',
+          { config: updatedConfig },
+          `config:${userAddress}` // Dedup key - collapses with other config writes
+        )
+        .catch((err) => {
+          logger.error('[NotificationSettings] enqueue failed for saveSettings, rolling back', err);
+          queryClient.setQueryData(buildConfigKey({ userAddress }), currentConfig);
+          setSettings(previousSettings);
+          showError(t`Failed to save notification setting`);
+        });
     } catch (error) {
       console.error('[NotificationSettings] Error saving settings:', error);
       throw error; // Re-throw so modal can show error

--- a/src/hooks/business/user/useUserSettings.ts
+++ b/src/hooks/business/user/useUserSettings.ts
@@ -1,14 +1,16 @@
 import { useState, useEffect } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
+import { t } from '@lingui/core/macro';
 import { usePasskeysContext, channel as secureChannel } from '@quilibrium/quilibrium-js-sdk-channels';
 import { useRegistration, buildConfigKey } from '../../queries';
 import { useRegistrationContext } from '../../../components/context/useRegistrationContext';
 import { useMessageDB } from '../../../components/context/useMessageDB';
-import type { BroadcastSpaceTag } from '@quilibrium/quorum-shared';
+import { type BroadcastSpaceTag, logger } from '@quilibrium/quorum-shared';
 import { DefaultImages } from '../../../utils';
 import { useUploadRegistration } from '../../mutations/useUploadRegistration';
 import { BackupService } from '../../../services/BackupService';
 import { getDeviceName } from '../../../utils/deviceInfo';
+import { showError } from '../../../utils/toast';
 
 export interface UseUserSettingsOptions {
   onSave?: () => void;
@@ -125,11 +127,18 @@ export const useUserSettings = (
           const updatedNames = { ...loadedNames, [inboxAddress]: autoName };
           const updatedConfig = { ...config, deviceNames: updatedNames };
           setDeviceNames(updatedNames);
-          actionQueueService.enqueue(
-            'save-user-config',
-            { config: updatedConfig },
-            `config:${currentPasskeyInfo.address}`
-          );
+          // Log-only on failure: this is a one-shot first-run autoname with no
+          // user action behind it. Toast would be confusing; the next session
+          // start will re-attempt since loadedNames still won't have the entry.
+          actionQueueService
+            .enqueue(
+              'save-user-config',
+              { config: updatedConfig },
+              `config:${currentPasskeyInfo.address}`
+            )
+            .catch((err) => {
+              logger.error('[UserSettings] enqueue failed for auto-device-name', err);
+            });
         }
       })();
     }
@@ -337,11 +346,23 @@ export const useUserSettings = (
       newConfig
     );
 
-    await actionQueueService.enqueue(
-      'save-user-config',
-      { config: newConfig },
-      `config:${currentPasskeyInfo.address}` // Dedup key
-    );
+    // Fire-and-forget with rollback: the optimistic cache update above already
+    // surfaced the new config to readers. If enqueue rejects (queue full, IDB
+    // write failure), restore the pre-update snapshot and toast the user.
+    actionQueueService
+      .enqueue(
+        'save-user-config',
+        { config: newConfig },
+        `config:${currentPasskeyInfo.address}` // Dedup key
+      )
+      .catch((err) => {
+        logger.error('[UserSettings] enqueue failed for saveChanges, rolling back', err);
+        queryClient.setQueryData(
+          buildConfigKey({ userAddress: currentPasskeyInfo.address }),
+          freshConfig
+        );
+        showError(t`Failed to save settings`);
+      });
 
     // Update TypingService gate immediately so toggle-OFF doesn't wait for
     // the action queue / IndexedDB round-trip. On ON→OFF transitions this


### PR DESCRIPTION
- fix(action-queue): roll back optimistic state on enqueue failure in useChannelMute
- fix(action-queue): roll back optimistic state on enqueue failure in useUserSettings
- fix(action-queue): roll back optimistic state on enqueue failure in DM hooks
- fix(action-queue): roll back optimistic state on enqueue failure in folder hooks
- fix(action-queue): roll back optimistic state on enqueue failure in useMentionNotificationSettings