### PR TITLE
docs(invites): close out joinInviteLink bugs + update invite-system doc

### DIFF
--- a/.agents/bugs/.solved/2025-08-03-joinspacemodal-invalid-json-network-error.md
+++ b/.agents/bugs/.solved/2025-08-03-joinspacemodal-invalid-json-network-error.md
@@ -1,21 +1,20 @@
 ---
 type: bug
 title: "JoinSpaceModal \"Invalid JSON\" Error Due to Network Issues"
-status: fix-in-flight-awaiting-verification
+status: solved
 created: 2026-01-09
 updated: 2026-06-08
-fix-attempted-by: task `2026-06-08-fix-join-invite-link.md`
+solved-by: PR #183 (task `2026-06-08-fix-join-invite-link.md`)
+verified-by: user end-to-end smoke test, 2026-06-08
 ---
 
-> **2026-06-08 — fix in flight, NOT yet verified.** Root cause appears to have been misattributed in the original report: investigation suggests this is NOT a network/JSON-parsing flakiness issue. The actual cause appears to be a server-side response-shape change for `/invite/eval` (object instead of legacy JSON-string) that desktop's `InvitationService.joinInviteLink` never accounted for. Every public-invite join attempt now fires `"[object Object]" is not valid JSON` at line 593 because `JSON.parse(inviteEval.data)` coerces an object to its string representation.
+> **2026-06-08 — solved.** Root cause was misattributed in the original report: this was NOT a network/JSON-parsing flakiness issue. The actual cause was a server-side response-shape change for `/invite/eval` (object instead of legacy JSON-string) that desktop's `InvitationService.joinInviteLink` never accounted for. Every public-invite join attempt fired `"[object Object]" is not valid JSON` at line 593 because `JSON.parse(inviteEval.data)` coerced an object to its string representation.
 >
-> The "regenerate the public link" workaround likely worked intermittently because regenerating re-uploads the manifest, which briefly aligns ephemeral keys (separate root cause — see [`2025-09-22-public-invite-link-intermittent-expiration.md`](2025-09-22-public-invite-link-intermittent-expiration.md)).
+> The "regenerate the public link" workaround appeared to work intermittently because regenerating re-uploads the manifest, which briefly aligned ephemeral keys (separate root cause — see the sibling bug report [`2025-09-22-public-invite-link-intermittent-expiration.md`](2025-09-22-public-invite-link-intermittent-expiration.md)).
 >
-> Proposed fix: normalize the server response at the API client layer in [`src/api/baseTypes.ts#getSpaceInviteEval`](../../src/api/baseTypes.ts) (handles both legacy string and current object shapes — same defensive pattern as `quorum-mobile/services/api/quorumClient.ts:710-738`). The consumer in `InvitationService.joinInviteLink` now reads `inviteEval.data.ciphertext` cleanly. No retry logic needed — the original proposal in this report would have been treating a symptom.
+> Fix: normalize the server response at the API client layer in [`src/api/baseTypes.ts#getSpaceInviteEval`](../../../src/api/baseTypes.ts) (handles both legacy string and current object shapes — same defensive pattern as `quorum-mobile/services/api/quorumClient.ts:710-738`). The consumer in `InvitationService.joinInviteLink` now reads `inviteEval.data.ciphertext` cleanly. No retry logic needed — the proposed "retry on JSON parse error" in the original report would have been treating a symptom.
 >
-> **Will only be moved to `.solved/` after end-to-end smoke testing confirms the fix.** Specifically:
-> - As a non-owner, click a public-invite link, click Join, confirm a space is added to the sidebar with no error.
-> - Repeat against a space the owner has updated (kicked a member, renamed a channel, etc.) since publishing the public invite — the previously-failing path covered by the sibling bug report.
+> Verified by user smoke test, 2026-06-08: joining via a public invite link now succeeds, including against a space the owner had updated since publishing the link (the path the sibling bug report covers).
 
 # JoinSpaceModal "Invalid JSON" Error Due to Network Issues
 

--- a/.agents/bugs/.solved/2025-09-22-public-invite-link-intermittent-expiration.md
+++ b/.agents/bugs/.solved/2025-09-22-public-invite-link-intermittent-expiration.md
@@ -1,22 +1,22 @@
 ---
 type: bug
 title: Public Invite Link Intermittent Expiration Bug
-status: fix-in-flight-awaiting-verification
+status: solved
 created: 2026-01-09T00:00:00.000Z
 updated: 2026-06-08
-fix-attempted-by: task `2026-06-08-fix-join-invite-link.md`
+solved-by: PR #183 (task `2026-06-08-fix-join-invite-link.md`)
+verified-by: user end-to-end smoke test, 2026-06-08
 ---
 
-> **2026-06-08 — fix in flight, NOT yet verified.** The 2026-06-07 `likely-resolved-by-consolidation` marker (below) was over-optimistic: the mobile-side server change to "serve the same eval to every joiner" was necessary but not sufficient. Re-analysis suggests the actual desktop-side bug is that `InvitationService.joinInviteLink` decrypts the invite eval using the manifest's `ephemeral_public_key`, but every `broadcastSpaceUpdate` (kick, role grant, settings edit, channel binding) re-encrypts the MANIFEST with a fresh ephemeral key while leaving the EVAL untouched. After any space update post-publish, the manifest's ephemeral key no longer matches the eval's — eval decryption fails — joiner sees "expired/invalid".
+> **2026-06-08 — solved.** The 2026-06-07 `likely-resolved-by-consolidation` marker (below) was over-optimistic: the mobile-side server change to "serve the same eval to every joiner" was necessary but not sufficient. The actual desktop-side bug was that `InvitationService.joinInviteLink` decrypted the invite eval using the manifest's `ephemeral_public_key`, but every `broadcastSpaceUpdate` (kick, role grant, settings edit, channel binding) re-encrypts the MANIFEST with a fresh ephemeral key while leaving the EVAL untouched. After any space update post-publish, the manifest's ephemeral key no longer matched the eval's — eval decryption failed — joiner saw "expired/invalid".
 >
-> Mobile's join code at [`quorum-mobile/hooks/chat/useSpaceActions.ts:271-279`](../../../quorum-mobile/hooks/chat/useSpaceActions.ts) handles this by using the eval's OWN ephemeral pubkey when the server provides it, falling back to the manifest's only on legacy servers. Desktop's proposed fix in [task `2026-06-08-fix-join-invite-link.md`](../tasks/2026-06-08-fix-join-invite-link.md) does the same.
+> Mobile's join code at [`quorum-mobile/hooks/chat/useSpaceActions.ts:271-279`](../../../../quorum-mobile/hooks/chat/useSpaceActions.ts) handles this by using the eval's OWN ephemeral pubkey when the server provides it, falling back to the manifest's only on legacy servers. Desktop now does the same — see [task `2026-06-08-fix-join-invite-link.md`](../../tasks/2026-06-08-fix-join-invite-link.md) for the full diagnosis and fix.
 >
-> The original "first 1-2 joiners succeed, later ones fail" pattern is consistent with this model: the owner's actions (kicking spammers, granting moderator roles, renaming a channel) interleave with concurrent join attempts. The "regenerate the public link" workaround likely worked because regenerating re-uploads the manifest with a fresh ephemeral key, briefly aligning with the new eval.
+> The original "first 1-2 joiners succeed, later ones fail" pattern was the same root cause: the owner's actions (kicking spammers, granting moderator roles, renaming a channel) interleave with join attempts, rotating the manifest's ephemeral key. The "regenerate the public link" workaround worked because regenerating re-uploads the manifest with a fresh ephemeral key, briefly aligning with the new eval. Now that desktop uses the eval's own ephemeral key, the workaround is no longer needed.
 >
-> **Will only be moved to `.solved/` after end-to-end smoke testing confirms the fix.** Specifically:
-> - Owner publishes a public invite, then performs a space update (kick/role/channel rename/settings edit). A non-owner clicks the same link and joins successfully — the previously-failing path.
+> Verified by user smoke test, 2026-06-08: as owner, published a public invite then updated the space; as non-owner, clicked the same link and joined successfully. Private one-time invites also tested as a regression check — still working as expected.
 
-> **Original 2026-06-07 marker (kept for history)**: the invite-system consolidation (see `tasks/2026-06-07-consolidate-invite-system-with-mobile.md`) likely makes this no longer reproducible. [...] To verify: in a fresh space, generate a public link, then have 5+ users join in quick succession. If all succeed, mark solved and move to `.solved/`. **— That verification was never run, and turned out to be insufficient anyway because the failure mode wasn't about concurrency, it was about post-publish space updates rotating the manifest ephemeral key.**
+> **Original 2026-06-07 marker (kept for history)**: the invite-system consolidation (see `tasks/2026-06-07-consolidate-invite-system-with-mobile.md`) likely makes this no longer reproducible. [...] To verify: in a fresh space, generate a public link, then have 5+ users join in quick succession. If all succeed, mark solved and move to `.solved/`. **— That verification was never run, and turned out to be insufficient anyway because the failure mode wasn't about concurrency, it was about post-publish space updates rotating the manifest ephemeral key. The actual fix landed in PR #183.**
 
 # Public Invite Link Intermittent Expiration Bug
 

--- a/.agents/docs/features/invite-system-analysis.md
+++ b/.agents/docs/features/invite-system-analysis.md
@@ -4,7 +4,7 @@ title: Invite System Documentation
 status: done
 ai_generated: true
 created: 2026-01-09T00:00:00.000Z
-updated: 2026-06-07T00:00:00.000Z
+updated: 2026-06-08T00:00:00.000Z
 ---
 
 # Invite System Documentation
@@ -183,12 +183,42 @@ https://app.quorummessenger.com/invite/#spaceId={SPACE_ID}&configKey={CONFIG_PRI
 1. Load `owner_key`, `hub_key`, `config_key` from local storage.
 2. Load the space's encryption state.
 3. Verify the local pool has at least `MAX_PUBLIC_EVALS = 1` eval; throw if exhausted.
-4. Generate an ephemeral X448 keypair (used for both eval and manifest encryption).
+4. Generate an ephemeral X448 keypair (used for both the eval and the manifest at THIS publish moment — but see "The eval's ephemeral key is NOT the manifest's" below: subsequent space updates rotate the manifest's key while leaving the eval's untouched, so joiners must use the eval's own key on the consumer side).
 5. Take the first eval (slice, don't mutate yet), build one encrypted eval payload using the existing config public key.
-6. Sign the eval payload with `owner_key`, POST to `apiClient.postSpaceInviteEvals`.
+6. Sign the eval payload with `owner_key`, POST to `apiClient.postSpaceInviteEvals`. The server stores the eval's ephemeral public key alongside the ciphertext so the joiner can decrypt with the right key later.
 7. Re-encrypt the local space manifest with the same config key + ephemeral key, sign with `owner_key`, POST to `apiClient.postSpaceManifest`.
 8. Set `space.inviteUrl = "{base}/invite/#spaceId={..}&configKey={..}"` using the EXISTING config private key. Save via `saveSpace`.
 9. Decrement the local pool (`session.evals.slice(MAX_PUBLIC_EVALS)`), persist via `saveEncryptionState`. This happens AFTER successful network calls so a failed upload doesn't leak a pool slot.
+
+**Joining via a Link (`InvitationService.joinInviteLink`):**
+
+Same function handles both one-time and public links; the branch is whether the URL carries `secret`, `template`, and `hubKey` directly (one-time) or just `spaceId` + `configKey` (public).
+
+1. Parse the URL via `parseInviteParams`.
+2. Fetch the space manifest from `apiClient.getSpaceManifest(spaceId)`. The response carries the encrypted manifest ciphertext PLUS the manifest's `ephemeral_public_key`. Decrypt with the URL's `configKey` and the manifest's ephemeral key to recover the `Space` record.
+3. **Public-link branch only** (no `secret`/`template`/`hubKey` in the URL):
+   - Derive `configPublicKey` from the URL's `configKey`.
+   - Fetch the eval from `apiClient.getSpaceInviteEval(configPublicKey)`. The response carries the encrypted eval ciphertext PLUS **the eval's own `ephemeral_public_key`** — which is a SEPARATE key from the manifest's.
+   - Decrypt the eval ciphertext with the URL's `configKey` and **the eval's own ephemeral public key**, falling back to the manifest's only on legacy servers that don't yet return the eval's. (Critical: see "The eval's ephemeral key is NOT the manifest's" below.)
+   - Recover `secret`, `template`, `hubKey` from the decrypted eval payload.
+4. From here both branches converge: generate the joiner's inbox keypair, derive hub/inbox addresses, build the joiner's encryption state from the template (advancing the ratchet by one), save via `saveEncryptionState`, register inbox + hub via `apiClient.postHubAdd`, send the join message into `spaceId/spaceId`.
+5. The joiner's local `Space` record is built from the decrypted manifest. Subsequent real-time updates arrive via WebSocket.
+
+> **The eval's ephemeral key is NOT the manifest's** — read this if you're touching the join path.
+>
+> When the owner generates a public link, the server stores TWO encrypted artifacts under the same `configPublicKey`: the **eval** (the joiner's onboarding payload) and the **manifest** (the space record). At generation time, both happen to share the same ephemeral X448 keypair (see "Public Links" step 4-7 above).
+>
+> But every subsequent `broadcastSpaceUpdate` — kicking a member, granting a role, editing settings, binding a channel — re-encrypts the **manifest** with a fresh ephemeral key while leaving the **eval** untouched. So after any post-publish space update, the two ephemeral keys diverge.
+>
+> The server-side response for `getSpaceInviteEval` carries the eval's own ephemeral key separately. The joiner MUST use that key (not the manifest's) when decrypting the eval. The fallback to the manifest's key only exists for legacy servers that don't yet return the eval's key. This was the root cause of the long-standing intermittent "expired/invalid public invite link" reports — fixed in PR #183 (task [`2026-06-08-fix-join-invite-link.md`](../../tasks/2026-06-08-fix-join-invite-link.md)).
+>
+> Mobile's equivalent in [`quorum-mobile/hooks/chat/useSpaceActions.ts:271-279`](../../../../quorum-mobile/hooks/chat/useSpaceActions.ts) documents the same thing.
+
+> **`getSpaceInviteEval` response shape — handle both string and object** — read this if you're touching `baseTypes.ts`.
+>
+> The server has shipped two response shapes for `/invite/eval` over its lifetime: a legacy JSON-encoded string of the sealed envelope (`"{\"ciphertext\":\"...\",...}"`), and a current plain JSON object `{ciphertext: "<json-string>", ephemeral_public_key: "<hex>"}`. The base API client at `baseTypes.ts:341-343` auto-parses the response via `response.json()` when `Content-Type: application/json`, so a JSON-string returns as a string and a JSON-object returns as an object.
+>
+> `getSpaceInviteEval` normalizes both into `{ciphertext: string, ephemeralPublicKey: string | null}` for the consumer. Assuming either shape unconditionally is a bug — the legacy variant fails `'ciphertext' in response`, the current variant breaks `JSON.parse(response)` with `"[object Object]" is not valid JSON`. Mirrored from mobile's [`quorum-mobile/services/api/quorumClient.ts:710-738`](../../../../quorum-mobile/services/api/quorumClient.ts).
 
 ### Database Operations
 
@@ -245,8 +275,9 @@ Both invite formats coexist on the same space, sharing one config keypair:
 1. **One-time invites consume finite secrets** — each generation permanently uses one secret from the local `evals` pool.
 2. **Public-link generation is cheap** — 1 server-side eval upload + 1 manifest re-publish, no member rekey, no new keypair.
 3. **Public-link URL is deterministic per space** — regenerating produces the same string; the server-side eval is what gets refreshed.
-4. **"Expiration" errors are validation failures** — typically eval pool exhaustion or stale links from before the 2026-06-07 consolidation.
-5. **No persistent user blocking** — kicked users can still receive invites and click public links.
+4. **The eval has its own ephemeral key, separate from the manifest's** — every space update rotates the manifest's ephemeral key while the eval's stays put. The joiner must decrypt the eval with the eval's own ephemeral key, not the manifest's (see "The eval's ephemeral key is NOT the manifest's" callout in Cryptographic Flow). Getting this wrong manifests as "expired/invalid public invite link" errors that mysteriously disappear after the owner republishes.
+5. **"Expiration" errors are cryptographic validation failures** — typically eval pool exhaustion or stale legacy links. Pre-PR-#183, the dominant cause was the joiner-side ephemeral-key bug above.
+6. **No persistent user blocking** — kicked users can still receive invites and click public links.
 
 ## Frequently Asked Questions
 
@@ -258,9 +289,11 @@ Both invite formats coexist on the same space, sharing one config keypair:
 
 These are cryptographic validation failures, not time-based expirations. Common causes:
 
-- **Eval pool exhaustion**: the space has used up its local pool.
+- **Eval pool exhaustion**: the space has used up its local pool. (Resolved before invite-time by the UI's `poolExhausted` callout; only joiners hit this directly when no eval has been published.)
 - **Stale public links from before 2026-06-07**: spaces that had a public link generated under the old desktop logic embedded a freshly-minted configKey in the URL. After the consolidation, regenerating the public link on the new build emits a URL built from the original space configKey instead — the old URL becomes a dead pointer. Owners can regenerate to get the new (current) URL.
 - **Missing or corrupted space configuration** in local storage.
+
+> **Historical: was the dominant cause for months.** Before PR #183 (2026-06-08), most "expired" errors weren't expirations at all — they were the joiner-side bug described in "The eval's ephemeral key is NOT the manifest's" above. Owners' "Republish to fix it" workaround happened to work because republishing re-uploaded the manifest with a fresh ephemeral key that briefly aligned with the (separately re-uploaded) eval's key. The desktop client now uses the eval's own ephemeral key directly, so the workaround is no longer needed and post-publish space updates don't break joins.
 
 ### Can kicked users rejoin via public invite links?
 
@@ -326,4 +359,4 @@ The invite system now dynamically detects the environment and uses appropriate d
 
 _Covers: SpaceSettingsModal/Invites.tsx, useInviteManagement.ts, useInviteValidation.ts, useSpaceJoining.ts, InvitationService.ts, MessageDB Context, InviteLink.tsx, inviteDomain.ts_
 
-_Last updated: 2026-06-07_
+_Last updated: 2026-06-08_

--- a/.agents/tasks/.done/2026-06-07-consolidate-invite-system-with-mobile.md
+++ b/.agents/tasks/.done/2026-06-07-consolidate-invite-system-with-mobile.md
@@ -4,8 +4,10 @@ title: Consolidate desktop invite system with mobile (cryptographic logic + UX)
 status: in-progress
 branch: feat/consolidate-invite-system-with-mobile
 created: 2026-06-07
-updated: 2026-06-07
+updated: 2026-06-08
 ---
+
+> **2026-06-08 follow-up note.** The §4 statement that "The join path already handles both public ... and private ... correctly" turned out to be wrong on **two** counts. Bug 1: the server response shape for `/invite/eval` had changed from a JSON-encoded string to a plain object, and desktop's `JSON.parse(inviteEval.data)` crashed on every public-invite join with `"[object Object]" is not valid JSON`. Bug 2: desktop was using the manifest's `ephemeral_public_key` to decrypt the eval, but the manifest's key gets rotated on every space update (kick/role/settings/channel) while the eval's doesn't — so any post-publish space update silently broke joining for everyone with the existing link. Mobile's join path handled both correctly already; we just didn't read it. Both bugs fixed in **PR #183** (task [`2026-06-08-fix-join-invite-link.md`](../2026-06-08-fix-join-invite-link.md)). Lesson for future "scope out the join path" decisions: actually diff desktop's `joinInviteLink` against mobile's equivalent before assuming parity.
 
 # Consolidate desktop invite system with mobile
 


### PR DESCRIPTION
## What

Follow-up cleanup after PR #183 (joinInviteLink fix). End-to-end smoke test confirmed the fix on 2026-06-08 against the previously-failing path (owner publishes a public invite, then updates the space, then a non-owner joins via the same link — was Bug 2 in #183's description). Private one-time invites also tested as a regression check, still working.

No runtime code changes. Doc cleanup only:

- Both bug reports moved from `.agents/bugs/` to `.agents/bugs/.solved/`, with `solved-by` + `verified-by` frontmatter and a closing note describing the actual root cause:
  - [`2025-08-03-joinspacemodal-invalid-json-network-error.md`](.agents/bugs/.solved/2025-08-03-joinspacemodal-invalid-json-network-error.md) — was misattributed to network issues; real cause was the response-shape mismatch.
  - [`2025-09-22-public-invite-link-intermittent-expiration.md`](.agents/bugs/.solved/2025-09-22-public-invite-link-intermittent-expiration.md) — the `likely-resolved-by-consolidation` marker turned out to be over-optimistic; real cause was the eval-vs-manifest ephemeral-key mismatch.

- Pointer added to [`.agents/tasks/.done/2026-06-07-consolidate-invite-system-with-mobile.md`](.agents/tasks/.done/2026-06-07-consolidate-invite-system-with-mobile.md) flagging that the "join path already handles this correctly" claim in §4 was wrong on both response-shape and ephemeral-key counts. Future readers don't re-trust that line.

- [`.agents/docs/features/invite-system-analysis.md`](.agents/docs/features/invite-system-analysis.md) updated:
  - New "Joining via a Link" subsection in Cryptographic Flow documenting the consumer-side flow + two callouts:
    - "The eval's ephemeral key is NOT the manifest's" — the long-standing root cause of intermittent expiration. Explains why the manifest's ephemeral key gets rotated on every space update while the eval's doesn't.
    - "`getSpaceInviteEval` response shape — handle both string and object" — documents the legacy/current shape divergence for anyone touching `baseTypes.ts`.
  - Generation step 4 reworded to flag the ephemeral-key divergence after subsequent space updates.
  - FAQ "Why do I get Invite Link Expired errors" gets a historical note explaining that pre-PR-#183 the dominant cause wasn't on the original list — it was the joiner-side ephemeral-key bug.
  - Summary point added covering the eval-vs-manifest ephemeral key distinction; the old "Expiration errors are typically pool exhaustion" framing corrected.

## Cross-repo summary

- **quorum-shared**: not touched.
- **quorum-desktop**: THIS PR (docs only).
- **quorum-mobile**: not touched.

## Smoke test

N/A — no runtime changes. The runtime fix verified in PR #183 is what this PR documents.