### PR TITLE
feat: consume Farcaster byte limits from shared

### DIFF
--- a/src/components/modals/SpaceSettingsModal/Account.tsx
+++ b/src/components/modals/SpaceSettingsModal/Account.tsx
@@ -21,7 +21,7 @@ import { useSpaceLeaving } from '../../../hooks/business/spaces/useSpaceLeaving'
 import { usePasskeysContext } from '@quilibrium/quilibrium-js-sdk-channels';
 import { useUserRoleDisplay } from '../../../hooks/business/user/useUserRoleDisplay';
 import { useChannelMute } from '../../../hooks/business/channels';
-import { MAX_BIO_LENGTH } from '../../../hooks/business/validation';
+import { MAX_BIO_INPUT_CHARS } from '../../../hooks/business/validation';
 import { getIconColorHex, IconColor } from '../../space/IconPicker/types';
 import type { Role } from '@quilibrium/quorum-shared';
 import type { SpaceNotificationTypeId } from '../../../types/notifications';
@@ -216,7 +216,7 @@ const Account: React.FunctionComponent<AccountProps> = ({
             rows={3}
             variant="filled"
             className="w-full"
-            maxLength={MAX_BIO_LENGTH}
+            maxLength={MAX_BIO_INPUT_CHARS}
             error={bioErrors.length > 0}
             errorMessage={
               bioErrors.length > 0

--- a/src/hooks/business/validation/errorTranslator.ts
+++ b/src/hooks/business/validation/errorTranslator.ts
@@ -29,7 +29,10 @@ const messages: Record<string, (vars: Vars) => string> = {
 
   // Display name
   'displayName.required': () => t`Display name is required`,
-  'displayName.tooLong': (vars) => t`Display name must be ${vars!.max} characters or less`,
+  // Bio and display name are byte-limited (Farcaster USER_DATA), not
+  // character-limited. A byte count is meaningless to show a user, so the
+  // message is intentionally generic with no number.
+  'displayName.tooLong': () => t`Display name is too long`,
   'displayName.reservedMention': () => t`This name conflicts with mention keywords.`,
   'displayName.reservedImpersonation': () => t`Names resembling admin, moderator, or support are reserved.`,
   'displayName.invalidChars': () => t`Display name cannot contain special characters`,
@@ -56,7 +59,7 @@ const messages: Record<string, (vars: Vars) => string> = {
 
   // User bio
   'userBio.invalidChars': () => t`Bio cannot contain special characters`,
-  'userBio.tooLong': (vars) => t`Bio must be ${vars!.max} characters or less`,
+  'userBio.tooLong': () => t`Bio is too long`,
 
   // User note
   'userNote.invalidContent': () => t`Note contains invalid content`,

--- a/src/hooks/business/validation/useSpaceNameValidation.ts
+++ b/src/hooks/business/validation/useSpaceNameValidation.ts
@@ -4,7 +4,7 @@ import {
   validateSpaceDescription as validateSpaceDescriptionShared,
   validateUserBio as validateUserBioShared,
   validateUserNote as validateUserNoteShared,
-  MAX_BIO_LENGTH,
+  MAX_BIO_BYTES,
   MAX_USER_NOTE_LENGTH,
 } from '@quilibrium/quorum-shared';
 import {
@@ -14,7 +14,18 @@ import {
 
 // Re-export shared constants so existing consumers that import them from
 // this module continue to work.
-export { MAX_BIO_LENGTH, MAX_USER_NOTE_LENGTH };
+export { MAX_BIO_BYTES, MAX_USER_NOTE_LENGTH };
+
+/**
+ * Coarse character cap for the bio <textarea maxLength>. The real limit is
+ * MAX_BIO_BYTES (256 UTF-8 bytes), which a single `maxLength` number can't
+ * express — one emoji is up to 4 bytes. We set the input's hard cap to the
+ * byte budget interpreted as characters: for ASCII it matches exactly, and for
+ * multi-byte text it's a generous upper bound that never blocks valid input —
+ * validateUserBio surfaces the real byte-overflow error first. It only stops a
+ * user from typing an absurdly long all-ASCII bio.
+ */
+export const MAX_BIO_INPUT_CHARS = MAX_BIO_BYTES;
 
 /**
  * Centralized space name validation logic


### PR DESCRIPTION
Consumes the byte-based validators from quorum-shared 2.1.0-28 (shared PR #37), which align display name and bio with Farcaster's USER_DATA limits.

## Why

Display name and bio can be published to a merged Farcaster profile, so they must satisfy Farcaster's byte limits (display ≤ 32 bytes, bio ≤ 256 bytes) or the relay rejects them. Shared now counts UTF-8 bytes instead of characters; this PR wires desktop to the new API.

## Changes

- Swap removed `MAX_BIO_LENGTH` for `MAX_BIO_BYTES`; add `MAX_BIO_INPUT_CHARS` coarse char guard for the per-space bio textarea `maxLength` (a byte budget can't be a single `maxLength` number — the real limit is enforced by `validateUserBio`)
- `displayName.tooLong` / `userBio.tooLong` messages drop the numeric var (a byte count is meaningless to show a user) → generic "is too long" copy
- Both global (`UserSettingsModal`) and per-space (`SpaceSettingsModal`) display name + bio already route through the shared validators, so the byte limits apply uniformly with no per-surface changes

## User-visible

- Bio limit rises 160 → 256 bytes
- Display name tightens to 32 bytes: existing 33-50 char names become invalid on next edit

## Verification

- `tsc --noEmit` clean on touched files (one pre-existing unrelated error in `ImportKeyStep.tsx`)
- Validation unit tests pass

## Follow-up

- Mobile convergence tracked in `mobile-tasks-pending.md` row 2 (adopt shared byte validators + hard-block at the Farcaster publish boundary)