### PR TITLE
fix: profile identity fallback (DM + spaces)

### DIFF
--- a/.agents/docs/debugging/dm-architecture-and-debug-playbook.md
+++ b/.agents/docs/debugging/dm-architecture-and-debug-playbook.md
@@ -3,7 +3,7 @@ type: doc
 title: DM Architecture and Debug Playbook
 status: living
 created: 2026-06-09
-updated: 2026-06-09
+updated: 2026-06-10
 audience: future agents debugging DM-related bugs (delivery, identity, sync)
 ---
 
@@ -15,9 +15,28 @@ audience: future agents debugging DM-related bugs (delivery, identity, sync)
 
 - DM identity (name, icon, bio) lives in `conversations` (IndexedDB). One row per partner, keyed by `conversationId = partnerAddress + '/' + partnerAddress`.
 - DM identity is captured **at session-init time** from the encrypted envelope's `user_profile`. Established sessions (`DoubleRatchetInboxDecrypt`) do NOT carry profile data on subsequent messages.
-- A change to a DM partner's pfp/name/bio is propagated by a **`dm-update-profile` control message** sent over the existing DM session whenever the partner saves their global profile in User Settings → General. This is intercepted on receive (never persisted as a chat post) and upserts the conversation row.
+- A change to a DM partner's pfp/name/bio is propagated by a **`dm-update-profile` control message** sent over the existing DM session whenever the partner saves their global profile in User Settings → General. This is intercepted on receive (never persisted as a chat post) and upserts the conversation row. This is the **push** path.
+- There is also a **pull/back-fill** path for identity the push never delivered (older contacts, missed messages): `useConversationsWithProfileBackfill` fetches the partner's server-side public profile and **writes it through to the `conversations` row**. See "Identity sources & the three sync paths" below. This is what makes the sidebar and the no-flash conversation open work for legacy contacts (added 2026-06-10).
 - Per-space profile saves (Space Settings → Account) are independent — they only touch `space_members`, never DMs.
 - **Network sync between two clients is not reliable.** Regular DMs from B to A sometimes never arrive. This is an open issue, not a code bug we've identified.
+
+## Identity sources & the three sync paths
+
+A DM partner's name/avatar/bio can reach you three ways. Knowing which one a given symptom belongs to is the whole game.
+
+**The durable source of truth is the local `conversations` row.** Every render surface (sidebar, header, per-message avatar) is *supposed* to read from it. A user has exactly **one** avatar/name; the routes below are just different ways that one value gets into your row. There is no separate "public-profile picture" distinct from the normal one.
+
+| # | Path | When it fires | Writes to row? | Notes |
+|---|------|---------------|----------------|-------|
+| 1 | **Session-init capture** | First incoming DM from a partner (`NewDoubleRatchetRecipientSession`) | Yes | Captures `display_name` + `user_icon` from the envelope once. Frozen after that. |
+| 2 | **`dm-update-profile` push** | Partner saves their global profile while you have an active session | Yes (upsert) | The privacy-preserving path — travels inside the encrypted DM channel, no server sees it. Only reaches active sessions, only going forward. |
+| 3 | **Public-profile pull + write-back** | You render a contact whose row still holds the `"Unknown User"` / default-icon placeholder | Yes (back-fill, placeholder fields only) | `useConversationsWithProfileBackfill`. Centralized HTTP `GET /users/:addr/public-profile`. Only works if the partner opted into a public profile. Heals legacy contacts that predate path 2. |
+
+**Read-after-write, never read-from-network-at-render.** Once any path has written the row, all surfaces read it locally — fast, offline, no flash. We do **not** poll the network on every conversation open. Path 3's fetch has a 1h React Query `staleTime` and only targets rows still on the placeholder, so it's effectively one-time-per-contact, then silent.
+
+**Why path 3 exists (the bug it fixed, 2026-06-10).** The sidebar read the raw row with no fallback, while the conversation view fell back to the public profile *in memory only* (`DirectMessage.tsx` `members` memo) and never persisted it. Result: header/messages showed the avatar, sidebar showed the default, and the conversation view re-fetched on every open (the 1-2s flash). Path 3 gives the sidebar the same fallback **and writes it through**, so the row is correct everywhere and the flash disappears. Safety: it only overwrites a field still holding the placeholder, so a path-2 value is never clobbered by a (possibly stale) public profile.
+
+**The honest gaps.** If a partner changes their avatar and you have no active session (or the message is missed), path 2 won't reach you; path 3 only helps if they also published a public profile. A contact with neither an active exchange nor a public profile (e.g. `@3` in testing) stays on the default until they actually send you data. That's a property of the model, not a bug.
 
 ## Architecture map
 
@@ -32,11 +51,14 @@ audience: future agents debugging DM-related bugs (delivery, identity, sync)
 
 ### Read paths (who shows DM identity)
 
-1. **DM list sidebar** — reads `conversations` via React Query `useConversations`. Cache key: `buildConversationsKey({ type: 'direct' })`.
+1. **DM list sidebar** — reads `conversations` via React Query `useConversations`. Cache key: `buildConversationsKey({ type: 'direct' })`. Enriched by `useConversationsWithProfileBackfill` (path 3 above): placeholder rows get the public profile merged in for render AND written back to the row.
 2. **DM chat header** — `useConversation` for the open conversation. Cache key: `buildConversationKey({ conversationId })`.
 3. **DM UserProfile sidebar** (the inline profile panel in DM view) — reads `conversation.bio` first, then falls back to `recipientPublicProfile?.bio` (server-side public profile, only present if the partner opted in). See [`DirectMessage.tsx`](src/components/direct/DirectMessage.tsx) `otherUser` memo.
 4. **DM message list per-message header** — reads `members` map produced by `useChannelData`-like logic; for DMs the map has one entry.
-5. **Public-profile fallback** — `useMembersWithPublicProfileFallback` fills missing/empty fields from `GET /users/:addr/public-profile`. 404 (user opted out) → no fallback data, the UI stays empty.
+5. **Public-profile fallback** — two hooks, same endpoint (`GET /users/:addr/public-profile`), different consumers:
+   - `useMembersWithPublicProfileFallback` — space message surfaces. Render-only fallback; fires only when a member has **neither** name **nor** icon (so it does NOT trigger for a row whose name is the literal `"Unknown User"`).
+   - `useConversationsWithProfileBackfill` — DM sidebar (path 3). Per-field (`"Unknown User"` / default icon each count as empty), and **writes the result back** to the `conversations` row.
+   - 404 (user opted out) → no fallback data; the field stays on its placeholder.
 
 ### Receive paths (where identity gets written)
 
@@ -108,10 +130,11 @@ Run the diagnostic scripts (`.agents/tools/dm-debug/`). Get both clients' `conve
 
 | Symptom | Look at |
 |---|---|
-| Initials + truncated address everywhere | `conversations.displayName` / `icon` — was identity ever captured? |
-| Name shows, pfp missing | `conversations.icon` is `null` or empty string. The init envelope arrived with no icon. |
-| Pfp shows but bio doesn't | `conversations.bio` field. If null, the user never broadcast `dm-update-profile`, or the broadcast didn't arrive. |
-| Stale identity (old pfp shown after partner changed it) | Same as bio — needs a `dm-update-profile` broadcast from partner. |
+| Initials + truncated address everywhere | `conversations.displayName` / `icon` — was identity ever captured? If the partner has a public profile, path 3 (`useConversationsWithProfileBackfill`) should fill it; run `.agents/tools/dm-debug/05-profile-sources.js` to confirm a source exists. |
+| Name shows, pfp missing | `conversations.icon` is the default / empty. Path 3 recovers it **if** the partner published a public-profile image; otherwise needs a `dm-update-profile` push. Use `05-profile-sources.js`: `storedIconIsDefault: true` + `pubHasImage: YES` = path 3 should fill it. |
+| Shows in conversation header/messages but NOT sidebar | Classic path-3 gap (the 2026-06-10 bug). The conversation view fell back to the public profile in memory; the row was never written. Should be fixed now — if it recurs, check that `useConversationsWithProfileBackfill` is wired into `DirectMessageContactsList` and that the write-back isn't erroring (look for `[DMProfileBackfill]` warnings). |
+| Pfp shows but bio doesn't | `conversations.bio` field. If null, the user never broadcast `dm-update-profile`, or the broadcast didn't arrive. (Bio is NOT back-filled to the row by path 3 — only name/icon are.) |
+| Stale identity (old pfp shown after partner changed it) | Needs a `dm-update-profile` broadcast from partner. Path 3 won't overwrite a non-placeholder value, so a stale-but-real pfp is intentionally left alone until path 2 updates it. |
 
 ### Step 3: add debug logs at three layers
 
@@ -145,7 +168,7 @@ If the send fires but receive is silent:
 - The transport-level reason DMs sometimes don't deliver. We have no theory yet.
 - The cause of asymmetric `conversations` tables between two clients in the same dev environment.
 - Whether the action queue or websocket processQueue has a starvation / dropped-message mode for DM-control payloads specifically.
-- Should we ship a "request profile from partner" pull mechanism for stuck-missing cases? Open design question.
+- ~~Should we ship a "request profile from partner" pull mechanism for stuck-missing cases?~~ **Partially done (2026-06-10):** `useConversationsWithProfileBackfill` pulls from the server-side *public profile* (not a P2P request to the partner) and writes it back to the row. A true peer-to-peer "request your profile" message is still unbuilt and would cover partners who never published a public profile.
 
 ## Files of interest
 
@@ -153,7 +176,9 @@ If the send fires but receive is silent:
 - [`src/components/context/MessageDB.tsx`](src/components/context/MessageDB.tsx) — `updateUserProfile` callback (line ~421).
 - [`src/hooks/business/user/useUserSettings.ts`](src/hooks/business/user/useUserSettings.ts) — `saveChanges` (the global profile save).
 - [`src/hooks/business/spaces/useSpaceProfile.ts`](src/hooks/business/spaces/useSpaceProfile.ts) — per-space profile save (does NOT touch DMs).
-- [`src/components/direct/DirectMessage.tsx`](src/components/direct/DirectMessage.tsx) — DM render path, `otherUser` memo for sidebar identity.
+- [`src/components/direct/DirectMessage.tsx`](src/components/direct/DirectMessage.tsx) — DM render path, `members` + `otherUser` memos (the in-memory public-profile fallback that path 3 makes durable).
+- [`src/hooks/business/conversations/useConversationsWithProfileBackfill.ts`](src/hooks/business/conversations/useConversationsWithProfileBackfill.ts) — path 3: sidebar public-profile pull + write-through to the `conversations` row.
+- [`src/components/direct/DirectMessageContactsList.tsx`](src/components/direct/DirectMessageContactsList.tsx) — DM sidebar; wires in path 3 after `useConversationPreviews`.
 - [`src/components/user/UserProfile.tsx`](src/components/user/UserProfile.tsx) — UserProfile modal used in spaces.
 - [`@quilibrium/quorum-shared/src/types/message.ts`](../../../../quorum-shared/src/types/message.ts) — `UpdateProfileMessage`, `DMUpdateProfileMessage`.
 - [`@quilibrium/quorum-shared/src/types/conversation.ts`](../../../../quorum-shared/src/types/conversation.ts) — `Conversation`.
@@ -166,4 +191,4 @@ If the send fires but receive is silent:
 - [DM Sync Non-Deterministic Failures](../../reports/action-queue/005-dm-sync-non-deterministic-failures.md) — known sync gap.
 
 ---
-*Last updated: 2026-06-09*
+*Last updated: 2026-06-10*

--- a/.agents/tasks/2026-06-10-space-message-list-public-profile-fallback.md
+++ b/.agents/tasks/2026-06-10-space-message-list-public-profile-fallback.md
@@ -1,0 +1,126 @@
+---
+type: task
+title: "Space message list: missing name/avatar (public-profile fallback not applied)"
+status: planned
+created: 2026-06-10
+related_docs:
+  - ".agents/docs/debugging/dm-architecture-and-debug-playbook.md"
+  - ".agents/docs/features/avatar-initials-system.md"
+related_files:
+  - "src/components/space/Channel.tsx"
+  - "src/components/message/MessageList.tsx"
+  - "src/hooks/business/user/useMembersWithPublicProfileFallback.ts"
+  - "src/hooks/business/channels/useChannelData.ts"
+---
+
+# Space message list: missing name/avatar
+
+> **⚠️ AI-investigated 2026-06-10.** Verify the root cause with a live test before implementing (see "How to confirm").
+
+## Symptom
+
+In a space channel's **main message list**, some senders render as a 6-char
+truncated address (e.g. `CRcRk8`, `UB6CqT`, `PhEcvj`) with an initials-only
+avatar, instead of their real name/pfp. Observed on the **test website**
+(deployed, ~2026-06-09 baseline), not specific to the DM-sidebar fix branch.
+Same class of issue as the DM identity gap, but a separate code path.
+
+## Root cause (high confidence)
+
+The public-profile back-fill is computed in `Channel.tsx` but **never reaches
+the message list render**.
+
+1. `Channel.tsx:289` builds `effectiveMembers = useMembersWithPublicProfileFallback(members, visibleSenderAddresses)` and an enriched `mapSenderToUser` (`Channel.tsx:298-313`) that reads from `effectiveMembers`.
+2. That enriched `mapSenderToUser` IS passed to side panels (bookmarks, pinned, composer, typing indicator — `Channel.tsx:1436/1470/1503/1535/1669/1695`).
+3. **It is NOT passed to `<MessageList>`.** The MessageList JSX (`Channel.tsx:~1638`) passes only `members={members}` — the **raw** map from `useChannelData`, with no public-profile fallback.
+4. `MessageList.tsx:290-305` builds its **own** internal `mapSenderToUser` from that raw `members` prop, and passes it to each `<Message>` (`MessageList.tsx:374`). When a member has no `displayName`, it falls back to `senderId.slice(-6)` (`MessageList.tsx:296`) — the truncated address you see.
+
+So the `Channel.tsx:294-297` comment ("all message-path consumers see the
+enriched data") is **inaccurate** — MessageList was missed. The enriched data
+exists; it just isn't wired into the one surface that renders the chat.
+
+### Secondary consideration (verify, may be a non-issue or an additional gap)
+
+`useMembersWithPublicProfileFallback` only fetches when a member has
+**neither** `displayName` **nor** `userIcon` (`useMembersWithPublicProfileFallback.ts:65`).
+`useChannelData` already nulls out the default icon to `undefined`
+(`useChannelData.ts:69-71`), so a member with no name and no real avatar
+*should* satisfy the condition and trigger a fetch. Confirm this holds for the
+affected users; if a member has a real icon but no name (or vice-versa) the
+condition would skip them — but that's not the case in the screenshot (initials
+avatars = no icon).
+
+If after wiring the fallback into MessageList some users STILL show as
+addresses, the remaining cause is benign: **those users have no public profile**
+(opted out / never created one → 404 → null). Nothing client-side can recover
+that; it needs a space `update-profile` broadcast from the user. Confirm with
+the diagnostic before assuming a code bug.
+
+## How to confirm (before coding)
+
+1. On a build that has the message-path fallback (>= 2026-06-08), open the
+   affected channel.
+2. In DevTools, check the Network tab for `GET /users/<addr>/public-profile`
+   calls for the truncated-address senders.
+   - **No request fired** → the fallback isn't reaching these senders (wiring
+     bug — this task). Most likely.
+   - **Request fired, 404** → user has no public profile (not recoverable
+     client-side; out of scope).
+   - **Request fired, 200 with display_name/profile_image** but still shows
+     address → confirms the enriched data isn't reaching MessageList render
+     (this task).
+3. Optionally adapt `.agents/tools/dm-debug/05-profile-sources.js` to read
+   `space_members` instead of `conversations` for a per-user source table.
+
+## Proposed fix
+
+Wire the enriched identity into the message list. Two clean options:
+
+**Option A (preferred) — pass the enriched `mapSenderToUser` to MessageList,
+and use it instead of the internal one.**
+- `Channel.tsx`: add `mapSenderToUser={mapSenderToUser}` to the `<MessageList>` props.
+- `MessageList.tsx`: accept an optional `mapSenderToUser` prop; when provided,
+  use it instead of the internally-built one (keep the internal one as fallback
+  for any caller that doesn't pass it — DMs, etc.).
+- Smallest blast radius; the enriched mapper already handles the
+  `displayName || slice(-6)` fallback identically.
+
+**Option B — pass `effectiveMembers` as the `members` prop to MessageList.**
+- `Channel.tsx`: `members={effectiveMembers}` on `<MessageList>`.
+- MessageList's internal `mapSenderToUser` then reads enriched data for free.
+- Risk: `members` is also used by MessageList for other things (mention
+  resolution, `users={Object.values(members)}`, `resolveSender`); changing the
+  identity of that prop could shift those behaviors. Audit every `members`
+  consumer in MessageList before choosing this.
+
+Recommend **Option A** — it's targeted and doesn't repurpose the `members` prop.
+
+### Scope / fetch-storm guard (already handled)
+
+The fetch set is already bounded to `visibleSenderAddresses` (senders in the
+loaded message list), NOT the whole roster — see `Channel.tsx:280-287`. So
+wiring the existing `effectiveMembers`/`mapSenderToUser` into MessageList does
+**not** introduce a roster-wide fetch storm. (The member-list *sidebar* — a
+separate surface — still uses raw `members` by design and is out of scope here.)
+
+## Out of scope
+
+- The space **member-list sidebar** (the `users` panel toggled by the people
+  icon) deliberately uses raw `members` to avoid fetching the whole roster.
+  Fixing that needs a virtualization-aware bounded fetch — separate task.
+- DM surfaces — already fixed (branch `fix/dm-sidebar-profile-fallback`,
+  2026-06-10).
+- Users with no public profile — not client-side recoverable.
+
+## Verification
+
+- Affected senders show real name + avatar in the message list (for users who
+  have a public profile).
+- No regression in DM message rendering (which also uses MessageList — confirm
+  the optional-prop fallback path).
+- No fetch storm: Network tab shows public-profile calls only for visible
+  senders, not the full roster.
+- `npx tsc --noEmit --skipLibCheck` clean; `yarn lint` clean.
+
+---
+*Last updated: 2026-06-10*

--- a/.agents/tasks/2026-06-10-space-message-list-public-profile-fallback.md
+++ b/.agents/tasks/2026-06-10-space-message-list-public-profile-fallback.md
@@ -103,14 +103,48 @@ wiring the existing `effectiveMembers`/`mapSenderToUser` into MessageList does
 **not** introduce a roster-wide fetch storm. (The member-list *sidebar* — a
 separate surface — still uses raw `members` by design and is out of scope here.)
 
+## Decision: render-only, do NOT write-through to `space_members` (2026-06-10)
+
+The DM fix (`useConversationsWithProfileBackfill`) writes the pulled public
+profile back into the `conversations` row (a write-through cache). We considered
+mirroring that for spaces and **deliberately decided against it.** Keep the
+space fallback **render-only**.
+
+Why the DM write-through does NOT transfer to spaces:
+
+1. **Weaker benefit.** The DM write-back killed a visible per-open 1-2s avatar
+   flash. The space fetch is already bounded to visible senders AND cached 1h in
+   React Query, so there's no comparable flash to eliminate — only a marginal
+   re-fetch saving.
+2. **Correctness risk (the dealbreaker).** `conversations` is the user's own
+   per-partner contact card — safe to enrich. `space_members` is **canonical,
+   shared protocol state** written by space sync/join + `update-profile`
+   broadcasts. Writing the *global* public profile into it could (a) clobber a
+   per-space identity/bio override, (b) persist a stale global value that then
+   suppresses a fresh `update-profile` merge, and (c) for `inMemberMap: false`
+   users, fabricate `space_members` rows for people the protocol never reported
+   as members — polluting membership state with derived data.
+3. **Masks the real bug.** The `inMemberMap: false` users exist because member
+   profile data isn't syncing into `space_members` (the deeper desktop/mobile
+   sync gap). Write-through would paper over that for the minority who published
+   a public profile, while hiding the underlying sync issue.
+
+If re-fetch cost ever becomes a measured problem, the safe option is a
+**separate derived cache** (own IndexedDB store keyed by address, never touching
+`space_members`), not write-through. Don't reintroduce write-through to
+`space_members`.
+
 ## Out of scope
 
 - The space **member-list sidebar** (the `users` panel toggled by the people
   icon) deliberately uses raw `members` to avoid fetching the whole roster.
   Fixing that needs a virtualization-aware bounded fetch — separate task.
-- DM surfaces — already fixed (branch `fix/dm-sidebar-profile-fallback`,
-  2026-06-10).
-- Users with no public profile — not client-side recoverable.
+- DM surfaces — already fixed (branch
+  `fix/profile-identity-fallback-dm-and-spaces`, 2026-06-10).
+- Users with no public profile (`404`) and `inMemberMap: false` users — not
+  client-side recoverable; root cause is the member-profile sync gap, a
+  separate network/sync investigation.
+- Write-through to `space_members` — explicitly rejected (see Decision above).
 
 ## Verification
 
@@ -121,6 +155,15 @@ separate surface — still uses raw `members` by design and is out of scope here
 - No fetch storm: Network tab shows public-profile calls only for visible
   senders, not the full roster.
 - `npx tsc --noEmit --skipLibCheck` clean; `yarn lint` clean.
+
+## Status
+
+Implemented (render-only) on branch `fix/profile-identity-fallback-dm-and-spaces`:
+- `MessageList` accepts optional `mapSenderToUser`; Channel passes its enriched
+  one (commit `3f2cfe08`).
+- `UserAvatar` falls back to initials on empty/broken image (commit `1dd64b84`).
+- Verified by user: names show in space messages + member sidebar; users with no
+  usable picture show initials; previously-blank avatars now show initials.
 
 ---
 *Last updated: 2026-06-10*

--- a/.agents/tools/dm-debug/05-profile-sources.js
+++ b/.agents/tools/dm-debug/05-profile-sources.js
@@ -1,0 +1,98 @@
+// === Quorum DM Profile-Source Diagnostic ===
+// For every DM, prints side-by-side:
+//   - stored conversation row: displayName + raw icon value (+ is-it-the-default flag)
+//   - live public-profile API: display_name + profile_image presence
+//
+// Purpose: pin down WHY the sidebar shows a default avatar while the open
+// conversation shows a real one. The open conversation falls back to the
+// public profile (in-memory only); the sidebar reads the stored row. This
+// snippet shows which source actually has the image for each contact.
+//
+// Usage: paste in DevTools console, run. No clipboard side effects.
+// The real default-avatar path is '/unknown.png' (DefaultImages.UNKNOWN_USER).
+
+(async () => {
+  const DEFAULT_ICON = '/unknown.png';
+  const UNKNOWN_NAME = 'Unknown User';
+
+  const db = await new Promise((res, rej) => {
+    const req = indexedDB.open('quorum_db');
+    req.onsuccess = () => res(req.result);
+    req.onerror = () => rej(req.error);
+  });
+
+  const all = (storeName) =>
+    new Promise((res) => {
+      try {
+        const req = db
+          .transaction(storeName, 'readonly')
+          .objectStore(storeName)
+          .getAll();
+        req.onsuccess = () => res(req.result);
+        req.onerror = () => res([]);
+      } catch {
+        res([]);
+      }
+    });
+
+  const conversations = await all('conversations');
+  const dms = conversations.filter((c) => c.type === 'direct');
+
+  // The app talks to a fixed API host (see src/config/config.quorum.ts), NOT
+  // same-origin — that's why an empty base returns ERR. Default to production;
+  // override via window.__QUORUM_API_BASE__ if you point the app elsewhere.
+  // Note: the endpoint may require the app's auth headers, so a raw fetch can
+  // still 401/ERR even with the right host. The authoritative signal is the
+  // stored row's icon (data:image/... = avatar persisted); this API column is
+  // only a cross-check.
+  const apiBase =
+    window.__QUORUM_API_BASE__ || 'https://api.quorummessenger.com';
+
+  const rows = [];
+  for (const c of dms) {
+    const storedIcon = c.icon;
+    const iconIsDefault =
+      !storedIcon || storedIcon === '' || storedIcon === DEFAULT_ICON;
+    const nameIsPlaceholder = !c.displayName || c.displayName === UNKNOWN_NAME;
+
+    let pubName = '(fetch failed)';
+    let pubHasImage = '(fetch failed)';
+    let pubStatus = '';
+    try {
+      const url = `${apiBase}/users/${c.address}/public-profile`;
+      const resp = await fetch(url, { credentials: 'include' });
+      pubStatus = resp.status;
+      if (resp.ok) {
+        const body = await resp.json();
+        const data = body?.data ?? body;
+        pubName = data?.display_name || '(empty)';
+        pubHasImage = data?.profile_image ? 'YES' : 'no';
+      } else if (resp.status === 404) {
+        pubName = '(no public profile)';
+        pubHasImage = 'n/a';
+      }
+    } catch (e) {
+      pubStatus = 'ERR';
+    }
+
+    rows.push({
+      partner: String(c.address).slice(0, 18) + '…',
+      storedName: c.displayName,
+      nameIsPlaceholder,
+      storedIconIsDefault: iconIsDefault,
+      storedIconSample:
+        typeof storedIcon === 'string' ? storedIcon.slice(0, 40) : storedIcon,
+      pubStatus,
+      pubName,
+      pubHasImage,
+      // The verdict the fix cares about:
+      sidebarCanRecoverAvatar:
+        iconIsDefault && pubHasImage === 'YES' ? 'YES (fix should fill)' : iconIsDefault ? 'NO source' : 'already has',
+    });
+  }
+
+  console.log('%c=== DM Profile Sources ===', 'color:#60a5fa;font-weight:bold;font-size:14px');
+  console.table(rows);
+  console.log('Full rows:', rows);
+  return rows;
+})();

--- a/.agents/tools/dm-debug/README.md
+++ b/.agents/tools/dm-debug/README.md
@@ -20,6 +20,7 @@ For background on the architecture and the debug ladder, read [`../../docs/debug
 | `02-dm-pairs.js` | Lists each client's DM partners. Quick check for asymmetric conversation rows. |
 | `03-encryption-states.js` | Shows the Double Ratchet state per conversation. Tells you whether a DM session actually exists. |
 | `04-stores.js` | Lists all IndexedDB object store names. Use when a snippet errors with "object store not found" — store names have drifted between builds. |
+| `05-profile-sources.js` | Per-DM, compares the stored conversation row's name/icon against the live public-profile API. Use to diagnose why an avatar/name shows in the open conversation (public-profile fallback, in-memory) but not in the sidebar (reads the stored row). A `data:image/...` stored icon means the avatar has been persisted to the row. |
 
 ## Workflow
 
@@ -38,4 +39,4 @@ For background on the architecture and the debug ladder, read [`../../docs/debug
 - **No output at all.** Console filter is hiding info-level. Set log level to "All levels" or "Verbose".
 
 ---
-*Last updated: 2026-06-09*
+*Last updated: 2026-06-10*

--- a/src/components/direct/DirectMessageContactsList.tsx
+++ b/src/components/direct/DirectMessageContactsList.tsx
@@ -17,6 +17,7 @@ import { UserAvatar } from '../user/UserAvatar';
 import { useModalContext } from '../context/ModalProvider';
 import { useConversationPolling } from '../../hooks';
 import { useConversationPreviews } from '../../hooks/business/conversations/useConversationPreviews';
+import { useConversationsWithProfileBackfill } from '../../hooks/business/conversations/useConversationsWithProfileBackfill';
 import { useMessageDB } from '../context/useMessageDB';
 import { useDMFavorites } from '../../hooks/business/dm/useDMFavorites';
 import { useDMMute } from '../../hooks/business/dm/useDMMute';
@@ -56,8 +57,13 @@ interface DirectMessageContactsListProps {
 
 const DirectMessageContactsList: React.FC<DirectMessageContactsListProps> = ({ forceExpanded } = {}) => {
   const { conversations: conversationsList } = useConversationPolling();
-  const { data: conversationsWithPreviews = conversationsList } =
-    useConversationPreviews(conversationsList);
+  // Back-fill displayName / icon from the public profile for contacts whose
+  // local row still holds the "Unknown User" / default-avatar placeholder,
+  // and write the result through to IndexedDB so later loads are instant.
+  const conversationsBackfilled =
+    useConversationsWithProfileBackfill(conversationsList);
+  const { data: conversationsWithPreviews = conversationsBackfilled } =
+    useConversationPreviews(conversationsBackfilled);
   const { openNewDirectMessage, openConversationSettings } = useModalContext();
   const [mockUtils, setMockUtils] = React.useState<any>(null);
 

--- a/src/components/message/MessageList.tsx
+++ b/src/components/message/MessageList.tsx
@@ -45,6 +45,16 @@ interface MessageListProps {
   messageList: MessageType[];
   stickers?: { [stickerId: string]: Sticker };
   members: any;
+  /** Optional sender->identity resolver. When provided (e.g. Channel's
+   *  public-profile-backfilled mapper, or DirectMessage's own), it is used
+   *  instead of the internal one built from the raw `members` map. This is how
+   *  the public-profile fallback reaches per-message name/avatar rendering. */
+  mapSenderToUser?: (senderId: string) => {
+    address?: string;
+    displayName?: string;
+    userIcon?: string;
+    [extra: string]: unknown;
+  };
   setInReplyTo: React.Dispatch<React.SetStateAction<MessageType | undefined>>;
   editor: React.RefObject<HTMLTextAreaElement | null>;
   submitMessage: (message: any) => Promise<void>;
@@ -142,6 +152,7 @@ export const MessageList = forwardRef<MessageListRef, MessageListProps>(
       messageList,
       stickers,
       members,
+      mapSenderToUser: mapSenderToUserProp,
       setInReplyTo,
       editor,
       submitMessage,
@@ -287,7 +298,11 @@ export const MessageList = forwardRef<MessageListRef, MessageListProps>(
       },
     }));
 
-    const mapSenderToUser = useCallback(
+    // Internal resolver from the raw `members` map — used only when the caller
+    // doesn't supply its own mapper. Space channels and DMs both pass an
+    // enriched mapper (with public-profile fallback) via the prop; this is the
+    // bare fallback for any caller that doesn't.
+    const mapSenderToUserInternal = useCallback(
       (senderId: string) => {
         const member = members[senderId];
         if (member) {
@@ -303,6 +318,8 @@ export const MessageList = forwardRef<MessageListRef, MessageListProps>(
       },
       [members]
     );
+
+    const mapSenderToUser = mapSenderToUserProp ?? mapSenderToUserInternal;
 
     // Strict variant — returns null when the address isn't a current, active
     // member of this space. Kicked members are explicitly treated as

--- a/src/components/space/Channel.tsx
+++ b/src/components/space/Channel.tsx
@@ -1636,6 +1636,11 @@ const Channel: React.FC<ChannelProps> = ({
                 setInReplyTo={composer.setInReplyTo}
                 customEmoji={space?.emojis}
                 members={members}
+                // Enriched resolver (public-profile back-fill for senders whose
+                // space_members row has no name/avatar). Without this, the
+                // message list rendered raw `members` and fell back to the
+                // 6-char address suffix for those senders.
+                mapSenderToUser={mapSenderToUser}
                 submitMessage={handleSubmitMessage}
                 onUserClick={userProfileModal.handleUserClick}
                 lastReadTimestamp={lastReadTimestamp}

--- a/src/components/user/UserAvatar/UserAvatar.native.tsx
+++ b/src/components/user/UserAvatar/UserAvatar.native.tsx
@@ -4,10 +4,12 @@ import { UserInitials } from '../UserInitials';
 import { DefaultImages } from '../../../utils';
 import { getColorFromDisplayName } from '@quilibrium/quorum-shared';
 
-// A userIcon string can be truthy but not actually a renderable image:
-// an empty/whitespace data URI, a malformed value, or a record whose image
-// payload never synced. Treat those as "no image" so we fall back to initials
-// instead of rendering a blank box.
+// A userIcon string can be truthy but not actually renderable: an
+// empty/whitespace data URI, the default placeholder, or an empty payload.
+// Treat those as "no image" so we fall back to initials instead of a blank
+// box. (Native CAN render a local file:// path from this device, so unlike
+// web we do NOT reject the file: scheme here — a synced file:// from another
+// device simply fails to load and hits onError.)
 const isLikelyRenderableImage = (icon?: string): boolean => {
   if (!icon) return false;
   const trimmed = icon.trim();

--- a/src/components/user/UserAvatar/UserAvatar.native.tsx
+++ b/src/components/user/UserAvatar/UserAvatar.native.tsx
@@ -1,8 +1,21 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState, useEffect } from 'react';
 import { Image, StyleSheet, ViewStyle } from 'react-native';
 import { UserInitials } from '../UserInitials';
 import { DefaultImages } from '../../../utils';
 import { getColorFromDisplayName } from '@quilibrium/quorum-shared';
+
+// A userIcon string can be truthy but not actually a renderable image:
+// an empty/whitespace data URI, a malformed value, or a record whose image
+// payload never synced. Treat those as "no image" so we fall back to initials
+// instead of rendering a blank box.
+const isLikelyRenderableImage = (icon?: string): boolean => {
+  if (!icon) return false;
+  const trimmed = icon.trim();
+  if (!trimmed) return false;
+  if (trimmed.includes(DefaultImages.UNKNOWN_USER)) return false;
+  if (/^data:[^,]*,\s*$/.test(trimmed)) return false;
+  return true;
+};
 
 interface UserAvatarProps {
   userIcon?: string;
@@ -23,16 +36,23 @@ export function UserAvatar({
   style,
   onPress
 }: UserAvatarProps) {
-  const hasValidImage = userIcon && !userIcon.includes(DefaultImages.UNKNOWN_USER);
+  const hasValidImage = isLikelyRenderableImage(userIcon);
+
+  // Track runtime image-load failure; on error fall back to initials.
+  const [imageFailed, setImageFailed] = useState(false);
+  useEffect(() => {
+    setImageFailed(false);
+  }, [userIcon]);
 
   // Memoize color calculation for performance (only recalculates when display name changes)
   const backgroundColor = useMemo(() => getColorFromDisplayName(displayName), [displayName]);
 
-  if (hasValidImage) {
+  if (hasValidImage && !imageFailed) {
     return (
       <Image
         testID={testID}
         source={{ uri: userIcon }}
+        onError={() => setImageFailed(true)}
         style={[
           {
             width: size,

--- a/src/components/user/UserAvatar/UserAvatar.web.tsx
+++ b/src/components/user/UserAvatar/UserAvatar.web.tsx
@@ -3,18 +3,28 @@ import { UserInitials } from '../UserInitials';
 import { DefaultImages } from '../../../utils';
 import { getColorFromDisplayName } from '@quilibrium/quorum-shared';
 
-// A userIcon string can be truthy but not actually a renderable image:
-// an empty/whitespace data URI, a malformed value, or a record whose image
-// payload never synced. Treat those as "no image" so we fall back to initials
-// instead of rendering a blank box.
+// A userIcon string can be truthy but not actually renderable on web:
+// an empty/whitespace data URI, the default placeholder, or a non-web URL
+// scheme. The last case is real: mobile sometimes stores an avatar as a
+// local `file:///var/mobile/.../ImagePicker/xxx.jpg` path, which is
+// meaningless (and blocked) on web — it must NOT be attempted as an <img>
+// src or it renders a blank box. Treat all of these as "no image" so we fall
+// back to initials.
 const isLikelyRenderableImage = (icon?: string): boolean => {
   if (!icon) return false;
   const trimmed = icon.trim();
   if (!trimmed) return false;
   if (trimmed.includes(DefaultImages.UNKNOWN_USER)) return false;
   // A data URI with no payload after the comma (e.g. "data:image/png;base64,")
-  // is present-but-empty — the most common broken case.
+  // is present-but-empty — a common broken case.
   if (/^data:[^,]*,\s*$/.test(trimmed)) return false;
+  // Only web-renderable schemes. Relative/path-less values (no scheme) are
+  // allowed through for back-compat with app-relative asset paths; explicit
+  // non-web schemes (file:, content:, etc.) are rejected.
+  const scheme = /^([a-zA-Z][a-zA-Z0-9+.-]*):/.exec(trimmed)?.[1]?.toLowerCase();
+  if (scheme && !['data', 'http', 'https', 'blob'].includes(scheme)) {
+    return false;
+  }
   return true;
 };
 

--- a/src/components/user/UserAvatar/UserAvatar.web.tsx
+++ b/src/components/user/UserAvatar/UserAvatar.web.tsx
@@ -1,7 +1,22 @@
-import { useMemo } from 'react';
+import { useMemo, useState, useEffect } from 'react';
 import { UserInitials } from '../UserInitials';
 import { DefaultImages } from '../../../utils';
 import { getColorFromDisplayName } from '@quilibrium/quorum-shared';
+
+// A userIcon string can be truthy but not actually a renderable image:
+// an empty/whitespace data URI, a malformed value, or a record whose image
+// payload never synced. Treat those as "no image" so we fall back to initials
+// instead of rendering a blank box.
+const isLikelyRenderableImage = (icon?: string): boolean => {
+  if (!icon) return false;
+  const trimmed = icon.trim();
+  if (!trimmed) return false;
+  if (trimmed.includes(DefaultImages.UNKNOWN_USER)) return false;
+  // A data URI with no payload after the comma (e.g. "data:image/png;base64,")
+  // is present-but-empty — the most common broken case.
+  if (/^data:[^,]*,\s*$/.test(trimmed)) return false;
+  return true;
+};
 
 interface UserAvatarProps {
   userIcon?: string;
@@ -24,27 +39,46 @@ export function UserAvatar({
   style,
   onClick
 }: UserAvatarProps) {
-  const hasValidImage = userIcon && !userIcon.includes(DefaultImages.UNKNOWN_USER);
+  const hasValidImage = isLikelyRenderableImage(userIcon);
+
+  // Track runtime image-load failure: a value that passes the static check can
+  // still 404 / be undecodable. On error we flip to initials. Reset when the
+  // icon changes so a later valid icon gets a fresh attempt.
+  const [imageFailed, setImageFailed] = useState(false);
+  useEffect(() => {
+    setImageFailed(false);
+  }, [userIcon]);
 
   // Memoize color calculation for performance (only recalculates when display name changes)
   const backgroundColor = useMemo(() => getColorFromDisplayName(displayName), [displayName]);
 
-  if (hasValidImage) {
+  if (hasValidImage && !imageFailed) {
     return (
       <div
         id={id}
-        className={`rounded-full ${className}`}
+        className={`rounded-full overflow-hidden ${className}`}
         style={{
-          backgroundImage: `url(${userIcon})`,
           width: size,
           height: size,
-          backgroundPosition: 'center',
-          backgroundSize: 'cover',
           flexShrink: 0,
           ...style
         }}
         onClick={onClick}
-      />
+      >
+        <img
+          src={userIcon}
+          alt={displayName}
+          width={size}
+          height={size}
+          onError={() => setImageFailed(true)}
+          style={{
+            width: '100%',
+            height: '100%',
+            objectFit: 'cover',
+            display: 'block',
+          }}
+        />
+      </div>
     );
   }
 

--- a/src/hooks/business/conversations/useConversationsWithProfileBackfill.ts
+++ b/src/hooks/business/conversations/useConversationsWithProfileBackfill.ts
@@ -1,0 +1,192 @@
+// useConversationsWithProfileBackfill
+//
+// The DM sidebar (DirectMessageContactsList) renders displayName / icon
+// straight off the local Conversation row. For contacts whose row was
+// created before the partner ever broadcast their profile, that row holds
+// the literal "Unknown User" name and the default avatar — so the sidebar
+// shows a stale identity even though the open-conversation view papers over
+// it with a public-profile fallback (DirectMessage.tsx:227-242).
+//
+// This hook closes that gap with a write-through cache:
+//   1. Read  — find rows whose displayName is "Unknown User" OR whose icon
+//              is the default (per-field: a contact may be missing only the
+//              avatar, only the name, or both).
+//   2. Fetch — query the public-profile endpoint for those addresses. Reuses
+//              publicProfileQueryKey so the cache is shared with the
+//              conversation view — usually already warm, no double fetch.
+//   3. Merge  — per-field. A real stored value always wins; only the
+//              default / "Unknown User" placeholder is replaced. The merged
+//              list is what the sidebar renders, so it's correct on first paint.
+//   4. Write-back — persist the resolved values onto the IndexedDB row and
+//              invalidate the conversation queries. Subsequent loads (and the
+//              conversation header / message avatars, which read the same row)
+//              render instantly from local storage with no network flash.
+//
+// Safety: only fields still holding the default placeholder are ever
+// overwritten. A value pushed via dm-update-profile is authoritative and is
+// never clobbered by a (possibly stale) public profile.
+
+import { useEffect, useMemo, useRef } from 'react';
+import { useQueries, useQueryClient } from '@tanstack/react-query';
+import type { Conversation } from '@quilibrium/quorum-shared';
+import { QuorumApiClient, isHandledFetchError } from '../../../api/baseTypes';
+import type { PublicProfileResponse } from '../../../api/baseTypes';
+import { publicProfileQueryKey } from '../user/useUserPublicProfile';
+import { useMessageDB } from '../../../components/context/useMessageDB';
+import { buildConversationsKey } from '../../queries/conversations/buildConversationsKey';
+import { buildConversationKey } from '../../queries/conversation/buildConversationKey';
+import { DefaultImages } from '../../../utils';
+import { logger } from '@quilibrium/quorum-shared';
+
+// "Unknown User" is the literal placeholder stored on rows with no real name
+// (MessageService.ts). We can't import the runtime-translated t`Unknown User`
+// here without coupling to the i18n macro, and the stored value is the
+// English literal at write time, so match that constant directly.
+const UNKNOWN_USER_NAME = 'Unknown User';
+
+const isPlaceholderName = (name?: string): boolean =>
+  !name || name === UNKNOWN_USER_NAME;
+
+const isPlaceholderIcon = (icon?: string): boolean =>
+  !icon || icon === DefaultImages.UNKNOWN_USER;
+
+export function useConversationsWithProfileBackfill(
+  conversations: Conversation[]
+): Conversation[] {
+  const { messageDB } = useMessageDB();
+  const queryClient = useQueryClient();
+
+  // Addresses whose row is missing a real name and/or a real avatar.
+  const addressesToFetch = useMemo(() => {
+    const out: string[] = [];
+    const seen = new Set<string>();
+    for (const c of conversations) {
+      if (!c.address || seen.has(c.address)) continue;
+      if (isPlaceholderName(c.displayName) || isPlaceholderIcon(c.icon)) {
+        seen.add(c.address);
+        out.push(c.address);
+      }
+    }
+    return out;
+  }, [conversations]);
+
+  const queries = useQueries({
+    queries: addressesToFetch.map((address) => ({
+      queryKey: publicProfileQueryKey(address),
+      queryFn: async (): Promise<PublicProfileResponse | null> => {
+        try {
+          const response = await new QuorumApiClient().getPublicProfile(address);
+          return response.data;
+        } catch (error: unknown) {
+          if (isHandledFetchError(error) && error.status === 404) {
+            return null;
+          }
+          throw error;
+        }
+      },
+      staleTime: 60 * 60 * 1000, // 1 hour — matches useUserPublicProfile
+      gcTime: 24 * 60 * 60 * 1000,
+      retry: false,
+    })),
+  });
+
+  // address -> resolved public profile (or null). Stable per render via the
+  // query data refs, which React Query keeps stable until a refetch.
+  const profileByAddress = useMemo(() => {
+    const map: Record<string, PublicProfileResponse | null> = {};
+    addressesToFetch.forEach((addr, i) => {
+      map[addr] = queries[i]?.data ?? null;
+    });
+    return map;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [addressesToFetch, queries.map((q) => q?.data ?? null).join('|')]);
+
+  // Merged list for rendering: placeholder fields fall back to the public
+  // profile, real fields are preserved.
+  const merged = useMemo(() => {
+    if (addressesToFetch.length === 0) return conversations;
+    return conversations.map((c) => {
+      const pub = profileByAddress[c.address];
+      if (!pub) return c;
+      const nameNeedsFill = isPlaceholderName(c.displayName);
+      const iconNeedsFill = isPlaceholderIcon(c.icon);
+      if (!nameNeedsFill && !iconNeedsFill) return c;
+      return {
+        ...c,
+        displayName:
+          nameNeedsFill && pub.display_name ? pub.display_name : c.displayName,
+        icon: iconNeedsFill && pub.profile_image ? pub.profile_image : c.icon,
+      };
+    });
+  }, [conversations, profileByAddress, addressesToFetch]);
+
+  // Write-through: persist resolved values back to IndexedDB so the next load
+  // is instant and the conversation view stops flashing. Guard against
+  // re-writing the same row repeatedly within a session.
+  const writtenRef = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    if (!messageDB) return;
+    for (const c of conversations) {
+      const pub = profileByAddress[c.address];
+      if (!pub) continue;
+
+      const nextName =
+        isPlaceholderName(c.displayName) && pub.display_name
+          ? pub.display_name
+          : undefined;
+      const nextIcon =
+        isPlaceholderIcon(c.icon) && pub.profile_image
+          ? pub.profile_image
+          : undefined;
+      if (!nextName && !nextIcon) continue;
+
+      // Dedupe writes by the values we're about to persist.
+      const writeKey = `${c.conversationId}|${nextName ?? ''}|${nextIcon ?? ''}`;
+      if (writtenRef.current.has(writeKey)) continue;
+      writtenRef.current.add(writeKey);
+
+      void (async () => {
+        try {
+          const existing = await messageDB.getConversation({
+            conversationId: c.conversationId,
+          });
+          if (!existing?.conversation) return;
+          // Re-check against the freshest stored row: a dm-update-profile
+          // broadcast may have landed a real value since we read the list.
+          const row = existing.conversation;
+          const merged: Conversation = {
+            ...row,
+            ...(nextName && isPlaceholderName(row.displayName)
+              ? { displayName: nextName }
+              : {}),
+            ...(nextIcon && isPlaceholderIcon(row.icon)
+              ? { icon: nextIcon }
+              : {}),
+          };
+          if (
+            merged.displayName === row.displayName &&
+            merged.icon === row.icon
+          ) {
+            return; // nothing to persist after the re-check
+          }
+          await messageDB.saveConversation(merged);
+          queryClient.invalidateQueries({
+            queryKey: buildConversationsKey({ type: 'direct' }),
+          });
+          queryClient.invalidateQueries({
+            queryKey: buildConversationKey({
+              conversationId: c.conversationId,
+            }),
+          });
+        } catch (err) {
+          logger.warn('[DMProfileBackfill] write-back failed', {
+            err,
+            conversationId: c.conversationId,
+          });
+        }
+      })();
+    }
+  }, [conversations, profileByAddress, messageDB, queryClient]);
+
+  return merged;
+}

--- a/src/hooks/business/user/useMembersWithPublicProfileFallback.ts
+++ b/src/hooks/business/user/useMembersWithPublicProfileFallback.ts
@@ -141,5 +141,41 @@ export function useMembersWithPublicProfileFallback(
   }
 
   cacheRef.current = { members, addressesToFetch, dataRefs, result };
+
+  // Gated diagnostic (ship-safe; off unless explicitly enabled). Enable with:
+  //   localStorage.setItem('debug_profile_fallback', 'true'); location.reload();
+  // For each address we tried to back-fill, prints whether a public profile
+  // was found and what name/icon it yielded — so we can tell "wiring bug"
+  // (profile exists, render still shows address) from "no public profile"
+  // (404 -> null -> nothing to fill). Disable with removeItem + reload.
+  try {
+    if (
+      typeof localStorage !== 'undefined' &&
+      localStorage.getItem('debug_profile_fallback') === 'true' &&
+      addressesToFetch.length > 0
+    ) {
+      console.table(
+        addressesToFetch.map((addr, i) => {
+          const pub = dataRefs[i];
+          const local = members[addr];
+          return {
+            address: addr.slice(0, 18) + '…',
+            inMemberMap: !!local,
+            localName: local?.displayName ?? '(none)',
+            localIcon: local?.userIcon ? 'has' : '(none)',
+            publicProfile: pub ? 'FOUND' : 'none/404',
+            pubName: pub?.display_name || '(empty)',
+            pubImage: pub?.profile_image ? 'YES' : 'no',
+            verdict: pub
+              ? 'fillable'
+              : 'NO public profile (not client-recoverable)',
+          };
+        })
+      );
+    }
+  } catch {
+    // localStorage access can throw in some sandboxed contexts — ignore.
+  }
+
   return result;
 }

--- a/src/hooks/business/user/useMembersWithPublicProfileFallback.ts
+++ b/src/hooks/business/user/useMembersWithPublicProfileFallback.ts
@@ -141,41 +141,5 @@ export function useMembersWithPublicProfileFallback(
   }
 
   cacheRef.current = { members, addressesToFetch, dataRefs, result };
-
-  // Gated diagnostic (ship-safe; off unless explicitly enabled). Enable with:
-  //   localStorage.setItem('debug_profile_fallback', 'true'); location.reload();
-  // For each address we tried to back-fill, prints whether a public profile
-  // was found and what name/icon it yielded — so we can tell "wiring bug"
-  // (profile exists, render still shows address) from "no public profile"
-  // (404 -> null -> nothing to fill). Disable with removeItem + reload.
-  try {
-    if (
-      typeof localStorage !== 'undefined' &&
-      localStorage.getItem('debug_profile_fallback') === 'true' &&
-      addressesToFetch.length > 0
-    ) {
-      console.table(
-        addressesToFetch.map((addr, i) => {
-          const pub = dataRefs[i];
-          const local = members[addr];
-          return {
-            address: addr.slice(0, 18) + '…',
-            inMemberMap: !!local,
-            localName: local?.displayName ?? '(none)',
-            localIcon: local?.userIcon ? 'has' : '(none)',
-            publicProfile: pub ? 'FOUND' : 'none/404',
-            pubName: pub?.display_name || '(empty)',
-            pubImage: pub?.profile_image ? 'YES' : 'no',
-            verdict: pub
-              ? 'fillable'
-              : 'NO public profile (not client-recoverable)',
-          };
-        })
-      );
-    }
-  } catch {
-    // localStorage access can throw in some sandboxed contexts — ignore.
-  }
-
   return result;
 }


### PR DESCRIPTION
Fixes name/avatar identity not showing across DM and space surfaces, plus a blank-avatar artifact.

## DM
- **Sidebar back-fill + write-through.** The DM sidebar read displayName/icon straight off the local conversation row with no fallback, while the open-conversation view fell back to the public profile in memory only. Adds `useConversationsWithProfileBackfill`: per-field public-profile back-fill (placeholder name / default icon each count as empty) that merges for render AND persists to IndexedDB, so later loads are instant and the conversation-view flash disappears. Only placeholder fields are overwritten; a `dm-update-profile`-pushed value is never clobbered.

## Spaces
- **Message-list fallback wiring.** Channel computed a public-profile-backfilled member map but never passed it to `<MessageList>`, which rendered raw members and fell back to a 6-char address suffix. MessageList now accepts an optional `mapSenderToUser` prop and prefers it; Channel passes its enriched mapper in. (DirectMessage already passed one that was previously silently dropped.) Fetch stays bounded to visible senders. Render-only by design — no write-through to the canonical `space_members` store (rationale documented).

## Avatar
- **Graceful fallback to initials.** A userIcon can be truthy-but-unrenderable: an empty data URI, or a mobile-leaked `file://` local path that synced out. The old CSS background-image rendered a blank box with no fallback. UserAvatar now rejects empty data URIs and non-web URL schemes up front, uses an `<img>` with onError to catch runtime failures, and degrades to initials.

## Docs / tooling
- DM playbook updated with the three identity sync paths (session-init capture, dm-update-profile push, public-profile pull + write-back).
- Space task doc records the render-only decision.
- Adds `.agents/tools/dm-debug/05-profile-sources.js` diagnostic snippet.

Type-check clean (pre-existing unrelated error in ImportKeyStep.tsx), lint clean.