### PR TITLE
feat: QNS username overrides display name

### DIFF
--- a/.agents/docs/features/qns-username-display.md
+++ b/.agents/docs/features/qns-username-display.md
@@ -1,0 +1,120 @@
+---
+type: doc
+title: "QNS Username Display (name resolution)"
+status: done
+ai_generated: true
+created: 2026-06-11
+updated: 2026-06-11
+related_docs: ["input-validation-reference.md"]
+related_tasks: [".agents/tasks/port-from-mobile/2026-06-11-qns-username-overrides-display-name-plan.md", ".agents/tasks/port-from-mobile/2026-06-10-qns-username-display-design.md"]
+---
+
+# QNS Username Display (name resolution)
+
+> **⚠️ AI-Generated**: May contain errors. Verify before use.
+
+## Overview
+
+A user can register a username on the Quilibrium Name Service (QNS) and elect it as their **primary username**. Desktop shows that name, rendered as `name.q`, as the user's identity across the app. The `.q` suffix uses the exact same font, size, weight, and color as the name it is attached to (no special styling). It is a trust marker: it only appears on verified QNS names and custom display names are blocked from imitating it.
+
+The feature answers one question everywhere a person's name renders: **"which of this user's names do we show?"**
+
+## The three name types
+
+Every user can have up to three names. Understanding the difference is the key to this feature:
+
+| Name | Code field | Where it is set | Where it lives | Meaning |
+|---|---|---|---|---|
+| **Per-space display name** | `displayName` (the "roster name") | Space Settings → Account, inside one space | The space's member roster (broadcast via `update-profile`) | "Call me this **in this space**" |
+| **Global display name** | `globalDisplayName` | User Settings (account-wide) | The user's published public profile (`display_name`) | "Call me this **by default**" |
+| **QNS primary username** | `primaryUsername` | QNS registration + electing it primary | The user's published public profile (`primary_username`) | "This is my **verified, owned identity**" (rendered `name.q`) |
+
+Important wrinkle: when a user joins a space, their global name is **copied** into the roster's `displayName`. So the roster field holds either a deliberate per-space name or just the global default, with no flag saying which (see "Custom-name detection" below).
+
+## The precedence rule
+
+Most specific wins:
+
+```
+custom per-space name  →  QNS primary username (.q)  →  global display name  →  truncated address
+```
+
+- In a **space**: a name the member deliberately set for that space wins; otherwise their QNS name; otherwise the global name; otherwise the address.
+- In a **DM** (no per-space concept): QNS name → display name → address.
+- The `.q` suffix renders **only** when the chosen name is the QNS username (`isQnsVerified: true`). It is never stored, always appended at render time.
+
+## Architecture
+
+### Resolvers (single source of truth)
+
+- `@quilibrium/quorum-shared` → `resolveDisplayName(member, { spaceOverrideName })` — the shared precedence rule, returns `{ name, isQnsVerified }`.
+- `src/utils/resolveMemberName.ts` — the desktop adapter over the shared helper. Three exports:
+  - `resolveMemberName(member)` — **DM/global contexts.** QNS wins over `displayName`.
+  - `resolveSpaceMemberName(member)` — **space contexts.** Implements custom-name detection (below), then delegates to `resolveMemberName`.
+  - `formatResolvedName(resolved)` — flattens to a plain string (`name.q` when verified) for non-JSX sites: placeholders, tooltips, aria-labels.
+- `src/components/user/ResolvedName.tsx` — the one JSX component that renders a resolved name with the `.q` suffix (same font/size/weight/color as the name). All JSX sites use it so the suffix treatment can never drift.
+
+Rule of thumb for new code: name sourced from a **space roster / effectiveMembers** → `resolveSpaceMemberName`. Name in a **DM or profile-global** context → `resolveMemberName`. Never re-implement precedence at a call site.
+
+### Custom-name detection (the comparison trick)
+
+The roster stores one `display_name` per member with no marker of origin (deliberate per-space name vs global default copied at join). The protocol offers no flag. Desktop tells them apart by comparison:
+
+```
+roster displayName ≠ globalDisplayName  →  deliberately typed for this space  →  it wins, no .q
+roster displayName = globalDisplayName  →  just the global default            →  QNS name wins, show .q
+globalDisplayName unknown               →  conservatively respect the roster name (never hide a possibly-deliberate choice)
+```
+
+This costs nothing extra: `globalDisplayName` comes from the same public-profile fetch that is the **only** source of `primaryUsername`. Whenever a QNS name is known, the global name is known too.
+
+### Data flow (sourcing)
+
+```
+user elects QNS primary name
+  → published in their signed public profile (primary_username + display_name)
+  → desktop fetches the public profile          ← the ONLY source of both fields
+  → fields land on member objects
+  → resolvers pick the name → <ResolvedName> renders it (.q when verified)
+```
+
+Fetch scopes (deliberate, perf-driven):
+
+- **Space message senders**: `useMembersWithPublicProfileFallback` fetches the public profile for **every visible message sender** in the open channel (bounded, 1h React Query cache shared with the profile-card key). It enriches `effectiveMembers` with `primaryUsername` + `globalDisplayName`.
+- **Member sidebar**: no fetches of its own. It cheap-merges `primaryUsername`/`globalDisplayName` from `effectiveMembers`, so only members who have posted show `.q` there. The full roster is deliberately never fetched (fetch-storm protection).
+- **Mention autocomplete**: candidates come from the roster merged with `effectiveMembers` (same cheap merge). Matching also runs against `primaryUsername`, so typing `@ali` finds `alice`. The pill displays the resolved name; the stored token stays `@<address>` (wire format unchanged).
+- **DMs**: `useUserPublicProfile(address)` per conversation partner; the DM list backfill (`useConversationsWithProfileBackfill`) fetches each partner's profile (small N) and returns `ConversationWithQns`.
+- **Profile card** (`UserProfile.tsx`): uses the member object's fields when present, otherwise does one on-demand profile fetch while open.
+
+### Local smoke-testing (no real data)
+
+Until mobile publishes `primary_username`, no real `.q` exists. To eyeball rendering locally, temporarily synthesize a fake `primary_username` in the public-profile `queryFn`. **Apply it in ALL hooks that write `publicProfileQueryKey`** — `useUserPublicProfile`, `useMembersWithPublicProfileFallback`, and `useConversationsWithProfileBackfill` — because they share one cache key: if any non-injected one resolves first, it caches a real `null` and the injected ones never run (this caused a confusing "callout never shows" during development). To exercise the custom-name-wins rule, also inject a stable `globalDisplayName` (e.g. snapshot the first-seen roster name) so changing a per-space name makes it differ. Use `yarn dev:clean` to clear the cached `null` between runs. Remove all injections before commit.
+
+### Trust / validation
+
+- QNS names are stored bare (`alice`); `.q` is appended only at render time.
+- The shared display-name validator rejects custom names ending in `.q` (after trimming + Unicode-confusable folding), so the suffix cannot be spoofed. Wired into both the global and per-space name inputs.
+
+## Privacy model
+
+`primary_username` travels **only in the published public profile**, never in the message broadcast. Consequence: a user's `.q` shows only if they opted into a public profile. This is a consistency decision: the QNS label follows the same public/private opt-in as the rest of profile metadata (name, avatar, bio).
+
+What the public/private toggle does NOT do: gate reachability. The QNS resolver (`GET names.quilibrium.com/resolve/:name`) is global and public; anyone who knows a registered name can resolve it to an address and start a DM, regardless of any Quorum profile setting. The toggle only controls whether Quorum *displays* the label.
+
+## Known limitations
+
+- **Custom name identical to the global name** reads as "not custom", so the QNS name shows. Tiny corner case; degrades to a correct name without honoring the (invisible) custom intent.
+- **Stale profile cache after a global rename** (up to 1h) can briefly read the roster name as custom, hiding `.q`. Always degrades to a correct name without `.q`, never a wrong name.
+- **Sidebar lurkers**: members who never posted in the open channel show no `.q` in the member sidebar (no profile fetch for them). It appears once they post or their profile card is opened. Full-roster enrichment would need virtualized visible-range tracking (possible follow-up).
+- **Search results and bookmark cards** do not QNS-resolve (different data source / frozen snapshot; deferred, logged in the implementation plan).
+- **Live data dependency**: no real `.q` shows until mobile actually publishes `primary_username` (two mobile-side bugs filed 2026-06-10 in `quorum-mobile/.agents/bugs/`).
+- **Protocol improvements that would simplify this** (lead-dev asks, pending): a batch public-profile endpoint (N lookups → 1 request) and an explicit is-custom-name flag on `update-profile` (would replace the comparison trick). Neither blocks the feature.
+
+## Related Documentation
+
+- Implementation plan: `.agents/tasks/port-from-mobile/2026-06-11-qns-username-overrides-display-name-plan.md` (includes the full surface audit)
+- Original design: `.agents/tasks/port-from-mobile/2026-06-10-qns-username-display-design.md`
+- Validation rules: `.agents/docs/features/input-validation-reference.md`
+
+---
+*Last updated: 2026-06-11*

--- a/.agents/tasks/port-from-mobile/2026-06-10-qns-username-display-plan.md
+++ b/.agents/tasks/port-from-mobile/2026-06-10-qns-username-display-plan.md
@@ -23,7 +23,11 @@
 | **3** | Profile `.q` display + `.q`-suffix validation in both settings inputs. | ⚠️ **built as Model A (secondary handle), BLOCKED on lead-dev Model A-vs-B decision** — see below. Validation + plumbing are keep-regardless; only the *render* is model-dependent. |
 | **4** | Mentions by QNS name (autocomplete + pill). | ❌ NOT started. Blocked on the same A-vs-B decision (mentions show a name; which name depends on the model). |
 
-### 🔴 THE BLOCKING DECISION: Model A vs Model B (awaiting lead dev, asked via Telegram 2026-06-10)
+### ✅ RESOLVED 2026-06-11 — Model B confirmed by lead dev (Cassie: "Agree")
+
+The Model A-vs-B decision below is **settled: Model B.** Cassie agreed the QNS primary username overrides the display name everywhere, except where a per-space custom name is set. The override conversion (Model A → Model B) across all name-render surfaces + Stage 4 mentions is now tracked in a dedicated plan: **`2026-06-11-qns-username-overrides-display-name-plan.md`** (branch `feat/qns-username-overrides-display-name`). That work is implemented and verified (tsc/lint/build green); only manual smoke remains (live `.q` still dormant pending the two mobile bugs). The historical decision context is preserved below.
+
+### 🔴 (HISTORICAL) THE BLOCKING DECISION: Model A vs Model B (awaiting lead dev, asked via Telegram 2026-06-10)
 
 The plan/design originally specified the resolution rule `per-space override → QNS primary_username → display name → address` (**Model B** — QNS name IS the name). But Stage 3 was **built as Model A** (mobile's pattern): the typed display name stays primary, and `.q` is appended as a small secondary handle, only in the profile card.
 

--- a/.agents/tasks/port-from-mobile/2026-06-11-qns-username-overrides-display-name-plan.md
+++ b/.agents/tasks/port-from-mobile/2026-06-11-qns-username-overrides-display-name-plan.md
@@ -1,0 +1,210 @@
+---
+type: task
+title: "QNS username overrides display name everywhere (Model B) + mentions"
+status: ready
+created: 2026-06-11
+branch: feat/qns-username-overrides-display-name
+supersedes-progress-in: 2026-06-10-qns-username-display-plan.md (the "Model A vs B" block)
+related-design: 2026-06-10-qns-username-display-design.md
+---
+
+# QNS username overrides display name everywhere + mentions by QNS name
+
+> **For agentic workers:** Steps use checkbox (`- [ ]`) syntax. Work phase-by-phase; typecheck after each phase. The audit in §3 is the authoritative surface checklist — every box there must end checked or explicitly deferred with a note.
+
+## 1. What unblocked this and what this branch does
+
+**Unblock (2026-06-11):** Lead dev Cassie confirmed ("Agree") the resolution model. A user's elected QNS `primary_username` (rendered `name.q`) **overrides their typed display name everywhere**, except in a space where they've set a per-space custom name (the override still wins locally). This is "Model B" from the prior plan — the original design's rule all along. Stages 1+2+3 already shipped as **Model A** in PR #190 (merged to `main`): display name stayed primary, `.q` shown only as a secondary handle on the profile card.
+
+**This branch (`feat/qns-username-overrides-display-name`) does two things:**
+1. **Override conversion (Model A → Model B):** route every user-name render site through the shared `resolveDisplayName` rule so the QNS name becomes the primary name wherever a person is identified. Scope decided 2026-06-11: **all surfaces** (full audit in §3), not just the original ~5.
+2. **Stage 4 — mentions by QNS name:** the mention autocomplete shows + matches space members by their QNS name; the mention pill renders `name.q`. Wire/storage format stays `@<address>` (unchanged).
+
+**Privacy decision (settled 2026-06-11, to be raised with Cassie as confirmation, not a blocker):** `primary_username` is published in the **public profile only**, never in the message broadcast. Rationale is *consistency*, not reachability: the QNS resolver (`GET /resolve/:name`) already makes `@name → address` globally public, so a broadcast couldn't gate reachability anyway. Public-profile-only means the QNS label follows the same public/private opt-in as the rest of profile metadata (display name, avatar, bio). Putting it in the broadcast would surface a private-profile user's QNS identity to everyone they DM, contradicting the private signal. **No code in this branch depends on that call** — the read path is already public-profile-sourced (`useMembersWithPublicProfileFallback`, `recipientPublicProfile`). See [[project_qns_username_broadcast_pending]].
+
+## 2. The one architecture decision: a desktop adapter, not direct helper calls
+
+The shared helper:
+```ts
+resolveDisplayName(member: { display_name?, name?, primary_username?, address }, { spaceOverrideName? })
+  → { name: string, isQnsVerified: boolean }
+// precedence: spaceOverrideName → primary_username → display_name → name → truncate(address)
+```
+
+**Impedance mismatch with desktop data** (verified, this is why we adapt instead of calling directly):
+- Shared uses **snake_case** (`display_name`, `primary_username`). Desktop member objects use **camelCase** (`displayName`, `primaryUsername`).
+- Shared's model splits "global `display_name`" from "`spaceOverrideName`". **Desktop has no such split**: `useChannelData.ts:72` sets `displayName: curr.display_name` where `curr.display_name` is *already the per-space override* (from the member roster broadcast). In DMs, `displayName` is just the name. So on desktop, **`displayName` already means "the name that applies in this context"** — there is no separate global field to pass as `display_name` while passing the override separately.
+
+**Decision: one thin desktop adapter** that maps desktop conventions onto the helper, so the precedence rule lives in exactly one place (the shared helper) and the camelCase/override-semantics bridge lives in exactly one place (the adapter). Every render site calls the adapter, never the helper directly, never re-implements precedence.
+
+```ts
+// src/utils/resolveMemberName.ts  (NEW)
+import { resolveDisplayName as resolveShared } from '@quilibrium/quorum-shared';
+import { getAddressSuffix } from '../utils';
+
+export interface ResolvedMemberName {
+  name: string;          // the readable name; never empty
+  isQnsVerified: boolean; // true → render with the ".q" accent suffix
+}
+
+/**
+ * Desktop adapter over shared resolveDisplayName. Desktop member objects carry
+ * the *contextual* name in `displayName` (in a space that's already the
+ * per-space override; in a DM it's just the name) and the QNS name in
+ * `primaryUsername`. We want: QNS name wins UNLESS a per-space override is set.
+ *
+ * Because desktop's `displayName` already folds the override in, we can't blindly
+ * feed it as the shared "display_name" (that would let it lose to the QNS name
+ * even when it IS an override). Callers that KNOW a value is a genuine per-space
+ * override pass it as `spaceOverrideName`; everyone else passes the member and
+ * we treat `displayName` as the global fallback (QNS wins over it — the desired
+ * Model B behavior).
+ */
+export function resolveMemberName(
+  member: { displayName?: string | null; primaryUsername?: string | null; address: string },
+  opts: { spaceOverrideName?: string | null } = {}
+): ResolvedMemberName {
+  const r = resolveShared(
+    {
+      address: member.address,
+      display_name: member.displayName ?? undefined,
+      primary_username: member.primaryUsername ?? undefined,
+    },
+    { spaceOverrideName: opts.spaceOverrideName }
+  );
+  // Desktop's truncation differs from shared's "Qm…1234"; keep desktop's so the
+  // address-only fallback looks identical to every other desktop surface.
+  if (!member.primaryUsername && !member.displayName && !opts.spaceOverrideName) {
+    return { name: getAddressSuffix(member.address), isQnsVerified: false };
+  }
+  return { name: r.name, isQnsVerified: r.isQnsVerified };
+}
+```
+
+> **Per-space override note — REVISED 2026-06-11 (second pass; supersedes the first CONFIRMED note):**
+> First finding (still true): the roster's `displayName` (`useChannelData.ts:72` ← `messageDB.getSpaceMembers`) is a SINGLE field holding either a deliberate per-space name **or** the member's global name — it's seeded from the global name at join (`InvitationService.ts:756`) and overwritten by `update-profile` (`MessageService.ts:1298`), with **no marker of origin** (verified down to the shared `SpaceMember` type: no flag exists).
+>
+> First implementation treated every roster name as an override (`spaceOverrideName`). **Live testing exposed that as wrong for the common case:** since everyone's roster name defaults to their global name, the QNS name never won, so `.q` never showed in spaces at all.
+>
+> **Final rule (implemented): comparison-based custom-name detection in `resolveSpaceMemberName`.** The member's GLOBAL display name (`globalDisplayName`) comes from the same public-profile fetch that is the only source of `primaryUsername` — so it's available at zero extra cost wherever a QNS name is known:
+> ```
+> roster name ≠ global name  → deliberately typed for this space → wins, no .q
+> roster name = global name  → just the global default            → QNS wins, .q shows
+> global name unknown        → conservatively respect the roster name
+> ```
+> Plumbing change this required: `useMembersWithPublicProfileFallback` now fetches the public profile for **every visible sender** (not only name-less ones) — bounded to visible senders, never the roster; 1h cache shared with the profile-card key. Edge cases (accepted, documented): custom name identical to global reads as not-custom; a stale cached profile after a global rename briefly hides `.q`. Both degrade to a correct name without `.q`, never a wrong name.
+>
+> Full feature doc: `.agents/docs/features/qns-username-display.md`. Pending lead-dev asks (non-blocking): batch profile endpoint; explicit is-custom-name flag on `update-profile` (would replace the comparison).
+
+**`.q` render helper.** The suffix + accent styling repeats across ~25 sites. Add a tiny presentational component so it's consistent and not copy-pasted:
+```tsx
+// src/components/user/ResolvedName.tsx  (NEW) — or a render fn if a component is too heavy per-site
+// Renders `name` and, when isQnsVerified, the ".q" accent suffix.
+// Use inline where a component fits; for string-only contexts (placeholders,
+// aria-labels, tooltips) use a `formatResolvedName(r)` that returns `name` +
+// (isQnsVerified ? '.q' : '') as a plain string.
+```
+Provide BOTH: a `<ResolvedName>` component for JSX sites and a `formatResolvedName(r): string` for string-only sites (placeholders, aria-labels, tooltip content, search match text).
+
+**Naming-collision caution:** `ThreadListItem.tsx` / `ThreadsListPanel.tsx` already use a LOCAL prop named `resolveDisplayName` (a `(senderId)=>string`). Do NOT import the shared symbol into those files under the same name — either leave their prop as-is (it'll be fed by the adapter upstream) or alias on import. The shared `resolveDisplayName` is currently imported nowhere.
+
+## 3. AUDIT — every name-render surface (authoritative checklist)
+
+Verified 2026-06-11 against `main` post-PR-#190. **Tier 1** = `primaryUsername` already in scope (one-line-ish swap). **Tier 2** = needs plumbing (prop/type/fetcher) first. Per-space override is NOT separately distinguishable at any render site except the editing form — see §2 note; treat `displayName` as the contextual fallback.
+
+### Tier 1 — primaryUsername already in scope — ✅ ALL DONE 2026-06-11
+
+> Note on avatars: `UserAvatar displayName=` props were deliberately left on the raw `displayName` (used only for initials/alt-text); converting them would change the initial letter to the QNS name's. Name *text* sites are all converted.
+
+- [x] **Message sender name (desktop)** — `src/components/message/Message.tsx:759` — `{sender.displayName}` — `sender` from `effectiveMembers` (has `primaryUsername`)
+- [ ] **Message sender name (mobile layout)** — `Message.tsx:853` — `{sender.displayName}`
+- [ ] **Reply preview sender** — `Message.tsx:562` — `{mapSenderToUser(reply.content.senderId).displayName}`
+- [ ] **System event message** — `Message.tsx:589` — `{formatEventMessage(sender.displayName, …)}` (low value; include for consistency)
+- [ ] **Pin tooltip (desktop+mobile)** — `Message.tsx:767,861` — `mapSenderToUser(pinnedBy)?.displayName` (string context → `formatResolvedName`)
+- [ ] **DM header name (3 breakpoints)** — `src/components/direct/DirectMessage.tsx:785,906,925` — `otherUser.displayName ?? otherUser.address` — `otherUser.primaryUsername` present (set lines 331-334)
+- [ ] **DM header avatar displayName props** — `DirectMessage.tsx:778,898-899` — pass resolved name (avatar uses it for initials/alt)
+- [ ] **DM composer placeholder** — `DirectMessage.tsx:1044-1046` — `user: otherUser.displayName ?? otherUser.address` (string → `formatResolvedName`)
+- [ ] **DM typing indicator resolveName** — `DirectMessage.tsx:1036` — `otherUser.displayName`
+- [ ] **Notifications sender** — `src/components/notifications/NotificationPanel.tsx:279,302` → `NotificationItem.tsx:143` — `sender?.displayName` — `sender` from enriched `mapSenderToUser`
+- [ ] **Reaction tooltip** — `src/components/message/ReactionsList.tsx:100` — `mapSenderToUser(id)?.displayName` (string → `formatResolvedName`)
+- [ ] **Pinned messages panel sender** — `src/components/message/PinnedMessagesPanel.tsx:75` — `sender?.displayName`
+- [ ] **Reply banner (composer)** — `src/components/message/MessageComposer.tsx:720` (+ `.native.tsx:315`) — `mapSenderToUser(...).displayName`
+- [ ] **Mention pill in message body** — `src/components/message/MessageMarkdownRenderer.tsx:657,668` — `resolvedUser?.displayName || truncateAddress(...)` → render `@name.q` when verified
+- [ ] **Thread "Started by" (panel)** — `src/components/thread/ThreadPanel.tsx:176,179,304` — `starterUser?.displayName` — `primaryUsername` dropped when building `starterUser` (line 176); carry it through then resolve
+- [ ] **Thread list "Started by"** — `ThreadsListPanel.tsx:49-50` (the local `resolveDisplayName` prop) → feed adapter-resolved name; `ThreadListItem.tsx:34` consumes it
+- [ ] **Typing indicator (channel/thread)** — `TypingIndicator.tsx` via `Channel.tsx:1674` & `ThreadPanel.tsx:416` — `mapSenderToUser(addr).displayName`
+- [ ] **UserProfile card (already Model A)** — `src/components/user/UserProfile.tsx:222-231` — **convert**: make resolved name the primary line (currently `props.user.displayName` at 222 + secondary `.q` at 224-231). Model B = primary line shows `name.q` when verified.
+
+### Tier 2 — needs plumbing first — ✅ DONE (except search + bookmarks, deferred & logged)
+
+- [x] **Space member sidebar (desktop+mobile)** — DONE via **cheap merge** (decided 2026-06-11): the sidebar `itemContent` resolves via `resolveSpaceMemberName` pulling `primaryUsername` from the already-enriched `effectiveMembers` (zero new fetches). Members who've sent a visible message show `.q`; silent lurkers light up on next post or when their profile opens (UserProfile does an on-demand fetch). Full-roster enrichment with virtualized visible-range tracking is a deliberate follow-up — the right place to spend perf effort, best done once `.q` is live. **Space member sidebar (desktop+mobile)** — `src/components/space/Channel.tsx:1793,2022` — `item.displayName ?? item.address` — `item` from RAW `members` map (no `primaryUsername`; `useMembersWithPublicProfileFallback` is applied to `effectiveMembers`/senders only, deliberately for perf). **Plumb:** either (a) apply the fallback enrichment to visible roster items too, or (b) on-demand fetch like `UserProfile` does. Prefer (a) scoped to currently-visible/virtualized rows to avoid a roster-wide fetch storm — match the existing perf guard in `useMembersWithPublicProfileFallback`.
+- [ ] **DM profile sidebar** — `src/components/direct/DMUserProfileSidebar.tsx:15-22,78,83` — prop type strips `primaryUsername`; parent `otherUser` HAS it. **Plumb:** widen prop interface to include `primaryUsername?`, pass it from `DirectMessage.tsx:1076,1091`, resolve.
+- [ ] **DM conversation list (strip + full)** — `src/components/direct/DirectMessageContactsList.tsx:344,353,358,375,487,508` + `DirectMessageContact.tsx:83,114` — `c.displayName`/`props.displayName` — `Conversation` DB row + `useConversationsWithProfileBackfill` carry no `primaryUsername`. **Plumb:** add `primary_username` to the backfill hook (it already fetches public profiles), thread `primaryUsername` through the contact prop.
+- [ ] **Mention autocomplete dropdown** — `src/components/message/MentionDropdown.tsx:190,197` — `option.data.displayName` — `users` from raw `members` (no `primaryUsername`). **Plumb (also Stage 4):** carry `primaryUsername` into the candidate objects + match against it. See Phase 5.
+- [ ] **Reactions modal list** — `src/components/modals/ReactionsModal.tsx:46,127,131` — `user.displayName` — prop `members` type strips it. **Plumb:** widen the modal's member type; source already has it via `mapSenderToUser`.
+- [~] **Search results (space + DM)** — `src/components/search/SearchResultItem.tsx:144` via `useBatchSearchResultsDisplay.ts:147,170` — **DEFERRED 2026-06-11 (logged).** `userInfo` comes from `buildUserInfoFetcher` → `messageDB.getUser` → a `channel.UserProfile` from the local user store, which does NOT carry `primary_username` (that lives on the public-profile endpoint, a different source). Wiring a public-profile fetch into the batch search hop is materially more work and a new data source; search is low-traffic and `.q` is dormant. Deferred to a follow-up rather than balloon this branch. Search keeps showing `display_name` (unchanged).
+- [~] **Bookmarks card** — `src/components/bookmarks/BookmarkCard.tsx:48` — **DEFERRED 2026-06-11 (logged).** `cachedPreview.senderName` is a FROZEN snapshot; the card deliberately synthesizes its own one-entry `mapSenderToUser` (bookmarks span all spaces/DMs, no live member list). Recomputing the QNS name needs a per-card public-profile fetch — lowest-value, highest-incremental-cost surface, and `.q` is dormant. Card keeps the snapshot name (correct as-of bookmark time). Follow-up.
+
+### Out of scope (record, don't convert)
+- **NavRail own name** — `src/components/shell/NavRail.tsx:264` — current user's own name from `currentPasskeyInfo`; no QNS-name-for-self plumbing exists. Leave; note as a possible follow-up (showing your OWN `.q` in the nav).
+- **Mute/Kick modals** — pass a `userName` filled by the click context; they inherit whatever the caller resolved. No independent change needed if callers pass resolved names.
+- **SpaceSettingsModal/Account `value={displayName}`** — editing form for your own per-space name; not a "display another user" surface. (Dot-`.q` validation already wired in Stage 3.)
+
+## 4. Phases
+
+### Phase 0 — adapter + render helper (foundation) ✅ DONE 2026-06-11
+- [x] Created `src/utils/resolveMemberName.ts` — exports `resolveMemberName` (DM/global), `resolveSpaceMemberName` (space-context, override-aware), `formatResolvedName` (string sites). Standalone module (no barrel; imported by path). Address fallback returns the shared helper's `Qm…1234` truncation.
+- [x] Created `src/components/user/ResolvedName.tsx` (`<ResolvedName resolved className suffixClassName />`), `.q` in `text-accent`.
+- [x] Unit test `src/dev/tests/utils/resolveMemberName.unit.test.ts` — **10 tests pass** (incl. the critical "per-space name wins over QNS name" case for `resolveSpaceMemberName`).
+- [x] **Confirmation task — RESOLVED:** roster `displayName` (from `useSpaceMembers` → `messageDB.getSpaceMembers`) IS the per-space broadcast name = a genuine per-space override. So space-context surfaces MUST use `resolveSpaceMemberName` (passes `displayName` as `spaceOverrideName`), NOT `resolveMemberName`. See the §2 CONFIRMED note. This split is encoded in the two adapter functions.
+- [x] `tsc --noEmit` clean (no new errors; pre-existing `ImportKeyStep` inherited from main).
+
+### Phase 1 — Tier 1 conversions
+- [ ] Convert every Tier 1 box in §3. For each: resolve via `resolveMemberName` (or `formatResolvedName` for string sites), render the `.q` suffix when `isQnsVerified`.
+- [ ] `UserProfile.tsx`: make the **resolved name the primary line**; drop or fold the now-redundant secondary `.q` handle (Model B = the primary line IS `name.q`).
+- [ ] Watch the thread-component naming collision (§2).
+- [ ] tsc + `yarn lint` clean.
+
+### Phase 2 — Tier 2 plumbing
+- [ ] Do each Tier 2 box in §3, smallest-blast-radius first: DM sidebar prop → reactions modal type → conversation-list backfill → member sidebar enrichment → search fetcher → bookmarks recompute.
+- [ ] Each plumbing addition is **additive + optional** (`primaryUsername?`) — no required-field changes.
+- [ ] tsc + lint clean after each sub-step.
+
+### Phase 3 — Stage 4 mentions
+- [ ] **Candidate source carries `primaryUsername`:** `Channel.tsx` builds the `users` array fed to the mention input from the raw `members` map. Ensure `primaryUsername` rides along (additive).
+- [ ] **Autocomplete match:** in the mention hook/filter, match the typed query against `primaryUsername` too (so `@ali` matches `alice`), in addition to existing `displayName`/`address`. Candidate label = `formatResolvedName(resolveMemberName(user))`.
+- [ ] **Pill render:** `src/utils/mentionPillDom.ts` — the pill's display name comes from `option.data.displayName`; pass the adapter-resolved name and render `.q` when verified. `dataset.mentionAddress` stays the address (unchanged storage).
+- [ ] Verify stored content is still `@<address>` (the mention regex still matches).
+- [ ] tsc + lint clean.
+
+### Phase 4 — verification gate ✅ DONE 2026-06-11 (manual smoke pending — see note)
+- [x] No shared changes this branch (desktop-only), so shared build/test untouched — N/A confirmed.
+- [x] `tsc --noEmit --jsx react-jsx --skipLibCheck` → clean (only pre-existing `ImportKeyStep` error).
+- [x] `yarn build` → **succeeds** (`✓ built in 27s`, only usual chunk-size warnings).
+- [x] Lint: the 5 `yarn lint` errors are all in the stale `.worktrees/secondary/` copy, NOT this work. Linting the 22 changed files directly → **0 errors, 20 warnings, all pre-existing** (legacy unused-vars/exhaustive-deps).
+- [x] Unit tests: `resolveMemberName.unit.test.ts` → **10/10 pass** (incl. per-space-override-wins-over-QNS).
+- [x] **Mobile insulation:** `quorum-mobile/package.json` pins `2.1.0-26` (published, not `link:`); this branch made **zero `quorum-shared` changes**, so mobile is trivially unaffected.
+- [ ] **Manual smoke — PENDING (requires running app + temp injection).** Live `.q` is dormant (no real user publishes `primary_username` yet — two mobile bugs). To verify: temp-inject a `primaryUsername` on one member, confirm it renders as the PRIMARY name with `.q` accent across message authors, DM header, profile card, member sidebar, mention autocomplete + pill; confirm a per-space-named member keeps their space name (override wins); confirm a member with only `displayName` is unchanged; then revert the injection. Left for the user to run via the app.
+- [x] §3 checkboxes updated; search + bookmarks deferrals logged.
+- [x] Prior plan PROGRESS block updated (Model B confirmed by Cassie 2026-06-11) — see below.
+
+## 5. Risks / watch-items
+- **The member sidebar fetch-storm** (Tier 2): the raw roster is raw deliberately. Don't naively enrich the whole roster — scope to visible rows or on-demand, matching `useMembersWithPublicProfileFallback`'s perf guard. This is the single highest-risk edit.
+- **`.q` dormant in real data:** can't fully verify live until mobile publishes `primary_username` (two mobile bugs, filed 2026-06-10). The render is correct; it lights up later. Don't treat "I can't see it live" as "it's broken."
+- **String vs JSX sites:** placeholders/aria-labels/tooltips need `formatResolvedName` (plain string), not the `<ResolvedName>` component. Don't render a component into a string slot.
+- **Avatar initials:** `UserAvatar` uses `displayName` for fallback initials/alt — feeding it the resolved name changes the initial letter to the QNS name's. Acceptable (consistent with showing the QNS name), but note it.
+
+---
+
+## Implementation status (2026-06-11)
+
+**Implemented & verified on branch `feat/qns-username-overrides-display-name`** (24 files: 4 new, 20 modified; +433/-99). tsc clean, build green, 10/10 unit tests, lint clean (the 5 `yarn lint` errors live in the stale `.worktrees/secondary/` copy, not this work). Mobile untouched (zero shared changes).
+
+- **Phase 0** — `resolveMemberName` / `resolveSpaceMemberName` / `formatResolvedName` adapter + `<ResolvedName>` component + unit tests. Confirmed roster `displayName` = per-space override → space surfaces use `resolveSpaceMemberName` (override wins over QNS), DM/global use `resolveMemberName` (QNS wins).
+- **Phase 1 (Tier 1)** — UserProfile Model A→B (resolved name is now the primary line); message authors (desktop/mobile/reply/event/pin); DM header + placeholder + typing; notifications; reactions tooltip; pinned panel; composer reply banner; mention pills in message body; thread "Started by" + list; channel/thread typing indicators.
+- **Phase 2 (Tier 2)** — DM profile sidebar (widened prop); reactions modal (widened MemberInfo); DM conversation list + strip (backfill hook now returns `ConversationWithQns`, previews hook made generic, fetches all DM partners — small N); member sidebar (cheap merge from `effectiveMembers`, no fetch storm). **Search results + bookmarks DEFERRED** (logged above — different data source / per-card fetch, low value, `.q` dormant).
+- **Phase 3 (Stage 4 mentions)** — autocomplete matches `primaryUsername`; candidate label + pill render `name.q`; wire format stays `@<address>`.
+
+**Remaining:** manual smoke in the running app with a temp-injected `primaryUsername` (live `.q` dormant until mobile publishes the field). Then open the PR (do NOT auto-merge).
+
+*Last updated: 2026-06-11*

--- a/src/components/direct/DMUserProfileSidebar.tsx
+++ b/src/components/direct/DMUserProfileSidebar.tsx
@@ -7,6 +7,8 @@ import { Icon } from '../primitives';
 import { UserAvatar } from '../user/UserAvatar';
 import { ClickToCopyContent } from '../ui';
 import { getAddressSuffix } from '../../utils';
+import { ResolvedName } from '../user/ResolvedName';
+import { resolveMemberName } from '../../utils/resolveMemberName';
 import { useMessageDB } from '../context/useMessageDB';
 import { useUserNote, buildUserNoteKey } from '../../hooks/queries/userNotes';
 import { validateUserNote, MAX_USER_NOTE_LENGTH } from '../../hooks/business/validation';
@@ -16,6 +18,9 @@ interface DMUserProfileSidebarProps {
   user: {
     address: string;
     displayName?: string;
+    /** QNS primary username (no ".q" suffix — render-time). In a DM the QNS
+     *  name overrides the display name (Model B). */
+    primaryUsername?: string;
     userIcon?: string;
     bio?: string;
   };
@@ -79,9 +84,14 @@ export const DMUserProfileSidebar: React.FC<DMUserProfileSidebarProps> = ({ user
           address={user.address}
           size={96}
         />
-        <span className="dm-profile-name truncate text-main font-semibold text-base">
-          {user.displayName ?? user.address}
-        </span>
+        <ResolvedName
+          resolved={resolveMemberName({
+            address: user.address,
+            displayName: user.displayName,
+            primaryUsername: user.primaryUsername,
+          })}
+          className="dm-profile-name truncate text-main font-semibold text-base"
+        />
         <div className="dm-profile-address">
           <ClickToCopyContent
             text={user.address}

--- a/src/components/direct/DirectMessage.tsx
+++ b/src/components/direct/DirectMessage.tsx
@@ -40,6 +40,11 @@ import { useResponsiveLayoutContext } from '../context/ResponsiveLayoutProvider'
 import { useOptionalShellState } from '../shell/useShellState';
 import { useModalContext } from '../context/ModalProvider';
 import { UserAvatar } from '../user/UserAvatar';
+import { ResolvedName } from '../user/ResolvedName';
+import {
+  resolveMemberName,
+  formatResolvedName,
+} from '../../utils/resolveMemberName';
 import {
   Button,
   Flex,
@@ -219,11 +224,14 @@ const DirectMessage: React.FC<{}> = () => {
       [address: string]: {
         displayName?: string;
         userIcon?: string;
+        /** QNS primary username, for in-DM author name resolution. */
+        primaryUsername?: string;
         address: string;
       };
     };
     const pubName = recipientPublicProfile?.display_name || undefined;
     const pubIcon = recipientPublicProfile?.profile_image || undefined;
+    const pubQns = recipientPublicProfile?.primary_username || undefined;
     if (conversation?.conversation) {
       // Priority 1: Use conversation data from IndexedDB (available offline).
       // Fall through to public profile only when local fields are empty/unknown.
@@ -238,6 +246,7 @@ const DirectMessage: React.FC<{}> = () => {
           localIcon && localIcon !== DefaultImages.UNKNOWN_USER
             ? localIcon
             : pubIcon ?? DefaultImages.UNKNOWN_USER,
+        primaryUsername: pubQns,
         address: address!,
       };
     } else if (registration?.registration) {
@@ -247,6 +256,7 @@ const DirectMessage: React.FC<{}> = () => {
       m[registration.registration.user_address] = {
         displayName: pubName ?? t`Unknown User`,
         userIcon: pubIcon ?? DefaultImages.UNKNOWN_USER,
+        primaryUsername: pubQns,
         address: registration.registration.user_address,
       };
     } else {
@@ -254,6 +264,7 @@ const DirectMessage: React.FC<{}> = () => {
       m[address!] = {
         displayName: pubName ?? t`Unknown User`,
         userIcon: pubIcon ?? DefaultImages.UNKNOWN_USER,
+        primaryUsername: pubQns,
         address: address!,
       };
     }
@@ -334,6 +345,18 @@ const DirectMessage: React.FC<{}> = () => {
         undefined,
     };
   }, [members, address, conversation, recipientPublicProfile]);
+
+  // DM: QNS name (when published) wins over the display name.
+  const resolvedOtherName = useMemo(
+    () =>
+      resolveMemberName({
+        address: otherUser.address,
+        displayName: otherUser.displayName,
+        primaryUsername: otherUser.primaryUsername,
+      }),
+    [otherUser.address, otherUser.displayName, otherUser.primaryUsername],
+  );
+  const otherNameString = formatResolvedName(resolvedOtherName);
 
   // Icon size for header icons
   const headerIconSize = 'lg';
@@ -781,9 +804,10 @@ const DirectMessage: React.FC<{}> = () => {
                   />
                 </Flex>
                 <div className="pl-2 flex items-center gap-2 overflow-hidden min-w-0">
-                  <span className="font-semibold truncate-user-name-chat flex-shrink min-w-0">
-                    {otherUser.displayName ?? otherUser.address}
-                  </span>
+                  <ResolvedName
+                    resolved={resolvedOtherName}
+                    className="font-semibold truncate-user-name-chat flex-shrink min-w-0"
+                  />
                   <span className="text-subtle flex-shrink-0 hidden xs:block">|</span>
                   <ClickToCopyContent
                     text={address ?? ''}
@@ -902,9 +926,10 @@ const DirectMessage: React.FC<{}> = () => {
               </Flex>
               {/* xs and up: horizontal layout with separator */}
               <div className="pl-2 hidden xs:flex items-center gap-2 overflow-hidden min-w-0">
-                <span className="font-semibold truncate-user-name-chat">
-                  {otherUser.displayName ?? otherUser.address}
-                </span>
+                <ResolvedName
+                  resolved={resolvedOtherName}
+                  className="font-semibold truncate-user-name-chat"
+                />
                 <span className="text-subtle flex-shrink-0">|</span>
                 <ClickToCopyContent
                   text={address ?? ''}
@@ -921,9 +946,10 @@ const DirectMessage: React.FC<{}> = () => {
               </div>
               {/* Below xs: vertical layout - name above address */}
               <div className="pl-2 flex xs:hidden flex-col min-w-0">
-                <span className="text-label font-semibold truncate">
-                  {otherUser.displayName ?? otherUser.address}
-                </span>
+                <ResolvedName
+                  resolved={resolvedOtherName}
+                  className="text-label font-semibold truncate"
+                />
                 <ClickToCopyContent
                   text={address ?? ''}
                   tooltipText={t`Copy address`}
@@ -1033,7 +1059,7 @@ const DirectMessage: React.FC<{}> = () => {
               <TypingIndicator
                 scope={typingScope}
                 resolveName={(addr) =>
-                  addr === otherUser.address ? otherUser.displayName : undefined
+                  addr === otherUser.address ? otherNameString : undefined
                 }
               />
               <MessageComposer
@@ -1042,7 +1068,7 @@ const DirectMessage: React.FC<{}> = () => {
                 onChange={composer.setPendingMessage}
                 onKeyDown={composer.handleKeyDown}
                 placeholder={i18n._('Send a message to {user}', {
-                  user: otherUser.displayName ?? otherUser.address,
+                  user: otherNameString,
                 })}
                 calculateRows={composer.calculateRows}
                 getRootProps={composer.getRootProps}

--- a/src/components/direct/DirectMessageContact.tsx
+++ b/src/components/direct/DirectMessageContact.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { getAddressSuffix } from '../../utils';
 import { UserAvatar } from '../user/UserAvatar';
+import { ResolvedName } from '../user/ResolvedName';
+import { resolveMemberName } from '../../utils/resolveMemberName';
 import { Icon } from '../primitives';
 import { formatConversationTime } from '../../utils/dateFormatting';
 import { useLongPressWithDefaults } from '../../hooks/useLongPress';
@@ -13,6 +15,9 @@ const DirectMessageContact: React.FunctionComponent<{
   unread: boolean;
   address: string;
   displayName?: string;
+  /** QNS primary username (no ".q" suffix — render-time). In a DM the QNS
+   *  name overrides the display name (Model B). */
+  primaryUsername?: string;
   userIcon?: string;
   lastMessagePreview?: string;
   previewIcon?: string;
@@ -73,6 +78,13 @@ const DirectMessageContact: React.FunctionComponent<{
 
   const isActive = address === props.address || isNavigating;
 
+  // Model B: the QNS name (name.q) overrides the display name in the DM list.
+  const resolvedName = resolveMemberName({
+    address: props.address,
+    displayName: props.displayName,
+    primaryUsername: props.primaryUsername,
+  });
+
   // Common content for both touch and desktop
   const contactContent = (
     <>
@@ -103,16 +115,15 @@ const DirectMessageContact: React.FunctionComponent<{
       <div className="flex flex-col flex-1 min-w-0 pl-2">
         {/* Line 1: Name + Time */}
         <div className="flex items-center justify-between gap-2">
-          <span
+          <ResolvedName
+            resolved={resolvedName}
             className={
               'truncate-user-name flex-1 min-w-0 ' +
               (props.unread && address !== props.address
                 ? 'font-extrabold'
                 : 'font-semibold')
             }
-          >
-            {props.displayName ?? getAddressSuffix(props.address)}
-          </span>
+          />
           {props.timestamp && (
             <span
               className={

--- a/src/components/direct/DirectMessageContactsList.tsx
+++ b/src/components/direct/DirectMessageContactsList.tsx
@@ -14,6 +14,7 @@ import {
   Tooltip,
 } from '../primitives';
 import { UserAvatar } from '../user/UserAvatar';
+import { resolveMemberName, formatResolvedName } from '../../utils/resolveMemberName';
 import { useModalContext } from '../context/ModalProvider';
 import { useConversationPolling } from '../../hooks';
 import { useConversationPreviews } from '../../hooks/business/conversations/useConversationPreviews';
@@ -62,8 +63,19 @@ const DirectMessageContactsList: React.FC<DirectMessageContactsListProps> = ({ f
   // and write the result through to IndexedDB so later loads are instant.
   const conversationsBackfilled =
     useConversationsWithProfileBackfill(conversationsList);
-  const { data: conversationsWithPreviews = conversationsBackfilled } =
+  const { data: conversationsWithPreviewsRaw = conversationsBackfilled } =
     useConversationPreviews(conversationsBackfilled);
+  // useConversationPreviews caches rows by message ID, dropping primaryUsername
+  // attached after it resolved — re-attach it here (by address) so name.q sticks.
+  const conversationsWithPreviews = React.useMemo(() => {
+    const qnsByAddress = new Map(
+      conversationsBackfilled.map((c) => [c.address, c.primaryUsername])
+    );
+    return conversationsWithPreviewsRaw.map((c) => {
+      const primaryUsername = qnsByAddress.get(c.address);
+      return primaryUsername ? { ...c, primaryUsername } : c;
+    });
+  }, [conversationsWithPreviewsRaw, conversationsBackfilled]);
   const { openNewDirectMessage, openConversationSettings } = useModalContext();
   const [mockUtils, setMockUtils] = React.useState<any>(null);
 
@@ -341,7 +353,13 @@ const DirectMessageContactsList: React.FC<DirectMessageContactsListProps> = ({ f
               <Tooltip
                 key={'dmc-strip-' + c.address}
                 id={`dm-strip-${c.address}`}
-                content={c.displayName || c.address}
+                content={formatResolvedName(
+                  resolveMemberName({
+                    address: c.address,
+                    displayName: c.displayName,
+                    primaryUsername: (c as { primaryUsername?: string }).primaryUsername,
+                  }),
+                )}
                 place="right"
                 showOnTouch={false}
               >
@@ -350,7 +368,13 @@ const DirectMessageContactsList: React.FC<DirectMessageContactsListProps> = ({ f
                   className={`direct-messages-strip-row sidebar-row-chrome ${isActive ? 'direct-messages-strip-row--active' : ''}`}
                   onClick={() => navigate(`/messages/${c.address}`)}
                   onContextMenu={handleContextMenu(c.address, c.conversationId)}
-                  aria-label={c.displayName || c.address}
+                  aria-label={formatResolvedName(
+                    resolveMemberName({
+                      address: c.address,
+                      displayName: c.displayName,
+                      primaryUsername: (c as { primaryUsername?: string }).primaryUsername,
+                    }),
+                  )}
                   aria-current={isActive ? 'page' : undefined}
                 >
                   <div className="direct-messages-strip-avatar">
@@ -485,6 +509,7 @@ const DirectMessageContactsList: React.FC<DirectMessageContactsListProps> = ({ f
                   address={c.address}
                   userIcon={c.icon}
                   displayName={c.displayName}
+                  primaryUsername={(c as { primaryUsername?: string }).primaryUsername}
                   lastMessagePreview={c.preview}
                   previewIcon={c.previewIcon}
                   timestamp={c.timestamp}

--- a/src/components/message/MentionDropdown.tsx
+++ b/src/components/message/MentionDropdown.tsx
@@ -5,6 +5,8 @@ import { UserAvatar } from '../user/UserAvatar';
 import { t } from '@lingui/core/macro';
 import type { MentionOption } from '../../hooks/business/mentions';
 import { getAddressSuffix } from '../../utils';
+import { ResolvedName } from '../user/ResolvedName';
+import { resolveSpaceMemberName } from '../../utils/resolveMemberName';
 import './MentionDropdown.scss';
 
 interface CaretPosition {
@@ -193,9 +195,15 @@ export const MentionDropdown: React.FC<MentionDropdownProps> = ({
               className="mention-dropdown__avatar"
             />
             <div className="mention-dropdown__info">
-              <span className="mention-dropdown__name">
-                {option.data.displayName || t`Unknown User`}
-              </span>
+              <ResolvedName
+                resolved={resolveSpaceMemberName({
+                  address: option.data.address,
+                  displayName: option.data.displayName,
+                  primaryUsername: option.data.primaryUsername,
+                  globalDisplayName: option.data.globalDisplayName,
+                })}
+                className="mention-dropdown__name"
+              />
               <span className="mention-dropdown__subtitle">
                 {getAddressSuffix(option.data.address)}
               </span>

--- a/src/components/message/Message.tsx
+++ b/src/components/message/Message.tsx
@@ -35,6 +35,12 @@ import { i18n } from '@lingui/core';
 import { YouTubeEmbed } from '../ui/YouTubeEmbed';
 import { useMobile } from '../context/MobileProvider';
 import { UserAvatar } from '../user/UserAvatar';
+import { ResolvedName } from '../user/ResolvedName';
+import {
+  resolveMemberName,
+  resolveSpaceMemberName,
+  formatResolvedName,
+} from '../../utils/resolveMemberName';
 import {
   useMessageActions,
   useEmojiPicker,
@@ -344,6 +350,34 @@ export const Message = React.memo(
     );
 
     const sender = mapSenderToUser(message.content?.senderId);
+
+    // Space messages use the override-aware resolver; DMs (spaceId===channelId)
+    // let the QNS name win over the plain displayName.
+    const isDmMessage = message.spaceId === message.channelId;
+    const resolveSenderName = useCallback(
+      (u: {
+        displayName?: string | null;
+        primaryUsername?: string | null;
+        globalDisplayName?: string | null;
+        address?: string;
+        userAddress?: string;
+      }) =>
+        isDmMessage
+          ? resolveMemberName({
+              address: u.address ?? u.userAddress ?? '',
+              displayName: u.displayName,
+              primaryUsername: u.primaryUsername,
+            })
+          : resolveSpaceMemberName({
+              address: u.address ?? u.userAddress ?? '',
+              displayName: u.displayName,
+              primaryUsername: u.primaryUsername,
+              globalDisplayName: u.globalDisplayName,
+            }),
+      [isDmMessage],
+    );
+    const resolvedSender = resolveSenderName({ ...sender, address: sender?.address ?? message.content?.senderId });
+
     const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
     const isNewMember = sender?.joinedAt != null &&
       Date.now() - sender.joinedAt < SEVEN_DAYS_MS &&
@@ -558,9 +592,15 @@ export const Message = React.memo(
                     size={32}
                     className="message-reply-sender-icon flex-shrink-0"
                   />
-                  <span className="message-reply-sender-name flex-shrink-0 truncate-user-name-chat">
-                    {mapSenderToUser(reply.content.senderId).displayName}
-                  </span>
+                  <ResolvedName
+                    resolved={resolveSenderName({
+                      ...mapSenderToUser(reply.content.senderId),
+                      address:
+                        mapSenderToUser(reply.content.senderId)?.address ??
+                        reply.content.senderId,
+                    })}
+                    className="message-reply-sender-name flex-shrink-0 truncate-user-name-chat"
+                  />
                   <span className="message-reply-text flex-1 min-w-0">
                     {replyTextWithNames}
                   </span>
@@ -586,7 +626,7 @@ export const Message = React.memo(
             <span
               className={`flex items-center min-w-0 flex-1 ${message.content.type === 'kick' ? 'text-danger' : 'text-subtle'}`}
             >
-              {formatEventMessage(sender.displayName, message.content.type)}
+              {formatEventMessage(formatResolvedName(resolvedSender), message.content.type)}
             </span>
           </Flex>
         )}
@@ -755,16 +795,17 @@ export const Message = React.memo(
                 <>
                   {/* Desktop layout: horizontal row with username and timestamp */}
                   <Flex align="center" className="items-center min-w-0 hidden xs:flex">
-                    <span className="message-sender-name truncate-user-name-chat flex-shrink min-w-0">
-                      {sender.displayName}
-                    </span>
+                    <ResolvedName
+                      resolved={resolvedSender}
+                      className="message-sender-name truncate-user-name-chat flex-shrink min-w-0"
+                    />
                     {sender.spaceTag && <SpaceTag tag={sender.spaceTag} size="sm" className="ml-1.5" />}
                     {message.isPinned && (
                       <Tooltip
                         id={`pin-indicator-${message.messageId}`}
                         content={
                           message.pinnedBy
-                            ? t`Pinned by ${mapSenderToUser(message.pinnedBy)?.displayName || message.pinnedBy}`
+                            ? t`Pinned by ${formatResolvedName(resolveSenderName({ ...mapSenderToUser(message.pinnedBy), address: mapSenderToUser(message.pinnedBy)?.address ?? message.pinnedBy }))}`
                             : t`Pinned`
                         }
                         showOnTouch={true}
@@ -849,16 +890,17 @@ export const Message = React.memo(
 
                     {/* Username row on mobile */}
                     <Flex align="center" className="items-center min-w-0">
-                      <span className="message-sender-name truncate-user-name-chat flex-shrink min-w-0">
-                        {sender.displayName}
-                      </span>
+                      <ResolvedName
+                        resolved={resolvedSender}
+                        className="message-sender-name truncate-user-name-chat flex-shrink min-w-0"
+                      />
                       {sender.spaceTag && <SpaceTag tag={sender.spaceTag} size="sm" className="ml-1.5" />}
                       {message.isPinned && (
                         <Tooltip
                           id={`pin-indicator-mobile-${message.messageId}`}
                           content={
                             message.pinnedBy
-                              ? t`Pinned by ${mapSenderToUser(message.pinnedBy)?.displayName || message.pinnedBy}`
+                              ? t`Pinned by ${formatResolvedName(resolveSenderName({ ...mapSenderToUser(message.pinnedBy), address: mapSenderToUser(message.pinnedBy)?.address ?? message.pinnedBy }))}`
                               : t`Pinned`
                           }
                           showOnTouch={true}

--- a/src/components/message/MessageComposer.tsx
+++ b/src/components/message/MessageComposer.tsx
@@ -4,6 +4,8 @@ import { t } from '@lingui/core/macro';
 import { i18n } from '@lingui/core';
 import type { AttachmentProcessingResult } from '../../utils/imageProcessing';
 import { useMentionInput, type MentionOption, useMentionPillEditor } from '../../hooks/business/mentions';
+import { ResolvedName } from '../user/ResolvedName';
+import { resolveSpaceMemberName, type NameResolvableUser } from '../../utils/resolveMemberName';
 import type { Group } from '@quilibrium/quorum-shared';
 import { useResponsiveLayout } from '../../hooks/useResponsiveLayout';
 import { isTouchDevice } from '../../utils/platform';
@@ -57,7 +59,7 @@ interface MessageComposerProps {
   fileError?: string | null;
   mentionError?: string | null;
   isProcessingImage?: boolean;
-  mapSenderToUser?: (senderId: string) => { displayName?: string };
+  mapSenderToUser?: (senderId: string) => NameResolvableUser | undefined;
   setInReplyTo?: (inReplyTo: any) => void;
 
   // Message validation props
@@ -716,9 +718,17 @@ export const MessageComposer = forwardRef<
               >
                 <span className="message-composer-reply-text flex items-center min-w-0 flex-1">
                   <span className="flex-shrink-0">{i18n._('Replying to')}</span>
-                  <span className="ml-1 truncate-user-name-chat">
-                    {mapSenderToUser(inReplyTo.content.senderId).displayName}
-                  </span>
+                  <ResolvedName
+                    resolved={resolveSpaceMemberName({
+                      address:
+                        mapSenderToUser(inReplyTo.content.senderId)?.address ??
+                        inReplyTo.content.senderId,
+                      displayName: mapSenderToUser(inReplyTo.content.senderId)?.displayName,
+                      primaryUsername: mapSenderToUser(inReplyTo.content.senderId)?.primaryUsername,
+                      globalDisplayName: mapSenderToUser(inReplyTo.content.senderId)?.globalDisplayName,
+                    })}
+                    className="ml-1 truncate-user-name-chat"
+                  />
                 </span>
                 <Icon
                   name="close"

--- a/src/components/message/MessageMarkdownRenderer.tsx
+++ b/src/components/message/MessageMarkdownRenderer.tsx
@@ -22,11 +22,12 @@ import { Icon } from '../primitives';
 import type { Role, Channel, PostMessage } from '@quilibrium/quorum-shared';
 import { getEmbeddedMediaSrc } from '../../utils/embeddedMedia';
 import { truncateAddress } from '../../utils';
+import { resolveSpaceMemberName, formatResolvedName, type NameResolvableUser } from '../../utils/resolveMemberName';
 
 interface MessageMarkdownRendererProps {
   content: string;
   className?: string;
-  mapSenderToUser?: (senderId: string) => { displayName?: string; userIcon?: string };
+  mapSenderToUser?: (senderId: string) => NameResolvableUser | undefined;
   /**
    * Strict variant of `mapSenderToUser`. Returns null when the address is not
    * a known member, so the renderer can distinguish a real user from a
@@ -35,7 +36,7 @@ interface MessageMarkdownRendererProps {
    * When not provided, the renderer falls back to the legacy behavior
    * (everything is interactive whenever `onUserClick` is set).
    */
-  resolveSender?: (senderId: string) => { displayName?: string; userIcon?: string } | null;
+  resolveSender?: (senderId: string) => NameResolvableUser | null;
   onUserClick?: (user: {
     address: string;
     displayName?: string;
@@ -654,7 +655,19 @@ export const MessageMarkdownRenderer: React.FC<MessageMarkdownRendererProps> = (
             ? resolveSender(address)
             : (mapSenderToUser ? mapSenderToUser(address) : null);
           const isResolved = resolvedUser != null;
-          const displayName = resolvedUser?.displayName || truncateAddress(address, 4, 4);
+          // Model B: a mentioned user shows their QNS name (name.q) unless they
+          // have a per-space name. The mention's stored token stays the address;
+          // only the displayed label changes.
+          const displayName = resolvedUser
+            ? formatResolvedName(
+                resolveSpaceMemberName({
+                  address: resolvedUser.address ?? address,
+                  displayName: resolvedUser.displayName,
+                  primaryUsername: resolvedUser.primaryUsername,
+                  globalDisplayName: resolvedUser.globalDisplayName,
+                }),
+              )
+            : truncateAddress(address, 4, 4);
           const interactive = isResolved && !!onUserClick;
 
           parts.push(

--- a/src/components/message/PinnedMessagesPanel.tsx
+++ b/src/components/message/PinnedMessagesPanel.tsx
@@ -14,6 +14,8 @@ import { t } from '@lingui/core/macro';
 import { usePinnedMessages } from '../../hooks';
 import { isTouchDevice } from '../../utils/platform';
 import { formatMessageDate } from '../../utils';
+import { ResolvedName } from '../user/ResolvedName';
+import { resolveSpaceMemberName } from '../../utils/resolveMemberName';
 import { buildMessageHash } from '../../utils/messageHashNavigation';
 import './PinnedMessagesPanel.scss';
 
@@ -71,9 +73,21 @@ const PinnedMessageItem: React.FC<PinnedMessageItemProps> = ({
         <Flex justify="between" className="result-meta-container">
           <Flex className="result-meta items-center min-w-0 flex-1 mr-2">
             <Icon name="user" className="result-user-icon flex-shrink-0" />
-            <span className="result-sender mr-2 truncate flex-shrink min-w-0">
-              {sender?.displayName || t`Unknown User`}
-            </span>
+            {sender ? (
+              <ResolvedName
+                resolved={resolveSpaceMemberName({
+                  address: sender.address ?? message.content?.senderId ?? '',
+                  displayName: sender.displayName,
+                  primaryUsername: sender.primaryUsername,
+                  globalDisplayName: sender.globalDisplayName,
+                })}
+                className="result-sender mr-2 truncate flex-shrink min-w-0"
+              />
+            ) : (
+              <span className="result-sender mr-2 truncate flex-shrink min-w-0">
+                {t`Unknown User`}
+              </span>
+            )}
             <Icon name="calendar-alt" className="result-date-icon flex-shrink-0 ml-1" />
             <span className="result-date flex-shrink-0 whitespace-nowrap ml-1">
               {formatMessageDate(message.createdDate, compactDate)}

--- a/src/components/message/ReactionsList.tsx
+++ b/src/components/message/ReactionsList.tsx
@@ -5,6 +5,7 @@ import { Flex, Tooltip } from '../primitives';
 import { useReactionsModal } from '../context/ReactionsModalProvider';
 import { isTouchDevice } from '../../utils/platform';
 import { emojiToUnified } from '../../utils/remarkTwemoji';
+import { resolveSpaceMemberName, formatResolvedName, type NameResolvableUser } from '../../utils/resolveMemberName';
 import type { Message as MessageType } from '@quilibrium/quorum-shared';
 import type { CustomEmoji } from '../emoji-picker/types';
 import type { MemberInfo } from '../modals/ReactionsModal';
@@ -36,7 +37,7 @@ interface ReactionsListProps {
   message: MessageType;
   userAddress: string;
   customEmojis: CustomEmoji[];
-  mapSenderToUser: (senderId: string) => { displayName?: string; userIcon?: string } | undefined;
+  mapSenderToUser: (senderId: string) => NameResolvableUser | undefined;
   onReactionClick: (emojiId: string) => void;
 }
 
@@ -60,6 +61,8 @@ export const ReactionsList: React.FC<ReactionsListProps> = ({
           const user = mapSenderToUser(id);
           memberRecord[id] = {
             displayName: user?.displayName,
+            primaryUsername: user?.primaryUsername,
+            globalDisplayName: user?.globalDisplayName,
             userIcon: user?.userIcon,
             address: id,
           };
@@ -97,7 +100,18 @@ export const ReactionsList: React.FC<ReactionsListProps> = ({
         const maxNames = 3;
         const reactorNames = r.memberIds
           .map((id) => {
-            const name = mapSenderToUser(id)?.displayName || id.slice(0, 8) + '...';
+            const u = mapSenderToUser(id);
+            const resolved = u
+              ? formatResolvedName(
+                  resolveSpaceMemberName({
+                    address: u.address ?? id,
+                    displayName: u.displayName,
+                    primaryUsername: u.primaryUsername,
+                    globalDisplayName: u.globalDisplayName,
+                  }),
+                )
+              : id.slice(0, 8) + '...';
+            const name = resolved;
             // Truncate long names in tooltip (max ~20 chars)
             return name.length > 20 ? name.slice(0, 18) + '...' : name;
           })

--- a/src/components/modals/ReactionsModal.tsx
+++ b/src/components/modals/ReactionsModal.tsx
@@ -3,12 +3,19 @@ import { t } from '@lingui/core/macro';
 import { parse as parseEmoji } from '@twemoji/parser';
 import { Modal, Flex, ScrollContainer } from '../primitives';
 import { UserAvatar } from '../user/UserAvatar';
+import { ResolvedName } from '../user/ResolvedName';
+import { resolveSpaceMemberName } from '../../utils/resolveMemberName';
 import { emojiToUnified } from '../../utils/remarkTwemoji';
 import type { Reaction } from '@quilibrium/quorum-shared';
 import type { CustomEmoji } from '../emoji-picker/types';
 
 export interface MemberInfo {
   displayName?: string;
+  /** QNS primary username (no ".q" suffix — render-time). */
+  primaryUsername?: string;
+  /** Global display name from the public profile — distinguishes a custom
+   *  per-space name from the global default in resolveSpaceMemberName. */
+  globalDisplayName?: string;
   userIcon?: string;
   address: string;
 }
@@ -44,6 +51,8 @@ export const ReactionsModal: React.FC<ReactionsModalProps> = ({
     const member = members[memberId];
     return {
       displayName: member?.displayName || memberId.slice(0, 8) + '...',
+      primaryUsername: member?.primaryUsername,
+      globalDisplayName: member?.globalDisplayName,
       userIcon: member?.userIcon,
       address: memberId,
     };
@@ -128,7 +137,15 @@ export const ReactionsModal: React.FC<ReactionsModalProps> = ({
                   address={user.address}
                   size={24}
                 />
-                <span className="truncate-user-name flex-1 min-w-0">{user.displayName}</span>
+                <ResolvedName
+                  resolved={resolveSpaceMemberName({
+                    address: user.address,
+                    displayName: user.displayName,
+                    primaryUsername: user.primaryUsername,
+                    globalDisplayName: user.globalDisplayName,
+                  })}
+                  className="truncate-user-name flex-1 min-w-0"
+                />
               </Flex>
             ))}
           </Flex>

--- a/src/components/modals/UserSettingsModal/General.tsx
+++ b/src/components/modals/UserSettingsModal/General.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Input, Icon, Spacer, Tooltip, TextArea, Select } from '../../primitives';
+import { Input, Icon, Spacer, Tooltip, TextArea, Select, Callout } from '../../primitives';
 import { t } from '@lingui/core/macro';
 import { Trans } from '@lingui/react/macro';
 import { ClickToCopyContent } from '../../ui';
@@ -19,6 +19,8 @@ interface EligibleSpaceTag {
 interface GeneralProps {
   displayName: string;
   setDisplayName: (value: string) => void;
+  /** The user's QNS primary name, if set — shows an override notice. */
+  primaryUsername?: string;
   bio: string;
   setBio: (value: string) => void;
   bioErrors: string[];
@@ -48,6 +50,7 @@ interface GeneralProps {
 const General: React.FunctionComponent<GeneralProps> = ({
   displayName,
   setDisplayName,
+  primaryUsername,
   bio,
   setBio,
   bioErrors,
@@ -129,6 +132,15 @@ const General: React.FunctionComponent<GeneralProps> = ({
           />
         </div>
       </div>
+      {primaryUsername && (
+        <div className="mt-4 px-5 max-md:px-4">
+          <Callout variant="info" size="sm" className="w-full">
+            <Trans>
+              Your QNS name <strong>{primaryUsername}.q</strong> is shown as your name.
+            </Trans>
+          </Callout>
+        </div>
+      )}
       <div className="modal-content-section">
         <Spacer size="md" direction="vertical" borderTop={true} />
         <div className="text-subtitle-2">

--- a/src/components/modals/UserSettingsModal/UserSettingsModal.tsx
+++ b/src/components/modals/UserSettingsModal/UserSettingsModal.tsx
@@ -21,6 +21,7 @@ import { useQuery } from '@tanstack/react-query';
 import { buildSpacesFetcher } from '../../../hooks/queries/spaces/buildSpacesFetcher';
 import { buildSpacesKey } from '../../../hooks/queries/spaces/buildSpacesKey';
 import { useMessageDB } from '../../context/useMessageDB';
+import { useUserPublicProfile } from '../../../hooks/business/user/useUserPublicProfile';
 import { validateDisplayName, validateUserBio } from '../../../hooks/business/validation';
 import type { BroadcastSpaceTag } from '@quilibrium/quorum-shared';
 import General from './General';
@@ -101,6 +102,11 @@ const UserSettingsModal: React.FunctionComponent<{
     removedDevices,
     isConfigLoaded,
   } = useUserSettings();
+
+  // The user's own QNS primary name (if any) — drives the override notice in
+  // General. Sourced from their public profile, same hook used elsewhere.
+  const { data: ownPublicProfile } = useUserPublicProfile(currentPasskeyInfo?.address);
+  const primaryUsername = ownPublicProfile?.primary_username || undefined;
 
   // Spaces for Space Tag selector (using useQuery to avoid Suspense requirement)
   const { messageDB } = useMessageDB();
@@ -231,6 +237,7 @@ const UserSettingsModal: React.FunctionComponent<{
                       <General
                         displayName={displayName}
                         setDisplayName={setDisplayName}
+                        primaryUsername={primaryUsername}
                         bio={bio}
                         setBio={setBio}
                         bioErrors={bioErrors}

--- a/src/components/notifications/NotificationPanel.tsx
+++ b/src/components/notifications/NotificationPanel.tsx
@@ -5,6 +5,7 @@ import { Flex, Icon, Button, Tooltip, Select } from '../primitives';
 import { DropdownPanel } from '../ui';
 import { isTouchDevice } from '../../utils/platform';
 import { buildMessageHash } from '../../utils/messageHashNavigation';
+import { resolveSpaceMemberName, formatResolvedName } from '../../utils/resolveMemberName';
 import { NotificationItem } from './NotificationItem';
 import { useAllMentions, useMentionNotificationSettings } from '../../hooks/business/mentions';
 import { useAllReplies } from '../../hooks/business/replies';
@@ -276,7 +277,18 @@ export const NotificationPanel: React.FC<NotificationPanelProps> = ({
                     <NotificationItem
                       notification={notification}
                       onNavigate={handleNavigate}
-                      displayName={sender?.displayName || t`Unknown User`}
+                      displayName={
+                        sender
+                          ? formatResolvedName(
+                              resolveSpaceMemberName({
+                                address: sender.address ?? notification.message.content?.senderId ?? '',
+                                displayName: sender.displayName,
+                                primaryUsername: sender.primaryUsername,
+                                globalDisplayName: sender.globalDisplayName,
+                              }),
+                            )
+                          : t`Unknown User`
+                      }
                       mapSenderToUser={mapSenderToUser}
                       spaceRoles={spaceRoles}
                       spaceChannels={spaceChannels}
@@ -299,7 +311,18 @@ export const NotificationPanel: React.FC<NotificationPanelProps> = ({
                     <NotificationItem
                       notification={notification}
                       onNavigate={handleNavigate}
-                      displayName={sender?.displayName || t`Unknown User`}
+                      displayName={
+                        sender
+                          ? formatResolvedName(
+                              resolveSpaceMemberName({
+                                address: sender.address ?? notification.message.content?.senderId ?? '',
+                                displayName: sender.displayName,
+                                primaryUsername: sender.primaryUsername,
+                                globalDisplayName: sender.globalDisplayName,
+                              }),
+                            )
+                          : t`Unknown User`
+                      }
                       mapSenderToUser={mapSenderToUser}
                       spaceRoles={spaceRoles}
                       spaceChannels={spaceChannels}

--- a/src/components/space/Channel.tsx
+++ b/src/components/space/Channel.tsx
@@ -30,6 +30,8 @@ import { MobileDrawer, ListSearchInput, TouchAwareListItem } from '../ui';
 import { getIconColorHex } from './IconPicker/types';
 import { isTouchDevice } from '../../utils/platform';
 import { parseMessageHash } from '../../utils/messageHashNavigation';
+import { resolveSpaceMemberName, formatResolvedName, type NameResolvableUser } from '../../utils/resolveMemberName';
+import { ResolvedName } from '../user/ResolvedName';
 import MessageComposer, {
   MessageComposerRef,
 } from '../message/MessageComposer';
@@ -299,10 +301,10 @@ const Channel: React.FC<ChannelProps> = ({
     (senderId: string) => {
       const member = effectiveMembers[senderId];
       if (member) {
-        return {
-          ...member,
-          displayName: member.displayName || senderId.slice(-6),
-        };
+        // Pass through unchanged, including an empty displayName. The name
+        // resolvers own the fallback; substituting the address-suffix here
+        // would look like a deliberate per-space name and suppress the QNS name.
+        return member;
       }
       // Fall back to whatever the original lookup would return — keeps
       // the "show address suffix" behavior for senders neither in the
@@ -310,6 +312,19 @@ const Channel: React.FC<ChannelProps> = ({
       return mapSenderToUserBase(senderId);
     },
     [effectiveMembers, mapSenderToUserBase]
+  );
+
+  // Mention autocomplete candidates: the raw roster members, cheaply enriched
+  // with primaryUsername from the sender-enriched map (same no-fetch-storm
+  // policy as the member sidebar). Lets the picker match + render QNS names.
+  const mentionUsers = useMemo(
+    () =>
+      (Object.values(members) as Array<{ address: string; displayName?: string; userIcon?: string }>).map((m) => ({
+        ...m,
+        primaryUsername: effectiveMembers[m.address]?.primaryUsername,
+        globalDisplayName: effectiveMembers[m.address]?.globalDisplayName,
+      })),
+    [members, effectiveMembers]
   );
 
   // Get pinned messages
@@ -1250,7 +1265,7 @@ const Channel: React.FC<ChannelProps> = ({
       isRepudiable: space?.isRepudiable,
       skipSigning,
       onSigningToggle: () => setSkipSigning(!skipSigning),
-      users: Object.values(members),
+      users: mentionUsers,
       mentionRoles: roles?.filter(role => role.isPublic !== false),
       spaceGroups,
       canUseEveryone,
@@ -1258,7 +1273,7 @@ const Channel: React.FC<ChannelProps> = ({
       currentUserAddress: user.currentPasskeyInfo?.address,
     });
   }, [
-    spaceId, channelId, effectiveMembers, members, roles, stickers, space?.emojis,
+    spaceId, channelId, effectiveMembers, members, mentionUsers, roles, stickers, space?.emojis,
     mapSenderToUser, isSpaceOwner, canDeleteMessages, canPinMessages,
     channel, spaceChannels, handleChannelClick, userProfileModal.handleUserClick,
     space?.spaceName, space?.isRepudiable, skipSigning, spaceGroups,
@@ -1660,7 +1675,7 @@ const Channel: React.FC<ChannelProps> = ({
                 hasNextPage={hasNextPage}
                 spaceName={space?.spaceName}
                 onRetryMessage={handleRetryMessage}
-                users={Object.values(members)}
+                users={mentionUsers}
                 mentionRoles={roles?.filter(role => role.isPublic !== false)}
                 groups={spaceGroups}
                 canUseEveryone={canUseEveryone}
@@ -1671,7 +1686,17 @@ const Channel: React.FC<ChannelProps> = ({
             <div className="message-editor-container" ref={composerContainerRef}>
               <TypingIndicator
                 scope={typingScope}
-                resolveName={(addr) => mapSenderToUser(addr).displayName}
+                resolveName={(addr) => {
+                  const u = mapSenderToUser(addr) as NameResolvableUser | undefined;
+                  return formatResolvedName(
+                    resolveSpaceMemberName({
+                      address: u?.address ?? addr,
+                      displayName: u?.displayName,
+                      primaryUsername: u?.primaryUsername,
+                      globalDisplayName: u?.globalDisplayName,
+                    }),
+                  );
+                }}
               />
               <MessageComposer
                 canUseEveryone={canUseEveryone}
@@ -1692,7 +1717,7 @@ const Channel: React.FC<ChannelProps> = ({
                 onSubmitMessage={composer.submitMessage}
                 onShowStickers={handleShowEmojiPanel}
                 inReplyTo={composer.inReplyTo}
-                users={Object.values(members)}
+                users={mentionUsers}
                 roles={roles?.filter(role => role.isPublic !== false)}
                 groups={spaceGroups}
                 fileError={composer.fileError}
@@ -1789,9 +1814,18 @@ const Channel: React.FC<ChannelProps> = ({
                             className="opacity-80 group-hover:opacity-100 transition-opacity duration-150 flex-shrink-0"
                           />
                           <div className="flex flex-row items-center ml-2 text-subtle group-hover:text-main transition-colors duration-150 min-w-0 flex-1">
-                            <span className="text-md font-bold truncate-user-name">
-                              {item.displayName ?? item.address}
-                            </span>
+                            <ResolvedName
+                              resolved={resolveSpaceMemberName({
+                                address: item.address,
+                                displayName: item.displayName,
+                                // QNS/global names merged from the sender map
+                                // (no roster-wide fetch); non-posters lack .q
+                                // until they post or their profile is opened.
+                                primaryUsername: effectiveMembers[item.address]?.primaryUsername,
+                                globalDisplayName: effectiveMembers[item.address]?.globalDisplayName,
+                              })}
+                              className="text-md font-bold truncate-user-name"
+                            />
                             {item.joinedAt != null && Date.now() - item.joinedAt < 7 * 24 * 60 * 60 * 1000 && (
                               <Icon
                                 name="seedling"
@@ -2018,9 +2052,15 @@ const Channel: React.FC<ChannelProps> = ({
                     className="opacity-80 flex-shrink-0"
                   />
                   <div className="flex flex-row items-center ml-2 text-subtle min-w-0 flex-1">
-                    <span className="text-md font-bold truncate-user-name">
-                      {item.displayName ?? item.address}
-                    </span>
+                    <ResolvedName
+                      resolved={resolveSpaceMemberName({
+                        address: item.address,
+                        displayName: item.displayName,
+                        primaryUsername: effectiveMembers[item.address]?.primaryUsername,
+                        globalDisplayName: effectiveMembers[item.address]?.globalDisplayName,
+                      })}
+                      className="text-md font-bold truncate-user-name"
+                    />
                     {item.joinedAt != null && Date.now() - item.joinedAt < 7 * 24 * 60 * 60 * 1000 && (
                       <Icon
                         name="seedling"

--- a/src/components/thread/ThreadPanel.tsx
+++ b/src/components/thread/ThreadPanel.tsx
@@ -12,6 +12,7 @@ import { useThreadSettingsModal } from '../context/ThreadSettingsModalProvider';
 import { useMobile } from '../context/MobileProvider';
 import { useResponsiveLayoutContext } from '../context/ResponsiveLayoutProvider';
 import { getThreadTitle } from '../../utils/threadTitle';
+import { resolveSpaceMemberName, formatResolvedName } from '../../utils/resolveMemberName';
 import type { CustomEmoji, EmojiData } from '../emoji-picker/types';
 import './ThreadPanel.scss';
 
@@ -173,10 +174,26 @@ export const ThreadPanel: React.FC = () => {
     if (!creatorId) return null;
     const user = channelProps.mapSenderToUser(creatorId);
     if (!user) return null;
-    return { address: creatorId, displayName: user.displayName, userIcon: user.userIcon, bio: user.bio };
+    return {
+      address: creatorId,
+      displayName: user.displayName,
+      primaryUsername: user.primaryUsername,
+      globalDisplayName: user.globalDisplayName,
+      userIcon: user.userIcon,
+      bio: user.bio,
+    };
   }, [rootMessage, channelProps]);
 
-  const starterName = starterUser?.displayName || null;
+  const starterName = starterUser
+    ? formatResolvedName(
+        resolveSpaceMemberName({
+          address: starterUser.address,
+          displayName: starterUser.displayName,
+          primaryUsername: starterUser.primaryUsername,
+          globalDisplayName: starterUser.globalDisplayName,
+        }),
+      )
+    : null;
 
   const isThreadAuthor = useMemo(() => {
     if (!rootMessage?.threadMeta?.createdBy || !channelProps?.currentUserAddress) return false;
@@ -413,7 +430,17 @@ export const ThreadPanel: React.FC = () => {
       <div className="thread-panel__composer">
         <TypingIndicator
           scope={typingScope}
-          resolveName={(addr) => channelProps.mapSenderToUser(addr).displayName}
+          resolveName={(addr) => {
+            const u = channelProps.mapSenderToUser(addr);
+            return formatResolvedName(
+              resolveSpaceMemberName({
+                address: u?.address ?? addr,
+                displayName: u?.displayName,
+                primaryUsername: u?.primaryUsername,
+                globalDisplayName: u?.globalDisplayName,
+              }),
+            );
+          }}
         />
         {isClosed ? (
           <div className="message-composer-container">

--- a/src/components/thread/ThreadsListPanel.tsx
+++ b/src/components/thread/ThreadsListPanel.tsx
@@ -9,6 +9,7 @@ import { useMessageDB } from '../context/useMessageDB';
 import { useThreadContext } from '../context/ThreadContext';
 import { isTouchDevice } from '../../utils/platform';
 import type { ChannelThread } from '@quilibrium/quorum-shared';
+import { resolveSpaceMemberName, formatResolvedName } from '../../utils/resolveMemberName';
 import './ThreadsListPanel.scss';
 
 const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
@@ -18,7 +19,12 @@ interface ThreadsListPanelProps {
   onClose: () => void;
   spaceId: string;
   channelId: string;
-  mapSenderToUser: (senderId: string) => { displayName?: string } | undefined;
+  mapSenderToUser: (senderId: string) => {
+    displayName?: string;
+    primaryUsername?: string;
+    globalDisplayName?: string;
+    address?: string;
+  } | undefined;
 }
 
 type ListItem =
@@ -46,8 +52,18 @@ export function ThreadsListPanel({
     if (!isOpen) setSearchQuery('');
   }, [isOpen]);
 
-  const resolveDisplayName = (senderId: string) =>
-    mapSenderToUser(senderId)?.displayName ?? senderId;
+  const resolveDisplayName = (senderId: string) => {
+    const u = mapSenderToUser(senderId);
+    if (!u) return senderId;
+    return formatResolvedName(
+      resolveSpaceMemberName({
+        address: u.address ?? senderId,
+        displayName: u.displayName,
+        primaryUsername: u.primaryUsername,
+        globalDisplayName: u.globalDisplayName,
+      }),
+    );
+  };
 
   const listItems = useMemo((): ListItem[] => {
     const now = Date.now();

--- a/src/components/user/ResolvedName.tsx
+++ b/src/components/user/ResolvedName.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import type { ResolvedMemberName } from '../../utils/resolveMemberName';
+
+interface ResolvedNameProps {
+  resolved: ResolvedMemberName;
+  className?: string;
+}
+
+/**
+ * Renders a resolved member name, appending ".q" (same styling as the name) when
+ * it's the verified QNS username. Single render site so the suffix can't drift
+ * across surfaces. For string contexts use `formatResolvedName`.
+ */
+export const ResolvedName: React.FunctionComponent<ResolvedNameProps> = ({
+  resolved,
+  className,
+}) => {
+  return (
+    <span className={className}>
+      {resolved.name}
+      {resolved.isQnsVerified && '.q'}
+    </span>
+  );
+};

--- a/src/components/user/UserProfile.tsx
+++ b/src/components/user/UserProfile.tsx
@@ -19,6 +19,11 @@ import { useMutedUsers } from '../../hooks/queries/mutedUsers';
 import { t } from '@lingui/core/macro';
 import { getAddressSuffix } from '../../utils';
 import { UserAvatar } from './UserAvatar';
+import { ResolvedName } from './ResolvedName';
+import {
+  resolveMemberName,
+  resolveSpaceMemberName,
+} from '../../utils/resolveMemberName';
 import { useUserNote, buildUserNoteKey } from '../../hooks/queries/userNotes';
 import { useUserPublicProfile } from '../../hooks/business/user/useUserPublicProfile';
 import { useQueryClient } from '@tanstack/react-query';
@@ -104,6 +109,24 @@ const UserProfile: React.FunctionComponent<{
     props.user.primaryUsername ||
     openedUserPublicProfile?.primary_username ||
     undefined;
+  // Global name (for the space resolver's custom-vs-default comparison).
+  const globalDisplayName =
+    (props.user.globalDisplayName as string | undefined) ||
+    openedUserPublicProfile?.display_name ||
+    undefined;
+
+  const resolvedName = props.spaceId
+    ? resolveSpaceMemberName({
+        address: props.user.address,
+        displayName: props.user.displayName,
+        primaryUsername,
+        globalDisplayName,
+      })
+    : resolveMemberName({
+        address: props.user.address,
+        displayName: props.user.displayName,
+        primaryUsername,
+      });
 
   // Bio resolution for the visible card:
   //   1. Per-space override on SpaceMember (props.user.bio) wins when set.
@@ -219,16 +242,8 @@ const UserProfile: React.FunctionComponent<{
         />
         <div className="user-profile-text">
           <div className="user-profile-username">
-            <span>{props.user.displayName}</span>
+            <ResolvedName resolved={resolvedName} />
           </div>
-          {primaryUsername && (
-            // Verified QNS handle. The ".q" suffix is render-time only and
-            // protected from spoofing by the shared dot-validation, so its
-            // presence here is a trust signal: this is a registered QNS name.
-            <div className="text-accent text-xs">
-              {primaryUsername}.q
-            </div>
-          )}
           <Flex className="py-1 text-subtle">
             <span className="text-xs text-subtle">
               {getAddressSuffix(props.user.address)}

--- a/src/dev/tests/utils/resolveMemberName.unit.test.ts
+++ b/src/dev/tests/utils/resolveMemberName.unit.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest';
+
+const ADDR = 'QmV5xWMo5CYSxgAAy6emKFZZPCKwCsBZKZxXD3mCUZF2nX';
+
+describe('resolveMemberName', () => {
+  it('uses the explicit per-space override above everything else', async () => {
+    const { resolveMemberName } = await import('../../../utils/resolveMemberName');
+    const r = resolveMemberName(
+      { address: ADDR, displayName: 'Ada', primaryUsername: 'alice' },
+      { spaceOverrideName: 'Ada (mod)' },
+    );
+    expect(r.name).toBe('Ada (mod)');
+    expect(r.isQnsVerified).toBe(false);
+  });
+
+  it('lets the QNS username win over the display name (Model B)', async () => {
+    const { resolveMemberName } = await import('../../../utils/resolveMemberName');
+    const r = resolveMemberName({
+      address: ADDR,
+      displayName: 'Whatever',
+      primaryUsername: 'alice',
+    });
+    expect(r.name).toBe('alice');
+    expect(r.isQnsVerified).toBe(true);
+  });
+
+  it('falls back to the display name when there is no QNS name', async () => {
+    const { resolveMemberName } = await import('../../../utils/resolveMemberName');
+    const r = resolveMemberName({ address: ADDR, displayName: 'Ada L.' });
+    expect(r.name).toBe('Ada L.');
+    expect(r.isQnsVerified).toBe(false);
+  });
+
+  it('falls back to the address when nothing else is present', async () => {
+    const { resolveMemberName } = await import('../../../utils/resolveMemberName');
+    const r = resolveMemberName({ address: ADDR });
+    expect(r.isQnsVerified).toBe(false);
+    // address-only fallback — non-empty, derived from the address
+    expect(r.name.length).toBeGreaterThan(0);
+    expect(ADDR).toContain(r.name.replace(/[…\.]/g, '').slice(0, 4));
+  });
+
+  it('treats empty/whitespace names as absent', async () => {
+    const { resolveMemberName } = await import('../../../utils/resolveMemberName');
+    const r = resolveMemberName(
+      { address: ADDR, displayName: '   ', primaryUsername: 'alice' },
+      { spaceOverrideName: '  ' },
+    );
+    expect(r.name).toBe('alice');
+    expect(r.isQnsVerified).toBe(true);
+  });
+
+  it('treats a null primaryUsername as absent and uses the display name', async () => {
+    const { resolveMemberName } = await import('../../../utils/resolveMemberName');
+    const r = resolveMemberName({
+      address: ADDR,
+      displayName: 'Ada',
+      primaryUsername: null,
+    });
+    expect(r.name).toBe('Ada');
+    expect(r.isQnsVerified).toBe(false);
+  });
+});
+
+describe('resolveSpaceMemberName', () => {
+  it('lets a CUSTOM space name (differs from global) win over the QNS name', async () => {
+    const { resolveSpaceMemberName } = await import('../../../utils/resolveMemberName');
+    // Roster name differs from the global name → deliberately typed for this
+    // space → it wins over the QNS name.
+    const r = resolveSpaceMemberName({
+      address: ADDR,
+      displayName: 'Ada (mod)',
+      globalDisplayName: 'Ada',
+      primaryUsername: 'alice',
+    });
+    expect(r.name).toBe('Ada (mod)');
+    expect(r.isQnsVerified).toBe(false);
+  });
+
+  it('lets the QNS name win when the roster name is just the global default', async () => {
+    const { resolveSpaceMemberName } = await import('../../../utils/resolveMemberName');
+    // Roster name equals the global name → not a custom space name → the QNS
+    // name overrides it (Model B).
+    const r = resolveSpaceMemberName({
+      address: ADDR,
+      displayName: 'Ada',
+      globalDisplayName: 'Ada',
+      primaryUsername: 'alice',
+    });
+    expect(r.name).toBe('alice');
+    expect(r.isQnsVerified).toBe(true);
+  });
+
+  it('respects the roster name when the global name is unknown (conservative)', async () => {
+    const { resolveSpaceMemberName } = await import('../../../utils/resolveMemberName');
+    // Can't verify the roster name is just the global echo → never hide a
+    // possibly-deliberate choice.
+    const r = resolveSpaceMemberName({
+      address: ADDR,
+      displayName: 'Ada (mod)',
+      primaryUsername: 'alice',
+    });
+    expect(r.name).toBe('Ada (mod)');
+    expect(r.isQnsVerified).toBe(false);
+  });
+
+  it('shows the QNS name when there is no roster name at all', async () => {
+    const { resolveSpaceMemberName } = await import('../../../utils/resolveMemberName');
+    const r = resolveSpaceMemberName({ address: ADDR, primaryUsername: 'alice' });
+    expect(r.name).toBe('alice');
+    expect(r.isQnsVerified).toBe(true);
+  });
+
+  it('falls back to the roster name when there is no QNS name', async () => {
+    const { resolveSpaceMemberName } = await import('../../../utils/resolveMemberName');
+    const r = resolveSpaceMemberName({ address: ADDR, displayName: 'Ada' });
+    expect(r.name).toBe('Ada');
+    expect(r.isQnsVerified).toBe(false);
+  });
+
+  it('ignores whitespace when comparing roster vs global name', async () => {
+    const { resolveSpaceMemberName } = await import('../../../utils/resolveMemberName');
+    const r = resolveSpaceMemberName({
+      address: ADDR,
+      displayName: ' Ada ',
+      globalDisplayName: 'Ada',
+      primaryUsername: 'alice',
+    });
+    expect(r.name).toBe('alice');
+    expect(r.isQnsVerified).toBe(true);
+  });
+});
+
+describe('formatResolvedName', () => {
+  it('appends ".q" only when verified', async () => {
+    const { formatResolvedName } = await import('../../../utils/resolveMemberName');
+    expect(formatResolvedName({ name: 'alice', isQnsVerified: true })).toBe('alice.q');
+    expect(formatResolvedName({ name: 'Ada L.', isQnsVerified: false })).toBe('Ada L.');
+  });
+});

--- a/src/hooks/business/conversations/useConversationPreviews.ts
+++ b/src/hooks/business/conversations/useConversationPreviews.ts
@@ -4,7 +4,12 @@ import { useMemo } from 'react';
 import type { Conversation } from '@quilibrium/quorum-shared';
 import { useMessageDB } from '../../../components/context/useMessageDB';
 
-export function useConversationPreviews(conversations: Conversation[]) {
+// Generic over the conversation shape so extra fields carried by callers
+// (e.g. the QNS `primaryUsername` added by useConversationsWithProfileBackfill)
+// survive in the returned type — the runtime already spreads `...conv`.
+export function useConversationPreviews<T extends Conversation>(
+  conversations: T[]
+) {
   const { messageDB } = useMessageDB();
 
   // Create a stable reference for the query key - only changes when lastMessageIds change

--- a/src/hooks/business/conversations/useConversationsWithProfileBackfill.ts
+++ b/src/hooks/business/conversations/useConversationsWithProfileBackfill.ts
@@ -50,22 +50,30 @@ const isPlaceholderName = (name?: string): boolean =>
 const isPlaceholderIcon = (icon?: string): boolean =>
   !icon || icon === DefaultImages.UNKNOWN_USER;
 
+/**
+ * A conversation row augmented with the partner's QNS primary username, sourced
+ * from the same public-profile fetch this hook already performs. Additive and
+ * desktop-only — the shared `Conversation` type is untouched, so mobile is
+ * unaffected. The DM sidebar resolves `name.q` (Model B) from this field.
+ */
+export type ConversationWithQns = Conversation & { primaryUsername?: string };
+
 export function useConversationsWithProfileBackfill(
   conversations: Conversation[]
-): Conversation[] {
+): ConversationWithQns[] {
   const { messageDB } = useMessageDB();
   const queryClient = useQueryClient();
 
-  // Addresses whose row is missing a real name and/or a real avatar.
+  // Fetch every distinct DM partner (small N, unlike a space roster): placeholder
+  // rows need name/icon backfill, established rows need primary_username for
+  // name.q. Cached 1h, shared with the open-conversation view's query key.
   const addressesToFetch = useMemo(() => {
     const out: string[] = [];
     const seen = new Set<string>();
     for (const c of conversations) {
       if (!c.address || seen.has(c.address)) continue;
-      if (isPlaceholderName(c.displayName) || isPlaceholderIcon(c.icon)) {
-        seen.add(c.address);
-        out.push(c.address);
-      }
+      seen.add(c.address);
+      out.push(c.address);
     }
     return out;
   }, [conversations]);
@@ -101,24 +109,27 @@ export function useConversationsWithProfileBackfill(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [addressesToFetch, queries.map((q) => q?.data ?? null).join('|')]);
 
-  // Merged list for rendering: placeholder fields fall back to the public
-  // profile, real fields are preserved.
-  const merged = useMemo(() => {
-    if (addressesToFetch.length === 0) return conversations;
+  // Placeholder name/icon fall back to the public profile; real values kept.
+  // primary_username is attached whenever the profile was fetched.
+  const merged = useMemo((): ConversationWithQns[] => {
     return conversations.map((c) => {
       const pub = profileByAddress[c.address];
       if (!pub) return c;
       const nameNeedsFill = isPlaceholderName(c.displayName);
       const iconNeedsFill = isPlaceholderIcon(c.icon);
-      if (!nameNeedsFill && !iconNeedsFill) return c;
+      const primaryUsername = pub.primary_username || undefined;
+      if (!nameNeedsFill && !iconNeedsFill) {
+        return primaryUsername ? { ...c, primaryUsername } : c;
+      }
       return {
         ...c,
         displayName:
           nameNeedsFill && pub.display_name ? pub.display_name : c.displayName,
         icon: iconNeedsFill && pub.profile_image ? pub.profile_image : c.icon,
+        primaryUsername,
       };
     });
-  }, [conversations, profileByAddress, addressesToFetch]);
+  }, [conversations, profileByAddress]);
 
   // Write-through: persist resolved values back to IndexedDB so the next load
   // is instant and the conversation view stops flashing. Guard against

--- a/src/hooks/business/mentions/useMentionInput.ts
+++ b/src/hooks/business/mentions/useMentionInput.ts
@@ -1,9 +1,16 @@
 import { useState, useEffect, useCallback } from 'react';
 import type { Channel, Group } from '@quilibrium/quorum-shared';
+import { resolveSpaceMemberName } from '../../../utils/resolveMemberName';
 
 interface User {
   address: string;
   displayName?: string;
+  /** QNS primary username (no ".q" suffix). Matched in autocomplete so typing
+   *  "@ali" finds "alice"; the pill renders the resolved name.q. */
+  primaryUsername?: string;
+  /** The member's global display name — lets the space resolver tell a custom
+   *  per-space name apart from the global default. */
+  globalDisplayName?: string;
   userIcon?: string;
 }
 
@@ -13,6 +20,18 @@ interface Role {
   roleTag: string;
   color: string;
 }
+
+// The name a user candidate is shown and matched by in the picker. Mentions
+// are a space feature, so the space rule applies: a custom per-space name
+// (roster name differing from the global name) wins; otherwise the QNS name
+// wins over the global name; then display name; then address.
+const mentionCandidateName = (u: User): string =>
+  resolveSpaceMemberName({
+    address: u.address,
+    displayName: u.displayName,
+    primaryUsername: u.primaryUsername,
+    globalDisplayName: u.globalDisplayName,
+  }).name;
 
 // Discriminated union for display
 export type MentionOption =
@@ -106,15 +125,16 @@ export function useMentionInput({
 
       const queryLower = query.toLowerCase();
 
-      // Filter users whose displayName or address matches the query
+      // Filter users whose QNS name, displayName, or address matches the query.
       const matches = users.filter(user => {
         const name = user.displayName?.toLowerCase() || '';
+        const qns = user.primaryUsername?.toLowerCase() || '';
         const addr = user.address.toLowerCase();
-        return name.includes(queryLower) || addr.includes(queryLower);
+        return name.includes(queryLower) || qns.includes(queryLower) || addr.includes(queryLower);
       });
 
-      // Sort by relevance and limit results
-      const sorted = sortByRelevance(matches, query, u => u.displayName || '');
+      // Sort by relevance against the name the user is shown as (QNS wins).
+      const sorted = sortByRelevance(matches, query, mentionCandidateName);
       return sorted.slice(0, maxDisplayResults);
     },
     [users, minQueryLength, maxDisplayResults, sortByRelevance]
@@ -127,15 +147,16 @@ export function useMentionInput({
 
       const queryLower = query.toLowerCase();
 
-      // Filter users whose displayName or address matches the query
+      // Filter users whose QNS name, displayName, or address matches the query.
       const matches = users.filter(user => {
         const name = user.displayName?.toLowerCase() || '';
+        const qns = user.primaryUsername?.toLowerCase() || '';
         const addr = user.address.toLowerCase();
-        return name.includes(queryLower) || addr.includes(queryLower);
+        return name.includes(queryLower) || qns.includes(queryLower) || addr.includes(queryLower);
       });
 
-      // Sort by relevance and limit results
-      const sorted = sortByRelevance(matches, query, u => u.displayName || '');
+      // Sort by relevance against the name the user is shown as (QNS wins).
+      const sorted = sortByRelevance(matches, query, mentionCandidateName);
       return sorted.slice(0, maxDisplayResults);
     },
     [users, maxDisplayResults, sortByRelevance]
@@ -279,7 +300,7 @@ export function useMentionInput({
       // User/role mentions with tiered filtering
       if (!query || query.length === 0) {
         // TIER 1: Empty query - show alphabetical users (first 10)
-        const alphabeticalUsers = sortByRelevance(users, '', u => u.displayName || '');
+        const alphabeticalUsers = sortByRelevance(users, '', mentionCandidateName);
         options = alphabeticalUsers
           .slice(0, 10)
           .map(u => ({ type: 'user' as const, data: u }));

--- a/src/hooks/business/spaces/useSpaceProfile.ts
+++ b/src/hooks/business/spaces/useSpaceProfile.ts
@@ -66,10 +66,13 @@ export const useSpaceProfile = (
     userIcon: string;
   }>({ displayName: '', bio: '', userIcon: '' });
 
-  // Use proper display name validation (replaces basic validation)
   const displayNameValidation = useDisplayNameValidation(displayName);
+  // Per-space name is optional, so empty is valid here (the "required" error
+  // doesn't apply); all other rules still do.
+  const displayNameError =
+    displayName.trim().length === 0 ? undefined : displayNameValidation.error;
   const bioErrors = validateUserBio(bio);
-  const hasValidationError = !!displayNameValidation.error || bioErrors.length > 0;
+  const hasValidationError = !!displayNameError || bioErrors.length > 0;
 
   // Load current member data
   useEffect(() => {
@@ -79,8 +82,10 @@ export const useSpaceProfile = (
       try {
         const member = await messageDB.getSpaceMember(spaceId, currentPasskeyInfo.address);
         setCurrentMember(member);
-        // Initialize display name from member or fallback to global
-        const initialDisplayName = member?.display_name || currentPasskeyInfo.displayName || '';
+        // Per-space name is an optional override: init from the member's name
+        // only, NOT the global name (that made an unset override look set and
+        // defeated clearing). Empty = use my global / QNS name here.
+        const initialDisplayName = member?.display_name ?? '';
         const initialBio = member?.bio ?? '';
         const initialUserIcon = member?.user_icon ?? '';
         setDisplayName(initialDisplayName);
@@ -211,7 +216,7 @@ export const useSpaceProfile = (
   }, [fileData, currentFile, currentMember, currentPasskeyInfo, markedForDeletion]);
 
   const onSave = useCallback(async () => {
-    if (!currentPasskeyInfo || displayNameValidation.error || bioErrors.length > 0) {
+    if (!currentPasskeyInfo || displayNameError || bioErrors.length > 0) {
       return;
     }
 
@@ -267,21 +272,18 @@ export const useSpaceProfile = (
         throw new Error('Space not found');
       }
 
-      // Send update-profile message. `submitChannelMessage` requires the
-      // `update-profile` payload to satisfy the UpdateProfileMessage type,
-      // which today types displayName and userIcon as required strings.
-      // The wire shape tolerates omitting them (mobile already does, and
-      // canonicalize() over a partial object is well-defined); fall back to
-      // baseline values for the typed fields when we're not actually
-      // broadcasting them so the type-check passes and a receiver running
-      // an older build still has something to overwrite-with-same.
+      // Include a field only when changed (mirrors bio): omitted displayName =
+      // no change, empty = clear the per-space name. userIcon stays required by
+      // the type, so fall back to baseline (overwrite-with-same is harmless).
       await submitChannelMessage(
         spaceId,
         space.defaultChannelId,
         {
           type: 'update-profile',
           senderId: currentPasskeyInfo.address,
-          displayName: changed.displayName ?? baseline.displayName,
+          ...(changed.displayName !== undefined
+            ? { displayName: changed.displayName }
+            : {}),
           userIcon: changed.userIcon ?? baseline.userIcon,
           ...(changed.bio !== undefined ? { bio: changed.bio } : {}),
         },
@@ -325,7 +327,7 @@ export const useSpaceProfile = (
     submitChannelMessage,
     queryClient,
     onSaveCallback,
-    displayNameValidation.error,
+    displayNameError,
     bioErrors.length,
     markedForDeletion,
   ]);
@@ -351,7 +353,7 @@ export const useSpaceProfile = (
     onSave,
     isSaving,
     hasValidationError,
-    displayNameError: displayNameValidation.error,
+    displayNameError,
     currentMember,
   };
 };

--- a/src/hooks/business/user/useMembersWithPublicProfileFallback.ts
+++ b/src/hooks/business/user/useMembersWithPublicProfileFallback.ts
@@ -1,14 +1,16 @@
 // useMembersWithPublicProfileFallback
 //
 // Takes a member map (address -> { displayName?, userIcon?, ... }) plus a
-// list of addresses currently rendered, and back-fills missing/empty
-// entries by fetching the public-profile endpoint for each address.
+// list of addresses currently rendered, and enriches each visible member by
+// fetching the public-profile endpoint for their address.
 //
-// Resolution rule (matches mobile's behavior):
-//   - If the local member has a populated displayName or userIcon, keep it.
-//   - If the local member has neither, fill from the public profile when
-//     available. Per-field merge: a field that's populated locally wins;
-//     a field that's empty locally falls back to the public profile.
+// Resolution rule:
+//   - Per-field merge for displayName/userIcon/bio: a field that's populated
+//     locally wins; an empty local field falls back to the public profile.
+//   - primaryUsername (QNS) and globalDisplayName come ONLY from the public
+//     profile, so every visible member is fetched — even fully-populated ones.
+//     (globalDisplayName is what lets resolveSpaceMemberName tell a custom
+//     per-space name apart from the global default echoed into the roster.)
 //   - Members not appearing in `visibleAddresses` are passed through
 //     untouched — we don't fetch profiles for the entire space roster.
 //
@@ -42,6 +44,11 @@ interface MemberRecord {
    *  the public-profile fallback so members we don't share fresh data with
    *  still show their verified name. */
   primaryUsername?: string;
+  /** The member's GLOBAL display name from their public profile (as opposed to
+   *  `displayName`, which is the roster name and may be a per-space custom
+   *  name). resolveSpaceMemberName compares the two to decide whether the
+   *  roster name was deliberately set for the space. */
+  globalDisplayName?: string;
   // Additional fields preserved opaquely (isKicked, spaceTag, joinedAt, etc).
   [extra: string]: unknown;
 }
@@ -52,22 +59,19 @@ export function useMembersWithPublicProfileFallback(
   members: MemberMap,
   visibleAddresses: string[]
 ): MemberMap {
-  // Determine which addresses need a public-profile query — addresses
-  // where we have no local record, OR the record exists but has neither
-  // displayName nor userIcon. Fully-populated members aren't queried.
+  // Fetch every visible sender's public profile (the only source of
+  // primary_username + globalDisplayName), not just members missing a name.
+  // Bounded to visible senders, never the whole roster; cached 1h.
   const addressesToFetch = useMemo(() => {
     const out: string[] = [];
     const seen = new Set<string>();
     for (const addr of visibleAddresses) {
       if (!addr || seen.has(addr)) continue;
       seen.add(addr);
-      const m = members[addr];
-      if (!m || (!m.displayName && !m.userIcon)) {
-        out.push(addr);
-      }
+      out.push(addr);
     }
     return out;
-  }, [members, visibleAddresses]);
+  }, [visibleAddresses]);
 
   const queries = useQueries({
     queries: addressesToFetch.map((address) => ({
@@ -135,6 +139,9 @@ export function useMembersWithPublicProfileFallback(
           (local?.primaryUsername as string | undefined) ||
           pub.primary_username ||
           undefined,
+        // The member's global display name, kept SEPARATE from the roster
+        // `displayName` so the space resolver can compare the two.
+        globalDisplayName: pub.display_name || undefined,
       };
     });
     result = merged;

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -1289,13 +1289,10 @@ export class MessageService {
       // Signature was already verified upstream; rejecting on mismatch would permanently
       // block profile updates after any key rotation.
       //
-      // Upsert-aware merge (mirrors mobile WebSocketContext.tsx:1841-1854):
-      // only apply fields that the sender actually included. Skipping
-      // empty-string displayName / userIcon avoids clobbering receivers'
-      // stored values when the sender broadcasts a partial update (e.g. a
-      // bio-only edit). Bio uses `!== undefined` so an explicit empty
-      // string deliberately clears the bio.
-      if (decryptedContent.content.displayName) {
+      // Upsert-aware merge: omitted field = no change, empty string = clear.
+      // displayName + bio use `!== undefined` (clearing propagates); userIcon
+      // keeps the truthy guard.
+      if (decryptedContent.content.displayName !== undefined) {
         participant.display_name = decryptedContent.content.displayName;
       }
       if (decryptedContent.content.userIcon) {
@@ -1807,7 +1804,8 @@ export class MessageService {
       //
       // Upsert-aware merge (mirrors mobile WebSocketContext.tsx:1841-1854):
       // see the same block in saveMessage above for the full rationale.
-      if (decryptedContent.content.displayName) {
+      // Presence semantics: omitted = no change, explicit empty = clear.
+      if (decryptedContent.content.displayName !== undefined) {
         participant.display_name = decryptedContent.content.displayName;
       }
       if (decryptedContent.content.userIcon) {

--- a/src/utils/mentionPillDom.ts
+++ b/src/utils/mentionPillDom.ts
@@ -8,6 +8,7 @@
  */
 
 import type { MentionOption } from '../hooks/business/mentions/useMentionInput';
+import { resolveSpaceMemberName, formatResolvedName } from './resolveMemberName';
 
 /**
  * Type of mention pill
@@ -49,9 +50,18 @@ export const MENTION_PILL_CLASSES = {
  */
 export function extractPillDataFromOption(option: MentionOption): PillData {
   if (option.type === 'user') {
+    // Model B: the pill shows the resolved name (name.q when QNS-verified). The
+    // ".q" is display-only — storage stays @<address> via dataset.mentionAddress
+    // in extractStorageTextFromEditor, so the wire format is unchanged.
+    const resolved = resolveSpaceMemberName({
+      address: option.data.address,
+      displayName: option.data.displayName,
+      primaryUsername: option.data.primaryUsername,
+      globalDisplayName: option.data.globalDisplayName,
+    });
     return {
       type: 'user',
-      displayName: option.data.displayName || 'Unknown User',
+      displayName: formatResolvedName(resolved) || 'Unknown User',
       address: option.data.address,
     };
   } else if (option.type === 'role') {

--- a/src/utils/resolveMemberName.ts
+++ b/src/utils/resolveMemberName.ts
@@ -1,0 +1,88 @@
+import { resolveDisplayName as resolveSharedDisplayName } from '@quilibrium/quorum-shared';
+
+export interface ResolvedMemberName {
+  /** The readable name to display. Never empty (falls back to the address). */
+  name: string;
+  /** True only when `name` is the QNS username — render with the ".q" suffix. */
+  isQnsVerified: boolean;
+}
+
+interface ResolvableMember {
+  displayName?: string | null;
+  primaryUsername?: string | null;
+  address: string;
+}
+
+/** Fields a `mapSenderToUser`/`resolveSender` result exposes for name resolution. */
+export interface NameResolvableUser {
+  displayName?: string;
+  primaryUsername?: string;
+  /** Global name from the public profile; lets resolveSpaceMemberName tell a
+   *  per-space name from the global default. */
+  globalDisplayName?: string;
+  address?: string;
+  userIcon?: string;
+}
+
+/**
+ * Desktop (camelCase) adapter over the shared `resolveDisplayName` rule, the
+ * single source of precedence: spaceOverrideName → QNS → displayName → address.
+ * For DM/global contexts the QNS name wins over `displayName`; space contexts
+ * use `resolveSpaceMemberName`. The ".q" suffix is applied at render
+ * (`<ResolvedName>` / `formatResolvedName`), not baked into `name`.
+ */
+export function resolveMemberName(
+  member: ResolvableMember,
+  opts: { spaceOverrideName?: string | null } = {},
+): ResolvedMemberName {
+  const { name, isQnsVerified } = resolveSharedDisplayName(
+    {
+      address: member.address,
+      display_name: member.displayName ?? undefined,
+      primary_username: member.primaryUsername ?? undefined,
+    },
+    { spaceOverrideName: opts.spaceOverrideName },
+  );
+  return { name, isQnsVerified };
+}
+
+/**
+ * Resolve a name shown in a SPACE context (roster / effectiveMembers). Use this,
+ * not `resolveMemberName`, for any space-sourced name.
+ *
+ * The roster `displayName` can't say whether it's a deliberate per-space name or
+ * just the global name echoed at join. We disambiguate by comparing it to
+ * `globalDisplayName` (free — same public-profile fetch that carries the QNS
+ * name): differs → deliberate, it wins; equal → QNS name wins; global unknown →
+ * keep the roster name. See .agents/docs/features/qns-username-display.md.
+ */
+export function resolveSpaceMemberName(member: {
+  displayName?: string | null;
+  primaryUsername?: string | null;
+  globalDisplayName?: string | null;
+  address: string;
+}): ResolvedMemberName {
+  const roster = (member.displayName ?? '').trim();
+  const global = (member.globalDisplayName ?? '').trim();
+  const qns = (member.primaryUsername ?? '').trim();
+
+  if (qns && roster && roster !== global) {
+    return { name: roster, isQnsVerified: false };
+  }
+
+  return resolveMemberName({
+    address: member.address,
+    displayName: member.displayName,
+    primaryUsername: member.primaryUsername,
+  });
+}
+
+/**
+ * Flatten a resolved name to a plain string for non-JSX contexts (input
+ * placeholders, aria-labels, tooltip content, search match text). Appends the
+ * ".q" suffix when the name is the verified QNS username. For JSX render sites,
+ * prefer the `<ResolvedName>` component so the suffix can be accent-styled.
+ */
+export function formatResolvedName(resolved: ResolvedMemberName): string {
+  return resolved.isQnsVerified ? `${resolved.name}.q` : resolved.name;
+}


### PR DESCRIPTION
Resolve and display a member's QNS primary username in place of their display name across DMs, channels, threads, mentions, reactions, notifications, and profile surfaces.

- Adds a shared `resolveMemberName` util and a `ResolvedName` component
- Wires QNS username resolution through conversation, mention, space-profile, and member hooks
- Updates message and conversation rendering paths to use the resolved name