### PR TITLE
fix(spaces): receive-side groundwork for hub-log migration (member upsert + null-guard)

### DIFF
--- a/.agents/INDEX.md
+++ b/.agents/INDEX.md
@@ -636,4 +636,4 @@ This is the main index for all documentation, bug reports, and task management.
 
 ---
 
-**Last Updated**: 2026-06-13 12:27:46
+**Last Updated**: 2026-06-13 12:35:56

--- a/.agents/INDEX.md
+++ b/.agents/INDEX.md
@@ -4,22 +4,25 @@ This is the main index for all documentation, bug reports, and task management.
 
 ## 📖 Documentation
 
-- [Complete Guide: Cross-Platform React Components for Web + Native](docs/cross-platform-components-guide.md) — multi-repo banner added (philosophy current; `.native.tsx` go in quorum-mobile)
-- [Component Management & Development Guide](docs/component-management-guide.md) — multi-repo banner added
+- [Complete Guide: Cross-Platform React Components for Web + Native](docs/cross-platform-components-guide.md)
+- [Component Management & Development Guide](docs/component-management-guide.md)
 - [Config Sync System](docs/config-sync-system.md)
 - [Cryptographic Architecture](docs/cryptographic-architecture.md)
 - [Device Naming](docs/device-naming.md)
-- [Expo Dev Testing Guide](docs/expo-dev-testing-guide.md) — ⚠️ deprecated (in-repo `mobile/` playground; use quorum-mobile)
+- [Expo Dev Testing Guide](docs/expo-dev-testing-guide.md)
 - [IndexedDB Schema Reference: `quorum_db`](docs/quorum-db-schema.md)
 - [Quorum Data Management Architecture](docs/data-management-architecture-guide.md)
-- [Quorum Ecosystem Architecture](docs/quorum-shared-architecture.md) — canonical current architecture
+- [Quorum Ecosystem Architecture](docs/quorum-shared-architecture.md)
 - [Styling Guidelines](docs/styling-guidelines.md)
 
-#### Archived docs (`.archived/`)
-- [Cross-Platform Repository Implementation](docs/.archived/cross-platform-repository-implementation.md) — ⚰️ ABANDONED single-repo build plan; kept as history only
+### .Archived
+- [Cross-Platform Repository Implementation](docs/.archived/cross-platform-repository-implementation.md)
+
+### Debugging
+- [DM Architecture and Debug Playbook](docs/debugging/dm-architecture-and-debug-playbook.md)
 
 ### Development
-- [Android Build Workflow](docs/development/android-build-workflow.md) — ⚠️ deprecated (in-repo `mobile/` playground; use quorum-mobile)
+- [Android Build Workflow](docs/development/android-build-workflow.md)
 - [Dependency Upgrade Guide](docs/development/dependency-upgrade-guide.md)
 
 ### Features
@@ -43,6 +46,7 @@ This is the main index for all documentation, bug reports, and task management.
 - [Offline Support](docs/features/offline-support.md)
 - [Onboarding Flow](docs/features/onboarding-flow.md)
 - [Profile Sync on Returning User Login](docs/features/profile-sync-returning-user-login.md)
+- [QNS Username Display (name resolution)](docs/features/qns-username-display.md)
 - [ReactTooltip Mobile Support Documentation](docs/features/reacttooltip-mobile.md)
 - [Responsive Layout System Documentation](docs/features/responsive-layout.md)
 - [Security Architecture](docs/features/security.md)
@@ -93,24 +97,15 @@ This is the main index for all documentation, bug reports, and task management.
 - [Space Permissions Architecture](docs/space-permissions/space-permissions-architecture.md)
 - [Space Roles System](docs/space-permissions/space-roles-system.md)
 
-### Debugging
-- [DM Architecture and Debug Playbook](docs/debugging/dm-architecture-and-debug-playbook.md) — DM identity flow, known sync gaps, debug ladder. Read before any DM investigation.
-
-## 🛠 Tools
-
-- [DM debug snippets](tools/dm-debug/README.md) — copy-paste console scripts for diagnosing DM identity / sync issues.
-
 ## 🐛 Bug Reports
 
 ### Active Issues
 - [Pinned Messages Panel Button Clicks Bug](bugs/2025-01-08-pinned-messages-panel-clicks-and-message-list-disappearing.md)
 - [Markdown Line Break Inconsistency](bugs/2025-01-21-markdown-line-break-inconsistency.md)
-- [JoinSpaceModal "Invalid JSON" Error Due to Network Issues](bugs/2025-08-03-joinspacemodal-invalid-json-network-error.md)
 - [Message Hash Navigation Conflict Bug](bugs/2025-08-03-message-hash-navigation-conflict.md)
 - [Modal Gesture Handling Technical Debt](bugs/2025-08-10-modal-gesture-handling-technical-debt.md)
 - [MessageDB Context: IndexedDB Platform Compatibility Issue](bugs/2025-08-21-messagedb-cross-platform-storage-issue.md)
 - [Kick User Button Remains Enabled After User is Kicked](bugs/2025-09-16-kick-user-button-state-after-kick.md)
-- [Public Invite Link Intermittent Expiration Bug](bugs/2025-09-22-public-invite-link-intermittent-expiration.md)
 - [Expired Invite Card Validation Timing Issue](bugs/2025-11-09-expired-invite-card-validation-timing.md)
 - [Encryption State Evals Causing Config Sync Bloat](bugs/2025-12-09-encryption-state-evals-bloat.md)
 - [Config Sync Space Loss Race Condition](bugs/2026-01-09-config-sync-space-loss-race-condition.md)
@@ -121,19 +116,20 @@ This is the main index for all documentation, bug reports, and task management.
 - [Bug: Display Name Input Grows Wider When Validation Error Appears](bugs/2026-04-14-display-name-input-layout-shift-on-error.md)
 - [Virtuoso measurement callback resets scrollTop on new messages](bugs/2026-05-24-virtuoso-measurement-scroll-reset.md)
 - [UserSettingsModal shows stale display name after remote UserConfig sync](bugs/2026-05-30-user-settings-modal-stale-display-name.md)
-- [Action queue errors silently swallowed across all config-writing hooks](bugs/2026-06-07-action-queue-errors-swallowed.md)
-- [Per-space mention-type filter doesn't sync across devices](bugs/2026-06-07-mention-type-filter-not-synced.md)
-- [`Save Changes` in Account tab throws "missing inbox configuration"](bugs/2026-06-07-space-profile-save-missing-inbox.md)
-- [@everyone owner-bypass propagates (send-side-only enforcement) — spans shared/desktop/mobile](bugs/2026-06-12-everyone-mention-owner-bypass-send-side-only.md) 🔴 cross-repo; extends #111
-- [Read-only channel receive-side enforcement incomplete (sticker/embed bypass; cache-only for posts)](bugs/2026-06-12-readonly-channel-receive-side-enforcement-gaps.md) 🟡 receive-side gaps
+- [UserSettingsModal fields flash empty on open](bugs/2026-06-08-user-settings-modal-fields-flash-empty-on-open.md)
+- [@everyone owner-bypass is a real propagating bug (send-side-only enforcement)](bugs/2026-06-12-everyone-mention-owner-bypass-send-side-only.md)
+- [Read-only channel receive-side enforcement is incomplete](bugs/2026-06-12-readonly-channel-receive-side-enforcement-gaps.md)
+- [Space members show truncated address — no `space_members` row](bugs/2026-06-13-space-members-missing-no-join-row.md)
 
 ### Solved Issues
 - [Icon Color Not Saving Issue](bugs/.solved/2025-01-15-icon-color-not-saving-issue.md)
 - [NewDirectMessage Modal: URL-to-State Conversion](bugs/.solved/2025-01-19-newdirectmessage-modal-url-to-state-conversion.md)
 - [React Hooks Violation: Conditional Return Before Hooks](bugs/.solved/2025-01-20-react-hooks-violation-conditional-return.md)
 - [Kick User UX Improvements](bugs/.solved/2025-01-30-kick-user-ux-improvements.md)
+- [JoinSpaceModal "Invalid JSON" Error Due to Network Issues](bugs/.solved/2025-08-03-joinspacemodal-invalid-json-network-error.md)
 - [Android 7.0 File Download Fix - Implementation Plan](bugs/.solved/2025-08-11-android-file-download-huawei-p9-lite.md)
 - [2025 09 09 Search Results Page Refresh And Focus Stealing](bugs/.solved/2025-09-09-search-results-page-refresh-and-focus-stealing.md)
+- [Public Invite Link Intermittent Expiration Bug](bugs/.solved/2025-09-22-public-invite-link-intermittent-expiration.md)
 - [Bug: Auto-Jump to First Unread Message - Blocked by Virtuoso Scroll Positioning](bugs/.solved/2025-11-11-auto-jump-unread-virtuoso-scroll-conflict.md)
 - [New Messages Separator - Intersection Observer Dismissal Issues](bugs/.solved/2025-11-12-new-messages-separator-intersection-observer-issues.md)
 - [Deleted Messages Reappear After Peer Sync](bugs/.solved/2025-12-18-deleted-messages-reappear-via-sync.md)
@@ -161,6 +157,9 @@ This is the main index for all documentation, bug reports, and task management.
 - [No visual feedback when dragging files onto dropzone areas](bugs/.solved/2026-04-07-missing-drag-feedback-file-uploads.md)
 - [SpaceMember field name mismatch between MessageDB and quorum-shared](bugs/.solved/2026-04-08-spacemember-type-mismatch-db-vs-shared.md)
 - [Profile sync not triggered after key import in new onboarding flow](bugs/.solved/2026-04-13-profile-sync-not-triggered-after-key-import.md)
+- [Action queue errors silently swallowed across all config-writing hooks](bugs/.solved/2026-06-07-action-queue-errors-swallowed.md)
+- [Per-space mention-type filter doesn't sync across devices](bugs/.solved/2026-06-07-mention-type-filter-not-synced.md)
+- [`Save Changes` in Account tab throws "missing inbox configuration"](bugs/.solved/2026-06-07-space-profile-save-missing-inbox.md)
 - [Bug: Emoji Picker Grid Has Empty Space on Right Side in Mobile Drawer](bugs/.solved/emoji-picker-mobile-drawer-empty-space.md)
 - [Channel/Group Save Race Condition](bugs/.solved/channel-group-save-race-condition.md)
 - [Config Save Missing React Query Cache Update Causes Stale allowSync](bugs/.solved/config-save-stale-cache-allowsync.md)
@@ -205,10 +204,8 @@ This is the main index for all documentation, bug reports, and task management.
 - [Spaces Highlights Feed — Design Spec](tasks/2026-06-04-spaces-highlights-feed-design.md)
 - [Spaces Highlights Feed Implementation Plan](tasks/2026-06-04-spaces-highlights-feed-plan.md)
 - [Unify Account tab's defer-vs-instant control semantics](tasks/2026-06-07-account-tab-defer-save-unification.md)
-- [Implementation plan — Notification settings UX alignment](tasks/2026-06-07-align-notification-settings-with-mobile-plan.md)
-- [Align notification settings UX between desktop and mobile](tasks/2026-06-07-align-notification-settings-with-mobile.md)
-- [`useDMMute` and `useDMFavorites` read stale config from messageDB](tasks/2026-06-07-dm-mute-cache-read.md)
-- [Add a real global notifications mute to desktop](tasks/2026-06-07-global-notifications-mute.md)
+- [UserProfile card layout polish pass](tasks/2026-06-08-userprofile-card-layout-polish.md)
+- [Migrate UserProfile card positioning to @floating-ui/react](tasks/2026-06-08-userprofile-positioning-floating-ui.md)
 
 ### .Archived
 - [🚀 Search Performance Optimization - Revised Implementation Plan](tasks/.archived/2025-11-12-search-performance-optimization-original.md)
@@ -275,32 +272,34 @@ This is the main index for all documentation, bug reports, and task management.
 ### Messagedb .Done
 - [Extract encryptAndSendToSpace() Helper](tasks/messagedb/.done/messageservice-extract-encrypt-helper.md)
 
-### Mobile Dev (historical reference — single-repo era; see README)
-- [README — folder status + cleanup pass](tasks/mobile-dev/README.md)
+### Mobile Dev
 - [Business Logic Extraction & Native Preparation Plan](tasks/mobile-dev/2025-08-01-business-logic-extraction-plan.md)
 - [Quilibrium SDK Mobile Integration Issue](tasks/mobile-dev/2025-08-08-mobile-sdk-integration-issue.md)
 - [Component Architecture Masterplan - Desktop/Mobile Unification](tasks/mobile-dev/2026-01-09-components-shared-arch-masterplan.md)
 - [Mobile/Touch Implementation Transition Plan](tasks/mobile-dev/2026-01-09-mobile-touch-transition-plan.md)
-
-### Mobile Dev Docs
-- [Component Architecture Workflow - Detailed Explanation](tasks/mobile-dev/docs/component-architecture-workflow-explained.md)
+- [mobile-dev — historical cross-platform planning](tasks/mobile-dev/README.md)
 
 ### Mobile Dev .Archived
-- [Cross-Platform Development : Revised Plan](tasks/mobile-dev/.archived/plan-quick-recap.md)
-- [Mobile Development Plan - Improved Version](tasks/mobile-dev/.archived/mobile-dev-plan.md)
-- [Native Business Components Implementation Plan](tasks/mobile-dev/.archived/native-business-components-plan.md)
-- [Primitive Migration Audit Report](tasks/mobile-dev/.archived/primitive-migration-audit.md)
-- [Sdk Shim Temporary Solutions](tasks/mobile-dev/.archived/sdk-shim-temporary-solutions.md)
 - [Cross-Platform Hooks Refactoring Plan](tasks/mobile-dev/.archived/2026-01-09-cross-platform-hooks-refactoring-plan.md)
 - [CSS to Mobile Colors Sync Script](tasks/mobile-dev/.archived/2026-01-09-css-to-mobile-colors-sync.md)
 - [File Upload Hooks Consolidation Task](tasks/mobile-dev/.archived/2026-01-09-file-upload-hooks-consolidation.md)
 - [Mobile Internationalization (i18n) Implementation Plan](tasks/mobile-dev/.archived/2026-01-09-internationalization-i18n-implementation-plan.md)
 - [Mobile Image Compression Implementation](tasks/mobile-dev/.archived/2026-01-09-mobile-image-compression.md)
 - [React Native Upgrade Risk Assessment](tasks/mobile-dev/.archived/2026-01-09-upgrade-to-react-80.md)
+- [Cross-Platform Development : Revised Plan](tasks/mobile-dev/.archived/plan-quick-recap.md)
+- [Mobile Development Plan - Improved Version](tasks/mobile-dev/.archived/mobile-dev-plan.md)
 - [Mobile/Desktop Behavioral Differences Audit Plan](tasks/mobile-dev/.archived/mobile-desktop-audit.md)
+- [Native Business Components Implementation Plan](tasks/mobile-dev/.archived/native-business-components-plan.md)
+- [Primitive Migration Audit Report](tasks/mobile-dev/.archived/primitive-migration-audit.md)
+- [Sdk Shim Temporary Solutions](tasks/mobile-dev/.archived/sdk-shim-temporary-solutions.md)
 - [Third-Party Component Migration Report](tasks/mobile-dev/.archived/third-party-component-migration-report.md)
 
+### Mobile Dev Docs
+- [Component Architecture Workflow - Detailed Explanation](tasks/mobile-dev/docs/component-architecture-workflow-explained.md)
+
 ### Port From Mobile
+- [Port skins — Phase 0 + Phase 1](tasks/port-from-mobile/2026-06-11-port-skins-phase-0-1.md)
+- [Skins (custom themes) — deep dive (candidate #27)](tasks/port-from-mobile/2026-06-11-skins-deep-dive.md)
 - [Cross-app feature diff (port-from-mobile) — Master Tracker](tasks/port-from-mobile/README.md)
 - [Mobile features not on desktop — candidate list](tasks/port-from-mobile/candidates.md)
 - [Port-from-mobile shipped log](tasks/port-from-mobile/shipped-log.md)
@@ -310,18 +309,23 @@ This is the main index for all documentation, bug reports, and task management.
 - [Unified `/spaces` Page (PR 1 of 2) — Implementation Plan](tasks/port-from-mobile/.done/2026-06-01-port-discover-spaces-plan.md)
 - [Unified `/spaces` page — PR 2 of 2](tasks/port-from-mobile/.done/2026-06-01-port-discover-spaces-pr2.md)
 - [Unified `/spaces` page — PR 1 of 2](tasks/port-from-mobile/.done/2026-06-01-port-discover-spaces.md)
+- [Port #29 — Non-owner read-only view of the public invite URL](tasks/port-from-mobile/.done/2026-06-08-port-non-owner-invite-view.md)
+- [Port per-space profile bio override](tasks/port-from-mobile/.done/2026-06-08-port-per-space-bio.md)
+- [Port public profile from mobile + remove speculative `/discover/people`](tasks/port-from-mobile/.done/2026-06-08-port-public-profile.md)
 - [QNS usernames on desktop — design](tasks/port-from-mobile/.done/2026-06-10-qns-username-display-design.md)
-- [QNS Usernames on Desktop — Implementation Plan (stages 1-3)](tasks/port-from-mobile/.done/2026-06-10-qns-username-display-plan.md)
-- [QNS username overrides display name everywhere + mentions](tasks/port-from-mobile/.done/2026-06-11-qns-username-overrides-display-name-plan.md)
+- [QNS Usernames on Desktop — Implementation Plan](tasks/port-from-mobile/.done/2026-06-10-qns-username-display-plan.md)
+- [Port — paste private key on import + copy private key in settings](tasks/port-from-mobile/.done/2026-06-11-port-key-paste-import-and-copy-export.md)
+- [QNS username overrides display name everywhere + mentions by QNS name](tasks/port-from-mobile/.done/2026-06-11-qns-username-overrides-display-name-plan.md)
 
 ### Port To Mobile
-- [Port-to-mobile — Master Tracker](tasks/port-to-mobile/README.md)
-- [Port-to-mobile candidates (feature-ports + convergence)](tasks/port-to-mobile/candidates.md)
+- [Port-to-mobile candidates](tasks/port-to-mobile/candidates.md)
+- [Port-to-mobile — desktop → mobile feature diff](tasks/port-to-mobile/README.md)
 
 ### Quorum Shared Migration
+- [Icon-picker vocabulary — implementation status & PR sequencing](tasks/quorum-shared-migration/2026-06-12-icon-picker-PR-notes.md)
+- [Promote the icon-picker vocabulary to quorum-shared](tasks/quorum-shared-migration/2026-06-12-promote-icon-picker-vocabulary-to-shared.md)
 - [Cross-repo PR workflow for the quorum-shared migration](tasks/quorum-shared-migration/cross-repo-workflow.md)
-- [Mobile tasks pending](tasks/quorum-shared-migration/mobile-tasks-pending.md)
-- [Promote icon-picker vocabulary to quorum-shared](tasks/quorum-shared-migration/2026-06-12-promote-icon-picker-vocabulary-to-shared.md)
+- [Mobile tasks pending — the unified tracker](tasks/quorum-shared-migration/mobile-tasks-pending.md)
 - [Quorum Shared Migration — Master Tracker](tasks/quorum-shared-migration/README.md)
 - [Quorum-shared migration — roadmap](tasks/quorum-shared-migration/roadmap.md)
 - [Quorum-shared migration — shipped log](tasks/quorum-shared-migration/shipped-log.md)
@@ -435,7 +439,13 @@ This is the main index for all documentation, bug reports, and task management.
 - [SpacesSidebar Polish — Implementation Plan (Track D, expanded)](tasks/.done/2026-06-03-spaces-sidebar-polish-plan.md)
 - [Bookmarks page in NavRail](tasks/.done/2026-06-04-bookmarks-page.md)
 - [Docs refresh after new-UI shell migration](tasks/.done/2026-06-04-docs-refresh-after-new-ui-shell.md)
+- [Implementation plan — Notification settings UX alignment](tasks/.done/2026-06-07-align-notification-settings-with-mobile-plan.md)
+- [Align notification settings UX between desktop and mobile](tasks/.done/2026-06-07-align-notification-settings-with-mobile.md)
 - [Consolidate desktop invite system with mobile](tasks/.done/2026-06-07-consolidate-invite-system-with-mobile.md)
+- [`useDMMute` and `useDMFavorites` read stale config from messageDB](tasks/.done/2026-06-07-dm-mute-cache-read.md)
+- [Add a real global notifications mute to desktop](tasks/.done/2026-06-07-global-notifications-mute.md)
+- [Fix `joinInviteLink` — public invite join is broken end-to-end](tasks/.done/2026-06-08-fix-join-invite-link.md)
+- [Space message list: missing name/avatar](tasks/.done/2026-06-10-space-message-list-public-profile-fallback.md)
 - [AccentColorSwitcher Cross-Platform Migration + Persistence](tasks/.done/accent-color-switcher-cross-platform-migration.md)
 - [Add Context to Desktop Notifications](tasks/.done/rich-desktop-notifications-context.md)
 - [Add DM-Specific Action Queue Handlers](tasks/.done/dm-action-queue-handlers.md)
@@ -625,4 +635,4 @@ This is the main index for all documentation, bug reports, and task management.
 
 ---
 
-**Last Updated**: 2026-06-07 17:48:27
+**Last Updated**: 2026-06-13 11:05:15

--- a/.agents/INDEX.md
+++ b/.agents/INDEX.md
@@ -635,4 +635,4 @@ This is the main index for all documentation, bug reports, and task management.
 
 ---
 
-**Last Updated**: 2026-06-13 11:05:15
+**Last Updated**: 2026-06-13 11:53:23

--- a/.agents/INDEX.md
+++ b/.agents/INDEX.md
@@ -119,6 +119,7 @@ This is the main index for all documentation, bug reports, and task management.
 - [UserSettingsModal fields flash empty on open](bugs/2026-06-08-user-settings-modal-fields-flash-empty-on-open.md)
 - [@everyone owner-bypass is a real propagating bug (send-side-only enforcement)](bugs/2026-06-12-everyone-mention-owner-bypass-send-side-only.md)
 - [Read-only channel receive-side enforcement is incomplete](bugs/2026-06-12-readonly-channel-receive-side-enforcement-gaps.md)
+- [Desktop shows stale synced config until restart](bugs/2026-06-13-config-not-refetched-stale-until-restart.md)
 - [Space members show truncated address — no `space_members` row](bugs/2026-06-13-space-members-missing-no-join-row.md)
 
 ### Solved Issues
@@ -635,4 +636,4 @@ This is the main index for all documentation, bug reports, and task management.
 
 ---
 
-**Last Updated**: 2026-06-13 11:53:23
+**Last Updated**: 2026-06-13 12:21:41

--- a/.agents/INDEX.md
+++ b/.agents/INDEX.md
@@ -636,4 +636,4 @@ This is the main index for all documentation, bug reports, and task management.
 
 ---
 
-**Last Updated**: 2026-06-13 12:21:41
+**Last Updated**: 2026-06-13 12:27:46

--- a/.agents/bugs/2026-01-09-config-sync-space-loss-race-condition.md
+++ b/.agents/bugs/2026-01-09-config-sync-space-loss-race-condition.md
@@ -151,6 +151,22 @@ The filtering logic **cannot simply be removed** - it was added to fix a differe
 
 See: [.agents/bugs/.solved/space-creation-config-save-race-condition.md](.agents/bugs/.solved/space-creation-config-save-race-condition.md)
 
+## Hub-log migration impact (2026-06-13)
+
+The incoming desktop **hub log** (mobile's durable, replay-on-reconnect transport;
+see [2026-06-13-space-members-missing-no-join-row.md](2026-06-13-space-members-missing-no-join-row.md)
+and [2026-06-13-config-not-refetched-stale-until-restart.md](2026-06-13-config-not-refetched-stale-until-restart.md))
+**does NOT fix the core of this bug.** The destructive part is `saveConfig`'s
+filter-and-overwrite logic, which drops spaces lacking complete local encryption state —
+that needs the merge/tombstone fix (Option A below) regardless of transport.
+
+What the hub log *does* change: it narrows the failure surface. This race partly depends
+on space sync being a fragile one-shot at startup ("space sync can fail silently mid-loop").
+A durable, replayable log makes the *delivery* of space-sync data more robust and retryable,
+shrinking the window in which a space is left "partially synced" and therefore filtered out.
+So the hub log reduces how often the race fires, but the `saveConfig` merge fix is still
+required to make it non-destructive. Do not treat the hub log as a substitute for Option A.
+
 ## Solution Options
 
 **Not yet implemented.** Requires architectural decision:

--- a/.agents/bugs/2026-05-30-user-settings-modal-stale-display-name.md
+++ b/.agents/bugs/2026-05-30-user-settings-modal-stale-display-name.md
@@ -49,3 +49,15 @@ The 2026-05-30 AES-GCM config-decrypt dedup refactor (commit on `session/2026-05
 ## Priority
 
 Low — cosmetic on the modal, doesn't block messaging or sync. But it's confusing UX (user thinks their change didn't propagate).
+
+## Hub-log migration impact (2026-06-13)
+
+Same "stale until something forces a re-read" family as
+[2026-06-13-config-not-refetched-stale-until-restart.md](2026-06-13-config-not-refetched-stale-until-restart.md).
+Here the synced value already reaches this client (channel views render it), so the hub
+log does NOT fix this bug — the gap is a missing React-Query invalidation on the modal's
+source. BUT the fix is likely shared: a hub-log-driven `invalidateQueries(buildConfigKey)`
+on an incoming config-sync signal would re-read the modal's source at the same time it
+fixes the stale-config bug. Worth fixing the two together once the config-refetch trigger
+exists, rather than patching the modal in isolation. Cross-link:
+[config-not-refetched-stale](2026-06-13-config-not-refetched-stale-until-restart.md).

--- a/.agents/bugs/2026-06-12-readonly-channel-receive-side-enforcement-gaps.md
+++ b/.agents/bugs/2026-06-12-readonly-channel-receive-side-enforcement-gaps.md
@@ -52,6 +52,24 @@ if (!isDM && isPostMessage) {
 2. **Enforce in BOTH paths.** Add the read-only validation to `saveMessage` (disk) as well as `addMessage` (cache), so a dropped message doesn't resurrect on refetch. Factor the check into a shared helper to avoid drift between the two paths — ideally reuse `quorum-shared`'s `canManageReadOnlyChannel` / `createChannelPermissionChecker(...).canPostMessage()` (no owner bypass, exactly this rule).
 3. Keep fail-secure semantics (no space/channel data → drop).
 
+## Hub-log migration impact (2026-06-13) — RAISES PRIORITY
+
+The incoming desktop **hub log** (mobile's durable transport, replayed via `log-since` on
+every reconnect/foreground; see
+[2026-06-13-space-members-missing-no-join-row.md](2026-06-13-space-members-missing-no-join-row.md))
+makes this bug **worse and more urgent**, not better. Today the "reappears on the next
+refetch from storage" resurrection is intermittent (remount/invalidate/navigate). Under a
+hub log that **replays every message on every reconnect**, the offending sticker/embed/post
+is re-delivered and — because the durable `saveMessage` path has no read-only check — re-
+persisted on each reconnect. The gap goes from occasional to reliably exercised.
+
+This puts the bug in the same "make receive handlers replay-safe before the hub log lands"
+category as the control-handler audit in
+[2026-06-13-space-members-missing-no-join-row.md](2026-06-13-space-members-missing-no-join-row.md).
+The fix (enforce in BOTH `addMessage` and `saveMessage`, cover all postable content types)
+is effectively a **prerequisite** for the hub-log migration to be safe. Consider bumping
+this above its current implicit priority and sequencing it with the migration prep.
+
 ## Note
 
 Mobile is being implemented WITHOUT these gaps (all content types, both live + batch receive paths, durable). This desktop bug should be brought to parity — ideally both consume the same shared `canManageReadOnlyChannel` check on receipt so the rule can't drift per-type or per-path.

--- a/.agents/bugs/2026-06-13-config-not-refetched-stale-until-restart.md
+++ b/.agents/bugs/2026-06-13-config-not-refetched-stale-until-restart.md
@@ -1,0 +1,112 @@
+---
+type: bug
+title: "Desktop shows stale synced config (e.g. public-profile toggle) until restart — config only server-fetched at startup"
+status: open
+created: 2026-06-13
+severity: medium
+repo: quorum-desktop
+root-cause: "Desktop's useConfig query reads IndexedDB only (buildConfigFetcher -> messageDB.getUserConfig; never the network). The only path that pulls the latest config from the server into IndexedDB is ConfigService.getConfig, which runs essentially once at app startup (RegistrationPersister). There is no periodic / foreground / websocket-driven config refetch. So a config change made on another device (e.g. mobile) reaches the server but desktop keeps serving its stale cached value until a restart."
+is-real-root-cause-of: "quorum-mobile .agents/bugs/2026-06-10-isprofilepublic-not-syncing-mobile-to-desktop.md"
+---
+
+# Desktop shows stale synced config until restart
+
+> Repo: **quorum-desktop** (filed from the mobile .agents while investigating the mobile-side
+> profile-sync work, since the sibling bug was originally filed here). This is the **real**
+> root cause of `2026-06-10-isprofilepublic-not-syncing-mobile-to-desktop.md`, which had
+> previously been mis-diagnosed as a missing mobile read-back bridge.
+
+## Symptom
+
+A synced config value changed on one device (e.g. the public-profile toggle, bio, device
+names, mute/favorite settings) does not appear on desktop until desktop is restarted
+(or, as the user observed, a full hard reset / re-import). On a long-lived app where users
+essentially never re-login, this means cross-device config changes effectively never
+reflect on desktop in practice.
+
+Concretely reported: mobile toggles `isProfilePublic` ON → server profile is published →
+desktop User Settings still shows OFF.
+
+## Root cause (verified in desktop source 2026-06-13)
+
+1. **The config query reads local storage only, never the network.**
+   `src/hooks/queries/config/useConfig.ts` runs `buildConfigFetcher`, whose `queryFn` is just
+   `messageDB.getUserConfig({ address })` — an IndexedDB read. The file even comments
+   `networkMode: 'always' // This query uses IndexedDB, not network`. So `useConfig` can only
+   ever return whatever is already in IndexedDB.
+
+2. **Only `ConfigService.getConfig` pulls fresh config from the server**, and it does so
+   correctly (server `getUserSettings` + timestamp LWW vs the stored copy, writing the newer
+   one to IndexedDB). But its runtime caller is startup/registration
+   (`src/components/context/RegistrationPersister.tsx` → `MessageDB.getConfig`). There is **no**
+   periodic refetch, no `refetchInterval`, no window-focus refetch, and no websocket-driven
+   `invalidateQueries(buildConfigKey(...))` when a config-sync arrives.
+
+3. **The settings screen also short-circuits on the cached query value.**
+   `src/hooks/business/user/useUserSettings.ts:140-143`:
+   ```ts
+   if (cachedConfig) { applyConfig(cachedConfig); return; }
+   ```
+   So even reopening Settings reuses the cached (stale) config rather than forcing a fresh
+   server pull.
+
+Net effect: after desktop has started, nothing refreshes config from the server, so a
+cross-device change is invisible until a restart re-runs the startup fetch.
+
+## Why mobile is NOT the cause
+
+- Mobile sends `isProfilePublic` to the synced config correctly (`updateProfile` →
+  `configUpdates.isProfilePublic` → `saveConfig`).
+- Desktop reads `isProfilePublic` from config correctly (`useUserSettings` line 133).
+- The only gap is desktop's refetch cadence. quorum-mobile PR #81 (the read-back bridge)
+  addresses the reverse direction and does not touch this.
+
+## Hub-log migration impact (2026-06-13)
+
+This bug is the same root-cause class as
+[2026-06-13-space-members-missing-no-join-row.md](2026-06-13-space-members-missing-no-join-row.md):
+**desktop fetches state once at startup and never reconciles after** (rosters there,
+synced config here). The lead dev is bringing mobile's durable **hub log** to desktop —
+a per-hub log replayed via `log-since` on every reconnect/foreground. That migration IS
+the delivery vehicle for Option 1 below: a config-sync / settings-update signal replayed
+over the hub log is exactly the websocket-driven trigger this bug needs. Once it lands,
+the fix collapses to "on that replayed signal, `ConfigService.getConfig` →
+`useInvalidateConfig()`" — no bespoke refetch transport required. Options 2 and 3 below
+become throwaway band-aids on a transport the hub log replaces; do not build them ahead
+of the migration. Sequence this bug's fix WITH the hub-log work, not before it.
+
+## Suggested fix direction (desktop)
+
+Add a trigger that refreshes config from the server after startup, then invalidates the
+config query so the UI re-reads it. Options (lead-dev call):
+
+1. **Websocket-driven (best — and the hub-log migration provides this):** when a
+   config-sync / settings-update signal arrives over the hub websocket (i.e. is replayed
+   by the incoming hub log), call `ConfigService.getConfig` (server fetch → IndexedDB)
+   then `useInvalidateConfig()` so `useConfig` re-reads. Real-time, no polling.
+2. **On window focus / app foreground:** re-run the server fetch + invalidate when the desktop
+   window regains focus. Cheap, covers the "I changed it on my phone then came back to my
+   desktop" case. (Superseded by Option 1 once the hub log lands.)
+3. **Periodic:** a modest `refetchInterval` or a timer that re-runs the server fetch. Simplest,
+   but polling. (Superseded by Option 1 once the hub log lands.)
+
+Also reconsider the `useUserSettings` `cachedConfig` short-circuit (line 140-143) so opening
+Settings can force a fresh pull, or so it re-reads after an invalidation.
+
+## Verification (once fixed)
+
+- [ ] With both clients open, toggle public profile on mobile → desktop reflects it without a
+      restart (within the chosen refresh window).
+- [ ] Toggle OFF on mobile → desktop reflects OFF (change propagates, not just blank-fill).
+- [ ] Same for bio and other synced config fields (device names, mute/favorite).
+
+## Related
+
+- Real root cause of: quorum-mobile `.agents/bugs/2026-06-10-isprofilepublic-not-syncing-mobile-to-desktop.md`
+- Mobile reverse-direction bridge: quorum-mobile PR #81 (`fix/profile-settings-sync-mobile-to-desktop`)
+- Sibling work: quorum-mobile `.agents/tasks/2026-06-10-primary-username-sync-and-publish.md`
+- Desktop files: `src/hooks/queries/config/{useConfig,buildConfigFetcher,useInvalidateConfig}.ts`, `src/hooks/business/user/useUserSettings.ts`, `src/components/context/RegistrationPersister.tsx`, `src/services/ConfigService.ts`
+
+---
+
+*Last updated: 2026-06-13*

--- a/.agents/bugs/2026-06-13-space-members-missing-no-join-row.md
+++ b/.agents/bugs/2026-06-13-space-members-missing-no-join-row.md
@@ -178,6 +178,17 @@ adopting (a slice of) mobile's durable hub-log catch-up on desktop, OR adding a
 desktop periodic/on-reconnect re-sync, OR an owner periodic roster re-broadcast.
 Each is an architecture decision with a cross-platform / wire-format dimension.
 **Raise with the lead dev (Telegram, per project convention) before building.**
+
+**Already tracked:** this is candidate **#32 "Hub-log sync transport (replace
+desktop P2P)"** in
+[port-from-mobile/candidates.md](../tasks/port-from-mobile/candidates.md) —
+surfaced 2026-06-11, parked as a lead-dev call, with a verified ~4-8 eng-day
+scope (port `buildListenHubFrame`/`buildLogSinceFrame` + cursor store + ingest;
+delete `SyncService.ts` + the 7 sync-* handlers + the `requestSync` loop), the
+privacy tradeoff (server retains the sealed log vs P2P device-only history), and
+two infra unknowns. This bug is the concrete user-facing symptom that motivates
+#32. The control-handler replay audit below is the receive-side prep that #32
+needs regardless of direction.
 Candidate approaches, by risk:
 - Desktop on-reconnect `requestSync` (re-fire the existing mechanism on every
   WS (re)connect, not just join+startup) — smallest change, stays within the

--- a/.agents/bugs/2026-06-13-space-members-missing-no-join-row.md
+++ b/.agents/bugs/2026-06-13-space-members-missing-no-join-row.md
@@ -220,6 +220,44 @@ transport divergence in Fix 3, which is unaddressed pending lead-dev input.
 Do not move to `.solved/` until the symptom no longer reproduces via the
 diagnostic below.
 
+## Control-handler replay audit (for the hub-log migration)
+
+The lead dev is bringing the durable **hub log** to desktop (mobile already has
+it). On adoption it will replay ALL past space control messages through the
+existing receive handlers on every reconnect. Any handler that bails or
+null-derefs when the sender/target has no `space_members` row will silently drop
+or crash on replayed messages for members whose `join` was missed — the same
+trap Fixes 1+2 close for `update-profile` and the non-repudiability check.
+
+Full audit of `MessageService.ts` space/group receive handlers (2026-06-13):
+
+**Already upsert-safe (no action):** `join` (`:3246`), `update-profile`
+new-session (`:1262`) + established (`:1783`, fixed here), `sync-members`
+(`:4023`), `sync-delta` member section (`:4325`), non-repudiability check
+(`:3178`, fixed here).
+
+**Must fix for the hub-log migration:**
+- `verify-kicked` (`:4093`) — `if (member)` guard means `isKicked: true` is never
+  persisted for a member with no row → a kicked member can appear live after
+  replay. Upsert `{ user_address, isKicked: true, inbox_address: '' }` when null.
+- `leave` (`:3585`) — searches `getSpaceMembers()` by `inbox_address`; if the
+  leaver has no row, the whole handler (incl. the "X left" system message) is
+  skipped. Also `space!` deref at `:3632` is unguarded.
+
+**Should fix (defensive):**
+- `kick` other-member path (`:3911`) — `if (kicked)` guard skips the tombstone
+  when no row exists; a kicked member could render live after replay.
+- `space!` non-null assertions in `join` (`:3329`), `rekey` (`:3736/3753/3760`),
+  `leave` (`:3632`) — throw if the space row is missing locally (swallowed by the
+  outer catch `:4372`). Guard with an early `if (!space) return`.
+
+**Fine to leave bailing:** `mute`/`unmute`, `pin`/`unpin`, `reaction`,
+`edit`/`remove-message` — these depend on the target message or `space.roles`,
+not a member row (their replay concern is message ordering, a separate matter).
+
+This audit is read-only context for the hub-log work; none of these are changed
+by the current PR (#199), which scopes only `update-profile` + the null-guard.
+
 ## How to reproduce / diagnose
 
 1. Open the affected space in the app.

--- a/.agents/bugs/2026-06-13-space-members-missing-no-join-row.md
+++ b/.agents/bugs/2026-06-13-space-members-missing-no-join-row.md
@@ -1,0 +1,174 @@
+---
+type: bug
+title: "Space members show truncated address — no space_members row (join broadcast never arrived)"
+status: open
+priority: high
+ai_generated: false
+created: 2026-06-13
+updated: 2026-06-13
+related_docs:
+  - ".agents/docs/debugging/dm-architecture-and-debug-playbook.md"
+  - ".agents/tasks/.done/2026-06-10-space-message-list-public-profile-fallback.md"
+  - ".agents/tasks/.done/per-space-profile-data-flow-analysis.md"
+related_files:
+  - "src/services/MessageService.ts"
+  - "src/hooks/business/user/useMembersWithPublicProfileFallback.ts"
+related_tools:
+  - ".agents/tools/dm-debug/06-space-member-sources.js"
+---
+
+# Space members show truncated address — no `space_members` row
+
+## Symptom
+
+In a space channel's message list, many senders render as a 6-char truncated
+address with an initials-only avatar instead of their real name/pfp — even
+though they have joined the space AND posted many messages. The earlier
+public-profile-fallback fix (PR #191) does not help them.
+
+## Root cause (confirmed by live diagnostic, 2026-06-13)
+
+**These senders have no row in `space_members` at all.** Their `join` control
+message never reached this client (offline at join time, dropped broadcast, or
+joined-before-us with no historical replay). Identity is therefore unresolvable
+and the render falls back to `senderId.slice(-6)`.
+
+### Live evidence
+
+Diagnostic `.agents/tools/dm-debug/06-space-member-sources.js` run against test
+space `QmZM3AKwKfMprQZvSk3Mpgii2JS31TS5izHrwJe1itprrG` ("Quorum Test 2"):
+
+- **89 distinct senders** have posted messages.
+- **46 of them (52%) have NO `space_members` row** — including every
+  truncated-address user from the reported screenshot (E9AouU, teSNCf, eH6cNY,
+  XHUczm, plus high-volume posters CRcRk8=64 msgs, eH6cNY=63, XHUczm=38).
+- The 43 "has row" senders are the ones whose `join` did arrive.
+- The space's `space_members` table has 69 rows but 89 senders posted — even the
+  rows present don't cover everyone active.
+
+### Why normal message traffic does NOT recover identity
+
+`space_members` is only ever WRITTEN by three paths, none triggered by receiving
+a normal `post`:
+
+1. `join` control message → `MessageService.ts:3246` creates the row.
+2. `update-profile` → only *updates* an existing row. On the established-session
+   path (`MessageService.ts:1783`) it `return`s early if the row is missing.
+   (The new-session path `MessageService.ts:1262` was already fixed to upsert.)
+3. `sync-members` / roster sync from owner → `MessageService.ts:4023`, `:4301`.
+
+The regular message-receive path (`MessageService.ts:3154`) only READS
+`space_members` to verify the sender's signature (non-repudiability). It never
+writes identity. So a sender with a missing row posts forever as a truncated
+address.
+
+### Latent secondary bug: null-deref on non-repudiable spaces
+
+At `MessageService.ts:3178`, the non-repudiability check reads
+`participant.inbox_address` with **no null guard**:
+
+```ts
+const participant = await this.messageDB.getSpaceMember(space.spaceId, decryptedContent.content.senderId);
+// ...
+const inboxMismatch =
+  !isUpdateProfile &&
+  participant.inbox_address !== inboxAddress &&   // participant may be null
+  participant.inbox_address;
+```
+
+When `participant` is null (the 46-sender case) AND the space is
+non-repudiable (`!space.isRepudiable`, line 3150), this throws a TypeError.
+The throw propagates to the outer catch at `MessageService.ts:4348`
+(`'Error processing hub/sync message'`), which logs and swallows it — so on a
+**non-repudiable space these senders' messages are silently dropped entirely.**
+
+The reported space renders the messages (truncated name) because it is
+**repudiable** — the `!space.isRepudiable` guard is false, the block is skipped,
+no deref. So the visible symptom (truncated name) and the latent symptom
+(dropped message) depend on the space's repudiability setting.
+
+## Why this is the transport/sync gap, not a render bug
+
+This is the same unsolved cluster flagged in the DM playbook ("Known sync issues
+— NOT yet fixed"): control-message delivery between clients is unreliable. The
+`join` broadcasts for half the roster never landed. The public-profile fallback
+(PR #191) can't help because it enriches *existing* rows — with no row, there's
+nothing to enrich.
+
+## Mobile parity check (2026-06-13)
+
+Investigated `quorum-mobile` `context/WebSocketContext.tsx` to see whether
+mobile already solves this, since desktop changes must not diverge from mobile
+on shared protocol behaviour.
+
+**Mobile is identical to desktop on the core gap: a plain `post`/`embed`/`sticker`
+NEVER writes `space_members`** (mobile live path lines 2067-2148, batch path
+3291-3335 — zero `saveSpaceMember` calls; they only READ a member row to build a
+notification preview). Mobile also has no signature-verification-driven
+inbox-address derivation that would seed a row from a raw post. So the
+"upsert-from-message-traffic" idea would be a desktop-only divergence, not a
+parity fix — **do NOT pursue it as the primary fix.**
+
+**Mobile IS ahead of desktop on one path:** its `update-profile` handler is a
+true upsert. When no member row exists (join missed), it creates one with
+`inbox_address: ''` rather than bailing. Mobile live path
+`WebSocketContext.tsx:1925-1985`, batch path `:3195-3241`, with an explicit
+comment naming the "join control was missed" recovery case. Desktop only has
+this upsert on the new-session path (`MessageService.ts:1262`); the
+established-session path (`:1783`) still bails. **This is the real parity gap to
+close.**
+
+Mobile's render-time recovery is the same as desktop's: `useMembersWithPublicProfileFallback`
+(`hooks/useMembersWithPublicProfileFallback.ts`) — render-only, no MMKV
+write-back. Field convention on mobile: `address` / `profile_image` (vs desktop
+`user_address` / `user_icon`); storage key `spaceMembers:<spaceId>` in MMKV.
+
+## Proposed fix (revised after mobile check)
+
+### Fix 1 (parity, do this): apply the line-1262 upsert to line 1783
+
+Desktop's established-session `update-profile` handler (`MessageService.ts:1783`)
+bails with `if (!participant) return`. Mirror the new-session upsert at
+`:1262` (and mobile's `:1925`) so a profile update from a sender whose `join`
+was missed CREATES the row instead of dropping the update. This is a true
+cross-platform parity fix, low-risk, and directly recovers identity for the
+affected users the moment they next save their profile.
+
+### Fix 2 (correctness, do this): null-guard line 3178
+
+`participant.inbox_address` at `MessageService.ts:3178` derefs a possibly-null
+`participant`. On a non-repudiable space this throws and the message is silently
+dropped (swallowed at the outer catch, `:4348`). Guard with
+`participant?.inbox_address`. Independent of Fix 1; fixes the message-dropping
+regression on non-repudiable spaces. Mobile does not have this bug because it
+does not do desktop's inbox-from-publicKey derivation in the receive path.
+
+### Fix 3 (deeper, needs design + lead-dev input): reliable `join`/roster delivery
+
+The root cause is that ~half the `join` broadcasts never arrive — the unsolved
+control-message transport gap (same cluster as the DM non-delivery issue). The
+robust fix is making join/`sync-members` delivery reliable, OR an owner-side
+periodic roster re-broadcast, OR a peer "request roster" pull. This is the only
+fix that recovers name+avatar for a silent member who never re-saves their
+profile. It is NOT client-render-side and should be raised with the lead dev
+(Telegram, per project convention) rather than patched unilaterally.
+
+### Explicitly NOT doing: upsert `space_members` from raw message traffic
+
+Considered (would seed an inbox-only row from a verified post) and rejected:
+(a) mobile doesn't do it → desktop-only divergence on shared protocol state;
+(b) it writes canonical membership state from a derived source, the same
+correctness risk the PR #191 task already rejected for write-through;
+(c) it only seeds inbox+address, still no name/avatar from a `post`, so the
+user-visible win is marginal over Fix 1 + the existing public-profile fallback.
+
+## How to reproduce / diagnose
+
+1. Open the affected space in the app.
+2. DevTools console (log level "All levels"), paste
+   `.agents/tools/dm-debug/06-space-member-sources.js`.
+3. `__spaceMissingSenders('<spaceId>')` — lists senders with no member row.
+4. `__spaceMemberSources('<spaceId>')` — classifies existing rows by source.
+
+---
+*Last updated: 2026-06-13*

--- a/.agents/bugs/2026-06-13-space-members-missing-no-join-row.md
+++ b/.agents/bugs/2026-06-13-space-members-missing-no-join-row.md
@@ -145,13 +145,47 @@ does not do desktop's inbox-from-publicKey derivation in the receive path.
 
 ### Fix 3 (deeper, needs design + lead-dev input): reliable `join`/roster delivery
 
-The root cause is that ~half the `join` broadcasts never arrive — the unsolved
-control-message transport gap (same cluster as the DM non-delivery issue). The
-robust fix is making join/`sync-members` delivery reliable, OR an owner-side
-periodic roster re-broadcast, OR a peer "request roster" pull. This is the only
-fix that recovers name+avatar for a silent member who never re-saves their
-profile. It is NOT client-render-side and should be raised with the lead dev
-(Telegram, per project convention) rather than patched unilaterally.
+Root cause now characterized (investigation 2026-06-13): **desktop and mobile
+use different transports for space control messages, and mobile's is
+self-healing while desktop's is not.**
+
+**Desktop (broken):** `join` / `update-profile` are ephemeral hub *group
+broadcasts*, fire-and-forget (`InvitationService.ts:848`, sealed via
+`SpaceService.ts:1201`). No durable replay. An existing member offline at
+broadcast time misses the `join` permanently. The only recovery is a one-shot
+`requestSync` (`SyncService.ts`) with a **30-second** acceptance window
+(`MessageService.ts:3961`), fired only on join (`InvitationService.ts:860`) and
+once on startup with a 10s delay (`MessageDB.tsx:528`). Miss that window and the
+rosters never reconcile. There is no `getHub` poll, no periodic re-sync, and
+`join`/`requestSync` are NOT in the durable ActionQueue (they use ephemeral
+`enqueueOutbound`, `WebsocketProvider.tsx:222`, lost on refresh). Secondary
+silent-failure: `js_verify_point` on a stale ratchet drops a received `join`
+with only `console.error` (`MessageService.ts:3243`), and non-owner
+`sync-members` is dropped unless an active 30s sync session exists
+(`MessageService.ts:4024`).
+
+**Mobile (self-healing):** uses a durable **hub log**. On every reconnect /
+foreground (`AppState` active), it issues `log-since` from a stored cursor and
+replays ALL missed `join`/`update-profile` control messages through the same
+member-writing pipeline (`WebSocketContext.tsx:4121-4248`, `hubLogSync.ts`,
+`hubLogCursor.ts`). It also re-broadcasts `update-profile` on every connect
+(`WebSocketContext.tsx:4270-4345`), and its receive handler upserts a row even
+with no prior `join` (`:1953-2023`). A mobile client that missed a join heals on
+next connect; desktop has no equivalent.
+
+So this is NOT a "mirror the DM fix" tweak and NOT a small client patch — it is
+adopting (a slice of) mobile's durable hub-log catch-up on desktop, OR adding a
+desktop periodic/on-reconnect re-sync, OR an owner periodic roster re-broadcast.
+Each is an architecture decision with a cross-platform / wire-format dimension.
+**Raise with the lead dev (Telegram, per project convention) before building.**
+Candidate approaches, by risk:
+- Desktop on-reconnect `requestSync` (re-fire the existing mechanism on every
+  WS (re)connect, not just join+startup) — smallest change, stays within the
+  existing sync protocol, no new wire type. Likely the safest first step.
+- Desktop `update-profile` re-broadcast on connect (mirrors mobile F2) — pairs
+  with Fix 1's upsert to heal rosters without a new transport.
+- Full hub-log catch-up parity with mobile — largest, most robust, biggest blast
+  radius.
 
 ### Explicitly NOT doing: upsert `space_members` from raw message traffic
 
@@ -161,6 +195,30 @@ Considered (would seed an inbox-only row from a verified post) and rejected:
 correctness risk the PR #191 task already rejected for write-through;
 (c) it only seeds inbox+address, still no name/avatar from a `post`, so the
 user-visible win is marginal over Fix 1 + the existing public-profile fallback.
+
+## Implementation status
+
+**Partial mitigation landed** on branch `fix/space-member-upsert-and-null-guard`
+(commit `05f04c8c`):
+
+- **Fix 1 (done):** `update-profile` established-session handler
+  (`MessageService.ts:1783`) now upserts a missing `space_members` row instead
+  of bailing on `!participant`. Mirrors the new-session handler (`:1262`) and
+  mobile (`WebSocketContext.tsx:1925`).
+- **Fix 2 (done):** null-guarded `participant?.inbox_address` at
+  `MessageService.ts:3178`, preventing the silent message-drop on non-repudiable
+  spaces.
+- Verified: `npx tsc --noEmit --skipLibCheck` clean; `eslint` on the file clean
+  (0 errors; 2 pre-existing warnings unrelated to the change).
+
+**Bug remains `open`** — Fixes 1+2 are correct and ship-worthy but do NOT resolve
+the reported symptom. Fix 1 only recovers identity when a missing member *next
+saves their profile*, and desktop (unlike mobile) does not re-broadcast profiles
+on reconnect, so a silent member's row still never appears. The headline symptom
+(joined + posted members showing as truncated addresses) is caused by the
+transport divergence in Fix 3, which is unaddressed pending lead-dev input.
+Do not move to `.solved/` until the symptom no longer reproduces via the
+diagnostic below.
 
 ## How to reproduce / diagnose
 

--- a/.agents/docs/debugging/dm-architecture-and-debug-playbook.md
+++ b/.agents/docs/debugging/dm-architecture-and-debug-playbook.md
@@ -163,6 +163,44 @@ If the send fires but receive is silent:
 - **Using `?? fallback` against possibly-empty-string envelope fields.** `??` only catches null/undefined. Use `||` or explicit `value && value.length > 0` when you're guarding against empty string.
 - **`React.useCallback([])` for the broadcast trigger.** Stale closures via HMR look exactly like "my new log isn't printing" and waste hours.
 
+## The "fetch-once-at-startup" pattern and the hub-log migration (2026-06-13)
+
+A recurring desktop architecture flaw underlies a whole cluster of bugs: **desktop
+fetches state once at startup (or on a one-shot event) and never reconciles after.**
+There is no durable, replay-on-reconnect catch-up. Whatever you miss while offline — or
+whatever changes on another device after your startup fetch — stays stale until a
+restart. Mobile does NOT have this problem: it uses a per-hub **durable log**, replayed
+via `log-since` on every reconnect/foreground (`quorum-mobile`
+`context/WebSocketContext.tsx:4121-4248`, `services/space/hubLogSync.ts`,
+`hubLogCursor.ts`), so missed `join` / `update-profile` / config-sync messages are caught
+up automatically.
+
+Confirmed instances of the pattern (all desktop):
+
+| Bug | What's fetched once and never reconciled |
+|---|---|
+| [space-members-missing-no-join-row](../../bugs/2026-06-13-space-members-missing-no-join-row.md) | Member roster — `join` is an ephemeral fire-and-forget broadcast; miss it and the row never appears (~52% missing in a live test). |
+| [config-not-refetched-stale-until-restart](../../bugs/2026-06-13-config-not-refetched-stale-until-restart.md) | Synced `UserConfig` — only server-fetched at startup; cross-device changes invisible until restart. |
+| [config-sync-space-loss-race-condition](../../bugs/2026-01-09-config-sync-space-loss-race-condition.md) | Space sync as a fragile one-shot startup loop (this also has a separate destructive `saveConfig` bug). |
+| [user-settings-modal-stale-display-name](../../bugs/2026-05-30-user-settings-modal-stale-display-name.md) | Settings modal reads a cached source not invalidated on incoming sync (same family, modal-local). |
+
+**The hub log is the general fix for this whole class.** The lead dev is bringing mobile's
+hub log to desktop. Rather than build per-bug refetch triggers (window-focus, polling,
+on-reconnect `requestSync`), the durable replay gives every one of these a single,
+reliable catch-up path. Implication for anyone touching these bugs: **don't build a
+bespoke refetch band-aid ahead of the migration** — sequence the fix WITH the hub log.
+
+**Two prerequisites the hub log needs on the receive side** (replay re-runs every handler
+on every reconnect, so any handler that bails or null-derefs on missing state silently
+drops or resurrects content):
+1. Control-message receive handlers must be upsert-safe / null-safe. Audit lives in
+   [space-members-missing-no-join-row](../../bugs/2026-06-13-space-members-missing-no-join-row.md)
+   ("Control-handler replay audit"). `update-profile` + non-repudiability fixed in PR #199;
+   `verify-kicked`, `leave`, and several `space!` derefs still need it.
+2. Durable-path enforcement must match cache-path enforcement, or replay resurrects blocked
+   content — see [readonly-channel-receive-side-enforcement-gaps](../../bugs/2026-06-12-readonly-channel-receive-side-enforcement-gaps.md)
+   (read-only check is cache-only; replay re-persists the offending message every reconnect).
+
 ## What still needs investigation
 
 - The transport-level reason DMs sometimes don't deliver. We have no theory yet.
@@ -191,4 +229,4 @@ If the send fires but receive is silent:
 - [DM Sync Non-Deterministic Failures](../../reports/action-queue/005-dm-sync-non-deterministic-failures.md) — known sync gap.
 
 ---
-*Last updated: 2026-06-10*
+*Last updated: 2026-06-13*

--- a/.agents/tasks/port-from-mobile/candidates.md
+++ b/.agents/tasks/port-from-mobile/candidates.md
@@ -210,6 +210,12 @@ The mnemonic half of #31 (see #31a in [Actionable now](#actionable-now) for the 
 - **Two unknowns that must be confirmed before any work (not answerable from desktop source):** (1) is the server-side hub-log transport **enrolled for desktop's hub addresses**? A mobile code comment says the server already dual-writes legacy `group` messages into the log, which suggests yes — but confirm at the infra layer. (2) Is hub-log the **intended convergence target**? Both are lead-dev/infra questions.
 - **Class C** (architectural shift + new transport + lead-dev coordination). Not engineering-ready until the two unknowns and the privacy tradeoff are resolved.
 - **History:** 2026-06-11 surfaced during the cold-start investigation; user explicitly won't self-pick, parked for the lead dev.
+- **2026-06-13 — this migration is the fix for a cluster of open bugs.** Confirmed (lead dev intends to bring the hub log to desktop) that #32 resolves the recurring desktop "fetch-once-at-startup, never reconcile" pattern. Bugs that depend on or are reframed by it:
+  - [space-members-missing-no-join-row](../../bugs/2026-06-13-space-members-missing-no-join-row.md) — ~52% of members have no roster row because `join` is an ephemeral one-shot broadcast (this candidate's exact P2P weakness). Includes a **control-handler replay audit** listing the receive handlers (`verify-kicked`, `leave`, several `space!` derefs) that must be made upsert/null-safe **before** the log replays every message on reconnect. PR #199 already hardened the `update-profile` + non-repudiability paths as groundwork.
+  - [config-not-refetched-stale-until-restart](../../bugs/2026-06-13-config-not-refetched-stale-until-restart.md) — hub-log replay of config-sync signals IS the websocket-driven refetch that bug needs.
+  - [config-sync-space-loss-race-condition](../../bugs/2026-01-09-config-sync-space-loss-race-condition.md) — narrows the failure surface (still needs its own `saveConfig` merge fix).
+  - [readonly-channel-receive-side-enforcement-gaps](../../bugs/2026-06-12-readonly-channel-receive-side-enforcement-gaps.md) — **prerequisite**: replay re-persists blocked content every reconnect unless durable-path enforcement is added first.
+  - Meta-pattern + the two receive-side prerequisites documented in [dm-architecture-and-debug-playbook.md](../../docs/debugging/dm-architecture-and-debug-playbook.md) ("fetch-once-at-startup pattern").
 
 ### #27 Skins (custom themes) — ❔ needs UX call (low priority 2026-06-10)
 

--- a/.agents/tools/dm-debug/06-space-member-sources.js
+++ b/.agents/tools/dm-debug/06-space-member-sources.js
@@ -1,0 +1,259 @@
+// === Quorum Space-Member Profile-Source Diagnostic ===
+// The spaces analog of 05-profile-sources.js. For a given space, prints every
+// member row in `space_members` side-by-side with:
+//   - what's stored locally  : display_name, user_icon (+ is-it-empty flag),
+//                              inbox_address presence, joinedAt
+//   - the live public-profile : display_name + profile_image presence (404 = none)
+//
+// Purpose: classify WHY a sender renders as a 6-char truncated address in a
+// space channel. Three buckets (see the dm-architecture playbook):
+//   A. NO ROW          -> their `join` broadcast never reached this client. The
+//                         deeper sync gap. Not recoverable from message traffic
+//                         (the receive path only READS space_members).
+//   B. ROW, EMPTY NAME -> row exists but display_name/user_icon never populated.
+//                         An update-profile or sync-members could fill it.
+//   C. ROW + PUBPROF   -> public profile has data the render fallback should use
+//                         (this is what PR #191 covers, render-only).
+//   D. NO PUBPROF (404)-> user never published a public profile AND no row data;
+//                         only a working join/update-profile/sync can fix it.
+//
+// Usage:
+//   1. Open the affected space/channel in the app first (so the data is loaded).
+//   2. Paste this whole file into the DevTools console and run.
+//   3. If you have more than one space, it lists them first — re-run with the
+//      target spaceId:  __spaceMemberSources('<spaceId>')
+//   4. Optionally pass a list of the truncated addresses you SEE in the UI to
+//      get a focused table:  __spaceMemberSources('<spaceId>', ['CRcRk8', ...])
+//      (match is by suffix, so the 6-char tail from the UI works directly.)
+//
+// No clipboard side effects; logs a table + the full array (also returned).
+
+window.__spaceMemberSources = async (spaceId, focusSuffixes) => {
+  const DEFAULT_ICON = '/unknown.png';
+  const UNKNOWN_NAME = 'Unknown User';
+  const apiBase =
+    window.__QUORUM_API_BASE__ || 'https://api.quorummessenger.com';
+
+  const db = await new Promise((res, rej) => {
+    const req = indexedDB.open('quorum_db');
+    req.onsuccess = () => res(req.result);
+    req.onerror = () => rej(req.error);
+  });
+
+  const all = (storeName) =>
+    new Promise((res) => {
+      try {
+        const req = db
+          .transaction(storeName, 'readonly')
+          .objectStore(storeName)
+          .getAll();
+        req.onsuccess = () => res(req.result);
+        req.onerror = () => res([]);
+      } catch {
+        res([]);
+      }
+    });
+
+  const members = await all('space_members');
+
+  // No spaceId given: list the spaces present so the caller can pick one.
+  if (!spaceId) {
+    const bySpace = {};
+    for (const m of members) {
+      (bySpace[m.spaceId] = bySpace[m.spaceId] || []).push(m);
+    }
+    const spaceList = await all('spaces').catch(() => []);
+    const nameFor = (id) =>
+      spaceList.find((s) => s.spaceId === id)?.name ?? '(unknown)';
+    console.log(
+      '%c=== Spaces present in space_members ===',
+      'color:#60a5fa;font-weight:bold;font-size:14px'
+    );
+    console.table(
+      Object.entries(bySpace).map(([id, ms]) => ({
+        spaceId: id,
+        name: nameFor(id),
+        memberRows: ms.length,
+        rowsWithName: ms.filter(
+          (m) => m.display_name && m.display_name !== UNKNOWN_NAME
+        ).length,
+        rowsWithIcon: ms.filter(
+          (m) => m.user_icon && m.user_icon !== DEFAULT_ICON
+        ).length,
+      }))
+    );
+    console.log(
+      '%cRe-run focused on one space:%c __spaceMemberSources("<spaceId>")',
+      'color:#fbbf24',
+      'color:#a3e635'
+    );
+    return Object.keys(bySpace);
+  }
+
+  let scoped = members.filter((m) => m.spaceId === spaceId);
+
+  // Optional focus on specific truncated addresses seen in the UI.
+  if (Array.isArray(focusSuffixes) && focusSuffixes.length) {
+    const tails = focusSuffixes.map((s) => String(s).toLowerCase());
+    scoped = scoped.filter((m) =>
+      tails.some((t) => String(m.user_address).toLowerCase().endsWith(t))
+    );
+  }
+
+  const rows = [];
+  for (const m of scoped) {
+    const storedIcon = m.user_icon;
+    const iconIsEmpty =
+      !storedIcon || storedIcon === '' || storedIcon === DEFAULT_ICON;
+    const nameIsPlaceholder =
+      !m.display_name || m.display_name === UNKNOWN_NAME;
+
+    let pubName = '(fetch failed)';
+    let pubHasImage = '(fetch failed)';
+    let pubStatus = '';
+    try {
+      const url = `${apiBase}/users/${m.user_address}/public-profile`;
+      const resp = await fetch(url, { credentials: 'include' });
+      pubStatus = resp.status;
+      if (resp.ok) {
+        const body = await resp.json();
+        const data = body?.data ?? body;
+        pubName = data?.display_name || '(empty)';
+        pubHasImage = data?.profile_image ? 'YES' : 'no';
+      } else if (resp.status === 404) {
+        pubName = '(no public profile)';
+        pubHasImage = 'n/a';
+      }
+    } catch {
+      pubStatus = 'ERR';
+    }
+
+    // Verdict: which bucket is this member in?
+    let bucket;
+    if (!nameIsPlaceholder && !iconIsEmpty) {
+      bucket = 'OK (row has name+icon)';
+    } else if (pubHasImage === 'YES' || pubName === '(empty)' || pubStatus === 200) {
+      bucket = 'C: pub-profile can fill (render-only fix)';
+    } else if (pubStatus === 404) {
+      bucket = 'D: no row data + no public profile (needs join/sync)';
+    } else {
+      bucket = 'B: empty row, pub-profile unverified';
+    }
+
+    rows.push({
+      address: String(m.user_address).slice(-6),
+      storedName: m.display_name ?? '(none)',
+      nameIsPlaceholder,
+      iconIsEmpty,
+      iconSample:
+        typeof storedIcon === 'string' ? storedIcon.slice(0, 32) : storedIcon,
+      hasInbox: !!m.inbox_address,
+      isKicked: !!m.isKicked,
+      joinedAt: m.joinedAt ?? '(none)',
+      pubStatus,
+      pubName,
+      pubHasImage,
+      bucket,
+    });
+  }
+
+  console.log(
+    `%c=== Space-Member Sources (space ${String(spaceId).slice(0, 12)}…, ${rows.length} rows) ===`,
+    'color:#60a5fa;font-weight:bold;font-size:14px'
+  );
+  console.table(rows);
+  console.log('Full rows:', rows);
+  console.log(
+    '%cReminder:%c "NO ROW" members (sender visible in chat but absent here) = ' +
+      'their join never reached you. List visible-but-missing addresses by ' +
+      'comparing the chat senders against this table.',
+    'color:#fbbf24',
+    'color:inherit'
+  );
+  return rows;
+};
+
+// === Companion: find senders with NO member row (bucket A) ===
+// The table above can only show rows that EXIST. A member whose `join` never
+// reached this client has no row at all, so they're invisible to it. This
+// helper reads the `messages` store for the space, collects every distinct
+// sender, and flags the ones absent from `space_members`. Those are the
+// "joined + posted but still a truncated address, unrecoverable from traffic"
+// users — the strongest evidence for the join/sync transport gap.
+//
+// Usage:  __spaceMissingSenders('<spaceId>')
+window.__spaceMissingSenders = async (spaceId) => {
+  if (!spaceId) {
+    console.log(
+      '%cPass a spaceId:%c __spaceMissingSenders("<spaceId>")  (run __spaceMemberSources() first to list them)',
+      'color:#fbbf24',
+      'color:#a3e635'
+    );
+    return;
+  }
+  const db = await new Promise((res, rej) => {
+    const req = indexedDB.open('quorum_db');
+    req.onsuccess = () => res(req.result);
+    req.onerror = () => rej(req.error);
+  });
+  const all = (s) =>
+    new Promise((res) => {
+      try {
+        const req = db.transaction(s, 'readonly').objectStore(s).getAll();
+        req.onsuccess = () => res(req.result);
+        req.onerror = () => res([]);
+      } catch {
+        res([]);
+      }
+    });
+
+  const messages = await all('messages');
+  const members = await all('space_members');
+  const memberAddrs = new Set(
+    members.filter((m) => m.spaceId === spaceId).map((m) => m.user_address)
+  );
+
+  // Distinct senders in this space's messages.
+  const senders = {};
+  for (const msg of messages) {
+    if (msg.spaceId !== spaceId) continue;
+    const id = msg.content?.senderId;
+    if (!id) continue;
+    senders[id] = (senders[id] || 0) + 1;
+  }
+
+  const rows = Object.entries(senders).map(([addr, count]) => ({
+    sender: String(addr).slice(-6),
+    fullAddress: addr,
+    messageCount: count,
+    hasMemberRow: memberAddrs.has(addr),
+    verdict: memberAddrs.has(addr)
+      ? 'has row (check 06 table for fields)'
+      : 'NO ROW — join never arrived (bucket A)',
+  }));
+  rows.sort((a, b) => Number(a.hasMemberRow) - Number(b.hasMemberRow));
+
+  const missing = rows.filter((r) => !r.hasMemberRow);
+  console.log(
+    `%c=== Senders in space ${String(spaceId).slice(0, 12)}… (${rows.length} distinct, ${missing.length} with NO member row) ===`,
+    'color:#60a5fa;font-weight:bold;font-size:14px'
+  );
+  console.table(rows);
+  if (missing.length) {
+    console.log(
+      '%c⚠ These senders posted but have NO space_members row — their join broadcast never reached this client. ' +
+        'Normal message traffic will never recover their name/avatar (the receive path only reads space_members). ' +
+        'Cross-check each against its public profile via __spaceMemberSources (they won\'t appear there since there\'s no row).',
+      'color:#f87171;font-weight:bold'
+    );
+  } else {
+    console.log(
+      '%c✅ Every sender has a member row. The truncated-address users are bucket B/C/D — check the 06 table.',
+      'color:#4ade80;font-weight:bold'
+    );
+  }
+  return rows;
+};
+
+// Auto-run: with no spaceId it prints the space picker.
+__spaceMemberSources();

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -1781,15 +1781,9 @@ export class MessageService {
         queryClient,
       });
     } else if (decryptedContent.content.type === 'update-profile') {
-      const participant = await this.messageDB.getSpaceMember(
-        spaceId,
-        decryptedContent.content.senderId
-      );
-      if (
-        !participant ||
-        !decryptedContent.publicKey ||
-        !decryptedContent.signature
-      ) {
+      // Drop unsigned messages — we can't validate authenticity or derive
+      // the inbox address without the signing key material.
+      if (!decryptedContent.publicKey || !decryptedContent.signature) {
         return;
       }
 
@@ -1797,6 +1791,28 @@ export class MessageService {
         Buffer.from(decryptedContent.publicKey, 'hex')
       );
       const inboxAddress = base58btc.baseEncode(sh.bytes);
+
+      // UPSERT: if we don't have a member record yet (joined the space after
+      // the sender sent their update, or join control was missed), create one
+      // from the profile data itself. Mirrors the new-session path above
+      // (saveMessage) and mobile WebSocketContext.tsx:1925-1985. Without this,
+      // an update-profile from a sender whose join broadcast never arrived was
+      // silently dropped, leaving every one of their messages on a truncated
+      // address with no path to recovery. See
+      // .agents/bugs/2026-06-13-space-members-missing-no-join-row.md.
+      const existing = await this.messageDB.getSpaceMember(
+        spaceId,
+        decryptedContent.content.senderId
+      );
+      const participant =
+        existing ??
+        ({
+          user_address: decryptedContent.content.senderId,
+          inbox_address: inboxAddress,
+        } as secureChannel.UserProfile & {
+          inbox_address: string;
+          isKicked?: boolean;
+        });
 
       // update-profile is itself a key rotation announcement — accept inbox address changes.
       // Signature was already verified upstream; rejecting on mismatch would permanently
@@ -3173,10 +3189,18 @@ export class MessageService {
               // The message IS the key rotation announcement, so skip inbox mismatch check.
               // For all other types: inbox mismatch invalidates the signature.
               const isUpdateProfile = decryptedContent.content.type === 'update-profile';
+              // participant may be null: the sender's join broadcast never
+              // reached us, so there is no space_members row yet (common — see
+              // .agents/bugs/2026-06-13-space-members-missing-no-join-row.md).
+              // Optional-chain the deref; a missing inbox_address means we have
+              // nothing to compare against, so there is no mismatch to flag and
+              // the signature is verified below as normal. Without the guard
+              // this threw a TypeError that the outer catch swallowed, silently
+              // dropping the message on non-repudiable spaces.
               const inboxMismatch =
                 !isUpdateProfile &&
-                participant.inbox_address !== inboxAddress &&
-                participant.inbox_address;
+                participant?.inbox_address !== inboxAddress &&
+                participant?.inbox_address;
               const messageIdMismatch =
                 decryptedContent.messageId !==
                 Buffer.from(messageId).toString('hex');


### PR DESCRIPTION
## What

Two targeted, low-risk fixes to the space message-receive path in `MessageService.ts`, plus a diagnostic and a bug report.

**Fix 1 — `update-profile` upserts a missing `space_members` row.** The established-session handler (`MessageService.ts:1783`) previously did `if (!participant) return`, silently dropping a profile update from any sender whose `join` broadcast we never received. It now upserts a minimal row, mirroring the new-session handler (`:1262`) and quorum-mobile (`WebSocketContext.tsx:1925`).

**Fix 2 — null-guard the non-repudiability inbox check.** `participant.inbox_address` at `MessageService.ts:3178` dereferenced a possibly-null `participant`. When no member row exists, this threw a `TypeError` that the outer catch swallowed, silently **dropping the message** on non-repudiable spaces. Guarded with `participant?.inbox_address`.

## Why this matters now

A live diagnostic found **~52% of senders in a test space have no `space_members` row** — their `join` broadcast never arrived (desktop uses ephemeral fire-and-forget hub broadcasts with a one-shot 30s sync window). They render as truncated addresses with no recovery path.

The proper fix is the **hub-log transport** the lead dev is bringing to desktop (mobile already has it: durable log replayed via `log-since` on every reconnect). **These two fixes are receive-side groundwork for that migration:** once the hub log replays past `update-profile` messages, Fix 1 is what lets them actually heal rosters instead of being dropped. Without it, the hub log would deliver the data and the old `!participant` bail would throw it away. Fix 2 is an independent correctness fix valid under either transport.

## Scope / non-goals

- Desktop-only; no `quorum-shared` changes; mobile unaffected.
- Does **not** resolve the headline symptom on its own — that needs the hub-log migration (tracked in the bug report). Fix 1 only recovers identity when a missing member next saves their profile, and desktop doesn't yet re-broadcast profiles on reconnect.
- A companion audit of the *other* control-message receive handlers (for the same drop-on-missing-row trap under replay) is summarized in the bug report for the hub-log work to pick up.

## Verification

- `npx tsc --noEmit --skipLibCheck` — clean
- `eslint src/services/MessageService.ts` — 0 errors (2 pre-existing warnings, unrelated)

## Docs

- Bug report: `.agents/bugs/2026-06-13-space-members-missing-no-join-row.md` (full analysis, mobile parity, root cause, control-handler audit)
- Diagnostic: `.agents/tools/dm-debug/06-space-member-sources.js`