### PR TITLE
fix(spaces): replay-safe membership handlers (kick/verify-kicked upserts + join/leave/rekey null-guards)

### DIFF
--- a/.agents/INDEX.md
+++ b/.agents/INDEX.md
@@ -636,4 +636,4 @@ This is the main index for all documentation, bug reports, and task management.
 
 ---
 
-**Last Updated**: 2026-06-13 12:35:56
+**Last Updated**: 2026-06-13 14:34:48

--- a/.agents/INDEX.md
+++ b/.agents/INDEX.md
@@ -636,4 +636,4 @@ This is the main index for all documentation, bug reports, and task management.
 
 ---
 
-**Last Updated**: 2026-06-13 14:34:48
+**Last Updated**: 2026-06-13 14:57:45

--- a/.agents/bugs/2026-06-12-readonly-channel-receive-side-enforcement-gaps.md
+++ b/.agents/bugs/2026-06-12-readonly-channel-receive-side-enforcement-gaps.md
@@ -70,6 +70,16 @@ The fix (enforce in BOTH `addMessage` and `saveMessage`, cover all postable cont
 is effectively a **prerequisite** for the hub-log migration to be safe. Consider bumping
 this above its current implicit priority and sequencing it with the migration prep.
 
+## Fixed (2026-06-13, branch `fix/control-handler-replay-safety`)
+
+Both gaps closed. A shared `isReadOnlyViolation` helper in `MessageService.ts`
+now reuses quorum-shared `canManageReadOnlyChannel` and is called from BOTH the
+cache path (`addMessage`) and the durable path (`saveMessage`), covering
+`post`/`embed`/`sticker` (no longer post-only). Fail-secure on missing
+space/channel; no owner bypass. tsc + eslint clean. Done as part of the
+receive-handler replay-safety hardening for the hub-log migration prep — see
+[2026-06-13-space-members-missing-no-join-row.md](2026-06-13-space-members-missing-no-join-row.md).
+
 ## Note
 
 Mobile is being implemented WITHOUT these gaps (all content types, both live + batch receive paths, durable). This desktop bug should be brought to parity — ideally both consume the same shared `canManageReadOnlyChannel` check on receipt so the rule can't drift per-type or per-path.

--- a/.agents/bugs/2026-06-12-readonly-channel-receive-side-enforcement-gaps.md
+++ b/.agents/bugs/2026-06-12-readonly-channel-receive-side-enforcement-gaps.md
@@ -70,15 +70,25 @@ The fix (enforce in BOTH `addMessage` and `saveMessage`, cover all postable cont
 is effectively a **prerequisite** for the hub-log migration to be safe. Consider bumping
 this above its current implicit priority and sequencing it with the migration prep.
 
-## Fixed (2026-06-13, branch `fix/control-handler-replay-safety`)
+## Attempted then reverted (2026-06-13) — defer to the hub-log migration
 
-Both gaps closed. A shared `isReadOnlyViolation` helper in `MessageService.ts`
-now reuses quorum-shared `canManageReadOnlyChannel` and is called from BOTH the
-cache path (`addMessage`) and the durable path (`saveMessage`), covering
-`post`/`embed`/`sticker` (no longer post-only). Fail-secure on missing
-space/channel; no owner bypass. tsc + eslint clean. Done as part of the
-receive-handler replay-safety hardening for the hub-log migration prep — see
-[2026-06-13-space-members-missing-no-join-row.md](2026-06-13-space-members-missing-no-join-row.md).
+A first attempt added a shared `isReadOnlyViolation` helper enforcing read-only
+on BOTH the cache and durable paths for `post`/`embed`/`sticker`. **Code review
+caught a worse failure mode and it was reverted:** the durable-path fail-secure
+reject could *permanently drop legitimate manager messages*. During sync replay
+a message can arrive before its space/channel row is loaded; the check then sees
+"no space → reject" and discards it from IndexedDB with no recovery — strictly
+worse than the resurface-on-replay bug being fixed. It also created a
+thread-reply asymmetry (`addMessage` short-circuits thread replies before the
+check; the durable path did not).
+
+**Conclusion:** the durable-path read-only enforcement must NOT fail-secure on
+not-yet-loaded space data. It belongs with the hub-log migration (#32), where
+sync/replay ordering is handled deterministically (you know when the log is
+caught up), so "space absent" can be distinguished from "genuinely not a
+manager." The cache-path enforcement remains as-is on `main` (unchanged). This
+bug stays **open** for the durable-path + sticker/embed coverage, to be done as
+part of #32.
 
 ## Note
 

--- a/.agents/bugs/2026-06-13-space-members-missing-no-join-row.md
+++ b/.agents/bugs/2026-06-13-space-members-missing-no-join-row.md
@@ -256,20 +256,29 @@ new-session (`:1262`) + established (`:1783`, fixed here), `sync-members`
 - `join` / `leave` / `rekey` — the "X joined/left/was kicked" system-message
   emission is now guarded behind a `space` null-check instead of `space!`
   assertions (which threw, and were swallowed, when the space row was absent).
-- Read-only enforcement — extracted a shared `isReadOnlyViolation` helper
-  (reuses quorum-shared `canManageReadOnlyChannel`) enforced on BOTH the cache
-  path (`addMessage`) and the durable path (`saveMessage`), covering
-  `post`/`embed`/`sticker` (was post-only + cache-only — see
-  2026-06-12-readonly-channel-receive-side-enforcement-gaps). Verified: tsc +
-  eslint clean.
+- Verified: tsc + eslint clean.
+
+**Attempted then reverted (code review):** durable-path read-only enforcement.
+A fail-secure reject on the durable path could permanently drop legitimate
+manager messages that arrive before their space row during sync replay — worse
+than the bug it fixed. Deferred to the hub-log migration (#32), where replay
+ordering is deterministic. See
+2026-06-12-readonly-channel-receive-side-enforcement-gaps.
+
+**Known limitation (pre-existing, not fixed here):** the `sync-members` cache
+merge reads `isKicked` from the React Query cache, not IndexedDB. A tombstone
+upserted this session for a previously-unknown member is correct in IndexedDB
+but may render as active in the *same session* until reload (the upsert's
+`setQueryData` maps existing entries only). Self-heals on reload. Belongs to the
+`sync-members` handler, untouched here.
 
 **Fine to leave bailing:** `mute`/`unmute`, `pin`/`unpin`, `reaction`,
 `edit`/`remove-message` — these depend on the target message or `space.roles`,
 not a member row (their replay concern is message ordering, a separate matter).
 
-With these in, the receive side is replay-safe: the hub-log migration (#32) can
-adopt the durable log without resurfacing blocked content, dropping kick/leave
-events, or null-deref'ing on a missing space row.
+With these in, the membership handlers (kick/leave/verify-kicked/join/rekey) are
+replay-safe against missing rows and null space data. Read-only durable
+enforcement remains for #32.
 
 ## How to reproduce / diagnose
 

--- a/.agents/bugs/2026-06-13-space-members-missing-no-join-row.md
+++ b/.agents/bugs/2026-06-13-space-members-missing-no-join-row.md
@@ -247,27 +247,29 @@ new-session (`:1262`) + established (`:1783`, fixed here), `sync-members`
 (`:4023`), `sync-delta` member section (`:4325`), non-repudiability check
 (`:3178`, fixed here).
 
-**Must fix for the hub-log migration:**
-- `verify-kicked` (`:4093`) — `if (member)` guard means `isKicked: true` is never
-  persisted for a member with no row → a kicked member can appear live after
-  replay. Upsert `{ user_address, isKicked: true, inbox_address: '' }` when null.
-- `leave` (`:3585`) — searches `getSpaceMembers()` by `inbox_address`; if the
-  leaver has no row, the whole handler (incl. the "X left" system message) is
-  skipped. Also `space!` deref at `:3632` is unguarded.
-
-**Should fix (defensive):**
-- `kick` other-member path (`:3911`) — `if (kicked)` guard skips the tombstone
-  when no row exists; a kicked member could render live after replay.
-- `space!` non-null assertions in `join` (`:3329`), `rekey` (`:3736/3753/3760`),
-  `leave` (`:3632`) — throw if the space row is missing locally (swallowed by the
-  outer catch `:4372`). Guard with an early `if (!space) return`.
+**Fixed directly (2nd batch, branch `fix/control-handler-replay-safety`):**
+- `verify-kicked` — now upserts a kicked tombstone (`isKicked: true`,
+  `inbox_address: ''`) when no row exists, so an address kicked before we saw
+  their join can't render as active after replay.
+- `kick` other-member path — now upserts the inactive tombstone
+  (`inbox_address: ''`) when no row exists.
+- `join` / `leave` / `rekey` — the "X joined/left/was kicked" system-message
+  emission is now guarded behind a `space` null-check instead of `space!`
+  assertions (which threw, and were swallowed, when the space row was absent).
+- Read-only enforcement — extracted a shared `isReadOnlyViolation` helper
+  (reuses quorum-shared `canManageReadOnlyChannel`) enforced on BOTH the cache
+  path (`addMessage`) and the durable path (`saveMessage`), covering
+  `post`/`embed`/`sticker` (was post-only + cache-only — see
+  2026-06-12-readonly-channel-receive-side-enforcement-gaps). Verified: tsc +
+  eslint clean.
 
 **Fine to leave bailing:** `mute`/`unmute`, `pin`/`unpin`, `reaction`,
 `edit`/`remove-message` — these depend on the target message or `space.roles`,
 not a member row (their replay concern is message ordering, a separate matter).
 
-This audit is read-only context for the hub-log work; none of these are changed
-by the current PR (#199), which scopes only `update-profile` + the null-guard.
+With these in, the receive side is replay-safe: the hub-log migration (#32) can
+adopt the durable log without resurfacing blocked content, dropping kick/leave
+events, or null-deref'ing on a missing space row.
 
 ## How to reproduce / diagnose
 

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -13,6 +13,7 @@ import {
   validateSpaceTagLetters,
   isValidSpaceTagUrl,
   hasPermission,
+  canManageReadOnlyChannel,
   SimpleRateLimiter,
   RATE_LIMITS,
 } from '@quilibrium/quorum-shared';
@@ -833,6 +834,58 @@ export class MessageService {
   }
 
   /**
+   * Returns true when an incoming message should be rejected for posting visible
+   * content (post/embed/sticker) to a read-only channel from a non-manager.
+   * Shared by the durable (saveMessage) and cache (addMessage) paths so the rule
+   * can't drift. Fail-secure: missing space/channel data → reject. Owners are not
+   * bypassed (receive side can't verify ownership), so they enforce via a manager
+   * role like everyone else, through the shared canManageReadOnlyChannel.
+   */
+  private async isReadOnlyViolation(
+    spaceId: string,
+    channelId: string,
+    decryptedContent: Message
+  ): Promise<boolean> {
+    // DMs have no channels/roles; only postable content can violate read-only.
+    const isDM = spaceId === channelId;
+    const type = decryptedContent.content.type;
+    const isPostable = type === 'post' || type === 'embed' || type === 'sticker';
+    if (isDM || !isPostable) {
+      return false;
+    }
+
+    const space = await this.messageDB.getSpace(spaceId);
+    // FAIL-SECURE: no space data → can't verify → reject.
+    if (!space) {
+      logger.warn(
+        `⚠️ Rejecting ${type} ${decryptedContent.messageId} — space ${spaceId} data unavailable`
+      );
+      return true;
+    }
+
+    const channel = space.groups
+      ?.find((g) => g.channels.find((c) => c.channelId === channelId))
+      ?.channels.find((c) => c.channelId === channelId);
+    // FAIL-SECURE: channel not found → reject.
+    if (!channel) {
+      logger.warn(
+        `⚠️ Rejecting ${type} ${decryptedContent.messageId} — channel ${channelId} not found in space ${spaceId}`
+      );
+      return true;
+    }
+
+    if (!channel.isReadOnly) {
+      return false; // not read-only → nothing to enforce
+    }
+
+    // Read-only: only manager-role members may post. isSpaceOwner is passed
+    // false because the receive side cannot verify ownership; owners enforce via
+    // a manager role like everyone else.
+    const senderId = decryptedContent.content.senderId;
+    return !canManageReadOnlyChannel(senderId, false, space, channel);
+  }
+
+  /**
    * Saves message to DB and updates query cache.
    * @param currentUserAddress - Pass current user's address when sending messages to update lastReadTimestamp
    */
@@ -1312,6 +1365,12 @@ export class MessageService {
           : undefined;
       await messageDB.saveSpaceMember(spaceId, participant);
     } else {
+      // Read-only enforcement on the durable path too, so a blocked post/embed/
+      // sticker isn't persisted (and can't resurface on a refetch/replay).
+      if (await this.isReadOnlyViolation(spaceId, channelId, decryptedContent)) {
+        return;
+      }
+
       // Check tombstone before saving - prevents deleted messages from being re-added during sync
       if (await messageDB.isMessageDeleted(decryptedContent.messageId)) {
         return;
@@ -1924,62 +1983,16 @@ export class MessageService {
         return;
       }
 
-      // Read-only channel validation - must validate BEFORE adding to cache
-      // Note: edit-message is handled earlier in the if-else chain (line ~310)
-      const isDM = spaceId === channelId;
-      const isPostMessage = decryptedContent.content.type === 'post';
-
-      if (!isDM && isPostMessage) {
-        const space = await this.messageDB.getSpace(spaceId);
-
-        // FAIL-SECURE: Reject if space data unavailable
-        if (!space) {
-          logger.warn(
-            `⚠️ Rejecting message ${decryptedContent.messageId} - space ${spaceId} data unavailable`
-          );
-          return;
-        }
-
-        // Find the target channel in space groups
-        const channel = space.groups
-          ?.find((g) => g.channels.find((c) => c.channelId === channelId))
-          ?.channels.find((c) => c.channelId === channelId);
-
-        // FAIL-SECURE: Reject if channel not found
-        if (!channel) {
-          logger.warn(
-            `⚠️ Rejecting message ${decryptedContent.messageId} - channel ${channelId} not found in space ${spaceId}`
-          );
-          return;
-        }
-
-        // Validate read-only channel permissions
-        if (channel.isReadOnly) {
-          const senderId = decryptedContent.content.senderId;
-
-          // Check if channel has manager roles configured
-          if (!channel.managerRoleIds || channel.managerRoleIds.length === 0) {
-            return;
-          }
-
-          // Check if sender is in a manager role
-          // Note: Space owners must explicitly join a manager role (privacy requirement)
-          const isChannelManager =
-            space.roles?.some(
-              (role) =>
-                channel.managerRoleIds?.includes(role.roleId) &&
-                role.members?.includes(senderId)
-            ) ?? false;
-
-          if (!isChannelManager) {
-            return;
-          }
-        }
+      // Read-only enforcement (post/embed/sticker) before adding to cache.
+      if (await this.isReadOnlyViolation(spaceId, channelId, decryptedContent)) {
+        return;
       }
 
       // Message length validation for post messages (defense-in-depth)
       // Note: text can be string | string[], must handle both
       // Edit-message validation is in the edit-message handler above (line ~310)
+      const isDM = spaceId === channelId;
+      const isPostMessage = decryptedContent.content.type === 'post';
       if (isPostMessage) {
         const text = (decryptedContent.content as PostMessage).text;
         const messageText = Array.isArray(text) ? text.join('') : text;
@@ -3321,38 +3334,44 @@ export class MessageService {
                 const space = await this.messageDB.getSpace(
                   conversationId.split('/')[0]
                 );
-                const messageId = await crypto.subtle.digest(
-                  'SHA-256',
-                  Buffer.from('join' + participant.inboxAddress, 'utf-8')
-                );
-                const msg = {
-                  channelId: space!.defaultChannelId,
-                  spaceId: conversationId.split('/')[0],
-                  messageId: Buffer.from(messageId).toString('hex'),
-                  digestAlgorithm: 'SHA-256',
-                  nonce: Buffer.from(messageId).toString('hex'),
-                  createdDate: participant.joinedAt ?? Date.now(),
-                  modifiedDate: participant.joinedAt ?? Date.now(),
-                  lastModifiedHash: '',
-                  content: {
-                    senderId: participant.address,
-                    type: 'join',
-                  } as JoinMessage,
-                } as Message;
-                await this.saveMessage(
-                  msg,
-                  this.messageDB,
-                  conversationId.split('/')[0],
-                  space!.defaultChannelId,
-                  'group',
-                  {}
-                );
-                await this.addMessage(
-                  queryClient,
-                  conversationId.split('/')[0],
-                  space!.defaultChannelId,
-                  msg
-                );
+                // Member row + ratchet state are already persisted above. The
+                // "X joined" system message needs the space's default channel, so
+                // skip it if the space row is missing (guards a null-deref under
+                // replay) rather than throwing past the rest of the handler.
+                if (space) {
+                  const messageId = await crypto.subtle.digest(
+                    'SHA-256',
+                    Buffer.from('join' + participant.inboxAddress, 'utf-8')
+                  );
+                  const msg = {
+                    channelId: space.defaultChannelId,
+                    spaceId: conversationId.split('/')[0],
+                    messageId: Buffer.from(messageId).toString('hex'),
+                    digestAlgorithm: 'SHA-256',
+                    nonce: Buffer.from(messageId).toString('hex'),
+                    createdDate: participant.joinedAt ?? Date.now(),
+                    modifiedDate: participant.joinedAt ?? Date.now(),
+                    lastModifiedHash: '',
+                    content: {
+                      senderId: participant.address,
+                      type: 'join',
+                    } as JoinMessage,
+                  } as Message;
+                  await this.saveMessage(
+                    msg,
+                    this.messageDB,
+                    conversationId.split('/')[0],
+                    space.defaultChannelId,
+                    'group',
+                    {}
+                  );
+                  await this.addMessage(
+                    queryClient,
+                    conversationId.split('/')[0],
+                    space.defaultChannelId,
+                    msg
+                  );
+                }
               }
             } else {
               console.error(pointResult);
@@ -3613,8 +3632,11 @@ export class MessageService {
                     conversationId.split('/')[0]
                   );
 
-                  // Remove leaving user from all roles
+                  // No space row locally → tombstone above already applied; we
+                  // can't build the "X left" system message without the space's
+                  // default channel, so skip it (guards a null-deref under replay).
                   if (space) {
+                    // Remove leaving user from all roles
                     space.roles = space.roles.map((role) => ({
                       ...role,
                       members: role.members.filter(
@@ -3622,40 +3644,40 @@ export class MessageService {
                       ),
                     }));
                     await this.messageDB.saveSpace(space);
-                  }
 
-                  const messageId = await crypto.subtle.digest(
-                    'SHA-256',
-                    Buffer.from('leave' + member.inbox_address, 'utf-8')
-                  );
-                  const msg = {
-                    channelId: space!.defaultChannelId,
-                    spaceId: conversationId.split('/')[0],
-                    messageId: Buffer.from(messageId).toString('hex'),
-                    digestAlgorithm: 'SHA-256',
-                    nonce: Buffer.from(messageId).toString('hex'),
-                    createdDate: Date.now(),
-                    modifiedDate: Date.now(),
-                    lastModifiedHash: '',
-                    content: {
-                      senderId: member.user_address,
-                      type: 'leave',
-                    } as LeaveMessage,
-                  } as Message;
-                  await this.saveMessage(
-                    msg,
-                    this.messageDB,
-                    conversationId.split('/')[0],
-                    space!.defaultChannelId,
-                    'group',
-                    {}
-                  );
-                  await this.addMessage(
-                    queryClient,
-                    conversationId.split('/')[0],
-                    space!.defaultChannelId,
-                    msg
-                  );
+                    const messageId = await crypto.subtle.digest(
+                      'SHA-256',
+                      Buffer.from('leave' + member.inbox_address, 'utf-8')
+                    );
+                    const msg = {
+                      channelId: space.defaultChannelId,
+                      spaceId: conversationId.split('/')[0],
+                      messageId: Buffer.from(messageId).toString('hex'),
+                      digestAlgorithm: 'SHA-256',
+                      nonce: Buffer.from(messageId).toString('hex'),
+                      createdDate: Date.now(),
+                      modifiedDate: Date.now(),
+                      lastModifiedHash: '',
+                      content: {
+                        senderId: member.user_address,
+                        type: 'leave',
+                      } as LeaveMessage,
+                    } as Message;
+                    await this.saveMessage(
+                      msg,
+                      this.messageDB,
+                      conversationId.split('/')[0],
+                      space.defaultChannelId,
+                      'group',
+                      {}
+                    );
+                    await this.addMessage(
+                      queryClient,
+                      conversationId.split('/')[0],
+                      space.defaultChannelId,
+                      msg
+                    );
+                  }
                   break;
                 }
               }
@@ -3727,13 +3749,16 @@ export class MessageService {
                 const space = await this.messageDB.getSpace(
                   conversationId.split('/')[0]
                 );
-                if (envelope.message.kick) {
+                // The "X was kicked" system message needs the space's default
+                // channel; require space so a missing row doesn't null-deref
+                // under replay (matches the space?.inviteUrl guard just below).
+                if (envelope.message.kick && space) {
                   const messageId = await crypto.subtle.digest(
                     'SHA-256',
                     Buffer.from('kick' + envelope.message.kick, 'utf-8')
                   );
                   const msg = {
-                    channelId: space!.defaultChannelId,
+                    channelId: space.defaultChannelId,
                     spaceId: conversationId.split('/')[0],
                     messageId: Buffer.from(messageId).toString('hex'),
                     digestAlgorithm: 'SHA-256',
@@ -3750,14 +3775,14 @@ export class MessageService {
                     msg,
                     this.messageDB,
                     conversationId.split('/')[0],
-                    space!.defaultChannelId,
+                    space.defaultChannelId,
                     'group',
                     {}
                   );
                   await this.addMessage(
                     queryClient,
                     conversationId.split('/')[0],
-                    space!.defaultChannelId,
+                    space.defaultChannelId,
                     msg
                   );
                 }
@@ -3912,27 +3937,27 @@ export class MessageService {
                     spaceId,
                     kickedAddress
                   );
-                  if (kicked) {
-                    await this.messageDB.saveSpaceMember(spaceId, {
-                      ...kicked,
-                      inbox_address: '',
-                    });
-                    await queryClient.setQueryData(
-                      buildSpaceMembersKey({ spaceId }),
-                      (
-                        oldData: (secureChannel.UserProfile & {
-                          inbox_address: string;
-                        })[]
-                      ) => {
-                        const previous = oldData ?? [];
-                        return previous.map((m) =>
-                          m.user_address === kickedAddress
-                            ? { ...m, inbox_address: '' }
-                            : m
-                        );
-                      }
-                    );
-                  }
+                  // Upsert: persist the inactive tombstone even if we never had a
+                  // row for them, so a replayed kick can't leave them renderable.
+                  await this.messageDB.saveSpaceMember(spaceId, {
+                    ...(kicked ?? { user_address: kickedAddress }),
+                    inbox_address: '',
+                  });
+                  await queryClient.setQueryData(
+                    buildSpaceMembersKey({ spaceId }),
+                    (
+                      oldData: (secureChannel.UserProfile & {
+                        inbox_address: string;
+                      })[]
+                    ) => {
+                      const previous = oldData ?? [];
+                      return previous.map((m) =>
+                        m.user_address === kickedAddress
+                          ? { ...m, inbox_address: '' }
+                          : m
+                      );
+                    }
+                  );
                 }
               }
             }
@@ -4094,12 +4119,16 @@ export class MessageService {
                   spaceId,
                   address
                 );
-                if (member) {
-                  await this.messageDB.saveSpaceMember(spaceId, {
-                    ...member,
-                    isKicked: true,
-                  });
-                }
+                // Upsert: if we have no row for this address (e.g. they were
+                // kicked before we ever saw their join), still persist a kicked
+                // tombstone so they can't later render as an active member.
+                await this.messageDB.saveSpaceMember(spaceId, {
+                  ...(member ?? {
+                    user_address: address,
+                    inbox_address: '',
+                  }),
+                  isKicked: true,
+                });
               }
               await queryClient.setQueryData(
                 buildSpaceMembersKey({ spaceId }),

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -13,7 +13,6 @@ import {
   validateSpaceTagLetters,
   isValidSpaceTagUrl,
   hasPermission,
-  canManageReadOnlyChannel,
   SimpleRateLimiter,
   RATE_LIMITS,
 } from '@quilibrium/quorum-shared';
@@ -834,58 +833,6 @@ export class MessageService {
   }
 
   /**
-   * Returns true when an incoming message should be rejected for posting visible
-   * content (post/embed/sticker) to a read-only channel from a non-manager.
-   * Shared by the durable (saveMessage) and cache (addMessage) paths so the rule
-   * can't drift. Fail-secure: missing space/channel data → reject. Owners are not
-   * bypassed (receive side can't verify ownership), so they enforce via a manager
-   * role like everyone else, through the shared canManageReadOnlyChannel.
-   */
-  private async isReadOnlyViolation(
-    spaceId: string,
-    channelId: string,
-    decryptedContent: Message
-  ): Promise<boolean> {
-    // DMs have no channels/roles; only postable content can violate read-only.
-    const isDM = spaceId === channelId;
-    const type = decryptedContent.content.type;
-    const isPostable = type === 'post' || type === 'embed' || type === 'sticker';
-    if (isDM || !isPostable) {
-      return false;
-    }
-
-    const space = await this.messageDB.getSpace(spaceId);
-    // FAIL-SECURE: no space data → can't verify → reject.
-    if (!space) {
-      logger.warn(
-        `⚠️ Rejecting ${type} ${decryptedContent.messageId} — space ${spaceId} data unavailable`
-      );
-      return true;
-    }
-
-    const channel = space.groups
-      ?.find((g) => g.channels.find((c) => c.channelId === channelId))
-      ?.channels.find((c) => c.channelId === channelId);
-    // FAIL-SECURE: channel not found → reject.
-    if (!channel) {
-      logger.warn(
-        `⚠️ Rejecting ${type} ${decryptedContent.messageId} — channel ${channelId} not found in space ${spaceId}`
-      );
-      return true;
-    }
-
-    if (!channel.isReadOnly) {
-      return false; // not read-only → nothing to enforce
-    }
-
-    // Read-only: only manager-role members may post. isSpaceOwner is passed
-    // false because the receive side cannot verify ownership; owners enforce via
-    // a manager role like everyone else.
-    const senderId = decryptedContent.content.senderId;
-    return !canManageReadOnlyChannel(senderId, false, space, channel);
-  }
-
-  /**
    * Saves message to DB and updates query cache.
    * @param currentUserAddress - Pass current user's address when sending messages to update lastReadTimestamp
    */
@@ -1365,12 +1312,6 @@ export class MessageService {
           : undefined;
       await messageDB.saveSpaceMember(spaceId, participant);
     } else {
-      // Read-only enforcement on the durable path too, so a blocked post/embed/
-      // sticker isn't persisted (and can't resurface on a refetch/replay).
-      if (await this.isReadOnlyViolation(spaceId, channelId, decryptedContent)) {
-        return;
-      }
-
       // Check tombstone before saving - prevents deleted messages from being re-added during sync
       if (await messageDB.isMessageDeleted(decryptedContent.messageId)) {
         return;
@@ -1983,16 +1924,62 @@ export class MessageService {
         return;
       }
 
-      // Read-only enforcement (post/embed/sticker) before adding to cache.
-      if (await this.isReadOnlyViolation(spaceId, channelId, decryptedContent)) {
-        return;
+      // Read-only channel validation - must validate BEFORE adding to cache
+      // Note: edit-message is handled earlier in the if-else chain (line ~310)
+      const isDM = spaceId === channelId;
+      const isPostMessage = decryptedContent.content.type === 'post';
+
+      if (!isDM && isPostMessage) {
+        const space = await this.messageDB.getSpace(spaceId);
+
+        // FAIL-SECURE: Reject if space data unavailable
+        if (!space) {
+          logger.warn(
+            `⚠️ Rejecting message ${decryptedContent.messageId} - space ${spaceId} data unavailable`
+          );
+          return;
+        }
+
+        // Find the target channel in space groups
+        const channel = space.groups
+          ?.find((g) => g.channels.find((c) => c.channelId === channelId))
+          ?.channels.find((c) => c.channelId === channelId);
+
+        // FAIL-SECURE: Reject if channel not found
+        if (!channel) {
+          logger.warn(
+            `⚠️ Rejecting message ${decryptedContent.messageId} - channel ${channelId} not found in space ${spaceId}`
+          );
+          return;
+        }
+
+        // Validate read-only channel permissions
+        if (channel.isReadOnly) {
+          const senderId = decryptedContent.content.senderId;
+
+          // Check if channel has manager roles configured
+          if (!channel.managerRoleIds || channel.managerRoleIds.length === 0) {
+            return;
+          }
+
+          // Check if sender is in a manager role
+          // Note: Space owners must explicitly join a manager role (privacy requirement)
+          const isChannelManager =
+            space.roles?.some(
+              (role) =>
+                channel.managerRoleIds?.includes(role.roleId) &&
+                role.members?.includes(senderId)
+            ) ?? false;
+
+          if (!isChannelManager) {
+            return;
+          }
+        }
       }
 
       // Message length validation for post messages (defense-in-depth)
       // Note: text can be string | string[], must handle both
       // Edit-message validation is in the edit-message handler above (line ~310)
-      const isDM = spaceId === channelId;
-      const isPostMessage = decryptedContent.content.type === 'post';
       if (isPostMessage) {
         const text = (decryptedContent.content as PostMessage).text;
         const messageText = Array.isArray(text) ? text.join('') : text;


### PR DESCRIPTION
## What

Hardens the space control-message receive handlers in `MessageService.ts` against missing-row and null-deref traps, prep for the durable hub-log transport (which will replay every control message on each reconnect).

- **`verify-kicked`** — upserts a kicked tombstone (`isKicked: true`, `inbox_address: ''`) when no member row exists, so an address kicked before we saw their join can't render as active after replay.
- **`kick` (other-member)** — upserts the inactive tombstone (`inbox_address: ''`) when no row exists.
- **`join` / `leave` / `rekey`** — the 'X joined/left/was kicked' system-message emission is guarded behind a `space` null-check instead of `space!` assertions, which threw (and were swallowed by the outer catch) when the space row was absent.

## Scope / non-goals

- Desktop-only; no `quorum-shared` change; mobile unaffected.
- **Read-only durable-path enforcement is NOT included.** An attempt was made and reverted after code review: a fail-secure reject on the durable path can permanently drop legitimate manager messages that arrive before their space row during sync replay — worse than the resurface-on-replay gap it addressed. Deferred to the hub-log migration where replay ordering is deterministic. The standing read-only gap remains tracked (open) and is unchanged from current `main`.
- Known pre-existing limitation (untouched here): the `sync-members` cache merge reads `isKicked` from the React Query cache, not IndexedDB, so a tombstone upserted this session may render as active until reload. Self-heals on reload.

## Verification

- `npx tsc --noEmit --skipLibCheck` — clean
- `eslint src/services/MessageService.ts` — 0 errors (2 pre-existing warnings, unrelated)
- Human code review (extra-high recall) run; the one risky change (read-only durable enforcement) was caught and reverted before this PR.