### PR TITLE
feat(messages): converge image-only sends onto post + embeddedMedia

### DIFF
--- a/src/components/message/Message.tsx
+++ b/src/components/message/Message.tsx
@@ -75,6 +75,85 @@ const createGifDetector = (url: string, isLargeGif?: boolean) => {
   );
 };
 
+// Renders a single embedded image with GIF-aware behavior, owning its own
+// animation state so multiple images in one message animate independently.
+// Behavior mirrors the legacy embed renderer:
+//   - static image      -> click opens the full-resolution modal
+//   - small GIF          -> the src IS the GIF, so it animates immediately; click is a no-op
+//   - large GIF          -> shows the static thumbnail + a play overlay; clicking swaps the
+//                           src to the full GIF (animates in place, no modal)
+// `isLargeGif` is derived by the caller from the embeddedMedia shape (a GIF that has a
+// separate thumbnail entry), not from a wire flag.
+const EmbeddedImage = ({
+  thumbnailSrc,
+  fullSrc,
+  isGif,
+  isLargeGif,
+  onOpenModal,
+}: {
+  thumbnailSrc: string;
+  fullSrc: string;
+  isGif: boolean;
+  isLargeGif: boolean;
+  onOpenModal: (
+    e: React.MouseEvent<HTMLImageElement>,
+    fullSrc: string,
+    hasThumbnail?: boolean
+  ) => void;
+}) => {
+  const [isShowingGifAnimation, setIsShowingGifAnimation] = useState(false);
+  const hasPlayOverlay = isLargeGif && thumbnailSrc !== fullSrc && !isShowingGifAnimation;
+
+  return (
+    <div className="relative inline-block mt-1">
+      <img
+        src={isShowingGifAnimation ? fullSrc : thumbnailSrc}
+        className={`message-image rounded-lg transition-opacity duration-200 ${
+          isGif
+            ? hasPlayOverlay
+              ? 'cursor-pointer' // Pointer cursor for GIF static thumbnails
+              : 'cursor-auto' // No pointer cursor for animating / small GIFs
+            : 'cursor-pointer hover:opacity-80' // Clickable for non-GIFs
+        }`}
+        onClick={(e) => {
+          if (isGif) {
+            // For GIFs: animate in-place, don't open modal.
+            // Large GIF with a separate thumbnail: swap to the full GIF on click.
+            // Small GIF: already animating, do nothing.
+            if (isLargeGif && thumbnailSrc !== fullSrc && !isShowingGifAnimation) {
+              const img = e.target as HTMLImageElement;
+              const originalSrc = img.src;
+              const handleError = () => {
+                logger.warn('Failed to load full GIF, reverting to thumbnail');
+                img.src = originalSrc;
+                img.removeEventListener('error', handleError);
+                setIsShowingGifAnimation(false);
+              };
+              img.addEventListener('error', handleError);
+              setIsShowingGifAnimation(true);
+            }
+          } else {
+            // For static images: open the full-resolution modal as usual.
+            onOpenModal(e, fullSrc, thumbnailSrc !== fullSrc);
+          }
+        }}
+        onError={(e) => {
+          (e.currentTarget.parentElement as HTMLElement).style.display = 'none';
+        }}
+      />
+      {hasPlayOverlay && (
+        <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+          <div className="bg-black/50 rounded-full p-2">
+            <svg className="w-6 h-6 text-white" fill="currentColor" viewBox="0 0 24 24">
+              <path d="M8 5v14l11-7z" />
+            </svg>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
 type MessageProps = {
   customEmoji?: Emoji[];
   stickers?: { [key: string]: Sticker };
@@ -1072,17 +1151,19 @@ export const Message = React.memo(
                             getEmbeddedMediaSrc(message.content as any, 'image', key);
                           const fullSrc = getEmbeddedMediaSrc(message.content as any, 'image', key);
                           if (!thumbnailSrc || !fullSrc) return null;
+                          // Derive GIF behavior from the embeddedMedia shape (no wire flag):
+                          // a GIF with a distinct thumbnail entry is the "large GIF" case.
+                          const isGif = createGifDetector(fullSrc);
+                          const isLargeGif = isGif && thumbnailSrc !== fullSrc;
                           return (
-                            <div key={key} className="relative inline-block mt-1">
-                              <img
-                                src={thumbnailSrc}
-                                className="message-image rounded-lg cursor-pointer hover:opacity-80"
-                                onClick={() => showImageModal(fullSrc)}
-                                onError={(e) => {
-                                  (e.currentTarget.parentElement as HTMLElement).style.display = 'none';
-                                }}
-                              />
-                            </div>
+                            <EmbeddedImage
+                              key={key}
+                              thumbnailSrc={thumbnailSrc}
+                              fullSrc={fullSrc}
+                              isGif={isGif}
+                              isLargeGif={isLargeGif}
+                              onOpenModal={formatting.handleImageClick}
+                            />
                           );
                         })}
                       </div>
@@ -1248,17 +1329,17 @@ export const Message = React.memo(
                       getEmbeddedMediaSrc(message.content as any, 'image', key);
                     const fullSrc = getEmbeddedMediaSrc(message.content as any, 'image', key);
                     if (!thumbnailSrc || !fullSrc) return null;
+                    const isGif = createGifDetector(fullSrc);
+                    const isLargeGif = isGif && thumbnailSrc !== fullSrc;
                     return (
-                      <div key={key} className="relative inline-block mt-1">
-                        <img
-                          src={thumbnailSrc}
-                          className="message-image rounded-lg cursor-pointer hover:opacity-80"
-                          onClick={() => showImageModal(fullSrc)}
-                          onError={(e) => {
-                            (e.currentTarget.parentElement as HTMLElement).style.display = 'none';
-                          }}
-                        />
-                      </div>
+                      <EmbeddedImage
+                        key={key}
+                        thumbnailSrc={thumbnailSrc}
+                        fullSrc={fullSrc}
+                        isGif={isGif}
+                        isLargeGif={isLargeGif}
+                        onOpenModal={formatting.handleImageClick}
+                      />
                     );
                   })}
                   </>

--- a/src/components/message/MessageComposer.scss
+++ b/src/components/message/MessageComposer.scss
@@ -250,6 +250,18 @@ html:not(.dark) .message-composer-row {
     }
   }
 
+  /* Active state when there is sendable content (text OR an attached image).
+     An image with no caption is sendable, so the button must look active even
+     when the row is not in the `typing` state. */
+  &.active {
+    background-color: var(--accent);
+    opacity: 1;
+
+    &:hover {
+      background-color: var(--accent-400);
+    }
+  }
+
   /* Disabled state */
   &.disabled {
     background-color: var(--surface-6) !important;

--- a/src/components/message/MessageComposer.tsx
+++ b/src/components/message/MessageComposer.tsx
@@ -896,7 +896,13 @@ export const MessageComposer = forwardRef<
           <Button
             type="unstyled"
             onClick={messageValidation?.isOverLimit || isProcessingImage ? undefined : handleSubmit}
-            className={`message-composer-send-btn ${messageValidation?.isOverLimit || isProcessingImage ? 'disabled' : ''}`}
+            className={`message-composer-send-btn ${
+              messageValidation?.isOverLimit || isProcessingImage
+                ? 'disabled'
+                : value.length > 0 || processedImage
+                  ? 'active'
+                  : ''
+            }`}
           >
             <svg width="18" height="14" viewBox="0 0 100 80" fill="none">
               <path d="M0 80L25 40.4181L0 0L100 40.4181L0 80Z" fill="white" />

--- a/src/hooks/business/messages/useMessageComposer.ts
+++ b/src/hooks/business/messages/useMessageComposer.ts
@@ -2,7 +2,6 @@ import { useState, useRef, useCallback, useEffect } from 'react';
 import { FileWithPath, useDropzone } from 'react-dropzone';
 import type {
   Message as MessageType,
-  EmbedMessage,
   StickerMessage,
 } from '@quilibrium/quorum-shared';
 import { t } from '@lingui/core/macro';
@@ -271,23 +270,39 @@ export function useMessageComposer(options: UseMessageComposerOptions) {
             await onSubmitMessage(pendingMessage, inReplyTo?.messageId);
           }
         } else if (processedImage) {
-          // --- Image only (EmbedMessage path) ---
-          const fullImageBuffer = await processedImage.full.file.arrayBuffer();
-          const fullImageUrl = `data:${processedImage.full.file.type};base64,${Buffer.from(fullImageBuffer).toString('base64')}`;
+          // --- Image only → PostMessage with embeddedMedia (empty text) ---
+          // Converged onto the same wire shape as text+image so there is one
+          // canonical image carrier. `embed` is now receive-only legacy.
+          // The large-GIF "show poster, animate on click" behavior is derived at
+          // render time from the presence of a separate thumbnail entry, so no
+          // isLargeGif flag travels on the wire.
+          const key = crypto.randomUUID();
 
-          let thumbnailUrl: string | undefined;
+          const fullBuffer = await processedImage.full.file.arrayBuffer();
+          const fullData = Buffer.from(fullBuffer).toString('base64');
+
+          const mediaEntries: Array<{ type: string; key: string; data: string; mimeType: string }> = [];
           if (processedImage.thumbnail) {
-            const thumbnailBuffer = await processedImage.thumbnail.file.arrayBuffer();
-            thumbnailUrl = `data:${processedImage.thumbnail.file.type};base64,${Buffer.from(thumbnailBuffer).toString('base64')}`;
+            const thumbBuffer = await processedImage.thumbnail.file.arrayBuffer();
+            const thumbData = Buffer.from(thumbBuffer).toString('base64');
+            mediaEntries.push({
+              type: 'image-thumbnail',
+              key,
+              data: thumbData,
+              mimeType: processedImage.thumbnail.file.type,
+            });
           }
+          mediaEntries.push({
+            type: 'image',
+            key,
+            data: fullData,
+            mimeType: processedImage.full.file.type,
+          });
 
-          const embedMessage: EmbedMessage = {
-            type: 'embed',
-            imageUrl: fullImageUrl,
-            thumbnailUrl,
-            isLargeGif: processedImage.isLargeGif,
-          } as EmbedMessage;
-          await onSubmitMessage(embedMessage, inReplyTo?.messageId);
+          await onSubmitMessage(
+            { type: 'post' as const, text: '', embeddedMedia: mediaEntries },
+            inReplyTo?.messageId
+          );
         }
 
         // Clear state after successful submission


### PR DESCRIPTION
## What

Image-only-no-caption messages were sent as `type:'embed'`, while image+caption already used `type:'post'` + `embeddedMedia`. Two carriers for the same content. Mobile only reads `embeddedMedia` on posts, so the `embed` path meant cross-platform image loss. This converges the image-only send path onto `post` + `embeddedMedia` (empty text) so there is **one canonical image carrier**. `embed` becomes receive-only legacy (old persisted embeds still render).

## Changes

- **Send** (`useMessageComposer.ts`): image-only branch now emits `post` + `embeddedMedia` (thumbnail entry when present, then full image, shared key, `text: ''`) instead of an `EmbedMessage`. Removed the now-unused `EmbedMessage` import.
- **Render** (`Message.tsx`): ported the large-GIF in-place playback (static poster + play overlay; click swaps to the animated full GIF, no modal) from the `embed` renderer into the `post`/`embeddedMedia` paths (both markdown and fallback) via a self-contained `EmbeddedImage` component that owns its own animation state, so multiple images animate independently. `isLargeGif` is derived from the `embeddedMedia` shape (a GIF that has a separate thumbnail entry) rather than a wire flag, so **no shared type change / no version bump**.
- **Send button** (`MessageComposer.tsx` + `.scss`): now shows the active accent style when there is sendable content (text **or** an attached image), not only while typing. An image with no caption is sendable, so the button must look active.

## GIF behavior preserved

- Small GIF (no thumbnail): animates immediately.
- Large GIF (has thumbnail): static poster + ▶ overlay; click animates in place (no modal).
- Static image: click opens the full-res modal.
- Legacy received `embed` messages: unchanged renderer, still render.

## Verification

- `tsc --noEmit` clean; `eslint` clean (no new warnings; one pre-existing unused-import warning removed).
- Manual smoke test confirmed: image-only static, small GIF, large GIF, image+caption, and the send-button-lights-up-on-attach all work.

## Context

Desktop half of the cross-repo image+caption convergence (mobile task: `2026-06-13-converge-image-caption-to-post-embeddedmedia.md`). Caveat about payload size was verified moot: the `embed` path already inlined base64, so this is not a size regression.