### PR TITLE
feat: role color uniqueness parity

### DIFF
--- a/.agents/tasks/2026-06-15-role-color-and-uniqueness-parity.md
+++ b/.agents/tasks/2026-06-15-role-color-and-uniqueness-parity.md
@@ -1,0 +1,107 @@
+---
+type: task
+title: "Bring desktop roles to parity: shared color tokens + tag/name uniqueness + remove-from-user confirm"
+status: in-progress
+created: 2026-06-15
+shared_dependency: "@quilibrium/quorum-shared 2.1.0-30 (merged to shared master; desktop sees it via link: on a local build; NOT yet published to npm — that's the mobile blocker, not desktop's)"
+mobile_status: "shipped to mobile (branch held for the -30 publish); desktop is the remaining client"
+---
+
+# Desktop role parity: shared color tokens + uniqueness + remove-from-user confirm
+
+## Why this exists
+
+Two role features were just built into `@quilibrium/quorum-shared` (merged to master,
+2.1.0-30) and consumed on **mobile**. Desktop is the remaining client and currently
+lacks all of it. None of this is urgent or breaking — desktop works today — but the two
+clients have now diverged, so this documents exactly what desktop needs to catch up.
+Desktop is our high-confidence home turf, so this is normal self-mergeable work
+(smoke-test runtime changes, then `/ship-pr`).
+
+Desktop consumes shared via `link:`, so on a local build it already sees the new
+exports. No publish is needed for desktop (the `-30` npm publish is the *mobile*
+blocker). So this can be done independently, now.
+
+### What shared now provides (all in `@quilibrium/quorum-shared`)
+
+- **Color tokens:** `getRoleColorHex(color)` (token / raw hex / legacy `rgb(var(--success))` / fallback → render hex, never throws), `getDefaultRoleColor(seed)` (deterministic token from a seed like roleId), `ROLE_COLORS` (palette). `Role.color` is now documented as a portable token (store a token, resolve to hex at render — same pattern as the icon/folder picker). `ICON_COLORS`/`FOLDER_COLORS` were extended (+teal/sky/indigo/pink; yellow `#ca8a04`→`#eab308`).
+- **Uniqueness:** `findRoleConflict(roles, candidate, excludeRoleId?)`, `isRoleIdentityAvailable(...)`, `getUniqueRoleDefaults(roles, baseName?, baseTag?)` (auto-numbered `New Role 2` / `newrole-2`).
+
+### The core problem on desktop today
+
+`role.color` is hardcoded to the **literal string `'rgb(var(--success))'`** on create
+(`src/hooks/business/spaces/useRoleManagement.ts:51`) — a web CSS variable that the
+browser resolves at paint, which is why every desktop role is the **same green** and
+there's no color picker. React Native can't parse that string, which is the cross-platform
+bug the shared token system fixes. Desktop also never dedupes role tag/name, so spamming
+"Add Role" makes identical roles.
+
+## Scope (minimal parity — each item independent)
+
+### 1. Color: store a token on create — **S**
+`src/hooks/business/spaces/useRoleManagement.ts:51` — replace
+`color: 'rgb(var(--success))'` with `color: getDefaultRoleColor(newRole.roleId)`
+(import from shared). New roles get a stable, distinct, deterministic color that syncs.
+
+### 2. Color: resolve the token at every render site — **S–M (×5 sites)**
+Desktop renders `role.color` **raw** everywhere (it relied on the browser resolving the
+css-var). Wrap each in `getRoleColorHex(...)`:
+- `src/components/modals/SpaceSettingsModal/Roles.tsx:116` — `backgroundColor: r.color`
+- `src/components/message/MentionDropdown.tsx:219` — `backgroundColor: option.data.color`
+- `src/components/modals/SpaceSettingsModal/Account.tsx:252-255` — currently hardcodes the css-var + ignores `r.color`; switch to `getRoleColorHex(r.color)`
+- `src/components/user/UserProfile.tsx:290` and `:299` — add `style={{ backgroundColor: getRoleColorHex(r.color) }}` to the `user-profile-role-tag` span (both branches); currently colored purely by CSS class hardcoded to the css-var
+- The hardcoded css-var in `UserProfile.scss:136` / `_modal_common.scss:950` can stay as a harmless visual fallback; no CSS change required for correctness.
+
+### 3. Uniqueness: auto-numbered defaults on add — **S**
+`src/hooks/business/spaces/useRoleManagement.ts:48-55` — replace the hardcoded
+`displayName: 'Role Name'` / `roleTag: 'role-tag'` with `getUniqueRoleDefaults(roles)`.
+Spamming "Add Role" then yields `Role Name 2` / `role-tag-2`, never duplicates.
+
+### 4. Uniqueness: collision check on edit — **M (UX decision)**
+`updateRoleTag` (`useRoleManagement.ts:86`) and `updateRoleDisplayName` (`:92`) set values
+with **no validation**. Wire `findRoleConflict(roles, { roleTag, displayName }, roleId)`.
+**Desktop uses an explicit Save button** (not autosave like mobile) — `categoryNeedsSave`
+includes Roles; `saveChanges` (`SpaceSettingsModal.tsx:348`) broadcasts all role edits at
+once. So the natural fit is: show the conflict inline AND block Save while a conflict
+exists. There's already a wired-but-unused `roleValidationError` slot
+(`SpaceSettingsModal.tsx:325-326`, displayed at `Roles.tsx:231`) — it's only ever set to
+`''`. Either drive that bottom-of-list error, or refactor to per-field inline errors.
+**Open choice:** per-field vs bottom-of-list error placement (the wired slot makes
+bottom-of-list the cheaper path).
+
+### 5. Remove-role-from-user confirmation — **SKIPPED (deliberate desktop divergence)**
+`src/components/user/UserProfile.tsx` calls `removeRole(...)` immediately, no confirm.
+Mobile just added a confirm here. **Decision (2026-06-15, user): desktop keeps the
+immediate, no-confirm behavior** — removing a role from a member is cheap and reversible
+on desktop, so the modal is friction we don't want. This is an intentional UX divergence
+from mobile, not an oversight. (Desktop still confirms role *deletion* from the Roles tab,
+which is a destructive action — that's untouched.)
+
+> **Lead-dev note:** worth a short Telegram heads-up that desktop chose NOT to mirror
+> mobile's remove-from-member confirm. Per atlas rules, the platform-divergence call is
+> the lead's to be aware of, even though the desktop UX call is ours.
+
+## Legacy data — no migration needed (verified)
+
+Existing desktop roles all carry `color: 'rgb(var(--success))'` in already-broadcast
+manifests. `getRoleColorHex` maps that exact string to green, so once the render sites
+(item 2) resolve through it, **legacy roles keep rendering green with zero migration, no
+re-broadcast, no schema change.** Item 2 is the only change legacy roles need.
+
+## Beyond parity — optional follow-up (NOT in this scope)
+
+**A desktop role color PICKER.** Parity only needs storing the deterministic default token
++ rendering it. But desktop has no way to *choose* a role's color (every role is one
+color today). A picker drawing from the shared `ROLE_COLORS` palette would be a real UX
+addition to the Roles settings tab. Mobile also has no explicit picker (it auto-assigns),
+so this isn't a parity gap, just an opportunity — spin it into its own task if wanted.
+
+## Suggested sequencing
+
+Items 1+2 (color) ship together — they're the actual cross-platform fix and the lowest
+risk. 3 is trivial. 4 and 5 each carry a small UX choice (error/confirm placement) but are
+otherwise straightforward. All consume already-merged shared code via `link:`; no shared
+work, no publish dependency for desktop. Standard desktop flow: smoke-test, `/ship-pr`.
+
+---
+*Last updated: 2026-06-15*

--- a/src/components/message/MentionDropdown.tsx
+++ b/src/components/message/MentionDropdown.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useEffect, useLayoutEffect, useState, useCallback } from 'react';
 import { Icon } from '../primitives';
 import { Portal } from '../primitives';
+import { getRoleColorHex } from '@quilibrium/quorum-shared';
 import { UserAvatar } from '../user/UserAvatar';
 import { t } from '@lingui/core/macro';
 import type { MentionOption } from '../../hooks/business/mentions';
@@ -216,7 +217,7 @@ export const MentionDropdown: React.FC<MentionDropdownProps> = ({
           <>
             <div
               className="mention-dropdown__badge mention-dropdown__badge--role"
-              style={{ backgroundColor: option.data.color }}
+              style={{ backgroundColor: getRoleColorHex(option.data.color) }}
             >
               <Icon name="users" size="sm" />
             </div>

--- a/src/components/modals/SpaceSettingsModal/Account.tsx
+++ b/src/components/modals/SpaceSettingsModal/Account.tsx
@@ -24,6 +24,7 @@ import { useChannelMute } from '../../../hooks/business/channels';
 import { MAX_BIO_INPUT_CHARS } from '../../../hooks/business/validation';
 import { getIconColorHex, IconColor } from '../../space/IconPicker/types';
 import type { Role } from '@quilibrium/quorum-shared';
+import { getRoleColorHex } from '@quilibrium/quorum-shared';
 import type { SpaceNotificationTypeId } from '../../../types/notifications';
 import { ReactTooltip } from '../../ui';
 
@@ -249,9 +250,9 @@ const Account: React.FunctionComponent<AccountProps> = ({
               {userRoles.map((r) => (
                 <Text
                   key={'user-role-' + r.roleId}
-                  className="inline-flex items-center py-[3px] px-3 rounded-full font-medium text-xs text-center select-none bg-success text-white"
+                  className="inline-flex items-center py-[3px] px-3 rounded-full font-medium text-xs text-center select-none text-white"
                   style={{
-                    background: 'rgb(var(--success))',
+                    backgroundColor: getRoleColorHex(r.color),
                   }}
                 >
                   {r.displayName}

--- a/src/components/modals/SpaceSettingsModal/Roles.tsx
+++ b/src/components/modals/SpaceSettingsModal/Roles.tsx
@@ -3,6 +3,7 @@ import { Button, Select, Icon, Tooltip, ScrollContainer, Callout } from '../../p
 import { Trans } from '@lingui/react/macro';
 import { t } from '@lingui/core/macro';
 import type { Permission } from '@quilibrium/quorum-shared';
+import { getRoleColorHex } from '@quilibrium/quorum-shared';
 
 interface Role {
   roleTag: string;
@@ -90,30 +91,12 @@ const Roles: React.FunctionComponent<RolesProps> = ({
                 <div
                   className="flex flex-col gap-4 py-4 sm:grid sm:grid-cols-[1fr_1fr_auto_auto]"
                 >
-                  {/* Cell 1: Role tag and name */}
+                  {/* Cell 1: Role name and tag */}
                   <div className="flex flex-col">
                     <div>
-                      @
-                      <input
-                        className="border-0 bg-transparent outline-none font-mono"
-                        style={{
-                          width:
-                            (roles.find((_, pi) => i == pi)
-                              ?.roleTag.length ?? 0) *
-                              11 +
-                            11 +
-                            'px',
-                        }}
-                        onChange={(e) =>
-                          updateRoleTag(i, e.target.value)
-                        }
-                        value={r.roleTag}
-                      />
-                    </div>
-                    <div className="mt-1">
                       <span
                         className="font-mono modal-role"
-                        style={{ backgroundColor: r.color }}
+                        style={{ backgroundColor: getRoleColorHex(r.color) }}
                       >
                         <input
                           className="border-0 bg-transparent outline-none"
@@ -133,6 +116,24 @@ const Roles: React.FunctionComponent<RolesProps> = ({
                           value={r.displayName}
                         />
                       </span>
+                    </div>
+                    <div className="mt-1">
+                      @
+                      <input
+                        className="border-0 bg-transparent outline-none font-mono"
+                        style={{
+                          width:
+                            (roles.find((_, pi) => i == pi)
+                              ?.roleTag.length ?? 0) *
+                              11 +
+                            11 +
+                            'px',
+                        }}
+                        onChange={(e) =>
+                          updateRoleTag(i, e.target.value)
+                        }
+                        value={r.roleTag}
+                      />
                     </div>
                   </div>
 

--- a/src/components/modals/SpaceSettingsModal/SpaceSettingsModal.tsx
+++ b/src/components/modals/SpaceSettingsModal/SpaceSettingsModal.tsx
@@ -12,6 +12,7 @@ import { useSpace } from '../../../hooks';
 import { useMessageDB } from '../../context/useMessageDB';
 import { useSpaceOwner } from '../../../hooks/queries/spaceOwner/useSpaceOwner';
 import type { Channel } from '@quilibrium/quorum-shared';
+import { findRoleConflict } from '@quilibrium/quorum-shared';
 import { t } from '@lingui/core/macro';
 import { usePasskeysContext } from '@quilibrium/quilibrium-js-sdk-channels';
 import { useQueryClient } from '@tanstack/react-query';
@@ -321,9 +322,32 @@ const SpaceSettingsModal: React.FunctionComponent<{
     }
   }, [mentionSettings, spaceProfile, queryClient, spaceId]);
 
-  // Role validation error state
+  // Role validation error state — derived from `roles`. Roles save in a batch
+  // via the explicit Save button (not autosave), so we surface the first
+  // tag/name collision inline and block Save while any conflict exists.
   const [roleValidationError, setRoleValidationError] =
     React.useState<string>('');
+
+  React.useEffect(() => {
+    for (let i = 0; i < roles.length; i++) {
+      const role = roles[i];
+      // Compare each role against the roles before it; the first duplicate
+      // (by tag or name, case-insensitive) is the one we report.
+      const conflict = findRoleConflict(
+        roles.slice(0, i),
+        { roleTag: role.roleTag, displayName: role.displayName }
+      );
+      if (conflict) {
+        setRoleValidationError(
+          conflict.field === 'roleTag'
+            ? t`Two roles can't share the tag @${role.roleTag.trim()}.`
+            : t`Two roles can't share the name "${role.displayName.trim()}".`
+        );
+        return;
+      }
+    }
+    setRoleValidationError('');
+  }, [roles]);
 
   // Save error state
   const [saveError, setSaveError] = React.useState<string>('');
@@ -688,7 +712,7 @@ const SpaceSettingsModal: React.FunctionComponent<{
                     disabled={
                       selectedCategory === 'account'
                         ? spaceProfile.isSaving || spaceProfile.hasValidationError || mentionSettings.isSaving
-                        : isSaving || (!!validateSpaceName(spaceName) && selectedCategory === 'general') || (descriptionErrors.length > 0 && selectedCategory === 'general')
+                        : isSaving || (!!validateSpaceName(spaceName) && selectedCategory === 'general') || (descriptionErrors.length > 0 && selectedCategory === 'general') || (!!roleValidationError && selectedCategory === 'roles')
                     }
                   >
                     {t`Save Changes`}

--- a/src/components/user/UserProfile.tsx
+++ b/src/components/user/UserProfile.tsx
@@ -4,7 +4,7 @@ import { Button, Flex, Icon } from '../primitives';
 // import UserOnlineStateIndicator from './UserOnlineStateIndicator'; // TODO: Re-enable when online/offline status is implemented
 import { ClickToCopyContent } from '../ui';
 import './UserProfile.scss';
-import { createChannelPermissionChecker, logger } from '@quilibrium/quorum-shared';
+import { createChannelPermissionChecker, getRoleColorHex, logger } from '@quilibrium/quorum-shared';
 import type { Role } from '@quilibrium/quorum-shared';
 import {
   useUserRoleManagement,
@@ -288,6 +288,7 @@ const UserProfile: React.FunctionComponent<{
                   <span
                     key={'user-profile-role-' + r.roleId}
                     className={'user-profile-role-tag'}
+                    style={{ backgroundColor: getRoleColorHex(r.color) }}
                   >
                     {r.displayName}
                   </span>
@@ -297,6 +298,7 @@ const UserProfile: React.FunctionComponent<{
                   <span
                     key={'user-profile-role-' + r.roleId}
                     className={'user-profile-role-tag'}
+                    style={{ backgroundColor: getRoleColorHex(r.color) }}
                   >
                     {loadingRoles.has(r.roleId) ? (
                       <span className="text-xs">{t`Removing...`}</span>

--- a/src/hooks/business/spaces/useRoleManagement.ts
+++ b/src/hooks/business/spaces/useRoleManagement.ts
@@ -3,6 +3,8 @@ import React from 'react';
 import {
   setRolePermissions,
   toggleRolePermission as toggleRolePermissionShared,
+  getDefaultRoleColor,
+  getUniqueRoleDefaults,
   type Permission,
   type Role,
 } from '@quilibrium/quorum-shared';
@@ -44,18 +46,25 @@ export const useRoleManagement = (
   }, [initialRoles]);
 
   const addRole = useCallback(() => {
-    const newRole: Role = {
-      roleId: crypto.randomUUID(),
-      roleTag: 'role-tag',
-      displayName: 'Role Name',
-      color: 'rgb(var(--success))',
-      members: [],
-      permissions: [],
-      isPublic: true, // New roles are public by default
-    };
-
-    setRoles((prev) => [...prev, newRole]);
-  }, [roles.length]);
+    setRoles((prev) => {
+      const roleId = crypto.randomUUID();
+      // Auto-number the tag/name against existing roles so repeatedly hitting
+      // "Add Role" never produces duplicates ("New Role 2" / "newrole-2", …).
+      const { displayName, roleTag } = getUniqueRoleDefaults(prev);
+      const newRole: Role = {
+        roleId,
+        roleTag,
+        displayName,
+        // Deterministic palette token (resolved to hex at render); syncs across
+        // platforms, unlike the legacy 'rgb(var(--success))' css-var.
+        color: getDefaultRoleColor(roleId),
+        members: [],
+        permissions: [],
+        isPublic: true, // New roles are public by default
+      };
+      return [...prev, newRole];
+    });
+  }, []);
 
   // Confirmation hook for role delete action
   const deleteConfirmation = useConfirmation({

--- a/src/styles/_modal_common.scss
+++ b/src/styles/_modal_common.scss
@@ -947,6 +947,9 @@
   padding: $s-0-5 $s-2-5;
   border-radius: $s-2;
   color: var(--color-text-main);
+  // Fallback only — the resolved role color is applied via inline
+  // backgroundColor (getRoleColorHex). Must stay overridable, so no !important
+  // here or in the .dark variant below.
   background: rgb(var(--success) / 0.5);
   display: inline-block;
   margin-right: $s-2;
@@ -954,7 +957,7 @@
 }
 
 .dark .modal-role {
-  background: rgb(var(--success) / 0.7) !important;
+  background: rgb(var(--success) / 0.7);
 }
 
 // Avatar + Name Layout Classes


### PR DESCRIPTION
Brings desktop roles to parity with the shared color-token + uniqueness system already on mobile.

- Store a deterministic palette token (\`getDefaultRoleColor\`) on role create instead of the legacy \`rgb(var(--success))\` css-var that React Native can't parse.
- Resolve \`role.color\` through \`getRoleColorHex\` at every render site: Roles settings tab, mention dropdown, Account "Your Roles", UserProfile role tags. Legacy roles keep rendering green with zero migration.
- Auto-number new role name/tag (\`getUniqueRoleDefaults\`) so repeated "Add Role" yields "New Role 2" / "newrole-2" instead of duplicates.
- Block Save and show an inline error on duplicate role tag/name (\`findRoleConflict\`).
- Drop \`!important\` from \`.dark .modal-role\` so the resolved inline color actually applies (was forcing every role green).
- Roles tab: show the colored name badge above the \`@tag\`.

Remove-role-from-member confirmation (mobile added one) was intentionally NOT mirrored on desktop per a UX decision — documented in the task file.

Verified: \`tsc --noEmit\` clean, lint clean on touched files, visual smoke test on the frontend.