### PR TITLE
feat: global notification panel

### DIFF
--- a/.agents/docs/features/mention-notification-system.md
+++ b/.agents/docs/features/mention-notification-system.md
@@ -543,6 +543,73 @@ Thread reply messages can contain @mentions that trigger notifications just like
 
 ---
 
+## Global Notification Panel
+
+A single, app-level notification panel that aggregates unread mentions and replies across **all** the user's spaces, opened from a bell in the `NavRail`. It complements the existing per-space header bell (which stays scoped to one space) without changing it.
+
+### Entry point and presentation
+
+- **NavRail bell** — `NavRail` has a `notifications` rail item (bell icon) inserted after `spaces`. It is not a route; clicking it sets local `notifOpen` state that mounts the panel. It never shows an "active" pathname state because it opens a panel rather than navigating.
+- **Centered panel** — `NotificationPanel` gains an opt-in `global` prop. In global mode it renders with `positionStyle="centered"` (dimmed backdrop) instead of the per-space `right-aligned` anchored dropdown.
+- **Presence dot** — the bell shows an unread dot (`.icon-unread-dot.nav-rail__notif-dot`) when `useSpaceMentionCounts` or `useSpaceReplyCounts` (driven by all spaces) report any unread. These are the existing early-exit count hooks (cheap; they cap at "9+"), so the dot costs no extra panel fetch. The dot clears once the relevant channels are read.
+
+### Data flow (Approach A: live aggregation)
+
+The panel does not maintain a separate notification store. It aggregates live from the same IndexedDB reads the per-space panel uses:
+
+- `useGlobalNotifications({ spaces, enabledTypes, replyEnabled })` composes two global hooks and returns `{ notifications, truncated, isLoading }`.
+  - `useAllMentionsGlobal` loops every space and calls the pure `fetchSpaceMentions(messageDB, space, userAddress, { ..., perChannelLimit })`.
+  - `useAllRepliesGlobal` loops every space and calls the pure `fetchSpaceReplies(messageDB, space, userAddress, { enabled, config, perChannelLimit })`.
+  - Both pure functions are the SAME source of truth the per-space `useAllMentions`/`useAllReplies` delegate to (each per-space hook scopes the space's channels to its `channelIds` and calls the same function). This guarantees the per-space bell and the global panel can never disagree on gating (mute, settings, read-state, thread read times).
+- Rows are merged and sorted newest-first across spaces; each row carries `spaceId` + `spaceName`.
+
+### Bounded fetch (performance cap)
+
+To keep memory bounded for heavy users (many large spaces, lots of unread), the global path caps per-channel fetches:
+
+- `GLOBAL_PER_CHANNEL_LIMIT = 50` — passed as `perChannelLimit` to `fetchSpaceMentions`/`fetchSpaceReplies` in global mode (the per-space path keeps the default `1000`, so per-space behavior is unchanged).
+- `GLOBAL_DISPLAY_CAP = 100` — applied as a slice **after** the global newest-first sort (order-independent, so no bias toward whichever space iterated first).
+- When the merged set exceeds the cap, `useGlobalNotifications` returns `truncated: true` and the panel renders a "Showing the 100 most recent notifications" note (no silent truncation).
+
+Constants live in `src/hooks/business/notifications/constants.ts` (standalone to avoid a circular import between the mention/reply global hooks and the composition hook).
+
+### Sender name resolution
+
+The per-space panel uses `Channel`'s `mapSenderToUser` (built from one space's enriched members). The global panel spans spaces, so it uses `useGlobalSenderResolver(spaces)`:
+
+- It pre-fetches each space's roster via `messageDB.getSpaceMembers(spaceId)` (React Query, 30s stale) and builds a synchronous resolver `(spaceId, senderId) => { address, displayName, userIcon }`, with an address-only fallback until rosters load or for unknown senders.
+- The pure core `buildGlobalSenderMap(membersBySpace)` in `src/utils/resolveGlobalSender.ts` is unit-tested in isolation.
+- Note: `Space.members` is `string[]` (addresses only); enriched member objects come from `getSpaceMembers` (`channel.UserProfile[]`). `primaryUsername`/`globalDisplayName` are not on the roster (they come from the public-profile fetch), so they are optional — parity with the per-space path when unenriched. The resolver output feeds the existing `resolveSpaceMemberName(...)` call in `NotificationPanel` unchanged.
+
+### Breadcrumb
+
+`NotificationItem` accepts an optional `spaceName` prop. When set (global mode only), the row leads with a `Space › #channel` breadcrumb (the space name uses the prominent text token, the channel uses the subtle one). Per-space callers omit `spaceName`, so their rows are unchanged.
+
+### Mark-all-read (cross-space, confirm-gated)
+
+`handleMarkAllReadCore` builds the set of `(spaceId, channelId)` pairs present in the visible notifications — in global mode each row supplies its own `spaceId`; in per-space mode it uses the panel `spaceId` — and writes read times (channel + thread) for each pair. Because the global action has a large blast radius, it is gated behind a `useConfirmation` modal (`variant: 'warning'`): "This marks mentions and replies as read across all your spaces." The per-space path calls the core directly (no confirm), unchanged.
+
+### Cache invalidation
+
+The global hooks use keys `['mention-notifications', 'global', ...]` / `['reply-notifications', 'global', ...]`. React Query prefix-matching requires the prefix to match in order, so the previously space-scoped invalidations (`['mention-notifications', spaceId]`) would NOT reach the global keys. `MessageService` (on new mention/reply) and `useUpdateReadTime` (on read) were broadened to the bare prefixes `['mention-notifications']` / `['reply-notifications']`, which match BOTH the per-space and the global variants. So a new notification or reading a channel refreshes the global panel too.
+
+### Per-space header bell is unchanged
+
+The per-space bell inside a space still uses the anchored right-aligned dropdown, current-space scope, no space breadcrumb, and an unconfirmed mark-all. Global mode is fully gated behind the `global` prop; when it is false/absent the panel is byte-equivalent to before (the only intra-component change is that per-space mark-all now invalidates channel-count keys at the bare-channel prefix instead of the space-scoped one — still correct).
+
+### Key files
+
+- `src/hooks/business/mentions/fetchSpaceMentions.ts`, `src/hooks/business/replies/fetchSpaceReplies.ts` — pure per-space fetchers (shared source of truth).
+- `src/hooks/business/mentions/useAllMentionsGlobal.ts`, `src/hooks/business/replies/useAllRepliesGlobal.ts` — per-space loops.
+- `src/hooks/business/notifications/useGlobalNotifications.ts` — composition + cap + `truncated`.
+- `src/hooks/business/notifications/useGlobalSenderResolver.ts`, `src/utils/resolveGlobalSender.ts` — cross-space sender names.
+- `src/hooks/business/notifications/constants.ts` — `GLOBAL_PER_CHANNEL_LIMIT`, `GLOBAL_DISPLAY_CAP`.
+- `src/components/notifications/NotificationPanel.tsx` — `global` mode.
+- `src/components/notifications/NotificationItem.tsx` — `spaceName` breadcrumb.
+- `src/components/shell/NavRail.tsx` — bell entry, presence dot, panel mount.
+
+---
+
 ## Key Design Decisions
 
 ### 1. Unified Notification Type System
@@ -750,3 +817,5 @@ All mention components use `tokenData.isInteractive` flag to determine CSS class
 *Verified: 2026-01-09 - Removed references to unsupported enhanced mention formats*
 
 _Updated: 2026-03-14 (added Thread Mentions section documenting thread-aware notification behavior: `thread_read_times` IndexedDB store, `channel › Thread` breadcrumb in NotificationPanel, navigation hash format, and persistence rules)_
+
+_Updated: 2026-06-23 (added Global Notification Panel section: NavRail bell, centered presentation, live cross-space aggregation via `useGlobalNotifications` → shared `fetchSpaceMentions`/`fetchSpaceReplies`, bounded-fetch cap, `useGlobalSenderResolver`, `Space › #channel` breadcrumb, broadened cache invalidations, confirm-gated cross-space mark-all; per-space bell unchanged)_

--- a/.agents/docs/features/mention-notification-system.md
+++ b/.agents/docs/features/mention-notification-system.md
@@ -549,9 +549,10 @@ A single, app-level notification panel that aggregates unread mentions and repli
 
 ### Entry point and presentation
 
-- **NavRail bell** — `NavRail` has a `notifications` rail item (bell icon) inserted after `spaces`. It is not a route; clicking it sets local `notifOpen` state that mounts the panel. It never shows an "active" pathname state because it opens a panel rather than navigating.
-- **Centered panel** — `NotificationPanel` gains an opt-in `global` prop. In global mode it renders with `positionStyle="centered"` (dimmed backdrop) instead of the per-space `right-aligned` anchored dropdown.
-- **Presence dot** — the bell shows an unread dot (`.icon-unread-dot.nav-rail__notif-dot`) when `useSpaceMentionCounts` or `useSpaceReplyCounts` (driven by all spaces) report any unread. These are the existing early-exit count hooks (cheap; they cap at "9+"), so the dot costs no extra panel fetch. The dot clears once the relevant channels are read.
+- **NavRail bell** — `NavRail` has a `notifications` rail item (bell icon) as the **last** item in the rail. It is not a route; clicking it calls `openNotifications()` from the `ModalProvider` context. It never shows an "active" pathname state because it opens a modal rather than navigating.
+- **Modal presentation** — `NotificationPanel` has an opt-in `global` prop. In global mode it renders its content inside the **`Modal` primitive** (`size="medium"`, 600px wide) rather than the per-space `DropdownPanel`. This gives the dimmed/blurred backdrop, escape/click-outside, focus management, and correct z-index above the AppShell chrome for free — the architecturally correct home for a top-level-triggered centered panel (see `.agents/docs/features/modals.md`). It is mounted via the **ModalProvider system** (router level), not inside NavRail, so its backdrop stacks above the rail/sidebar. A Suspense-isolated container `GlobalNotificationsModal` owns the suspense-backed `useSpaces` / `useGlobalSenderResolver` calls and renders the panel.
+- **Taller, longer preview (global only)** — `.notification-panel--global` makes the modal taller (`max-height: 85vh`, `min-height: min(85vh, 560px)`) without widening it, and is a flex column whose inner list is the single scroll region (the modal root is `overflow: hidden` so there's exactly one scrollbar). Global rows also show a longer message preview (char cap 400 vs 200; `-webkit-line-clamp: 5` vs 2). The per-space panel keeps its compact 350px list, 200-char cap, and 2-line clamp.
+- **Presence dot** — the bell shows an unread **badge** (`.nav-rail__notif-dot`, scoped under `.nav-rail`) when `useSpaceMentionCounts` or `useSpaceReplyCounts` (driven by all spaces) report any unread. These are the existing early-exit count hooks (cheap; they cap at "9+"), so the dot costs no extra panel fetch. It is positioned over the bell's right side with a ring in the rail background. The dot clears once the relevant channels are read.
 
 ### Data flow (Approach A: live aggregation)
 
@@ -581,9 +582,26 @@ The per-space panel uses `Channel`'s `mapSenderToUser` (built from one space's e
 - The pure core `buildGlobalSenderMap(membersBySpace)` in `src/utils/resolveGlobalSender.ts` is unit-tested in isolation.
 - Note: `Space.members` is `string[]` (addresses only); enriched member objects come from `getSpaceMembers` (`channel.UserProfile[]`). `primaryUsername`/`globalDisplayName` are not on the roster (they come from the public-profile fetch), so they are optional — parity with the per-space path when unenriched. The resolver output feeds the existing `resolveSpaceMemberName(...)` call in `NotificationPanel` unchanged.
 
-### Breadcrumb
+### Row layout (mobile-style, both panels)
 
-`NotificationItem` accepts an optional `spaceName` prop. When set (global mode only), the row leads with a `Space › #channel` breadcrumb (the space name uses the prominent text token, the channel uses the subtle one). Per-space callers omit `spaceName`, so their rows are unchanged.
+`NotificationItem` was redesigned to mirror the mobile notifications screen so the notification type is scannable at a glance. Each row is a **leading circular type badge** + a **3-line body**:
+
+- **Badge** — a 36px circle (soft accent tint via `color-mix(in srgb, var(--accent) 16%, transparent)`) holding the type icon (accent-colored, 18px). Icon by type: `@you → at`, `@everyone → bullhorn`, role mention → `shield`, reply → `reply`. The badge is centered with `display: grid; place-items: center` and the SVG forced to an exact 18px square.
+- **Line 1 — location**: `#channel` (per-space) or `Space › #channel` (global), with `› Thread` appended for thread replies. Driven by the optional `spaceName` prop, which is set only in global mode (`isGlobal = !!spaceName`); per-space rows omit the space name.
+- **Line 2 — author + preview**: `Author:` (medium weight) followed by the message preview with mention formatting, clamped (2 lines per-space, 5 global).
+- **Line 3 — relative time**: `dayjs(message.createdDate).fromNow()` (e.g. "8 minutes ago"). The old calendar icon + formatted date were removed.
+
+The previous single-line meta (channel · inline-type-icon · sender · calendar-date) was replaced entirely. `spaceName` doubles as the global-mode signal (it also drives the taller layout and longer preview).
+
+### Panel title
+
+- **Per-space**: "X Notification(s) in this Space" (makes the scope explicit).
+- **Global**: plain "X notification(s)".
+- The title is computed in `NotificationPanel` from `global` + `allNotifications.length`.
+
+### Loading / empty state
+
+Both the loading spinner and empty state render as a vertical stack (`Flex direction="column"`): icon on top, text below, centered.
 
 ### Mark-all-read (cross-space, confirm-gated)
 
@@ -593,9 +611,9 @@ The per-space panel uses `Channel`'s `mapSenderToUser` (built from one space's e
 
 The global hooks use keys `['mention-notifications', 'global', ...]` / `['reply-notifications', 'global', ...]`. React Query prefix-matching requires the prefix to match in order, so the previously space-scoped invalidations (`['mention-notifications', spaceId]`) would NOT reach the global keys. `MessageService` (on new mention/reply) and `useUpdateReadTime` (on read) were broadened to the bare prefixes `['mention-notifications']` / `['reply-notifications']`, which match BOTH the per-space and the global variants. So a new notification or reading a channel refreshes the global panel too.
 
-### Per-space header bell is unchanged
+### Per-space header bell vs global panel
 
-The per-space bell inside a space still uses the anchored right-aligned dropdown, current-space scope, no space breadcrumb, and an unconfirmed mark-all. Global mode is fully gated behind the `global` prop; when it is false/absent the panel is byte-equivalent to before (the only intra-component change is that per-space mark-all now invalidates channel-count keys at the bare-channel prefix instead of the space-scoped one — still correct).
+The per-space bell inside a space still uses the anchored right-aligned `DropdownPanel`, current-space scope, an unconfirmed mark-all, and the compact list (350px cap, 2-line clamp, 200-char preview). Global behavior — Modal shell, cross-space aggregation, taller layout, longer preview, space breadcrumb, confirm-gated mark-all — is gated behind the `global` prop. NOTE: the **row redesign (leading type badge + 3-line layout + relative time) applies to BOTH panels** — it is not global-only. The per-space-only differences are the breadcrumb space name, the list height/preview length, and the title ("…in this Space"). The per-space mark-all now invalidates channel-count keys at the bare-channel prefix instead of the space-scoped one (still correct).
 
 ### Key files
 
@@ -604,9 +622,11 @@ The per-space bell inside a space still uses the anchored right-aligned dropdown
 - `src/hooks/business/notifications/useGlobalNotifications.ts` — composition + cap + `truncated`.
 - `src/hooks/business/notifications/useGlobalSenderResolver.ts`, `src/utils/resolveGlobalSender.ts` — cross-space sender names.
 - `src/hooks/business/notifications/constants.ts` — `GLOBAL_PER_CHANNEL_LIMIT`, `GLOBAL_DISPLAY_CAP`.
-- `src/components/notifications/NotificationPanel.tsx` — `global` mode.
-- `src/components/notifications/NotificationItem.tsx` — `spaceName` breadcrumb.
-- `src/components/shell/NavRail.tsx` — bell entry, presence dot, panel mount.
+- `src/components/notifications/GlobalNotificationsModal.tsx` — Suspense-isolated container rendered by ModalProvider; owns `useSpaces`/`useGlobalSenderResolver` and mounts the panel in global mode.
+- `src/components/notifications/NotificationPanel.tsx` — `global` mode (Modal shell vs DropdownPanel; context-aware title; cross-space confirm mark-all).
+- `src/components/notifications/NotificationItem.tsx` / `.scss` — leading type badge + 3-line row (location / author+preview / relative time); `spaceName` drives global breadcrumb, taller layout, longer preview.
+- `src/components/shell/NavRail.tsx` / `.scss` — bell entry (last item), `openNotifications()` trigger, presence-dot badge.
+- `src/hooks/business/ui/useModalState.ts` + `src/components/context/ModalProvider.tsx` — `notifications` modal state + `openNotifications`/`closeNotifications`.
 
 ---
 
@@ -819,3 +839,5 @@ All mention components use `tokenData.isInteractive` flag to determine CSS class
 _Updated: 2026-03-14 (added Thread Mentions section documenting thread-aware notification behavior: `thread_read_times` IndexedDB store, `channel › Thread` breadcrumb in NotificationPanel, navigation hash format, and persistence rules)_
 
 _Updated: 2026-06-23 (added Global Notification Panel section: NavRail bell, centered presentation, live cross-space aggregation via `useGlobalNotifications` → shared `fetchSpaceMentions`/`fetchSpaceReplies`, bounded-fetch cap, `useGlobalSenderResolver`, `Space › #channel` breadcrumb, broadened cache invalidations, confirm-gated cross-space mark-all; per-space bell unchanged)_
+
+_Updated: 2026-06-24 (Global Notification Panel refinements: moved to the Modal primitive via ModalProvider + `GlobalNotificationsModal` container for a proper backdrop/z-index; bell moved to last rail item + overlapping presence badge; mobile-style row redesign across BOTH panels (leading type badge with at/bullhorn/shield/reply icons + 3-line location/author-preview/relative-time layout, calendar icon removed); per-space title "…in this Space"; taller global modal with longer preview and single scroll region; vertical loading/empty state)_

--- a/.agents/tasks/2026-06-23-global-notification-panel-design.md
+++ b/.agents/tasks/2026-06-23-global-notification-panel-design.md
@@ -1,0 +1,266 @@
+# Global Notification Panel (Desktop) — Design
+
+> Design spec. No code changed yet. Brings desktop to parity with mobile's
+> global, in-app notification surface: one panel aggregating mentions/replies
+> across ALL spaces, opened from the left shell rail. Mirrors the existing
+> bookmarks pattern (global in the rail, scoped-to-here in the channel header).
+
+## Status
+
+- **Type:** feature design
+- **Created:** 2026-06-23
+- **Architecture decision:** Approach A (live-derived, extended global) — settled with user
+- **Related docs:**
+  - `.agents/docs/features/mention-notification-system.md` (desktop, current per-space panel)
+  - `.agents/docs/features/notification-indicators-system.md` (desktop, badges/counts)
+  - `../../quorum-mobile/.agents/docs/features/notification-system.md` (mobile reference)
+  - `../../quorum-mobile/.agents/docs/2026-06-23-notification-system-mobile-vs-desktop.md` (divergence analysis)
+
+---
+
+## TL;DR
+
+Desktop today has a **per-space** notification panel: a bell in the channel
+header that lists unread mentions/replies for the current space only, derived
+live from IndexedDB. This adds a **global** panel — one inbox across all spaces —
+opened from a new **NavRail bell** as a **centered modal overlay**. The existing
+per-space header bell stays exactly as-is. Same components, two scopes — the same
+split bookmarks already uses (`/bookmarks` page global, header dropdown scoped).
+
+No new storage, no persisted log, no schema migration. The global panel computes
+its list the same way the per-space one does, just looped over every space.
+
+---
+
+## Decisions (settled with user, 2026-06-23)
+
+1. **Architecture: Approach A (live-derived).** Aggregate the existing per-space
+   live queries across all spaces. NOT a persisted log (mobile uses a log only
+   because its WebSocket layer discards the message; desktop keeps every message
+   in IndexedDB, so the data for live derivation is always present). No new store,
+   no migration, no second source of truth — count badges and the panel stay in
+   lockstep automatically.
+2. **Cross-device sync: unchanged, out of scope.** `lastReadTimestamp` is
+   device-local on both apps (`saveReadTime` is a local `store.put`, never sent to
+   the server — confirmed `src/db/messages.ts:954`). Reading a mention on desktop
+   does NOT clear it on mobile, and vice-versa. This is a deliberate privacy
+   tradeoff (the server can't see channel IDs inside encrypted envelopes) and is
+   identical under Approach A or B. This design does not change it.
+3. **Entry point: new NavRail bell** (global) + keep the channel-header bell
+   (per-space). Mirrors the bookmarks pattern.
+4. **Presentation: centered modal overlay** from the rail bell
+   (`DropdownPanel positionStyle="centered"`), dimmed backdrop, list scrolls
+   inside, dismiss on backdrop-click/Escape, no route change. Header bell stays an
+   anchored dropdown.
+5. **Grouping: flat list, newest-first**, with a `Space › #channel` breadcrumb per
+   row. No per-space sections, no type sections.
+6. **Filtering: type filter only** (`@you / @everyone / @roles / Replies`), applied
+   globally as a pure UI filter. No space filter (breadcrumb shows origin; the
+   per-space view is the header bell).
+7. **Rail badge: simple presence dot, no number.** Consistent with the existing
+   Messages DM dot on the rail.
+8. **Mark all as read: global scope, gated behind a confirm dialog** (danger
+   variant) because the blast radius spans all spaces.
+
+---
+
+## Architecture & data flow
+
+### Shared per-space fetch, two callers
+
+The per-space query bodies of `useAllMentions` / `useAllReplies` are extracted
+into plain async functions so the new global hooks reuse them verbatim (no
+duplicated gating logic, zero behavior drift):
+
+```
+fetchSpaceMentions(messageDB, space, userAddress, { enabledTypes, userRoleIds })
+   → MentionNotification[]   (for ONE space; existing per-space logic)
+fetchSpaceReplies(messageDB, space, userAddress, { enabled })
+   → ReplyNotification[]     (for ONE space)
+```
+
+Both encapsulate the current logic exactly:
+- per-space `notificationSettings` lookup + `isMuted` short-circuit
+- muted-channel exclusion (`getMutedChannelsForSpace`)
+- per-channel `lastReadTimestamp` + per-thread `thread_read_times` gating
+- `isMentionedWithSettings` (mentions) / `getUnreadReplies` (replies)
+
+The existing per-space hooks (`useAllMentions`, `useAllReplies`) keep their exact
+current public API — they just call the extracted function internally. **This
+guarantees the existing header bell is untouched.**
+
+### New global hooks
+
+```
+useAllMentionsGlobal({ spaces, enabledTypes })   // loops fetchSpaceMentions over spaces
+useAllRepliesGlobal({ spaces, enabled })         // loops fetchSpaceReplies over spaces
+```
+
+- Source of `spaces`: `useSpaces()`.
+- Each result row is augmented with `spaceId` + `spaceName` (in addition to the
+  existing `channelId` / `channelName`) so the row can render the breadcrumb.
+- Per-space user role IDs computed via `getUserRoles(userAddress, space)` inside
+  the loop (same as `useSpaceMentionCounts` already does).
+- Flatten + sort newest-first by `message.createdDate`.
+- React Query keys: `['mention-notifications', 'global', userAddress, ...spaceIds.sort()]`
+  and `['reply-notifications', 'global', ...]`. `staleTime: 30000`,
+  `refetchOnWindowFocus: true` — matches per-space.
+
+> Optional: a single `useGlobalNotifications` composing both hooks + the merged
+> sorted list, to keep the panel component thin. Decided during planning.
+
+### Cache invalidation
+
+`MessageService.ts` (new message) and `useUpdateReadTime` (channel read) already
+invalidate `['mention-notifications', ...]` / `['reply-notifications', ...]`.
+Confirm these prefixes also match the new `'global'` keys (React Query prefix
+matching: `['mention-notifications']` invalidates `['mention-notifications', 'global', ...]`,
+so a broad invalidation covers it — verify the existing calls aren't over-scoped
+to a specific `spaceId` in a way that misses global). Add explicit global-key
+invalidations where the existing ones are space-scoped.
+
+---
+
+## Entry point & presentation
+
+### NavRail bell (`src/components/shell/NavRail.tsx`)
+
+- Add a `notifications` entry to `buildItems()`: `icon: 'bell'`, `label: t\`Notifications\``.
+- Unlike other rail items, it does **not** navigate. `onItemClick` gets a branch:
+  `id === 'notifications'` toggles local `isPanelOpen` state instead of `navigate()`.
+  (Bookmarks navigates to `/bookmarks`; ours opens a centered overlay — the one
+  intentional divergence, driven by decision #4.)
+- **Unread dot:** render `.icon-unread-dot` on the bell when any unread
+  mention/reply exists across all spaces. Source:
+  `useSpaceMentionCounts(spaces)` + `useSpaceReplyCounts(spaces)` — dot shows if
+  either returned map is non-empty. (Both hooks exist, early-exit at 10, 90s
+  stale.)
+- The NavRail is a global shell component; it gains the `spaces` query +
+  the global panel render. Keep added state minimal (one `isPanelOpen` boolean).
+
+### Presentation
+
+- Global panel = the existing `NotificationPanel` rendered with
+  `positionStyle="centered"` → centered overlay, dimmed backdrop, internal scroll,
+  dismiss on backdrop-click/Escape. No URL change.
+- Header per-space bell (`src/components/space/Channel.tsx` ~L1497):
+  **unchanged** — anchored dropdown, current-space scope.
+
+### Sender-name resolution
+
+The per-space `mapSenderToUser` is built inside `Channel` from that space's
+member data. The global panel spans spaces, so resolve sender names per row from
+the row's own `spaceId` → that space's member data (each row already carries
+`spaceId`). No new infrastructure; confirm the cleanest resolver wiring during
+planning (likely a small helper that takes `spaceId` + `senderId` and looks up
+the member in the cached space data).
+
+---
+
+## Panel internals
+
+### Layout
+
+- Flat list, newest-first, across all spaces (`NotificationPanel` already sorts
+  the combined mentions+replies array by `createdDate`).
+- `NotificationItem` gains an **optional `spaceName` prop**. When present, render a
+  `Space › #channel` breadcrumb (space name leads; `#channel` follows in muted
+  channel styling, reusing existing classes). When absent (per-space header bell),
+  render `#channel` only — **zero visual change to the existing header panel**.
+- Thread rows keep the existing `#channel › Thread` treatment; with a space it
+  becomes `Space › #channel › Thread`.
+
+### Filtering
+
+- Reuse the existing `@you / @everyone / @roles / Replies` multi-select filter,
+  applied globally.
+- **Global filter is a pure UI filter over types**, all four selected by default —
+  NOT derived from any single space's saved `enabledNotificationTypes` (those
+  differ per space). The per-space *eligibility gating* still happens inside the
+  aggregation hooks per each space's own settings: a space where `@everyone` is
+  disabled contributes no `@everyone` rows regardless of the global filter. The
+  global filter only narrows what is already eligible.
+- No space filter.
+
+### Navigation
+
+- Unchanged. `handleNavigate(spaceId, channelId, messageId, threadId?)` builds the
+  `#msg-…` / `#thread-…-msg-…` hash and navigates to
+  `/spaces/{spaceId}/{channelId}{hash}`. Rows carry `spaceId` explicitly, so
+  cross-space jumps work as today. Navigating closes the centered panel.
+
+---
+
+## Global "Mark all as read" (with confirm)
+
+- Reuse `useConfirmation({ type: 'modal', modalConfig: { variant: 'danger', … } })`
+  + the existing `ConfirmationModalProvider`. The mark-all button opens a confirm
+  dialog warning it marks notifications read across **all** spaces.
+- On confirm: collect every `(spaceId, channelId)` present in the current global
+  list, `saveReadTime` for each, gather their threads and `bulkSaveThreadReadTimes`,
+  then invalidate global + space + channel caches. This is the per-space
+  `handleMarkAllRead` routine (already in `NotificationPanel.tsx`) generalized over
+  multiple spaces rather than one `spaceId`.
+
+---
+
+## Components & files
+
+### New
+- `src/hooks/business/mentions/useAllMentionsGlobal.ts` — global mention aggregation
+- `src/hooks/business/replies/useAllRepliesGlobal.ts` — global reply aggregation
+- (optional) `src/hooks/business/.../useGlobalNotifications.ts` — composition + merge
+
+### Modified
+- `src/hooks/business/mentions/useAllMentions.ts` — extract `fetchSpaceMentions`,
+  call it internally (no API change)
+- `src/hooks/business/replies/useAllReplies.ts` — extract `fetchSpaceReplies`,
+  call it internally (no API change)
+- `src/hooks/business/mentions/index.ts`, `.../replies/index.ts` — export new hooks
+- `src/components/shell/NavRail.tsx` — bell item, toggle state, unread dot, render
+  global panel
+- `src/components/notifications/NotificationPanel.tsx` — accept a `global` mode:
+  centered presentation, global hooks, breadcrumb-enabled rows, global mark-all +
+  confirm. (Keep per-space path intact via props.)
+- `src/components/notifications/NotificationItem.tsx` — optional `spaceName` prop +
+  breadcrumb render
+- `NotificationPanel.scss` / `NotificationItem.scss` — breadcrumb + centered-mode
+  styling as needed
+
+### Reused as-is
+- `useSpaces`, `useSpaceMentionCounts`, `useSpaceReplyCounts`
+- `DropdownPanel` (`positionStyle="centered"`)
+- `useConfirmation` + `ConfirmationModalProvider`
+- `buildMessageHash`, `useMessageFormatting`, `useSearchResultFormatting`
+- `isMentionedWithSettings`, `getUnreadMentions`, `getUnreadReplies`,
+  `getDefaultNotificationSettings`, `getUserRoles` (from `@quilibrium/quorum-shared`)
+
+---
+
+## Out of scope / non-goals
+
+- **Cross-device read-state sync** (see decision #2) — separate, much larger
+  project; unchanged by this work.
+- **Persisted notification log / "Clear all" history** — explicitly rejected
+  (Approach B). The global panel shows currently-unread items only, consistent
+  with desktop's existing model.
+- **DMs in the panel** — desktop surfaces DM unread via the NavRail dot; out of
+  scope here (mirrors mobile, where DMs-in-panel is a separate open task).
+- **Farcaster** — desktop has no Farcaster notifications; not applicable.
+- **No `@quilibrium/quorum-shared` change** — detection + settings types already
+  shared; nothing new on the wire.
+
+---
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Refactor of `useAllMentions`/`useAllReplies` breaks the existing header bell | Extract pure functions; keep hook public APIs byte-identical; the header bell path is unchanged |
+| Global query is slow with many spaces × many channels | Same per-channel `getUnreadMentions`/`getUnreadReplies` queries the per-space panel already runs; 30s stale + focus-refetch; consider a result cap if needed (decide in planning) |
+| Global cache keys missed by existing invalidations | Audit `MessageService` / `useUpdateReadTime` invalidations; rely on React Query prefix matching or add explicit global-key invalidations |
+| Sender resolution differs from per-space `mapSenderToUser` | Resolve per row from the row's `spaceId` space data; confirm wiring in planning |
+
+---
+
+*Last updated: 2026-06-23*

--- a/.agents/tasks/2026-06-23-global-notification-panel-design.md
+++ b/.agents/tasks/2026-06-23-global-notification-panel-design.md
@@ -109,6 +109,31 @@ useAllRepliesGlobal({ spaces, enabled })         // loops fetchSpaceReplies over
 > Optional: a single `useGlobalNotifications` composing both hooks + the merged
 > sorted list, to keep the panel component thin. Decided during planning.
 
+### Performance: bounded global fetch (decided 2026-06-23)
+
+Opening the global panel fans out per-channel IndexedDB reads across ALL spaces
+(`getConversation` + `getThreadReadTimesForChannel` + `getUnreadMentions`/
+`getUnreadReplies` per channel). This is local (no network) and React-Query-cached
+(30s stale), and it is the SAME per-channel query the per-space panel already runs.
+For typical users (a few spaces, modest unread) it is a non-issue. The worst case
+(many large spaces, heavy unread) is bounded as follows so we never pull thousands
+of message objects to render a panel that shows a few dozen:
+
+- **Lower the per-channel limit** for the global path from `1000` to `GLOBAL_PER_CHANNEL_LIMIT = 50`.
+  No single channel realistically contributes more than ~50 of the newest visible
+  rows. (The per-space header bell keeps its existing `1000` — unchanged.)
+- **Still fetch every space** (skipping spaces would drop newer items from
+  later-iterated spaces), but each channel's contribution is bounded by the limit.
+- **Sort the merged set newest-first, then slice to `GLOBAL_DISPLAY_CAP = 100`.**
+  Slicing AFTER the global sort is order-independent — no bias toward
+  whichever space was iterated first.
+- **No silent truncation:** when the merged count exceeds the cap, the panel shows
+  a subtle "Showing 100 most recent" footer/affordance rather than implying the
+  list is exhaustive.
+- The **unread dot** stays cheap: it reads the existing early-exit count hooks
+  (`useSpaceMentionCounts`/`useSpaceReplyCounts`, capped at 10), NOT the panel
+  fetch. So the always-on indicator cost is unchanged from today.
+
 ### Cache invalidation
 
 `MessageService.ts` (new message) and `useUpdateReadTime` (channel read) already

--- a/.agents/tasks/2026-06-23-global-notification-panel-plan.md
+++ b/.agents/tasks/2026-06-23-global-notification-panel-plan.md
@@ -1,0 +1,1324 @@
+# Global Notification Panel (Desktop) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a global notification panel to Quorum Desktop that aggregates unread mentions and replies across ALL spaces, opened from a new NavRail bell as a centered modal overlay, while keeping the existing per-space header bell unchanged.
+
+**Architecture:** Approach A (live-derived). The per-space query bodies of `useAllMentions`/`useAllReplies` are extracted into pure async functions reused by new global hooks that loop over `useSpaces()`. No persisted log, no IndexedDB schema change, no `quorum-shared` change. The global panel reuses `NotificationPanel`/`NotificationItem` with a `global` mode (centered presentation, breadcrumb rows, global mark-all + confirm).
+
+**Tech Stack:** React 18, TypeScript, TanStack Query (React Query), Vitest (tests in `src/dev/tests/`), Lingui (`t` macro), IndexedDB via `MessageDB`, SCSS. Shared logic from `@quilibrium/quorum-shared`.
+
+**Branch:** `feat/global-notification-panel` (already created; design spec committed there).
+
+**Spec:** `.agents/tasks/2026-06-23-global-notification-panel-design.md`
+
+---
+
+## File Structure
+
+### Create
+- `src/hooks/business/mentions/fetchSpaceMentions.ts` — pure async fn: unread mentions for ONE space
+- `src/hooks/business/replies/fetchSpaceReplies.ts` — pure async fn: unread replies for ONE space
+- `src/hooks/business/mentions/useAllMentionsGlobal.ts` — global mention aggregation hook
+- `src/hooks/business/replies/useAllRepliesGlobal.ts` — global reply aggregation hook
+- `src/hooks/business/notifications/useGlobalNotifications.ts` — composes both + merged sorted list + global unread flag
+- `src/hooks/business/notifications/index.ts` — barrel for the new composition hook
+- `src/utils/resolveGlobalSender.ts` — resolve a sender's display name from a space's member data, given `spaceId`
+- `src/dev/tests/hooks/fetchSpaceMentions.unit.test.ts` — tests for the extracted mention fn
+- `src/dev/tests/hooks/fetchSpaceReplies.unit.test.ts` — tests for the extracted reply fn
+- `src/dev/tests/utils/resolveGlobalSender.unit.test.ts` — tests for the global sender resolver
+
+### Modify
+- `src/hooks/business/mentions/useAllMentions.ts` — call `fetchSpaceMentions` internally (no public API change), add `spaceId`/`spaceName` to rows
+- `src/hooks/business/replies/useAllReplies.ts` — call `fetchSpaceReplies` internally (no public API change), add `spaceId`/`spaceName` to rows
+- `src/hooks/business/mentions/index.ts` — export `useAllMentionsGlobal`, `fetchSpaceMentions`
+- `src/hooks/business/replies/index.ts` — export `useAllRepliesGlobal`, `fetchSpaceReplies`
+- `src/components/notifications/NotificationItem.tsx` — optional `spaceName` prop + breadcrumb render
+- `src/components/notifications/NotificationItem.scss` — breadcrumb styling
+- `src/components/notifications/NotificationPanel.tsx` — `global` mode (centered, global hooks, global mark-all + confirm)
+- `src/components/shell/NavRail.tsx` — bell item, toggle state, unread dot, render global panel
+- `src/components/shell/NavRail.scss` — unread dot positioning on a rail item
+
+### Reused as-is (no change)
+- `useSpaces`, `useSpaceMentionCounts`, `useSpaceReplyCounts`
+- `DropdownPanel` (`positionStyle="centered"`, `headerContent` slot)
+- `useConfirmation` + `ConfirmationModalProvider`
+- `buildMessageHash`, `useMessageFormatting`, `useSearchResultFormatting`
+- `isMentionedWithSettings`, `getUnreadMentions`, `getUnreadReplies`, `getDefaultNotificationSettings`, `getUserRoles`, `resolveSpaceMemberName`
+
+---
+
+## Type contracts (locked — used across tasks)
+
+`MentionNotification` (existing, in `useAllMentions.ts`) gains two optional fields:
+
+```typescript
+export interface MentionNotification {
+  message: Message;
+  channelId: string;
+  channelName: string;
+  mentionType: 'you' | 'everyone' | 'roles';
+  spaceId?: string;    // NEW — set by global path; undefined for per-space path
+  spaceName?: string;  // NEW — set by global path; undefined for per-space path
+}
+```
+
+`ReplyNotification` is re-exported from `quorum-shared` (cannot edit there per scope). The global reply rows need `spaceId`/`spaceName` too, so the global hooks return a desktop-local widened type:
+
+```typescript
+// in src/hooks/business/notifications/useGlobalNotifications.ts
+import type { ReplyNotification } from '../../../types/notifications';
+import type { MentionNotification } from '../mentions/useAllMentions';
+
+export type GlobalReplyNotification = ReplyNotification & { spaceId: string; spaceName: string };
+export type GlobalMentionNotification = MentionNotification & { spaceId: string; spaceName: string };
+export type GlobalNotification = GlobalMentionNotification | GlobalReplyNotification;
+```
+
+Extracted fn signatures (locked):
+
+```typescript
+// fetchSpaceMentions.ts
+export async function fetchSpaceMentions(
+  messageDB: MessageDB,
+  space: Space,
+  userAddress: string,
+  opts: {
+    enabledTypes?: ('mention-you' | 'mention-everyone' | 'mention-roles')[];
+    userRoleIds: string[];
+    config: UserConfig | undefined; // pre-fetched user config (avoids N getUserConfig calls)
+  },
+): Promise<MentionNotification[]>
+
+// fetchSpaceReplies.ts
+export async function fetchSpaceReplies(
+  messageDB: MessageDB,
+  space: Space,
+  userAddress: string,
+  opts: {
+    enabled: boolean;
+    config: UserConfig | undefined;
+  },
+): Promise<ReplyNotification[]>
+```
+
+Both set `spaceId: space.spaceId` and `spaceName: space.name` on every row they return.
+
+> **Note on `space.name`:** verify the field name on `Space` during Task 1 (`Space` type from `quorum-shared`). `useSpaceReplyCounts` uses `space.spaceId`; the human name field is referenced as `space.name` in this plan — if the type uses a different key (e.g. `spaceName`), use that and keep it consistent across all tasks.
+
+---
+
+### Task 1: Extract `fetchSpaceMentions` (pure fn) + verify Space.name
+
+**Files:**
+- Create: `src/hooks/business/mentions/fetchSpaceMentions.ts`
+- Create: `src/dev/tests/hooks/fetchSpaceMentions.unit.test.ts`
+
+- [ ] **Step 1: Confirm the `Space` human-name field**
+
+Run: `npx tsc --noEmit -p tsconfig.json` is not needed yet. Instead inspect the type:
+Open `node_modules/@quilibrium/quorum-shared/dist/**` or the source, OR grep usage:
+Run: `rg "space\.name|spaceName:" src/components/space/SpacesSidebar.tsx -n`
+Expected: find the property used for a space's display name. Use that exact key as `SPACE_NAME_FIELD` everywhere below. (Plan assumes `space.name`.)
+
+- [ ] **Step 2: Write the failing test**
+
+```typescript
+// src/dev/tests/hooks/fetchSpaceMentions.unit.test.ts
+import { describe, it, expect, vi } from 'vitest';
+
+const ME = 'QmMeAddr0000000000000000000000000000000000';
+const SENDER = 'QmSender000000000000000000000000000000000';
+
+function makeSpace() {
+  return {
+    spaceId: 'space-1',
+    name: 'Test Space',
+    roles: [],
+    members: {},
+    groups: [{ channels: [{ channelId: 'chan-1', channelName: 'general' }] }],
+  } as any;
+}
+
+function makeMessage(overrides: any = {}) {
+  return {
+    messageId: 'm1',
+    createdDate: 1000,
+    content: { senderId: SENDER, text: 'hey @<' + ME + '>' },
+    mentions: { memberIds: [ME], roleIds: [], everyone: false, channelIds: [] },
+    ...overrides,
+  };
+}
+
+function makeDB(over: any = {}) {
+  return {
+    getUserConfig: vi.fn().mockResolvedValue({ notificationSettings: {}, mutedChannels: {} }),
+    getSpace: vi.fn().mockResolvedValue(makeSpace()),
+    getConversation: vi.fn().mockResolvedValue({ conversation: { lastReadTimestamp: 0 } }),
+    getThreadReadTimesForChannel: vi.fn().mockResolvedValue({}),
+    getUnreadMentions: vi.fn().mockResolvedValue([makeMessage()]),
+    ...over,
+  } as any;
+}
+
+describe('fetchSpaceMentions', () => {
+  it('returns a mention row tagged with spaceId and spaceName', async () => {
+    const { fetchSpaceMentions } = await import('../../../hooks/business/mentions/fetchSpaceMentions');
+    const db = makeDB();
+    const rows = await fetchSpaceMentions(db, makeSpace(), ME, {
+      enabledTypes: ['mention-you', 'mention-everyone', 'mention-roles'],
+      userRoleIds: [],
+      config: { notificationSettings: {}, mutedChannels: {} } as any,
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].spaceId).toBe('space-1');
+    expect(rows[0].spaceName).toBe('Test Space');
+    expect(rows[0].channelName).toBe('general');
+    expect(rows[0].mentionType).toBe('you');
+  });
+
+  it('returns [] when the space is muted', async () => {
+    const { fetchSpaceMentions } = await import('../../../hooks/business/mentions/fetchSpaceMentions');
+    const db = makeDB();
+    const rows = await fetchSpaceMentions(db, makeSpace(), ME, {
+      enabledTypes: ['mention-you'],
+      userRoleIds: [],
+      config: { notificationSettings: { 'space-1': { isMuted: true } } } as any,
+    });
+    expect(rows).toEqual([]);
+  });
+
+  it('excludes muted channels', async () => {
+    const { fetchSpaceMentions } = await import('../../../hooks/business/mentions/fetchSpaceMentions');
+    const db = makeDB();
+    const rows = await fetchSpaceMentions(db, makeSpace(), ME, {
+      enabledTypes: ['mention-you'],
+      userRoleIds: [],
+      config: { notificationSettings: {}, mutedChannels: { 'space-1': ['chan-1'] } } as any,
+    });
+    expect(rows).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `yarn vitest src/dev/tests/hooks/fetchSpaceMentions.unit.test.ts --run`
+Expected: FAIL — cannot resolve module `fetchSpaceMentions`.
+
+- [ ] **Step 4: Implement `fetchSpaceMentions`**
+
+Copy the per-channel loop body out of the current `useAllMentions` queryFn verbatim, parameterized. The config is passed in (not fetched) so the global hook fetches it once.
+
+```typescript
+// src/hooks/business/mentions/fetchSpaceMentions.ts
+import { isMentionedWithSettings, getDefaultNotificationSettings } from '@quilibrium/quorum-shared';
+import type { Message, Space } from '@quilibrium/quorum-shared';
+import { getMutedChannelsForSpace } from '../../../utils/channelUtils';
+import type { MessageDB } from '../../../db/messages';
+import type { MentionNotification } from './useAllMentions';
+
+function getMentionType(message: Message, userAddress: string): 'you' | 'everyone' | 'roles' {
+  if (message.mentions?.everyone) return 'everyone';
+  if (message.mentions?.roleIds?.length && message.mentions.roleIds.length > 0) return 'roles';
+  if (message.mentions?.memberIds?.includes(userAddress)) return 'you';
+  return 'you';
+}
+
+export async function fetchSpaceMentions(
+  messageDB: MessageDB,
+  space: Space,
+  userAddress: string,
+  opts: {
+    enabledTypes?: ('mention-you' | 'mention-everyone' | 'mention-roles')[];
+    userRoleIds: string[];
+    config: any; // UserConfig | undefined
+  },
+): Promise<MentionNotification[]> {
+  const { enabledTypes, userRoleIds, config } = opts;
+  const settings = config?.notificationSettings?.[space.spaceId];
+  if (settings?.isMuted) return [];
+
+  let typesToCheck: string[];
+  if (enabledTypes) {
+    typesToCheck = enabledTypes;
+  } else {
+    const allTypes = settings?.enabledNotificationTypes
+      || getDefaultNotificationSettings(space.spaceId).enabledNotificationTypes;
+    typesToCheck = allTypes.filter((tp: string) => tp.startsWith('mention-'));
+  }
+  if (typesToCheck.length === 0) return [];
+
+  const mutedChannelIds = getMutedChannelsForSpace(space.spaceId, config?.mutedChannels);
+  const channelIds = space.groups.flatMap((g) => g.channels.map((c) => c.channelId));
+  const out: MentionNotification[] = [];
+
+  for (const channelId of channelIds) {
+    if (mutedChannelIds.includes(channelId)) continue;
+    const conversationId = `${space.spaceId}/${channelId}`;
+    const { conversation } = await messageDB.getConversation({ conversationId });
+    const lastReadTimestamp = conversation?.lastReadTimestamp || 0;
+    const threadReadTimes = await messageDB.getThreadReadTimesForChannel({ spaceId: space.spaceId, channelId });
+    const messages = await messageDB.getUnreadMentions({
+      spaceId: space.spaceId, channelId, afterTimestamp: lastReadTimestamp, limit: 1000,
+    });
+    const channel = space.groups.flatMap((g) => g.channels).find((c) => c.channelId === channelId);
+
+    const unread = messages.filter((message: Message) => {
+      if (message.isThreadReply && message.threadId) {
+        const trt = threadReadTimes[message.threadId];
+        if (trt !== undefined && message.createdDate <= trt) return false;
+      } else if (message.createdDate <= lastReadTimestamp) {
+        return false;
+      }
+      return isMentionedWithSettings(message, {
+        userAddress, enabledTypes: typesToCheck, userRoles: userRoleIds, space,
+      });
+    });
+
+    for (const message of unread) {
+      out.push({
+        message,
+        channelId,
+        channelName: channel?.channelName || 'Unknown Channel',
+        mentionType: getMentionType(message, userAddress),
+        spaceId: space.spaceId,
+        spaceName: space.name,
+      });
+    }
+  }
+  return out;
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `yarn vitest src/dev/tests/hooks/fetchSpaceMentions.unit.test.ts --run`
+Expected: PASS (3 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/hooks/business/mentions/fetchSpaceMentions.ts src/dev/tests/hooks/fetchSpaceMentions.unit.test.ts
+git commit -m "feat(notifications): extract fetchSpaceMentions pure fn"
+```
+
+---
+
+### Task 2: Refactor `useAllMentions` to use `fetchSpaceMentions`
+
+**Files:**
+- Modify: `src/hooks/business/mentions/useAllMentions.ts`
+
+- [ ] **Step 1: Replace the queryFn body to call the extracted fn**
+
+Keep the hook's props/return identical. Fetch config once, loop channels via the shared fn (the fn already loops channels for the whole space, so call it once per the single `spaceId`, passing only `channelIds` indirectly — but `useAllMentions` is single-space with an explicit `channelIds` list that may be a subset). To preserve the explicit `channelIds` contract, keep the existing channel loop but delegate the per-message logic. SIMPLEST: since `fetchSpaceMentions` derives channels from `space.groups`, and the per-space panel passes ALL channels of the space, call the shared fn and rely on the same channel set.
+
+Replace `useAllMentions.ts` queryFn with:
+
+```typescript
+    queryFn: async () => {
+      if (!userAddress) return [];
+      try {
+        const config = await messageDB.getUserConfig({ address: userAddress });
+        const space = await messageDB.getSpace(spaceId);
+        if (!space) return [];
+
+        // Mirror the previous channelIds contract: filter the space's channels
+        // down to the explicit channelIds the caller passed.
+        const allowed = new Set(channelIds);
+        const scoped = {
+          ...space,
+          groups: space.groups.map((g) => ({
+            ...g,
+            channels: g.channels.filter((c) => allowed.has(c.channelId)),
+          })),
+        };
+
+        const rows = await fetchSpaceMentions(messageDB, scoped, userAddress, {
+          enabledTypes,
+          userRoleIds,
+          config,
+        });
+        rows.sort((a, b) => b.message.createdDate - a.message.createdDate);
+        return rows;
+      } catch (error) {
+        console.error('[AllMentions] Error fetching mentions:', error);
+        return [];
+      }
+    },
+```
+
+Add the import at the top:
+
+```typescript
+import { fetchSpaceMentions } from './fetchSpaceMentions';
+```
+
+Add `spaceId`/`spaceName` to the `MentionNotification` interface:
+
+```typescript
+export interface MentionNotification {
+  message: Message;
+  channelId: string;
+  channelName: string;
+  mentionType: 'you' | 'everyone' | 'roles';
+  spaceId?: string;
+  spaceName?: string;
+}
+```
+
+Remove the now-unused local `getMentionType` helper at the bottom of the file (it moved into `fetchSpaceMentions`). Remove now-unused imports (`isMentionedWithSettings`, `getDefaultNotificationSettings`, `getMutedChannelsForSpace`) if no longer referenced — let tsc tell you.
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npx tsc --noEmit --skipLibCheck`
+Expected: PASS (no errors in `useAllMentions.ts`). Fix unused-import errors by deleting them.
+
+- [ ] **Step 3: Run the full existing suite to confirm no regression**
+
+Run: `yarn vitest src/dev/tests/ --run`
+Expected: PASS — all currently-passing tests still pass (no behavior change to the per-space path).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/hooks/business/mentions/useAllMentions.ts
+git commit -m "refactor(notifications): useAllMentions delegates to fetchSpaceMentions"
+```
+
+---
+
+### Task 3: Extract `fetchSpaceReplies` + refactor `useAllReplies`
+
+**Files:**
+- Create: `src/hooks/business/replies/fetchSpaceReplies.ts`
+- Create: `src/dev/tests/hooks/fetchSpaceReplies.unit.test.ts`
+- Modify: `src/hooks/business/replies/useAllReplies.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/dev/tests/hooks/fetchSpaceReplies.unit.test.ts
+import { describe, it, expect, vi } from 'vitest';
+
+const ME = 'QmMeAddr0000000000000000000000000000000000';
+
+function makeSpace() {
+  return {
+    spaceId: 'space-1',
+    name: 'Test Space',
+    roles: [],
+    members: {},
+    groups: [{ channels: [{ channelId: 'chan-1', channelName: 'general' }] }],
+  } as any;
+}
+
+function makeReply() {
+  return {
+    messageId: 'r1',
+    createdDate: 2000,
+    content: { senderId: 'QmSomeoneElse', text: 'reply text' },
+    replyMetadata: { parentAuthor: ME },
+  };
+}
+
+function makeDB(over: any = {}) {
+  return {
+    getConversation: vi.fn().mockResolvedValue({ conversation: { lastReadTimestamp: 0 } }),
+    getThreadReadTimesForChannel: vi.fn().mockResolvedValue({}),
+    getUnreadReplies: vi.fn().mockResolvedValue([makeReply()]),
+    ...over,
+  } as any;
+}
+
+describe('fetchSpaceReplies', () => {
+  it('returns a reply row tagged with spaceId and spaceName when enabled', async () => {
+    const { fetchSpaceReplies } = await import('../../../hooks/business/replies/fetchSpaceReplies');
+    const rows = await fetchSpaceReplies(makeDB(), makeSpace(), ME, {
+      enabled: true,
+      config: { notificationSettings: {}, mutedChannels: {} } as any,
+    });
+    expect(rows).toHaveLength(1);
+    expect((rows[0] as any).spaceId).toBe('space-1');
+    expect((rows[0] as any).spaceName).toBe('Test Space');
+    expect(rows[0].type).toBe('reply');
+  });
+
+  it('returns [] when not enabled', async () => {
+    const { fetchSpaceReplies } = await import('../../../hooks/business/replies/fetchSpaceReplies');
+    const rows = await fetchSpaceReplies(makeDB(), makeSpace(), ME, {
+      enabled: false,
+      config: { notificationSettings: {} } as any,
+    });
+    expect(rows).toEqual([]);
+  });
+
+  it('returns [] when the space is muted', async () => {
+    const { fetchSpaceReplies } = await import('../../../hooks/business/replies/fetchSpaceReplies');
+    const rows = await fetchSpaceReplies(makeDB(), makeSpace(), ME, {
+      enabled: true,
+      config: { notificationSettings: { 'space-1': { isMuted: true } } } as any,
+    });
+    expect(rows).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `yarn vitest src/dev/tests/hooks/fetchSpaceReplies.unit.test.ts --run`
+Expected: FAIL — cannot resolve module `fetchSpaceReplies`.
+
+- [ ] **Step 3: Implement `fetchSpaceReplies`**
+
+```typescript
+// src/hooks/business/replies/fetchSpaceReplies.ts
+import { isNotificationTypeEnabled } from '@quilibrium/quorum-shared';
+import type { Space } from '@quilibrium/quorum-shared';
+import type { ReplyNotification } from '../../../types/notifications';
+import { getMutedChannelsForSpace } from '../../../utils/channelUtils';
+import type { MessageDB } from '../../../db/messages';
+
+export async function fetchSpaceReplies(
+  messageDB: MessageDB,
+  space: Space,
+  userAddress: string,
+  opts: { enabled: boolean; config: any },
+): Promise<(ReplyNotification & { spaceId: string; spaceName: string })[]> {
+  const { enabled, config } = opts;
+  const settings = config?.notificationSettings?.[space.spaceId];
+  if (settings?.isMuted) return [];
+
+  // `enabled` overrides persistent settings (matches old useAllReplies semantics).
+  const shouldFetch = enabled !== undefined ? enabled : isNotificationTypeEnabled(settings, 'reply');
+  if (!shouldFetch) return [];
+
+  const mutedChannelIds = getMutedChannelsForSpace(space.spaceId, config?.mutedChannels);
+  const channelIds = space.groups.flatMap((g) => g.channels.map((c) => c.channelId));
+  const out: (ReplyNotification & { spaceId: string; spaceName: string })[] = [];
+
+  for (const channelId of channelIds) {
+    if (mutedChannelIds.includes(channelId)) continue;
+    const conversationId = `${space.spaceId}/${channelId}`;
+    const { conversation } = await messageDB.getConversation({ conversationId });
+    const lastReadTimestamp = conversation?.lastReadTimestamp || 0;
+    const threadReadTimes = await messageDB.getThreadReadTimesForChannel({ spaceId: space.spaceId, channelId });
+    const messages = await messageDB.getUnreadReplies({
+      spaceId: space.spaceId, channelId, userAddress, afterTimestamp: lastReadTimestamp, limit: 1000,
+    });
+    const channel = space.groups.flatMap((g) => g.channels).find((c) => c.channelId === channelId);
+
+    for (const message of messages) {
+      if (message.isThreadReply && message.threadId) {
+        const trt = threadReadTimes[message.threadId];
+        if (trt !== undefined && message.createdDate <= trt) continue;
+      }
+      out.push({
+        message,
+        channelId,
+        channelName: channel?.channelName || 'Unknown Channel',
+        type: 'reply',
+        spaceId: space.spaceId,
+        spaceName: space.name,
+      });
+    }
+  }
+  return out;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `yarn vitest src/dev/tests/hooks/fetchSpaceReplies.unit.test.ts --run`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Refactor `useAllReplies` to delegate**
+
+Replace the `useAllReplies.ts` queryFn with:
+
+```typescript
+    queryFn: async () => {
+      if (!userAddress) return [];
+      try {
+        const config = await messageDB.getUserConfig({ address: userAddress });
+        const space = await messageDB.getSpace(spaceId);
+        if (!space) return [];
+
+        const allowed = new Set(channelIds);
+        const scoped = {
+          ...space,
+          groups: space.groups.map((g) => ({
+            ...g,
+            channels: g.channels.filter((c) => allowed.has(c.channelId)),
+          })),
+        };
+
+        const rows = await fetchSpaceReplies(messageDB, scoped, userAddress, { enabled: enabled as boolean, config });
+        rows.sort((a, b) => b.message.createdDate - a.message.createdDate);
+        return rows;
+      } catch (error) {
+        console.error('[AllReplies] Error fetching replies:', error);
+        return [];
+      }
+    },
+```
+
+Add import: `import { fetchSpaceReplies } from './fetchSpaceReplies';`
+Remove now-unused imports (`isNotificationTypeEnabled`, `getMutedChannelsForSpace`) if tsc flags them.
+
+Note: the old `useAllReplies` used `enabled !== undefined ? enabled : isNotificationTypeEnabled(...)`. The hook always passes `enabled` from the panel, so passing it straight through preserves behavior. Keep the `enabled as boolean` cast since the prop is optional.
+
+- [ ] **Step 6: Typecheck + full suite**
+
+Run: `npx tsc --noEmit --skipLibCheck`
+Expected: PASS.
+Run: `yarn vitest src/dev/tests/ --run`
+Expected: PASS (all prior tests + 3 new).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/hooks/business/replies/fetchSpaceReplies.ts src/dev/tests/hooks/fetchSpaceReplies.unit.test.ts src/hooks/business/replies/useAllReplies.ts
+git commit -m "feat(notifications): extract fetchSpaceReplies, useAllReplies delegates"
+```
+
+---
+
+### Task 4: Global aggregation hooks
+
+**Files:**
+- Create: `src/hooks/business/mentions/useAllMentionsGlobal.ts`
+- Create: `src/hooks/business/replies/useAllRepliesGlobal.ts`
+- Modify: `src/hooks/business/mentions/index.ts`
+- Modify: `src/hooks/business/replies/index.ts`
+
+- [ ] **Step 1: Implement `useAllMentionsGlobal`**
+
+```typescript
+// src/hooks/business/mentions/useAllMentionsGlobal.ts
+import { useQuery } from '@tanstack/react-query';
+import { usePasskeysContext } from '@quilibrium/quilibrium-js-sdk-channels';
+import { getUserRoles } from '@quilibrium/quorum-shared';
+import type { Space } from '@quilibrium/quorum-shared';
+import { useMessageDB } from '../../../components/context/useMessageDB';
+import { fetchSpaceMentions } from './fetchSpaceMentions';
+import type { MentionNotification } from './useAllMentions';
+
+interface Props {
+  spaces: Space[];
+  enabledTypes?: ('mention-you' | 'mention-everyone' | 'mention-roles')[];
+}
+
+export function useAllMentionsGlobal({ spaces, enabledTypes }: Props) {
+  const user = usePasskeysContext();
+  const { messageDB } = useMessageDB();
+  const userAddress = user.currentPasskeyInfo?.address;
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['mention-notifications', 'global', userAddress, ...spaces.map((s) => s.spaceId).sort(), ...(enabledTypes?.slice().sort() || [])],
+    queryFn: async () => {
+      if (!userAddress) return [] as MentionNotification[];
+      const config = await messageDB.getUserConfig({ address: userAddress });
+      const all: MentionNotification[] = [];
+      for (const space of spaces) {
+        const userRoleIds = getUserRoles(userAddress, space).map((r) => r.roleId);
+        const rows = await fetchSpaceMentions(messageDB, space, userAddress, { enabledTypes, userRoleIds, config });
+        all.push(...rows);
+      }
+      all.sort((a, b) => b.message.createdDate - a.message.createdDate);
+      return all;
+    },
+    enabled: !!userAddress && spaces.length > 0,
+    staleTime: 30000,
+    refetchOnWindowFocus: true,
+  });
+
+  return { mentions: data || [], isLoading };
+}
+```
+
+- [ ] **Step 2: Implement `useAllRepliesGlobal`**
+
+```typescript
+// src/hooks/business/replies/useAllRepliesGlobal.ts
+import { useQuery } from '@tanstack/react-query';
+import { usePasskeysContext } from '@quilibrium/quilibrium-js-sdk-channels';
+import type { Space } from '@quilibrium/quorum-shared';
+import { useMessageDB } from '../../../components/context/useMessageDB';
+import { fetchSpaceReplies } from './fetchSpaceReplies';
+import type { ReplyNotification } from '../../../types/notifications';
+
+interface Props {
+  spaces: Space[];
+  enabled: boolean;
+}
+
+export function useAllRepliesGlobal({ spaces, enabled }: Props) {
+  const user = usePasskeysContext();
+  const { messageDB } = useMessageDB();
+  const userAddress = user.currentPasskeyInfo?.address;
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['reply-notifications', 'global', userAddress, ...spaces.map((s) => s.spaceId).sort(), enabled],
+    queryFn: async () => {
+      if (!userAddress) return [] as (ReplyNotification & { spaceId: string; spaceName: string })[];
+      const config = await messageDB.getUserConfig({ address: userAddress });
+      const all: (ReplyNotification & { spaceId: string; spaceName: string })[] = [];
+      for (const space of spaces) {
+        const rows = await fetchSpaceReplies(messageDB, space, userAddress, { enabled, config });
+        all.push(...rows);
+      }
+      all.sort((a, b) => b.message.createdDate - a.message.createdDate);
+      return all;
+    },
+    enabled: !!userAddress && spaces.length > 0,
+    staleTime: 30000,
+    refetchOnWindowFocus: true,
+  });
+
+  return { replies: data || [], isLoading };
+}
+```
+
+- [ ] **Step 3: Export from barrels**
+
+Append to `src/hooks/business/mentions/index.ts`:
+
+```typescript
+export { useAllMentionsGlobal } from './useAllMentionsGlobal';
+export { fetchSpaceMentions } from './fetchSpaceMentions';
+```
+
+Append to `src/hooks/business/replies/index.ts`:
+
+```typescript
+export { useAllRepliesGlobal } from './useAllRepliesGlobal';
+export { fetchSpaceReplies } from './fetchSpaceReplies';
+```
+
+- [ ] **Step 4: Typecheck**
+
+Run: `npx tsc --noEmit --skipLibCheck`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hooks/business/mentions/useAllMentionsGlobal.ts src/hooks/business/replies/useAllRepliesGlobal.ts src/hooks/business/mentions/index.ts src/hooks/business/replies/index.ts
+git commit -m "feat(notifications): add global mention/reply aggregation hooks"
+```
+
+---
+
+### Task 4b: Invalidate the global keys on new messages and on read
+
+**Files:**
+- Modify: `src/services/MessageService.ts:2106-2108` and `:2129-2131`
+- Modify: `src/hooks/business/conversations/useUpdateReadTime.ts`
+
+**Why:** The global hooks use keys `['mention-notifications', 'global', ...]` /
+`['reply-notifications', 'global', ...]`. Existing invalidations are scoped to
+`['mention-notifications', spaceId]` / `['reply-notifications', spaceId]`
+(`MessageService.ts:2107`/`:2130`). React Query prefix-matching requires a
+matching prefix in order — `['mention-notifications', spaceId]` does NOT match
+`['mention-notifications', 'global', ...]` (the second element differs). So
+without this task, a new mention/reply (or reading a channel) refreshes the
+per-space panel but leaves the GLOBAL panel stale for up to 30s. Broadening to
+`['mention-notifications']` (one element) matches BOTH `spaceId` and `'global'`
+variants.
+
+- [ ] **Step 1: Broaden the MessageService notification-list invalidations**
+
+In `src/services/MessageService.ts`, change the mention-notifications invalidation
+(around line 2106) from the space-scoped key to the bare prefix:
+
+```typescript
+      // Also invalidate notification inbox query (per-space AND global panels).
+      // Bare prefix matches both ['mention-notifications', spaceId] and
+      // ['mention-notifications', 'global', ...].
+      await queryClient.invalidateQueries({
+        queryKey: ['mention-notifications'],
+      });
+```
+
+And the reply-notifications invalidation (around line 2129):
+
+```typescript
+      await queryClient.invalidateQueries({
+        queryKey: ['reply-notifications'],
+      });
+```
+
+- [ ] **Step 2: Broaden the useUpdateReadTime notification-list invalidations**
+
+`useUpdateReadTime` currently invalidates count keys but NOT the notification-list
+keys. Add two broad invalidations in its `onSuccess` (after the existing
+`['mention-counts', 'space']` / `['reply-counts', 'space']` calls), so reading a
+channel refreshes the global panel too:
+
+```typescript
+      // Notification inbox lists (per-space + global). Bare prefixes match both.
+      queryClient.invalidateQueries({ queryKey: ['mention-notifications'] });
+      queryClient.invalidateQueries({ queryKey: ['reply-notifications'] });
+```
+
+- [ ] **Step 3: Typecheck + full suite**
+
+Run: `npx tsc --noEmit --skipLibCheck`
+Expected: PASS.
+Run: `yarn vitest src/dev/tests/ --run`
+Expected: PASS (MessageService.unit.test.tsx may assert invalidation keys — if a
+test asserts `['mention-notifications', spaceId]` exactly, update it to the bare
+prefix and note the per-space panel still refreshes via prefix match).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/services/MessageService.ts src/hooks/business/conversations/useUpdateReadTime.ts
+git commit -m "fix(notifications): broaden inbox invalidations to cover the global panel"
+```
+
+---
+
+### Task 5: `useGlobalNotifications` composition hook
+
+**Files:**
+- Create: `src/hooks/business/notifications/useGlobalNotifications.ts`
+- Create: `src/hooks/business/notifications/index.ts`
+
+- [ ] **Step 1: Implement the composition hook**
+
+```typescript
+// src/hooks/business/notifications/useGlobalNotifications.ts
+import { useMemo } from 'react';
+import type { Space } from '@quilibrium/quorum-shared';
+import { useAllMentionsGlobal } from '../mentions/useAllMentionsGlobal';
+import { useAllRepliesGlobal } from '../replies/useAllRepliesGlobal';
+import type { MentionNotification } from '../mentions/useAllMentions';
+import type { ReplyNotification } from '../../../types/notifications';
+
+export type GlobalMentionNotification = MentionNotification & { spaceId: string; spaceName: string };
+export type GlobalReplyNotification = ReplyNotification & { spaceId: string; spaceName: string };
+export type GlobalNotification = GlobalMentionNotification | GlobalReplyNotification;
+
+interface Props {
+  spaces: Space[];
+  enabledTypes: ('mention-you' | 'mention-everyone' | 'mention-roles')[];
+  replyEnabled: boolean;
+}
+
+export function useGlobalNotifications({ spaces, enabledTypes, replyEnabled }: Props) {
+  const { mentions, isLoading: mLoading } = useAllMentionsGlobal({ spaces, enabledTypes });
+  const { replies, isLoading: rLoading } = useAllRepliesGlobal({ spaces, enabled: replyEnabled });
+
+  const notifications = useMemo<GlobalNotification[]>(() => {
+    return [...(mentions as GlobalMentionNotification[]), ...(replies as GlobalReplyNotification[])]
+      .sort((a, b) => b.message.createdDate - a.message.createdDate);
+  }, [mentions, replies]);
+
+  return { notifications, isLoading: mLoading || rLoading };
+}
+```
+
+- [ ] **Step 2: Barrel**
+
+```typescript
+// src/hooks/business/notifications/index.ts
+export { useGlobalNotifications } from './useGlobalNotifications';
+export type {
+  GlobalNotification,
+  GlobalMentionNotification,
+  GlobalReplyNotification,
+} from './useGlobalNotifications';
+```
+
+- [ ] **Step 3: Typecheck + commit**
+
+Run: `npx tsc --noEmit --skipLibCheck`
+Expected: PASS.
+
+```bash
+git add src/hooks/business/notifications/
+git commit -m "feat(notifications): add useGlobalNotifications composition hook"
+```
+
+---
+
+### Task 6: Global sender resolver
+
+**Files:**
+- Create: `src/utils/resolveGlobalSender.ts`
+- Create: `src/dev/tests/utils/resolveGlobalSender.unit.test.ts`
+
+The global panel can't use `Channel`'s `mapSenderToUser` (it's per-space and built from enriched members). It resolves a sender's name from the sender's own space data.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/dev/tests/utils/resolveGlobalSender.unit.test.ts
+import { describe, it, expect } from 'vitest';
+
+const SENDER = 'QmSender000000000000000000000000000000000';
+
+describe('resolveGlobalSender', () => {
+  it('resolves a sender to its member object from the matching space', async () => {
+    const { makeResolveGlobalSender } = await import('../../../utils/resolveGlobalSender');
+    const spaces = [
+      { spaceId: 's1', members: { [SENDER]: { address: SENDER, displayName: 'Ada' } } },
+    ] as any;
+    const resolve = makeResolveGlobalSender(spaces);
+    const user = resolve('s1', SENDER);
+    expect(user?.displayName).toBe('Ada');
+  });
+
+  it('returns a minimal address-only object when the sender is unknown', async () => {
+    const { makeResolveGlobalSender } = await import('../../../utils/resolveGlobalSender');
+    const resolve = makeResolveGlobalSender([{ spaceId: 's1', members: {} }] as any);
+    const user = resolve('s1', SENDER);
+    expect(user?.address).toBe(SENDER);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `yarn vitest src/dev/tests/utils/resolveGlobalSender.unit.test.ts --run`
+Expected: FAIL — cannot resolve module.
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// src/utils/resolveGlobalSender.ts
+import type { Space } from '@quilibrium/quorum-shared';
+
+/**
+ * Build a sender-resolver for the GLOBAL notification panel. Unlike Channel's
+ * per-space `mapSenderToUser` (built from enriched/back-filled members), this
+ * resolves a sender from the member map of whichever space the row came from.
+ * Falls back to an address-only object so name resolvers show the address suffix.
+ */
+export function makeResolveGlobalSender(spaces: Space[]) {
+  const bySpace = new Map<string, Space>();
+  for (const s of spaces) bySpace.set(s.spaceId, s);
+
+  return (spaceId: string, senderId: string): any => {
+    const space = bySpace.get(spaceId);
+    const member = (space?.members as Record<string, any> | undefined)?.[senderId];
+    if (member) return member;
+    return { address: senderId };
+  };
+}
+```
+
+> Verify `Space` exposes `members` as a `Record<address, member>` during this task (grep `space.members` in `src/`). If members live elsewhere (e.g. an array), adapt the lookup. `Channel` builds its map from a `members` prop, so the data exists on the space; confirm the shape.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `yarn vitest src/dev/tests/utils/resolveGlobalSender.unit.test.ts --run`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/resolveGlobalSender.ts src/dev/tests/utils/resolveGlobalSender.unit.test.ts
+git commit -m "feat(notifications): add global sender resolver"
+```
+
+---
+
+### Task 7: `NotificationItem` breadcrumb
+
+**Files:**
+- Modify: `src/components/notifications/NotificationItem.tsx`
+- Modify: `src/components/notifications/NotificationItem.scss`
+
+- [ ] **Step 1: Add `spaceName` prop + breadcrumb render**
+
+In `NotificationItemProps` add:
+
+```typescript
+  spaceName?: string; // When set (global panel), renders a "Space › #channel" breadcrumb
+```
+
+Destructure it in the component signature (`spaceName,`). Then in the JSX, change the channel meta block so the space name leads when present. Replace the existing channel `<span>` block:
+
+```tsx
+        <Flex className="notification-meta min-w-0">
+          {spaceName && (
+            <>
+              <span className="notification-space truncate-channel-name flex-shrink min-w-0">{spaceName}</span>
+              <span className="notification-thread-chevron">›</span>
+            </>
+          )}
+          <Icon name="hashtag" className="notification-channel-icon flex-shrink-0" />
+          <span className={`notification-channel ${isThread ? '' : 'mr-2'} truncate-channel-name flex-shrink min-w-0`}>{channelName}</span>
+          {isThread && (
+            <>
+              <span className="notification-thread-chevron">›</span>
+              <span className="notification-thread-label mr-2">{t`Thread`}</span>
+            </>
+          )}
+          <Icon name={notificationIcon} className="notification-mention-type-icon flex-shrink-0" />
+          <span className="notification-sender truncate-user-name flex-shrink min-w-0">{displayName}</span>
+        </Flex>
+```
+
+- [ ] **Step 2: Add SCSS for the space lead**
+
+Append to `src/components/notifications/NotificationItem.scss`:
+
+```scss
+.notification-space {
+  font-weight: 600;
+  color: var(--text-heading, inherit);
+  margin-right: 4px;
+}
+```
+
+> Verify the heading text token name in `src/styles/_variables.scss` during this task; use the project's existing heading color variable (the codebase uses semantic tokens — match the one `notification-sender`/headings already use). Do NOT introduce a new arbitrary color.
+
+- [ ] **Step 3: Typecheck**
+
+Run: `npx tsc --noEmit --skipLibCheck`
+Expected: PASS. Per-space callers omit `spaceName` → no breadcrumb → unchanged.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/notifications/NotificationItem.tsx src/components/notifications/NotificationItem.scss
+git commit -m "feat(notifications): NotificationItem renders optional space breadcrumb"
+```
+
+---
+
+### Task 8: `NotificationPanel` global mode
+
+**Files:**
+- Modify: `src/components/notifications/NotificationPanel.tsx`
+
+This task adds an opt-in `global` path. When `global` is true, the panel:
+- uses `useGlobalNotifications` (driven by `spaces`) instead of per-space hooks,
+- renders centered (`positionStyle="centered"`),
+- passes `spaceName` to rows,
+- uses a global mark-all-read gated by a confirm dialog.
+
+- [ ] **Step 1: Extend props**
+
+Add to `NotificationPanelProps`:
+
+```typescript
+  /** Global mode: aggregate across all spaces, centered presentation. */
+  global?: boolean;
+  /** Required in global mode: all the user's spaces. */
+  spaces?: Space[];
+  /** Global mode sender resolver (spaceId, senderId) → user. */
+  resolveGlobalSender?: (spaceId: string, senderId: string) => any;
+```
+
+Import: `import type { Space } from '@quilibrium/quorum-shared';` and `import { useGlobalNotifications } from '../../hooks/business/notifications';` and `import { useConfirmation } from '../../hooks/ui/useConfirmation';` and the confirmation modal piece (see Step 4).
+
+- [ ] **Step 2: Branch the data source**
+
+Replace the current `useAllMentions`/`useAllReplies` calls with a conditional. Because hooks can't be called conditionally, call BOTH the per-space and global hooks but gate each with `enabled` semantics via empty inputs:
+
+```typescript
+  const mentionTypes = selectedTypes.filter((tp) => tp.startsWith('mention-')) as ('mention-you' | 'mention-everyone' | 'mention-roles')[];
+  const replyEnabled = selectedTypes.includes('reply');
+
+  // Per-space path (existing) — pass empty channelIds in global mode to disable.
+  const { mentions: spaceMentions, isLoading: smLoading } = useAllMentions({
+    spaceId,
+    channelIds: global ? [] : channelIds,
+    enabledTypes: mentionTypes,
+    userRoleIds,
+  });
+  const { replies: spaceReplies, isLoading: srLoading } = useAllReplies({
+    spaceId,
+    channelIds: global ? [] : channelIds,
+    enabled: replyEnabled,
+  });
+
+  // Global path — pass empty spaces in per-space mode to disable.
+  const { notifications: globalNotifications, isLoading: gLoading } = useGlobalNotifications({
+    spaces: global ? (spaces ?? []) : [],
+    enabledTypes: mentionTypes,
+    replyEnabled,
+  });
+
+  const allNotifications = global
+    ? globalNotifications
+    : [...spaceMentions, ...spaceReplies].sort((a, b) => b.message.createdDate - a.message.createdDate);
+
+  const isLoading = global ? (gLoading || settingsLoading) : (smLoading || srLoading || settingsLoading);
+```
+
+(Both hooks have `enabled: spaces.length > 0` / `channelIds.length > 0` already, so the disabled side does no work.)
+
+- [ ] **Step 3: Pass `spaceName` + global sender resolver to rows**
+
+In BOTH the touch and desktop row maps, change the sender lookup and `NotificationItem` props:
+
+```tsx
+                const senderId = notification.message.content?.senderId;
+                const rowSpaceId = (notification as any).spaceId ?? spaceId;
+                const sender = global && resolveGlobalSender
+                  ? resolveGlobalSender(rowSpaceId, senderId)
+                  : mapSenderToUser(senderId);
+```
+
+And add to the `<NotificationItem ... />` props:
+
+```tsx
+                      spaceName={global ? (notification as any).spaceName : undefined}
+```
+
+- [ ] **Step 4: Global mark-all-read with confirm**
+
+Generalize `handleMarkAllRead` to iterate the `(spaceId, channelId)` pairs present in `allNotifications` (in global mode each row carries its own `spaceId`; in per-space mode use the panel `spaceId`):
+
+```typescript
+  const handleMarkAllReadCore = useCallback(async () => {
+    try {
+      const now = Date.now();
+      // Build the set of (spaceId, channelId) pairs to mark read.
+      const pairs = new Map<string, { spaceId: string; channelId: string }>();
+      for (const n of allNotifications) {
+        const sId = global ? ((n as any).spaceId ?? spaceId) : spaceId;
+        pairs.set(`${sId}/${n.channelId}`, { spaceId: sId, channelId: n.channelId });
+      }
+      for (const { spaceId: sId, channelId } of pairs.values()) {
+        await messageDB.saveReadTime({ conversationId: `${sId}/${channelId}`, lastMessageTimestamp: now });
+      }
+      const threadEntries: Array<{ threadId: string; spaceId: string; channelId: string; lastReadTimestamp: number }> = [];
+      for (const { spaceId: sId, channelId } of pairs.values()) {
+        const threads = await messageDB.getChannelThreads({ spaceId: sId, channelId });
+        for (const thread of threads) {
+          threadEntries.push({ threadId: thread.threadId, spaceId: sId, channelId, lastReadTimestamp: now });
+        }
+      }
+      if (threadEntries.length > 0) await messageDB.bulkSaveThreadReadTimes(threadEntries);
+
+      queryClient.invalidateQueries({ queryKey: ['mention-counts', 'space'] });
+      queryClient.invalidateQueries({ queryKey: ['reply-counts', 'space'] });
+      queryClient.invalidateQueries({ queryKey: ['unread-counts', 'space'] });
+      queryClient.invalidateQueries({ queryKey: ['mention-counts', 'channel'] });
+      queryClient.invalidateQueries({ queryKey: ['reply-counts', 'channel'] });
+      queryClient.invalidateQueries({ queryKey: ['unread-counts', 'channel'] });
+      queryClient.invalidateQueries({ queryKey: ['mention-notifications'] });
+      queryClient.invalidateQueries({ queryKey: ['reply-notifications'] });
+      queryClient.invalidateQueries({ queryKey: ['conversation'] });
+      onClose();
+    } catch (error) {
+      console.error('[NotificationPanel] Error marking all as read:', error);
+    }
+  }, [allNotifications, spaceId, global, messageDB, queryClient, onClose]);
+
+  // Confirm gate for the GLOBAL blast-radius action only.
+  const confirm = useConfirmation({
+    type: 'modal',
+    modalConfig: {
+      variant: 'warning',
+      title: t`Mark all as read?`,
+      message: t`This marks mentions and replies as read across all your spaces. This can't be undone.`,
+      confirmText: t`Mark all read`,
+      cancelText: t`Cancel`,
+    },
+  });
+
+  const handleMarkAllRead = useCallback((e: React.MouseEvent) => {
+    if (global) {
+      confirm.handleClick(e, handleMarkAllReadCore);
+    } else {
+      handleMarkAllReadCore();
+    }
+  }, [global, confirm, handleMarkAllReadCore]);
+```
+
+Render the confirmation modal when `confirm.showModal` is true. The codebase exposes confirmation modals via `ConfirmationModalProvider`; mirror an existing consumer. Find the pattern:
+Run during this task: `rg "useConfirmation\(" src/ -l` then open one consumer (e.g. `src/hooks/business/messages/usePinnedMessages.ts` or `ConversationSettingsModal.tsx`) and replicate exactly how it renders `confirm.modalConfig` (either a local `<ConfirmationModal>` or the provider). Use that established pattern — do not invent a new modal.
+
+> The `handleMarkAllRead` signature changes from `() => ...` to `(e) => ...`. Update the `<Button onClick={...}>` — the primitive `Button`'s `onClick` already passes the event, so `onClick={handleMarkAllRead}` works.
+
+- [ ] **Step 5: Centered presentation + dynamic title**
+
+In the `DropdownPanel`, make `positionStyle` conditional:
+
+```tsx
+      positionStyle={global ? 'centered' : 'right-aligned'}
+```
+
+Leave `maxWidth`/`maxHeight` as-is (centered honors both).
+
+- [ ] **Step 6: Typecheck + full suite**
+
+Run: `npx tsc --noEmit --skipLibCheck`
+Expected: PASS.
+Run: `yarn vitest src/dev/tests/ --run`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/notifications/NotificationPanel.tsx
+git commit -m "feat(notifications): NotificationPanel global mode (centered, breadcrumb, confirm mark-all)"
+```
+
+---
+
+### Task 9: NavRail bell + global panel mount + unread dot
+
+**Files:**
+- Modify: `src/components/shell/NavRail.tsx`
+- Modify: `src/components/shell/NavRail.scss`
+
+- [ ] **Step 1: Add the notifications rail item**
+
+In `RailSectionId` add `'notifications'`. In `buildItems()` insert after the `spaces` entry:
+
+```typescript
+  {
+    id: 'notifications',
+    icon: 'bell',
+    label: t`Notifications`,
+    route: '', // not navigated — opens the global panel
+  },
+```
+
+- [ ] **Step 2: Add panel state + spaces + unread dot data**
+
+Inside the component, before `return`:
+
+```tsx
+  const [notifOpen, setNotifOpen] = React.useState(false);
+  const { data: spaces = [] } = useSpaces();
+  const mentionCounts = useSpaceMentionCounts({ spaces });
+  const replyCounts = useSpaceReplyCounts({ spaces });
+  const hasUnreadNotifications =
+    Object.keys(mentionCounts).length > 0 || Object.keys(replyCounts).length > 0;
+  const resolveGlobalSender = React.useMemo(() => makeResolveGlobalSender(spaces), [spaces]);
+```
+
+Imports:
+
+```typescript
+import { useSpaces } from '../../hooks/queries/spaces';
+import { useSpaceMentionCounts } from '../../hooks/business/mentions';
+import { useSpaceReplyCounts } from '../../hooks/business/replies';
+import { makeResolveGlobalSender } from '../../utils/resolveGlobalSender';
+import { NotificationPanel } from '../notifications/NotificationPanel';
+```
+
+> `useSpaces` uses `useSuspenseQuery`. NavRail renders inside the app shell which already sits under a Suspense boundary (spaces are loaded app-wide). Confirm NavRail is within a Suspense boundary during this task (it renders alongside SpacesSidebar which already calls `useSpaces`). If not, wrap the counts in a child component. Verify by running the app (Task 10).
+
+- [ ] **Step 3: Branch `onItemClick` for notifications**
+
+At the top of `onItemClick`:
+
+```typescript
+    if (item.id === 'notifications') {
+      setNotifOpen(true);
+      return;
+    }
+```
+
+- [ ] **Step 4: Render the unread dot on the bell**
+
+In the item render, the icon is wrapped in `<span className="relative flex-shrink-0">`. Add a dot for the notifications item:
+
+```tsx
+              <span className="relative flex-shrink-0">
+                <Icon name={item.icon} size="xl" />
+                {item.id === 'notifications' && hasUnreadNotifications && (
+                  <span className="icon-unread-dot nav-rail__notif-dot" aria-hidden="true" />
+                )}
+              </span>
+```
+
+- [ ] **Step 5: Render the global panel**
+
+Just before the closing `</nav>` (after the user avatar block), add:
+
+```tsx
+      <NotificationPanel
+        global
+        isOpen={notifOpen}
+        onClose={() => setNotifOpen(false)}
+        spaces={spaces}
+        resolveGlobalSender={resolveGlobalSender}
+        spaceId=""
+        channelIds={[]}
+        mapSenderToUser={() => undefined}
+      />
+```
+
+(`spaceId`/`channelIds`/`mapSenderToUser` are required by the existing props but unused in global mode; pass inert values.)
+
+- [ ] **Step 6: SCSS for the dot on a rail item**
+
+Append to `src/components/shell/NavRail.scss`:
+
+```scss
+.nav-rail__notif-dot {
+  position: absolute;
+  top: -2px;
+  right: -2px;
+}
+```
+
+> `.icon-unread-dot` base visual lives in `src/styles/_components.scss`; this only nudges its anchor for the rail icon. Verify the dot sits on the top-right of the bell during Task 10; adjust offsets if needed.
+
+- [ ] **Step 7: Typecheck + full suite**
+
+Run: `npx tsc --noEmit --skipLibCheck`
+Expected: PASS.
+Run: `yarn vitest src/dev/tests/ --run`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/components/shell/NavRail.tsx src/components/shell/NavRail.scss
+git commit -m "feat(notifications): NavRail bell opens global notification panel"
+```
+
+---
+
+### Task 10: Manual verification (browser) + docs
+
+**Files:**
+- Modify: `.agents/docs/features/mention-notification-system.md` (add a "Global panel" subsection)
+
+- [ ] **Step 1: Run the app and verify behavior**
+
+Run: `yarn dev` (or use the project `run` skill / `mcp__Claude_Preview__preview_start`).
+Verify in the browser:
+1. A bell item appears in the NavRail with the label "Notifications".
+2. Clicking it opens a CENTERED panel with a dimmed backdrop.
+3. With unread mentions/replies in any space, rows show `Space › #channel` breadcrumbs and the correct sender names.
+4. The type filter (@you/@everyone/@roles/Replies) narrows the global list.
+5. Clicking a row navigates to the message in the right space/channel and closes the panel.
+6. The bell shows a presence dot when unread mentions/replies exist anywhere; it clears after reading those channels.
+7. "Mark all as read" opens a confirm dialog; confirming clears notifications across all spaces.
+8. The per-space header bell inside a space still works unchanged (anchored dropdown, current-space scope, NO space breadcrumb on its rows).
+
+- [ ] **Step 2: Update the feature doc**
+
+Add a `## Global Notification Panel` section to `.agents/docs/features/mention-notification-system.md` documenting: NavRail bell entry, centered presentation, Approach A (live aggregation via `useGlobalNotifications` → `fetchSpaceMentions`/`fetchSpaceReplies`), `Space › #channel` breadcrumb, presence dot from `useSpaceMentionCounts`+`useSpaceReplyCounts`, global mark-all + confirm, and that the per-space header bell is unchanged. End with a `*Last updated: 2026-06-23*` line.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .agents/docs/features/mention-notification-system.md
+git commit -m "docs(notifications): document the global notification panel"
+```
+
+---
+
+## Self-Review notes (addressed)
+
+- **Spec coverage:** Approach A live aggregation (T1–5), cache-invalidation correctness for the new global keys (T4b — found during self-review: existing `MessageService`/`useUpdateReadTime` invalidations were spaceId-scoped and would NOT reach `['*-notifications','global',...]`), NavRail centered entry (T9, T8), flat newest-first + breadcrumb (T7, T8), type-filter-only (T8 reuses existing filter), presence dot (T9), global mark-all + confirm (T8), per-space bell unchanged (T2/T3 keep public APIs; T8 gates global behind `global` prop). All covered.
+- **Type consistency:** `MentionNotification` gains `spaceId?`/`spaceName?` (T1/T2); global rows widen to required via `GlobalNotification` (T5); `fetchSpaceMentions`/`fetchSpaceReplies` signatures fixed in T1/T3 and consumed unchanged in T4. `handleMarkAllRead` signature change noted in T8.
+- **Verification flags:** three "verify during this task" notes (Space name field, Space.members shape, heading color token, Suspense boundary) are real lookups, each with a stated default and fallback — not deferred design decisions.
+
+*Last updated: 2026-06-23*

--- a/.agents/tasks/2026-06-23-global-notification-panel-plan.md
+++ b/.agents/tasks/2026-06-23-global-notification-panel-plan.md
@@ -1287,6 +1287,19 @@ git commit -m "feat(notifications): NotificationPanel global mode (centered, bre
 - Modify: `src/components/shell/NavRail.tsx`
 - Modify: `src/components/shell/NavRail.scss`
 
+> **DEVIATION FROM ORIGINAL SPEC (2026-06-23).** Two corrections vs the steps below:
+> 1. The sender resolver is the `useGlobalSenderResolver(spaces)` HOOK (Task 6
+>    deviation), NOT `makeResolveGlobalSender(spaces)` + `useMemo`. Import it from
+>    `../../hooks/business/notifications`. The steps below referencing
+>    `makeResolveGlobalSender` are obsolete.
+> 2. Suspense: verified NavRail renders under the app-level `<Suspense>` in
+>    `App.tsx` (line ~120), same boundary the sibling `SpacesSidebar` relies on for
+>    its own `useSpaces()` call. So `useSpaces()` is called directly in NavRail (no
+>    extra local boundary needed); the cached query won't re-suspend.
+> 3. The `.nav-rail__notif-dot` SCSS must also reset the base `.icon-unread-dot`'s
+>    `left: -15px` / `top: 50%` / `transform` (which position it left-of-an-avatar):
+>    `top: -2px; right: -2px; left: auto; transform: none;`.
+
 - [ ] **Step 1: Add the notifications rail item**
 
 In `RailSectionId` add `'notifications'`. In `buildItems()` insert after the `spaces` entry:

--- a/.agents/tasks/2026-06-23-global-notification-panel-plan.md
+++ b/.agents/tasks/2026-06-23-global-notification-panel-plan.md
@@ -85,8 +85,9 @@ export async function fetchSpaceMentions(
   userAddress: string,
   opts: {
     enabledTypes?: ('mention-you' | 'mention-everyone' | 'mention-roles')[];
-    userRoleIds: string[];
+    userRoleIds?: string[];
     config: UserConfig | undefined; // pre-fetched user config (avoids N getUserConfig calls)
+    perChannelLimit?: number; // default 1000 (per-space); global path passes 50
   },
 ): Promise<MentionNotification[]>
 
@@ -98,13 +99,34 @@ export async function fetchSpaceReplies(
   opts: {
     enabled: boolean;
     config: UserConfig | undefined;
+    perChannelLimit?: number; // default 1000 (per-space); global path passes 50
   },
 ): Promise<ReplyNotification[]>
 ```
 
-Both set `spaceId: space.spaceId` and `spaceName: space.name` on every row they return.
+Both set `spaceId: space.spaceId` and `spaceName: space.spaceName` on every row they return.
 
-> **Note on `space.name`:** verify the field name on `Space` during Task 1 (`Space` type from `quorum-shared`). `useSpaceReplyCounts` uses `space.spaceId`; the human name field is referenced as `space.name` in this plan — if the type uses a different key (e.g. `spaceName`), use that and keep it consistent across all tasks.
+### Performance cap constants (locked — global path only)
+
+Defined in a STANDALONE module to avoid a circular import (the global hooks in
+`mentions/`/`replies/` import the per-channel limit; `useGlobalNotifications`
+imports those hooks — so the constants must NOT live in `useGlobalNotifications.ts`):
+
+```typescript
+// src/hooks/business/notifications/constants.ts
+export const GLOBAL_PER_CHANNEL_LIMIT = 50;  // passed as perChannelLimit to the fetch fns
+export const GLOBAL_DISPLAY_CAP = 100;        // max rows shown after global sort
+```
+
+Rationale (see design doc "Performance" section): the global fetch fans out per-channel
+reads across ALL spaces. Lowering the per-channel `limit` from 1000→50 and slicing the
+globally-sorted result to 100 bounds memory without biasing by space iteration order
+(slice happens AFTER the merge+sort). The per-space header bell keeps `limit: 1000`
+(its default) and is unaffected. The composition hook exposes a `truncated` flag when
+the merged count exceeds the cap so the UI can show "Showing 100 most recent" (no silent
+truncation).
+
+> **RESOLVED (Task 1):** the `Space` human-name field is **`space.spaceName`** (NOT `space.name`). Use `space.spaceName` everywhere.
 
 ---
 
@@ -407,7 +429,7 @@ const ME = 'QmMeAddr0000000000000000000000000000000000';
 function makeSpace() {
   return {
     spaceId: 'space-1',
-    name: 'Test Space',
+    spaceName: 'Test Space',
     roles: [],
     members: {},
     groups: [{ channels: [{ channelId: 'chan-1', channelName: 'general' }] }],
@@ -472,21 +494,33 @@ Expected: FAIL — cannot resolve module `fetchSpaceReplies`.
 
 - [ ] **Step 3: Implement `fetchSpaceReplies`**
 
+> **Apply the Task 1 review lessons here from the start** (so this file doesn't
+> repeat them): type `messageDB` as the full `MessageDB` (not `Pick<>`), type
+> `config` as `UserConfig | undefined` (imported from `../../../db/messages`), and
+> hoist the channel list once (`const allChannels = space.groups.flatMap(...)`)
+> instead of re-flatMapping inside the loop. Add a JSDoc note that output is
+> unsorted (caller sorts).
+
 ```typescript
 // src/hooks/business/replies/fetchSpaceReplies.ts
 import { isNotificationTypeEnabled } from '@quilibrium/quorum-shared';
 import type { Space } from '@quilibrium/quorum-shared';
 import type { ReplyNotification } from '../../../types/notifications';
 import { getMutedChannelsForSpace } from '../../../utils/channelUtils';
-import type { MessageDB } from '../../../db/messages';
+import type { MessageDB, UserConfig } from '../../../db/messages';
 
+/**
+ * Fetch unread replies for ONE space (pure; no React). Replicates the per-space
+ * gating from `useAllReplies`. Returns rows in channel-iteration order — the
+ * CALLER sorts (the global hook sorts after merging across all spaces).
+ */
 export async function fetchSpaceReplies(
   messageDB: MessageDB,
   space: Space,
   userAddress: string,
-  opts: { enabled: boolean; config: any },
+  opts: { enabled: boolean; config: UserConfig | undefined; perChannelLimit?: number },
 ): Promise<(ReplyNotification & { spaceId: string; spaceName: string })[]> {
-  const { enabled, config } = opts;
+  const { enabled, config, perChannelLimit = 1000 } = opts;
   const settings = config?.notificationSettings?.[space.spaceId];
   if (settings?.isMuted) return [];
 
@@ -495,7 +529,8 @@ export async function fetchSpaceReplies(
   if (!shouldFetch) return [];
 
   const mutedChannelIds = getMutedChannelsForSpace(space.spaceId, config?.mutedChannels);
-  const channelIds = space.groups.flatMap((g) => g.channels.map((c) => c.channelId));
+  const allChannels = space.groups.flatMap((g) => g.channels);
+  const channelIds = allChannels.map((c) => c.channelId);
   const out: (ReplyNotification & { spaceId: string; spaceName: string })[] = [];
 
   for (const channelId of channelIds) {
@@ -505,9 +540,9 @@ export async function fetchSpaceReplies(
     const lastReadTimestamp = conversation?.lastReadTimestamp || 0;
     const threadReadTimes = await messageDB.getThreadReadTimesForChannel({ spaceId: space.spaceId, channelId });
     const messages = await messageDB.getUnreadReplies({
-      spaceId: space.spaceId, channelId, userAddress, afterTimestamp: lastReadTimestamp, limit: 1000,
+      spaceId: space.spaceId, channelId, userAddress, afterTimestamp: lastReadTimestamp, limit: perChannelLimit,
     });
-    const channel = space.groups.flatMap((g) => g.channels).find((c) => c.channelId === channelId);
+    const channel = allChannels.find((c) => c.channelId === channelId);
 
     for (const message of messages) {
       if (message.isThreadReply && message.threadId) {
@@ -520,7 +555,7 @@ export async function fetchSpaceReplies(
         channelName: channel?.channelName || 'Unknown Channel',
         type: 'reply',
         spaceId: space.spaceId,
-        spaceName: space.name,
+        spaceName: space.spaceName,
       });
     }
   }
@@ -588,10 +623,33 @@ git commit -m "feat(notifications): extract fetchSpaceReplies, useAllReplies del
 ### Task 4: Global aggregation hooks
 
 **Files:**
+- Create: `src/hooks/business/notifications/constants.ts` (cap constants — standalone to avoid circular import)
+- Modify: `src/hooks/business/mentions/fetchSpaceMentions.ts` (add `perChannelLimit` param)
 - Create: `src/hooks/business/mentions/useAllMentionsGlobal.ts`
 - Create: `src/hooks/business/replies/useAllRepliesGlobal.ts`
 - Modify: `src/hooks/business/mentions/index.ts`
 - Modify: `src/hooks/business/replies/index.ts`
+
+- [ ] **Step 0a: Create the cap constants module**
+
+```typescript
+// src/hooks/business/notifications/constants.ts
+export const GLOBAL_PER_CHANNEL_LIMIT = 50;  // per-channel getUnreadMentions/Replies cap (global path)
+export const GLOBAL_DISPLAY_CAP = 100;        // max rows shown after the global newest-first sort
+```
+
+- [ ] **Step 0b: Retrofit `perChannelLimit` into `fetchSpaceMentions`**
+
+Task 1 created `fetchSpaceMentions` with a hardcoded `limit: 1000` in the
+`getUnreadMentions` call. `fetchSpaceReplies` (Task 3) already takes
+`perChannelLimit?: number` (default 1000). Make `fetchSpaceMentions` symmetric:
+- Add `perChannelLimit?: number;` to its `opts` type.
+- Destructure with default: `const { enabledTypes, userRoleIds = [], config, perChannelLimit = 1000 } = opts;`
+- Change the `getUnreadMentions` call's `limit: 1000` → `limit: perChannelLimit`.
+This is additive — the per-space `useAllMentions` (which doesn't pass it) keeps `1000`.
+
+Run: `yarn vitest src/dev/tests/hooks/fetchSpaceMentions.unit.test.ts --run`
+Expected: still 3 PASS (default unchanged).
 
 - [ ] **Step 1: Implement `useAllMentionsGlobal`**
 
@@ -604,6 +662,7 @@ import type { Space } from '@quilibrium/quorum-shared';
 import { useMessageDB } from '../../../components/context/useMessageDB';
 import { fetchSpaceMentions } from './fetchSpaceMentions';
 import type { MentionNotification } from './useAllMentions';
+import { GLOBAL_PER_CHANNEL_LIMIT } from '../notifications/constants';
 
 interface Props {
   spaces: Space[];
@@ -623,7 +682,9 @@ export function useAllMentionsGlobal({ spaces, enabledTypes }: Props) {
       const all: MentionNotification[] = [];
       for (const space of spaces) {
         const userRoleIds = getUserRoles(userAddress, space).map((r) => r.roleId);
-        const rows = await fetchSpaceMentions(messageDB, space, userAddress, { enabledTypes, userRoleIds, config });
+        const rows = await fetchSpaceMentions(messageDB, space, userAddress, {
+          enabledTypes, userRoleIds, config, perChannelLimit: GLOBAL_PER_CHANNEL_LIMIT,
+        });
         all.push(...rows);
       }
       all.sort((a, b) => b.message.createdDate - a.message.createdDate);
@@ -648,6 +709,7 @@ import type { Space } from '@quilibrium/quorum-shared';
 import { useMessageDB } from '../../../components/context/useMessageDB';
 import { fetchSpaceReplies } from './fetchSpaceReplies';
 import type { ReplyNotification } from '../../../types/notifications';
+import { GLOBAL_PER_CHANNEL_LIMIT } from '../notifications/constants';
 
 interface Props {
   spaces: Space[];
@@ -666,7 +728,9 @@ export function useAllRepliesGlobal({ spaces, enabled }: Props) {
       const config = await messageDB.getUserConfig({ address: userAddress });
       const all: (ReplyNotification & { spaceId: string; spaceName: string })[] = [];
       for (const space of spaces) {
-        const rows = await fetchSpaceReplies(messageDB, space, userAddress, { enabled, config });
+        const rows = await fetchSpaceReplies(messageDB, space, userAddress, {
+          enabled, config, perChannelLimit: GLOBAL_PER_CHANNEL_LIMIT,
+        });
         all.push(...rows);
       }
       all.sort((a, b) => b.message.createdDate - a.message.createdDate);
@@ -789,6 +853,10 @@ git commit -m "fix(notifications): broaden inbox invalidations to cover the glob
 
 - [ ] **Step 1: Implement the composition hook**
 
+The composition hook merges + sorts, then applies the global display cap and
+exposes a `truncated` flag (so the UI can say "Showing N most recent" — no silent
+truncation, per the design's perf section).
+
 ```typescript
 // src/hooks/business/notifications/useGlobalNotifications.ts
 import { useMemo } from 'react';
@@ -797,6 +865,7 @@ import { useAllMentionsGlobal } from '../mentions/useAllMentionsGlobal';
 import { useAllRepliesGlobal } from '../replies/useAllRepliesGlobal';
 import type { MentionNotification } from '../mentions/useAllMentions';
 import type { ReplyNotification } from '../../../types/notifications';
+import { GLOBAL_DISPLAY_CAP } from './constants';
 
 export type GlobalMentionNotification = MentionNotification & { spaceId: string; spaceName: string };
 export type GlobalReplyNotification = ReplyNotification & { spaceId: string; spaceName: string };
@@ -812,12 +881,18 @@ export function useGlobalNotifications({ spaces, enabledTypes, replyEnabled }: P
   const { mentions, isLoading: mLoading } = useAllMentionsGlobal({ spaces, enabledTypes });
   const { replies, isLoading: rLoading } = useAllRepliesGlobal({ spaces, enabled: replyEnabled });
 
-  const notifications = useMemo<GlobalNotification[]>(() => {
-    return [...(mentions as GlobalMentionNotification[]), ...(replies as GlobalReplyNotification[])]
+  const { notifications, truncated } = useMemo(() => {
+    const merged = [...(mentions as GlobalMentionNotification[]), ...(replies as GlobalReplyNotification[])]
       .sort((a, b) => b.message.createdDate - a.message.createdDate);
+    // Slice AFTER the global sort so the cap is order-independent (no bias toward
+    // whichever space was iterated first).
+    return {
+      notifications: merged.slice(0, GLOBAL_DISPLAY_CAP) as GlobalNotification[],
+      truncated: merged.length > GLOBAL_DISPLAY_CAP,
+    };
   }, [mentions, replies]);
 
-  return { notifications, isLoading: mLoading || rLoading };
+  return { notifications, truncated, isLoading: mLoading || rLoading };
 }
 ```
 
@@ -826,6 +901,7 @@ export function useGlobalNotifications({ spaces, enabledTypes, replyEnabled }: P
 ```typescript
 // src/hooks/business/notifications/index.ts
 export { useGlobalNotifications } from './useGlobalNotifications';
+export { GLOBAL_DISPLAY_CAP, GLOBAL_PER_CHANNEL_LIMIT } from './constants';
 export type {
   GlobalNotification,
   GlobalMentionNotification,
@@ -1040,7 +1116,7 @@ Replace the current `useAllMentions`/`useAllReplies` calls with a conditional. B
   });
 
   // Global path — pass empty spaces in per-space mode to disable.
-  const { notifications: globalNotifications, isLoading: gLoading } = useGlobalNotifications({
+  const { notifications: globalNotifications, truncated: globalTruncated, isLoading: gLoading } = useGlobalNotifications({
     spaces: global ? (spaces ?? []) : [],
     enabledTypes: mentionTypes,
     replyEnabled,
@@ -1054,6 +1130,22 @@ Replace the current `useAllMentions`/`useAllReplies` calls with a conditional. B
 ```
 
 (Both hooks have `enabled: spaces.length > 0` / `channelIds.length > 0` already, so the disabled side does no work.)
+
+**Truncation affordance (global only):** when `global && globalTruncated`, render a
+subtle footer below the list, e.g.:
+
+```tsx
+      {global && globalTruncated && (
+        <div className="notification-panel__truncation-note">
+          {t`Showing the ${GLOBAL_DISPLAY_CAP} most recent notifications`}
+        </div>
+      )}
+```
+
+Import `GLOBAL_DISPLAY_CAP` from `../../hooks/business/notifications`. Add a muted
+small-text style for `.notification-panel__truncation-note` in `NotificationPanel.scss`
+(use an existing muted-text token; `text-sm`-equivalent, centered, padded). This
+satisfies the "no silent caps" rule — the user is told the list is capped.
 
 - [ ] **Step 3: Pass `spaceName` + global sender resolver to rows**
 

--- a/.agents/tasks/2026-06-23-global-notification-panel-plan.md
+++ b/.agents/tasks/2026-06-23-global-notification-panel-plan.md
@@ -925,9 +925,32 @@ git commit -m "feat(notifications): add useGlobalNotifications composition hook"
 
 **Files:**
 - Create: `src/utils/resolveGlobalSender.ts`
+- Create: `src/hooks/business/notifications/useGlobalSenderResolver.ts`
 - Create: `src/dev/tests/utils/resolveGlobalSender.unit.test.ts`
+- Modify: `src/hooks/business/notifications/index.ts`
 
 The global panel can't use `Channel`'s `mapSenderToUser` (it's per-space and built from enriched members). It resolves a sender's name from the sender's own space data.
+
+> **DEVIATION FROM ORIGINAL SPEC (2026-06-23).** The original spec read
+> `space.members[senderId]`, assuming `Space.members` was a `Record<address, member>`.
+> Verified false: `Space.members` is `string[]` (addresses only); enriched member
+> objects (`display_name`, `user_icon`) come from `messageDB.getSpaceMembers(spaceId)`
+> (returns `channel.UserProfile[]`). Corrected design (approved by user — "Async map
+> via getSpaceMembers"):
+> - `resolveGlobalSender.ts` exports a PURE core `buildGlobalSenderMap(membersBySpace)`
+>   → `(spaceId, senderId) => ResolvedGlobalSender`, mapping `user_address`→`address`,
+>   `display_name`→`displayName`, `user_icon`→`userIcon`. Unknown → `{ address: senderId }`.
+> - `useGlobalSenderResolver(spaces)` hook fetches each space's roster via
+>   `messageDB.getSpaceMembers` (React Query, 30s stale) and returns the sync resolver,
+>   with an address-only fallback until rosters load.
+> - `primaryUsername`/`globalDisplayName` are NOT on the roster (they come from the
+>   public-profile fetch), so they're optional — parity with the per-space path when
+>   unenriched. Output shape feeds the existing `resolveSpaceMemberName(...)` call in
+>   `NotificationPanel` unchanged.
+> - Import `UserProfile` via the `channel` namespace (`import type { channel }` →
+>   `channel.UserProfile`); it is NOT exported from the package root.
+> The code blocks below are the ORIGINAL (broken) spec, kept for history. See the
+> shipped files for the real implementation.
 
 - [ ] **Step 1: Write the failing test**
 

--- a/src/components/bookmarks/BookmarksPanel.tsx
+++ b/src/components/bookmarks/BookmarksPanel.tsx
@@ -176,9 +176,13 @@ export const BookmarksPanel: React.FC<BookmarksPanelProps> = ({
       maxWidth={500}
       maxHeight={Math.min(window.innerHeight * 0.8, 600)}
       title={
-        contextCount === 1
-          ? t`${contextCount} bookmark here`
-          : t`${contextCount} bookmarks here`
+        searchContext.type === 'dm'
+          ? contextCount === 1
+            ? t`${contextCount} bookmark in this conversation`
+            : t`${contextCount} bookmarks in this conversation`
+          : contextCount === 1
+            ? t`${contextCount} bookmark in this Space`
+            : t`${contextCount} bookmarks in this Space`
       }
       className="bookmarks-panel"
       showCloseButton={true}

--- a/src/components/context/ModalProvider.tsx
+++ b/src/components/context/ModalProvider.tsx
@@ -10,6 +10,7 @@ import BlockUserModal from '../modals/BlockUserModal';
 import NewDirectMessageModal from '../modals/NewDirectMessageModal';
 import ConversationSettingsModal from '../modals/ConversationSettingsModal';
 import FolderEditorModal from '../modals/FolderEditorModal';
+import { GlobalNotificationsModal } from '../notifications/GlobalNotificationsModal';
 import {
   useModalState,
   type ModalState,
@@ -49,6 +50,8 @@ interface ModalContextType {
   closeConversationSettings: () => void;
   openFolderEditor: (folderId?: string) => void;
   closeFolderEditor: () => void;
+  openNotifications: () => void;
+  closeNotifications: () => void;
   // Legacy compatibility with existing useModalContext
   isNewDirectMessageOpen: boolean;
 }
@@ -140,6 +143,8 @@ export const ModalProvider: React.FC<ModalProviderProps> = ({
     closeConversationSettings: modalState.closeConversationSettings,
     openFolderEditor: modalState.openFolderEditor,
     closeFolderEditor: modalState.closeFolderEditor,
+    openNotifications: modalState.openNotifications,
+    closeNotifications: modalState.closeNotifications,
     // Legacy compatibility
     isNewDirectMessageOpen: modalState.isNewDirectMessageOpen,
   };
@@ -252,6 +257,11 @@ export const ModalProvider: React.FC<ModalProviderProps> = ({
           onClose={modalState.closeFolderEditor}
         />
       )}
+
+      <GlobalNotificationsModal
+        isOpen={modalState.state.notifications.isOpen}
+        onClose={modalState.closeNotifications}
+      />
 
       {children}
     </ModalContext.Provider>

--- a/src/components/notifications/GlobalNotificationsModal.tsx
+++ b/src/components/notifications/GlobalNotificationsModal.tsx
@@ -1,0 +1,50 @@
+import React, { Suspense } from 'react';
+import { useSpaces } from '../../hooks/queries/spaces';
+import { useGlobalSenderResolver } from '../../hooks/business/notifications';
+import { NotificationPanel } from './NotificationPanel';
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Suspense-isolated container for the global notification panel, rendered by
+ * ModalProvider (router level) so its backdrop stacks above the AppShell chrome
+ * — see .agents/docs/features/modals.md.
+ *
+ * `useSpaces` is suspense-backed and ModalProvider sits ABOVE the Layout's
+ * Suspense boundary, so this wraps its own <Suspense> to keep a brief
+ * spaces-load from bubbling to the router. The inner component only mounts when
+ * `isOpen` (the Modal itself no-ops when not visible, but gating the data hooks
+ * avoids fetching rosters for a closed panel).
+ */
+const GlobalNotificationsInner: React.FC<Props> = ({ isOpen, onClose }) => {
+  const { data: spaces = [] } = useSpaces();
+  const resolveGlobalSender = useGlobalSenderResolver(spaces);
+
+  return (
+    <NotificationPanel
+      global
+      isOpen={isOpen}
+      onClose={onClose}
+      spaces={spaces}
+      resolveGlobalSender={resolveGlobalSender}
+      // Required by the shared props but unused in global mode.
+      spaceId=""
+      channelIds={[]}
+      mapSenderToUser={() => undefined}
+    />
+  );
+};
+
+export const GlobalNotificationsModal: React.FC<Props> = ({ isOpen, onClose }) => {
+  if (!isOpen) return null;
+  return (
+    <Suspense fallback={null}>
+      <GlobalNotificationsInner isOpen={isOpen} onClose={onClose} />
+    </Suspense>
+  );
+};
+
+export default GlobalNotificationsModal;

--- a/src/components/notifications/NotificationItem.scss
+++ b/src/components/notifications/NotificationItem.scss
@@ -92,6 +92,15 @@
   flex-shrink: 0;
 }
 
+// Global panel: space name leads the breadcrumb ("Space › #channel"). Uses the
+// prominent text token (channel/sender use the subtle one) so the space reads as
+// the breadcrumb root.
+.notification-space {
+  color: rgb(var(--color-text-main));
+  font-weight: $font-medium;
+  margin-right: $s-1;
+}
+
 // Mobile drawer responsive layout: Let date flow naturally to second row when needed
 .mobile-drawer__item-box {
   .notification-item {

--- a/src/components/notifications/NotificationItem.scss
+++ b/src/components/notifications/NotificationItem.scss
@@ -50,6 +50,27 @@
   @extend .dropdown-result-meta;
 }
 
+// Global panel: two-line meta. Line 1 = location breadcrumb, line 2 = sender +
+// date. Each line is its own flex row so fields truncate independently.
+.notification-header--stacked {
+  @extend .dropdown-result-header;
+  display: flex;
+  flex-direction: column;
+  gap: $s-1;
+
+  .notification-meta--location,
+  .notification-meta--sender {
+    @extend .dropdown-result-meta;
+    width: 100%;
+    align-items: center;
+  }
+
+  // The sender line lays sender (truncating) against the date (fixed).
+  .notification-meta--sender {
+    justify-content: space-between;
+  }
+}
+
 .notification-channel-icon {
   @extend .dropdown-result-type-icon;
 }

--- a/src/components/notifications/NotificationItem.scss
+++ b/src/components/notifications/NotificationItem.scss
@@ -54,11 +54,12 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  line-height: 0; // kill inline-SVG baseline whitespace so the icon centers
 }
 
 .notification-badge-icon {
-  font-size: $text-lg;
   color: var(--accent);
+  display: block; // block SVG centers exactly within the flex badge (no baseline shift)
 }
 
 // Body: vertical stack of the three lines, allowed to shrink + truncate.

--- a/src/components/notifications/NotificationItem.scss
+++ b/src/components/notifications/NotificationItem.scss
@@ -45,21 +45,34 @@
   }
 }
 
-// Leading circular type badge (36px), muted fill, accent-colored icon.
+// Leading circular type badge (36px): a soft accent-tinted chip with the
+// accent-colored type icon. The tint reads clearly against the panel surface
+// (plain --surface-3 was nearly invisible in dark mode).
 .notification-badge {
   width: $s-9;
   height: $s-9;
   border-radius: $rounded-full;
-  background-color: var(--surface-3);
+  background-color: color-mix(in srgb, var(--accent) 16%, transparent);
   display: flex;
   align-items: center;
   justify-content: center;
-  line-height: 0; // kill inline-SVG baseline whitespace so the icon centers
+  line-height: 0; // kill inline-SVG baseline whitespace
+
+  // Center whatever the Icon renders (svg or wrapper) both axes, with no
+  // intrinsic margins, so the glyph sits dead-center regardless of its viewBox.
+  > * {
+    display: block;
+    margin: 0;
+  }
+
+  svg {
+    display: block;
+  }
 }
 
 .notification-badge-icon {
   color: var(--accent);
-  display: block; // block SVG centers exactly within the flex badge (no baseline shift)
+  display: block;
 }
 
 // Body: vertical stack of the three lines, allowed to shrink + truncate.

--- a/src/components/notifications/NotificationItem.scss
+++ b/src/components/notifications/NotificationItem.scss
@@ -136,6 +136,12 @@
   overflow: hidden;
 }
 
+// Global panel: taller rows show a longer preview before clamping.
+.notification-item--global .notification-text {
+  -webkit-line-clamp: 5;
+  line-clamp: 5;
+}
+
 .notification-author {
   font-weight: $font-medium;
   color: var(--color-text-subtle);

--- a/src/components/notifications/NotificationItem.scss
+++ b/src/components/notifications/NotificationItem.scss
@@ -1,9 +1,13 @@
 @use '../../styles/dropdown-result-item';
 @use '../../styles/variables' as *;
 
-// Notification item uses shared dropdown result item styling
+// Notification item: leading type badge + a 3-line body (location, author +
+// preview, relative time). Mirrors the mobile notifications screen so the type
+// is scannable at a glance.
 .notification-item {
-  // Base styles from dropdown-result-item (manually applied to avoid @extend across media queries)
+  display: flex;
+  align-items: flex-start;
+  gap: $s-3;
   padding: $s-4 $s-5;
   border-bottom: $border solid var(--surface-3);
   cursor: pointer;
@@ -41,99 +45,81 @@
   }
 }
 
-// Use shared styling for notification components
-.notification-header {
-  @extend .dropdown-result-header;
+// Leading circular type badge (36px), muted fill, accent-colored icon.
+.notification-badge {
+  width: $s-9;
+  height: $s-9;
+  border-radius: $rounded-full;
+  background-color: var(--surface-3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
-.notification-meta {
-  @extend .dropdown-result-meta;
+.notification-badge-icon {
+  font-size: $text-lg;
+  color: var(--accent);
 }
 
-// Global panel: two-line meta. Line 1 = location breadcrumb, line 2 = sender +
-// date. Each line is its own flex row so fields truncate independently.
-.notification-header--stacked {
-  @extend .dropdown-result-header;
+// Body: vertical stack of the three lines, allowed to shrink + truncate.
+.notification-body {
+  flex: 1 1 auto;
   display: flex;
   flex-direction: column;
-  gap: $s-1;
+  gap: $s-0-5;
+}
 
-  .notification-meta--location,
-  .notification-meta--sender {
-    @extend .dropdown-result-meta;
-    width: 100%;
-    align-items: center;
-  }
-
-  // The sender line lays sender (truncating) against the date (fixed).
-  .notification-meta--sender {
-    justify-content: space-between;
-  }
+// Line 1 — location breadcrumb ([Space ›] #channel [› Thread]).
+.notification-location {
+  @extend .dropdown-result-meta;
+  align-items: center;
 }
 
 .notification-channel-icon {
   @extend .dropdown-result-type-icon;
 }
 
-.notification-mention-type-icon {
-  @extend .dropdown-result-user-icon;
-}
-
-.notification-date-icon {
-  @extend .dropdown-result-date-icon;
-}
-
-.notification-date {
-  @extend .dropdown-result-date;
-}
-
-.notification-channel,
-.notification-sender {
+.notification-channel {
   @extend .dropdown-result-channel;
 }
 
-.notification-content {
-  @extend .dropdown-result-content;
-}
-
-.notification-text {
-  @extend .dropdown-result-text;
-}
-
-.notification-thread-chevron {
-  color: var(--text-3);
-  font-size: $text-xs;
-  margin: 0 $s-1;
-  flex-shrink: 0;
-}
-
-.notification-thread-label {
-  color: var(--text-3);
-  font-size: $text-xs;
-  flex-shrink: 0;
-}
-
-// Global panel: space name leads the breadcrumb ("Space › #channel"). Uses the
-// prominent text token (channel/sender use the subtle one) so the space reads as
-// the breadcrumb root.
+// Space name leads the breadcrumb in global mode; prominent text token so it
+// reads as the breadcrumb root (channel uses the subtle token).
 .notification-space {
   color: rgb(var(--color-text-main));
   font-weight: $font-medium;
   margin-right: $s-1;
 }
 
-// Mobile drawer responsive layout: Let date flow naturally to second row when needed
-.mobile-drawer__item-box {
-  .notification-item {
-    .notification-header {
-      flex-wrap: wrap; // Allow wrapping when content doesn't fit
-      gap: $s-1; // Add gap between wrapped items
-      align-items: flex-start; // Align items to top when wrapped
+.notification-thread-chevron {
+  color: var(--color-text-subtle);
+  font-size: $text-xs;
+  margin: 0 $s-1;
+  flex-shrink: 0;
+}
 
-      // When items wrap, they should align to the left
-      .notification-meta:last-child {
-        justify-content: flex-start; // Align left instead of right when wrapped
-      }
-    }
-  }
+.notification-thread-label {
+  color: var(--color-text-subtle);
+  font-size: $text-xs;
+  flex-shrink: 0;
+}
+
+// Line 2 — author prefix + message preview (clamped to two lines).
+.notification-text {
+  @extend .dropdown-result-text;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.notification-author {
+  font-weight: $font-medium;
+  color: var(--color-text-subtle);
+}
+
+// Line 3 — relative time.
+.notification-date {
+  @extend .dropdown-result-date;
+  color: var(--color-text-subtle);
 }

--- a/src/components/notifications/NotificationItem.scss
+++ b/src/components/notifications/NotificationItem.scss
@@ -53,20 +53,29 @@
   height: $s-9;
   border-radius: $rounded-full;
   background-color: color-mix(in srgb, var(--accent) 16%, transparent);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  line-height: 0; // kill inline-SVG baseline whitespace
+  // Center the icon with grid place-items: more reliable than flex for a single
+  // child, and immune to inline-SVG baseline/whitespace shifts.
+  display: grid;
+  place-items: center;
+  line-height: 0;
 
-  // Center whatever the Icon renders (svg or wrapper) both axes, with no
-  // intrinsic margins, so the glyph sits dead-center regardless of its viewBox.
-  > * {
-    display: block;
-    margin: 0;
-  }
-
+  // Force the rendered SVG to an exact 18px square, centered, no intrinsic
+  // margin/alignment — so the glyph sits dead-center regardless of how Icon
+  // wraps or sizes it. `svg` reaches the glyph at any nesting depth.
   svg {
     display: block;
+    width: 18px;
+    height: 18px;
+    margin: 0;
+    vertical-align: middle;
+  }
+
+  // Any wrapper Icon renders around the svg: shrink to content, no margin, so it
+  // can't introduce its own offset within the grid cell.
+  > * {
+    display: grid;
+    place-items: center;
+    margin: 0;
   }
 }
 

--- a/src/components/notifications/NotificationItem.tsx
+++ b/src/components/notifications/NotificationItem.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { t } from '@lingui/core/macro';
+import type { IconName } from '@quilibrium/quorum-shared';
 import { Icon, Flex } from '../primitives';
 import { TouchAwareListItem } from '../ui';
 import { useSearchResultFormatting } from '../../hooks/business/search';
 import { useMessageFormatting } from '../../hooks/business/messages/useMessageFormatting';
+import dayjs from '../../utils/dayjs';
 import type { MentionNotification } from '../../hooks/business/mentions';
 import type { ReplyNotification } from '../../types/notifications';
 import './NotificationItem.scss';
@@ -102,22 +104,26 @@ export const NotificationItem: React.FC<NotificationItemProps> = ({
     disableMentionInteractivity: true, // Non-interactive in notifications
   });
 
-  const { formattedDate, handleClick } = useSearchResultFormatting({
+  // We render relative time (dayjs fromNow) rather than the formatted date, but
+  // still pass compactDate through for API compatibility with callers.
+  const { handleClick } = useSearchResultFormatting({
     message,
     onNavigate,
     compactDate,
   });
 
-  // Determine notification type and icon
+  // Leading badge icon by notification type (mirrors the mobile notifications
+  // screen so the type is scannable at a glance): @you → at, @everyone →
+  // bullhorn, role mention → shield, reply → reply arrow.
   const isReply = 'type' in notification && notification.type === 'reply';
   const mentionType = 'mentionType' in notification ? notification.mentionType : null;
-  const notificationIcon = isReply
+  const typeIcon: IconName = isReply
     ? 'reply'
     : mentionType === 'everyone'
     ? 'bullhorn'
     : mentionType === 'roles'
-    ? 'users'
-    : 'user';
+    ? 'shield'
+    : 'at';
 
   // Render message content with proper mention formatting
   const renderedContent = renderMessageContent(message, formatting, 200);
@@ -125,66 +131,48 @@ export const NotificationItem: React.FC<NotificationItemProps> = ({
   // Detect if this notification came from a thread
   const isThread = !!(message.threadId || message.isThreadReply);
 
+  // Relative time ("a few seconds ago", "8 minutes ago", …) via dayjs.
+  const relativeTime = dayjs(message.createdDate).fromNow();
+
   return (
     <TouchAwareListItem
       className={`notification-item ${className || ''}`}
       onClick={handleClick}
       tabIndex={0}
     >
-      {spaceName ? (
-        // Global panel: two-line meta. Line 1 is the location breadcrumb
-        // (Space › #channel [› Thread]); line 2 is sender + date. Gives each
-        // field room and truncates independently on narrow viewports.
-        <div className="notification-header notification-header--stacked">
-          <Flex className="notification-meta notification-meta--location min-w-0">
-            <span className="notification-space truncate-channel-name flex-shrink min-w-0">{spaceName}</span>
-            <span className="notification-thread-chevron">›</span>
-            <Icon name="hashtag" className="notification-channel-icon flex-shrink-0" />
-            <span className="notification-channel truncate-channel-name flex-shrink min-w-0">{channelName}</span>
-            {isThread && (
-              <>
-                <span className="notification-thread-chevron">›</span>
-                <span className="notification-thread-label">{t`Thread`}</span>
-              </>
-            )}
-          </Flex>
-          <Flex justify="between" className="notification-meta notification-meta--sender min-w-0">
-            <Flex className="min-w-0">
-              <Icon name={notificationIcon} className="notification-mention-type-icon flex-shrink-0" />
-              <span className="notification-sender truncate-user-name flex-shrink min-w-0">{displayName}</span>
-            </Flex>
-            <Flex className="flex-shrink-0 whitespace-nowrap">
-              <Icon name="calendar-alt" className="notification-date-icon flex-shrink-0" />
-              <span className="notification-date">{formattedDate}</span>
-            </Flex>
-          </Flex>
-        </div>
-      ) : (
-        // Per-space panel: original single-line meta (unchanged).
-        <Flex justify="between" className="notification-header">
-          <Flex className="notification-meta min-w-0">
-            <Icon name="hashtag" className="notification-channel-icon flex-shrink-0" />
-            <span className={`notification-channel ${isThread ? '' : 'mr-2'} truncate-channel-name flex-shrink min-w-0`}>{channelName}</span>
-            {isThread && (
-              <>
-                <span className="notification-thread-chevron">›</span>
-                <span className="notification-thread-label mr-2">{t`Thread`}</span>
-              </>
-            )}
-            <Icon name={notificationIcon} className="notification-mention-type-icon flex-shrink-0" />
-            <span className="notification-sender truncate-user-name flex-shrink min-w-0">{displayName}</span>
-          </Flex>
-          <Flex className="notification-meta flex-shrink-0 whitespace-nowrap">
-            <Icon name="calendar-alt" className="notification-date-icon flex-shrink-0" />
-            <span className="notification-date">{formattedDate}</span>
-          </Flex>
-        </Flex>
-      )}
+      {/* Leading type badge — conveys notification kind at a glance (mirrors the
+          mobile notifications screen). */}
+      <div className="notification-badge flex-shrink-0" aria-hidden="true">
+        <Icon name={typeIcon} className="notification-badge-icon" />
+      </div>
 
-      <div className="notification-content">
+      <div className="notification-body min-w-0">
+        {/* Line 1 — location: [Space ›] #channel [› Thread] */}
+        <Flex className="notification-location min-w-0">
+          {spaceName && (
+            <>
+              <span className="notification-space truncate-channel-name flex-shrink min-w-0">{spaceName}</span>
+              <span className="notification-thread-chevron">›</span>
+            </>
+          )}
+          <Icon name="hashtag" className="notification-channel-icon flex-shrink-0" />
+          <span className="notification-channel truncate-channel-name flex-shrink min-w-0">{channelName}</span>
+          {isThread && (
+            <>
+              <span className="notification-thread-chevron">›</span>
+              <span className="notification-thread-label">{t`Thread`}</span>
+            </>
+          )}
+        </Flex>
+
+        {/* Line 2 — author + message preview */}
         <div className="notification-text">
+          <span className="notification-author">{displayName}: </span>
           {renderedContent}
         </div>
+
+        {/* Line 3 — relative time */}
+        <div className="notification-date">{relativeTime}</div>
       </div>
     </TouchAwareListItem>
   );

--- a/src/components/notifications/NotificationItem.tsx
+++ b/src/components/notifications/NotificationItem.tsx
@@ -17,6 +17,7 @@ interface NotificationItemProps {
   spaceRoles?: any[]; // Space roles for mention formatting
   spaceChannels?: any[]; // Space channels for mention formatting
   compactDate?: boolean; // Compact date format (omit time for today/yesterday)
+  spaceName?: string; // When set (global panel), renders a "Space › #channel" breadcrumb
 }
 
 // Helper function to render message content with proper mention formatting
@@ -86,6 +87,7 @@ export const NotificationItem: React.FC<NotificationItemProps> = ({
   spaceRoles = [],
   spaceChannels = [],
   compactDate = false,
+  spaceName,
 }) => {
   const { message, channelName } = notification;
 
@@ -131,6 +133,12 @@ export const NotificationItem: React.FC<NotificationItemProps> = ({
     >
       <Flex justify="between" className="notification-header">
         <Flex className="notification-meta min-w-0">
+          {spaceName && (
+            <>
+              <span className="notification-space truncate-channel-name flex-shrink min-w-0">{spaceName}</span>
+              <span className="notification-thread-chevron">›</span>
+            </>
+          )}
           <Icon name="hashtag" className="notification-channel-icon flex-shrink-0" />
           <span className={`notification-channel ${isThread ? '' : 'mr-2'} truncate-channel-name flex-shrink min-w-0`}>{channelName}</span>
           {isThread && (

--- a/src/components/notifications/NotificationItem.tsx
+++ b/src/components/notifications/NotificationItem.tsx
@@ -131,30 +131,55 @@ export const NotificationItem: React.FC<NotificationItemProps> = ({
       onClick={handleClick}
       tabIndex={0}
     >
-      <Flex justify="between" className="notification-header">
-        <Flex className="notification-meta min-w-0">
-          {spaceName && (
-            <>
-              <span className="notification-space truncate-channel-name flex-shrink min-w-0">{spaceName}</span>
-              <span className="notification-thread-chevron">›</span>
-            </>
-          )}
-          <Icon name="hashtag" className="notification-channel-icon flex-shrink-0" />
-          <span className={`notification-channel ${isThread ? '' : 'mr-2'} truncate-channel-name flex-shrink min-w-0`}>{channelName}</span>
-          {isThread && (
-            <>
-              <span className="notification-thread-chevron">›</span>
-              <span className="notification-thread-label mr-2">{t`Thread`}</span>
-            </>
-          )}
-          <Icon name={notificationIcon} className="notification-mention-type-icon flex-shrink-0" />
-          <span className="notification-sender truncate-user-name flex-shrink min-w-0">{displayName}</span>
+      {spaceName ? (
+        // Global panel: two-line meta. Line 1 is the location breadcrumb
+        // (Space › #channel [› Thread]); line 2 is sender + date. Gives each
+        // field room and truncates independently on narrow viewports.
+        <div className="notification-header notification-header--stacked">
+          <Flex className="notification-meta notification-meta--location min-w-0">
+            <span className="notification-space truncate-channel-name flex-shrink min-w-0">{spaceName}</span>
+            <span className="notification-thread-chevron">›</span>
+            <Icon name="hashtag" className="notification-channel-icon flex-shrink-0" />
+            <span className="notification-channel truncate-channel-name flex-shrink min-w-0">{channelName}</span>
+            {isThread && (
+              <>
+                <span className="notification-thread-chevron">›</span>
+                <span className="notification-thread-label">{t`Thread`}</span>
+              </>
+            )}
+          </Flex>
+          <Flex justify="between" className="notification-meta notification-meta--sender min-w-0">
+            <Flex className="min-w-0">
+              <Icon name={notificationIcon} className="notification-mention-type-icon flex-shrink-0" />
+              <span className="notification-sender truncate-user-name flex-shrink min-w-0">{displayName}</span>
+            </Flex>
+            <Flex className="flex-shrink-0 whitespace-nowrap">
+              <Icon name="calendar-alt" className="notification-date-icon flex-shrink-0" />
+              <span className="notification-date">{formattedDate}</span>
+            </Flex>
+          </Flex>
+        </div>
+      ) : (
+        // Per-space panel: original single-line meta (unchanged).
+        <Flex justify="between" className="notification-header">
+          <Flex className="notification-meta min-w-0">
+            <Icon name="hashtag" className="notification-channel-icon flex-shrink-0" />
+            <span className={`notification-channel ${isThread ? '' : 'mr-2'} truncate-channel-name flex-shrink min-w-0`}>{channelName}</span>
+            {isThread && (
+              <>
+                <span className="notification-thread-chevron">›</span>
+                <span className="notification-thread-label mr-2">{t`Thread`}</span>
+              </>
+            )}
+            <Icon name={notificationIcon} className="notification-mention-type-icon flex-shrink-0" />
+            <span className="notification-sender truncate-user-name flex-shrink min-w-0">{displayName}</span>
+          </Flex>
+          <Flex className="notification-meta flex-shrink-0 whitespace-nowrap">
+            <Icon name="calendar-alt" className="notification-date-icon flex-shrink-0" />
+            <span className="notification-date">{formattedDate}</span>
+          </Flex>
         </Flex>
-        <Flex className="notification-meta flex-shrink-0 whitespace-nowrap">
-          <Icon name="calendar-alt" className="notification-date-icon flex-shrink-0" />
-          <span className="notification-date">{formattedDate}</span>
-        </Flex>
-      </Flex>
+      )}
 
       <div className="notification-content">
         <div className="notification-text">

--- a/src/components/notifications/NotificationItem.tsx
+++ b/src/components/notifications/NotificationItem.tsx
@@ -125,8 +125,12 @@ export const NotificationItem: React.FC<NotificationItemProps> = ({
     ? 'shield'
     : 'at';
 
+  // The global panel (spaceName present) is taller and shows a longer preview;
+  // the per-space panel stays compact.
+  const isGlobal = !!spaceName;
+
   // Render message content with proper mention formatting
-  const renderedContent = renderMessageContent(message, formatting, 200);
+  const renderedContent = renderMessageContent(message, formatting, isGlobal ? 400 : 200);
 
   // Detect if this notification came from a thread
   const isThread = !!(message.threadId || message.isThreadReply);
@@ -136,7 +140,7 @@ export const NotificationItem: React.FC<NotificationItemProps> = ({
 
   return (
     <TouchAwareListItem
-      className={`notification-item ${className || ''}`}
+      className={`notification-item ${isGlobal ? 'notification-item--global' : ''} ${className || ''}`}
       onClick={handleClick}
       tabIndex={0}
     >

--- a/src/components/notifications/NotificationItem.tsx
+++ b/src/components/notifications/NotificationItem.tsx
@@ -143,7 +143,7 @@ export const NotificationItem: React.FC<NotificationItemProps> = ({
       {/* Leading type badge — conveys notification kind at a glance (mirrors the
           mobile notifications screen). */}
       <div className="notification-badge flex-shrink-0" aria-hidden="true">
-        <Icon name={typeIcon} className="notification-badge-icon" />
+        <Icon name={typeIcon} size={18} className="notification-badge-icon" />
       </div>
 
       <div className="notification-body min-w-0">

--- a/src/components/notifications/NotificationPanel.scss
+++ b/src/components/notifications/NotificationPanel.scss
@@ -6,6 +6,27 @@
 // notification list it reads as an oversized, floating band. Reshape it into a
 // compact header bar that flows into the controls row below.
 .notification-panel--global {
+  // Taller than the default medium modal (70vh) so more notifications are
+  // visible at once. Width stays at the medium 600px — only height grows.
+  max-height: 85vh;
+  min-height: min(85vh, 560px);
+
+  // The modal root must NOT scroll — only the inner list does. Otherwise the
+  // modal's own overflow:auto plus the list's overflow:auto produce two nested
+  // scrollbars. Make it a flex column and clip its overflow; the list flex-grows
+  // and owns the single scrollbar.
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+
+  .quorum-modal-container {
+    flex: 1 1 auto;
+    min-height: 0; // allow the flex child to shrink so its inner scroll works
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
   // Title bar: fixed height so the close button can center against it exactly
   // ($s-4 vertical padding + $text-lg line-height). Box-sizing keeps the height
   // honest regardless of padding.
@@ -46,6 +67,16 @@
   // border already separates them, so drop the controls' own top border.
   .notification-panel__controls {
     border-top: none;
+  }
+
+  // The list is the single scroll region: it flex-grows to fill the taller
+  // modal and owns the only scrollbar (the per-space 350px cap is removed here).
+  .notification-panel__list {
+    @media (hover: hover) and (pointer: fine) {
+      flex: 1 1 auto;
+      min-height: 0;
+      max-height: none;
+    }
   }
 }
 

--- a/src/components/notifications/NotificationPanel.scss
+++ b/src/components/notifications/NotificationPanel.scss
@@ -6,24 +6,37 @@
 // notification list it reads as an oversized, floating band. Reshape it into a
 // compact header bar that flows into the controls row below.
 .notification-panel--global {
-  // Title bar: $s-4 (16px) vertical padding + $text-lg line-height (28px) = 60px
-  // tall. Keep these in sync with the close-button centering below.
+  // Title bar: fixed height so the close button can center against it exactly
+  // ($s-4 vertical padding + $text-lg line-height). Box-sizing keeps the height
+  // honest regardless of padding.
+  $title-bar-height: 60px;
+
   .quorum-modal-title {
+    box-sizing: border-box;
+    height: $title-bar-height;
+    display: flex;
+    align-items: center;
     font-size: $text-lg;
     line-height: $text-lg-lh;
     font-weight: $font-bold;
     margin-bottom: 0;
-    padding: $s-4 $s-12 $s-4 $s-4; // right padding leaves room for the close button
+    padding: 0 $s-12 0 $s-4; // vertical centering handled by flex; right pad clears the close button
     border-bottom: $border solid var(--color-border-panel);
   }
 
-  // Vertically center the close button on the title bar (half of the 60px bar =
-  // 30px), regardless of the button's own box size. translateY(-50%) makes this
-  // self-correcting instead of pixel-guessing against the primitive's top: $s-3.
+  // Center the close button on the title bar. Fixed square button (so the hover
+  // circle stays compact) positioned at the bar's vertical center:
+  // top = (bar - button) / 2. Symmetric gap, no guessing against the icon box.
+  $close-size: 32px;
+
   .quorum-modal-close {
-    top: 30px !important;
-    right: $s-4;
-    transform: translateY(-50%);
+    // Equal distance from the top border and the right edge of the bar.
+    top: calc((#{$title-bar-height} - #{$close-size}) / 2) !important;
+    right: calc((#{$title-bar-height} - #{$close-size}) / 2);
+    width: $close-size;
+    height: $close-size;
+    margin: 0;
+    padding: 0;
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/components/notifications/NotificationPanel.scss
+++ b/src/components/notifications/NotificationPanel.scss
@@ -73,3 +73,10 @@
 .empty-hint {
   @extend .dropdown-empty-hint;
 }
+
+.notification-panel__truncation-note {
+  text-align: center;
+  padding: $s-2 $s-4;
+  font-size: $text-sm;
+  color: var(--color-text-subtle);
+}

--- a/src/components/notifications/NotificationPanel.scss
+++ b/src/components/notifications/NotificationPanel.scss
@@ -1,6 +1,41 @@
 @use '../../styles/variables' as *;
 @use '../../styles/dropdown-result-item';
 
+// Global (modal) variant: the Modal primitive's title is a tall section heading
+// ($text-2xl, margin-bottom $s-6) meant to sit above form fields. For the
+// notification list it reads as an oversized, floating band. Reshape it into a
+// compact header bar that flows into the controls row below.
+.notification-panel--global {
+  // Title bar: $s-4 (16px) vertical padding + $text-lg line-height (28px) = 60px
+  // tall. Keep these in sync with the close-button centering below.
+  .quorum-modal-title {
+    font-size: $text-lg;
+    line-height: $text-lg-lh;
+    font-weight: $font-bold;
+    margin-bottom: 0;
+    padding: $s-4 $s-12 $s-4 $s-4; // right padding leaves room for the close button
+    border-bottom: $border solid var(--color-border-panel);
+  }
+
+  // Vertically center the close button on the title bar (half of the 60px bar =
+  // 30px), regardless of the button's own box size. translateY(-50%) makes this
+  // self-correcting instead of pixel-guessing against the primitive's top: $s-3.
+  .quorum-modal-close {
+    top: 30px !important;
+    right: $s-4;
+    transform: translateY(-50%);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  // Controls sit directly under the title with no extra top gap; the title's
+  // border already separates them, so drop the controls' own top border.
+  .notification-panel__controls {
+    border-top: none;
+  }
+}
+
 // Notification Panel styling
 
 .notification-panel__header {

--- a/src/components/notifications/NotificationPanel.tsx
+++ b/src/components/notifications/NotificationPanel.tsx
@@ -215,7 +215,7 @@ export const NotificationPanel: React.FC<NotificationPanelProps> = ({
   const renderEmptyState = () => {
     if (isLoading) {
       return (
-        <Flex justify="center" align="center" className="notification-loading-state">
+        <Flex direction="column" justify="center" align="center" className="notification-loading-state">
           <Icon name="spinner" className="loading-icon icon-spin" />
           <span className="loading-message">{t`Loading notifications...`}</span>
         </Flex>
@@ -223,7 +223,7 @@ export const NotificationPanel: React.FC<NotificationPanelProps> = ({
     }
 
     return (
-      <Flex justify="center" align="center" className="notification-empty-state">
+      <Flex direction="column" justify="center" align="center" className="notification-empty-state">
         <Icon name="bell" size="3xl" className="empty-icon" />
         <span className="empty-message">{t`No unread notifications`}</span>
         <span className="empty-hint">
@@ -233,10 +233,15 @@ export const NotificationPanel: React.FC<NotificationPanelProps> = ({
     );
   };
 
-  const panelTitle =
-    allNotifications.length === 1
+  // Per-space panel makes the scope explicit in the title; the global panel
+  // (across all spaces) keeps the plain count.
+  const panelTitle = global
+    ? allNotifications.length === 1
       ? t`${allNotifications.length} notification`
-      : t`${allNotifications.length} notifications`;
+      : t`${allNotifications.length} notifications`
+    : allNotifications.length === 1
+      ? t`${allNotifications.length} Notification in this Space`
+      : t`${allNotifications.length} Notifications in this Space`;
 
   const panelBody = (
       <>

--- a/src/components/notifications/NotificationPanel.tsx
+++ b/src/components/notifications/NotificationPanel.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { t } from '@lingui/core/macro';
-import { Flex, Icon, Button, Tooltip, Select } from '../primitives';
+import { Flex, Icon, Button, Tooltip, Select, Modal } from '../primitives';
 import { DropdownPanel } from '../ui';
 import { isTouchDevice } from '../../utils/platform';
 import { buildMessageHash } from '../../utils/messageHashNavigation';
@@ -233,23 +233,13 @@ export const NotificationPanel: React.FC<NotificationPanelProps> = ({
     );
   };
 
-  return (
-    <>
-      <DropdownPanel
-        isOpen={isOpen}
-        onClose={onClose}
-        position="absolute"
-        positionStyle={global ? 'centered' : 'right-aligned'}
-        maxWidth={500}
-        maxHeight={Math.min(window.innerHeight * 0.8, 600)}
-        title={
-          allNotifications.length === 1
-            ? t`${allNotifications.length} notification`
-            : t`${allNotifications.length} notifications`
-        }
-        className={`notification-panel ${className || ''}`}
-        showCloseButton={true}
-      >
+  const panelTitle =
+    allNotifications.length === 1
+      ? t`${allNotifications.length} notification`
+      : t`${allNotifications.length} notifications`;
+
+  const panelBody = (
+      <>
         {/* Filter controls - only show when there are notifications */}
         {!isLoading && allNotifications.length > 0 && (
           <div className="notification-panel__controls">
@@ -378,7 +368,42 @@ export const NotificationPanel: React.FC<NotificationPanelProps> = ({
             {t`Showing the ${GLOBAL_DISPLAY_CAP} most recent notifications`}
           </div>
         )}
-      </DropdownPanel>
+      </>
+  );
+
+  return (
+    <>
+      {global ? (
+        // Global mode: top-level centered Modal (backdrop + blur + correct
+        // z-index above the AppShell chrome — see .agents/docs/features/modals.md).
+        <Modal
+          visible={isOpen}
+          onClose={onClose}
+          title={panelTitle}
+          size="medium"
+          closeOnBackdropClick
+          closeOnEscape
+          noPadding
+          className={`notification-panel notification-panel--global ${className || ''}`}
+        >
+          {panelBody}
+        </Modal>
+      ) : (
+        // Per-space mode: anchored right-aligned dropdown (unchanged).
+        <DropdownPanel
+          isOpen={isOpen}
+          onClose={onClose}
+          position="absolute"
+          positionStyle="right-aligned"
+          maxWidth={500}
+          maxHeight={Math.min(window.innerHeight * 0.8, 600)}
+          title={panelTitle}
+          className={`notification-panel ${className || ''}`}
+          showCloseButton={true}
+        >
+          {panelBody}
+        </DropdownPanel>
+      )}
 
       {confirm?.modalConfig && (
         <ConfirmationModal

--- a/src/components/notifications/NotificationPanel.tsx
+++ b/src/components/notifications/NotificationPanel.tsx
@@ -9,9 +9,13 @@ import { resolveSpaceMemberName, formatResolvedName } from '../../utils/resolveM
 import { NotificationItem } from './NotificationItem';
 import { useAllMentions, useMentionNotificationSettings } from '../../hooks/business/mentions';
 import { useAllReplies } from '../../hooks/business/replies';
+import { useGlobalNotifications, GLOBAL_DISPLAY_CAP } from '../../hooks/business/notifications';
 import { useMessageDB } from '../context/useMessageDB';
 import { useQueryClient } from '@tanstack/react-query';
+import { useConfirmation } from '../../hooks/ui/useConfirmation';
+import ConfirmationModal from '../modals/ConfirmationModal';
 import type { SpaceNotificationTypeId } from '../../types/notifications';
+import type { Space } from '@quilibrium/quorum-shared';
 import './NotificationPanel.scss';
 
 interface NotificationPanelProps {
@@ -24,6 +28,12 @@ interface NotificationPanelProps {
   userRoleIds?: string[];
   spaceRoles?: any[];
   spaceChannels?: any[];
+  /** Global mode: aggregate across all spaces, centered presentation. */
+  global?: boolean;
+  /** Required in global mode: all the user's spaces. */
+  spaces?: Space[];
+  /** Global mode sender resolver (spaceId, senderId) → user. */
+  resolveGlobalSender?: (spaceId: string, senderId: string) => any;
 }
 
 export const NotificationPanel: React.FC<NotificationPanelProps> = ({
@@ -36,6 +46,9 @@ export const NotificationPanel: React.FC<NotificationPanelProps> = ({
   userRoleIds = [],
   spaceRoles = [],
   spaceChannels = [],
+  global = false,
+  spaces,
+  resolveGlobalSender,
 }) => {
   const navigate = useNavigate();
   const { messageDB } = useMessageDB();
@@ -56,28 +69,36 @@ export const NotificationPanel: React.FC<NotificationPanelProps> = ({
   // Derive mention-only filter for useAllMentions (unified format)
   const mentionTypes = selectedTypes.filter(t => t.startsWith('mention-')) as ('mention-you' | 'mention-everyone' | 'mention-roles')[];
 
-  // Fetch mentions with current filter
-  const { mentions, isLoading: mentionsLoading } = useAllMentions({
+  // Whether reply notifications are enabled
+  const replyEnabled = selectedTypes.includes('reply');
+
+  // Per-space path (existing) — empty channelIds in global mode disables it.
+  const { mentions: spaceMentions, isLoading: smLoading } = useAllMentions({
     spaceId,
-    channelIds,
-    enabledTypes: mentionTypes, // Pass empty array when no mention types selected
+    channelIds: global ? [] : channelIds,
+    enabledTypes: mentionTypes,
     userRoleIds,
   });
-
-  // Fetch replies based on UI filter state
-  const { replies, isLoading: repliesLoading } = useAllReplies({
+  const { replies: spaceReplies, isLoading: srLoading } = useAllReplies({
     spaceId,
-    channelIds,
-    enabled: selectedTypes.includes('reply'),
+    channelIds: global ? [] : channelIds,
+    enabled: replyEnabled,
   });
 
-  // Combine mentions and replies - filtering is now handled by the hooks
-  const allNotifications = [
-    ...mentions,
-    ...replies,
-  ].sort((a, b) => b.message.createdDate - a.message.createdDate);
+  // Global path — empty spaces in per-space mode disables it.
+  const { notifications: globalNotifications, truncated: globalTruncated, isLoading: gLoading } = useGlobalNotifications({
+    spaces: global ? (spaces ?? []) : [],
+    enabledTypes: mentionTypes,
+    replyEnabled,
+  });
 
-  const isLoading = mentionsLoading || repliesLoading || settingsLoading;
+  const allNotifications = global
+    ? globalNotifications
+    : [...spaceMentions, ...spaceReplies].sort((a, b) => b.message.createdDate - a.message.createdDate);
+
+  const isLoading = global
+    ? (gLoading || settingsLoading)
+    : (smLoading || srLoading || settingsLoading);
 
   // Filter options for Select primitive
   const filterOptions = [
@@ -127,63 +148,68 @@ export const NotificationPanel: React.FC<NotificationPanelProps> = ({
     }, 8000);
   }, [navigate, onClose]);
 
-  // Handle mark all as read
-  const handleMarkAllRead = useCallback(async () => {
+  // Core mark-all-read logic (handles both per-space and global modes)
+  const handleMarkAllReadCore = useCallback(async () => {
     try {
-      // Get current timestamp
       const now = Date.now();
-
-      // Update last read time for all channels with notifications
-      const channelsWithNotifications = new Set(allNotifications.map(n => n.channelId));
-
-      for (const channelId of channelsWithNotifications) {
-        const conversationId = `${spaceId}/${channelId}`;
+      const pairs = new Map<string, { spaceId: string; channelId: string }>();
+      for (const n of allNotifications) {
+        const sId = global ? ((n as any).spaceId ?? spaceId) : spaceId;
+        pairs.set(`${sId}/${n.channelId}`, { spaceId: sId, channelId: n.channelId });
+      }
+      for (const { spaceId: sId, channelId } of pairs.values()) {
         await messageDB.saveReadTime({
-          conversationId,
+          conversationId: `${sId}/${channelId}`,
           lastMessageTimestamp: now,
         });
       }
 
-      // Also save thread read times for all threads in channels that have notifications.
       const threadEntries: Array<{ threadId: string; spaceId: string; channelId: string; lastReadTimestamp: number }> = [];
-
-      for (const channelId of channelsWithNotifications) {
-        const threads = await messageDB.getChannelThreads({ spaceId, channelId });
+      for (const { spaceId: sId, channelId } of pairs.values()) {
+        const threads = await messageDB.getChannelThreads({ spaceId: sId, channelId });
         for (const thread of threads) {
-          threadEntries.push({
-            threadId: thread.threadId,
-            spaceId,
-            channelId,
-            lastReadTimestamp: now,
-          });
+          threadEntries.push({ threadId: thread.threadId, spaceId: sId, channelId, lastReadTimestamp: now });
         }
       }
+      if (threadEntries.length > 0) await messageDB.bulkSaveThreadReadTimes(threadEntries);
 
-      if (threadEntries.length > 0) {
-        await messageDB.bulkSaveThreadReadTimes(threadEntries);
-      }
-
-      // Invalidate all notification-related caches
-      // Space-level counts (for SpaceIcon indicators in NavMenu)
+      // Invalidate all notification-related caches (broad prefix so global mode refreshes every space)
       queryClient.invalidateQueries({ queryKey: ['mention-counts', 'space'] });
       queryClient.invalidateQueries({ queryKey: ['reply-counts', 'space'] });
       queryClient.invalidateQueries({ queryKey: ['unread-counts', 'space'] });
-      // Channel-level counts (for ChannelList indicators)
-      queryClient.invalidateQueries({ queryKey: ['mention-counts', 'channel', spaceId] });
-      queryClient.invalidateQueries({ queryKey: ['reply-counts', 'channel', spaceId] });
-      queryClient.invalidateQueries({ queryKey: ['unread-counts', 'channel', spaceId] });
-      // NotificationPanel data
-      queryClient.invalidateQueries({ queryKey: ['mention-notifications', spaceId] });
-      queryClient.invalidateQueries({ queryKey: ['reply-notifications', spaceId] });
-      // Conversation data (for read timestamps)
+      queryClient.invalidateQueries({ queryKey: ['mention-counts', 'channel'] });
+      queryClient.invalidateQueries({ queryKey: ['reply-counts', 'channel'] });
+      queryClient.invalidateQueries({ queryKey: ['unread-counts', 'channel'] });
+      queryClient.invalidateQueries({ queryKey: ['mention-notifications'] });
+      queryClient.invalidateQueries({ queryKey: ['reply-notifications'] });
       queryClient.invalidateQueries({ queryKey: ['conversation'] });
 
-      // Close dropdown
       onClose();
     } catch (error) {
       console.error('[NotificationPanel] Error marking all as read:', error);
     }
-  }, [allNotifications, spaceId, messageDB, queryClient, onClose]);
+  }, [allNotifications, spaceId, global, messageDB, queryClient, onClose]);
+
+  // Confirmation hook for global mode mark-all-read
+  const confirm = useConfirmation({
+    type: 'modal',
+    modalConfig: {
+      variant: 'warning',
+      title: t`Mark all as read?`,
+      message: t`This marks mentions and replies as read across all your spaces. This can't be undone.`,
+      confirmText: t`Mark all read`,
+      cancelText: t`Cancel`,
+    },
+  });
+
+  // In global mode, gate mark-all-read behind a confirmation modal
+  const handleMarkAllRead = useCallback((e: React.MouseEvent) => {
+    if (global) {
+      confirm.handleClick(e, handleMarkAllReadCore);
+    } else {
+      handleMarkAllReadCore();
+    }
+  }, [global, confirm, handleMarkAllReadCore]);
 
   // Render empty state
   const renderEmptyState = () => {
@@ -208,133 +234,166 @@ export const NotificationPanel: React.FC<NotificationPanelProps> = ({
   };
 
   return (
-    <DropdownPanel
-      isOpen={isOpen}
-      onClose={onClose}
-      position="absolute"
-      positionStyle="right-aligned"
-      maxWidth={500}
-      maxHeight={Math.min(window.innerHeight * 0.8, 600)}
-      title={
-        allNotifications.length === 1
-          ? t`${allNotifications.length} notification`
-          : t`${allNotifications.length} notifications`
-      }
-      className={`notification-panel ${className || ''}`}
-      showCloseButton={true}
-    >
-      {/* Filter controls - only show when there are notifications */}
-      {!isLoading && allNotifications.length > 0 && (
-        <div className="notification-panel__controls">
-          <Flex className="items-center justify-between gap-2">
-            <Select
-              value={selectedTypes}
-              onChange={handleFilterChange}
-              options={filterOptions}
-              multiple={true}
-              compactMode={true}
-              compactIcon="filter"
-              showSelectionCount={false}
-              showSelectAllOption={false}
-              selectAllLabel={t`All`}
-              clearAllLabel={t`Clear`}
-              size="medium"
-              dropdownClassName="panel-select-dropdown"
-            />
-
-            <Tooltip
-              id="mark-all-read-tooltip"
-              content={t`Mark all as read`}
-              place="top"
-            >
-              <Button
-                type="unstyled"
-                onClick={handleMarkAllRead}
-                className="notification-panel__mark-read"
-                iconName="check-circle"
-                iconOnly
+    <>
+      <DropdownPanel
+        isOpen={isOpen}
+        onClose={onClose}
+        position="absolute"
+        positionStyle={global ? 'centered' : 'right-aligned'}
+        maxWidth={500}
+        maxHeight={Math.min(window.innerHeight * 0.8, 600)}
+        title={
+          allNotifications.length === 1
+            ? t`${allNotifications.length} notification`
+            : t`${allNotifications.length} notifications`
+        }
+        className={`notification-panel ${className || ''}`}
+        showCloseButton={true}
+      >
+        {/* Filter controls - only show when there are notifications */}
+        {!isLoading && allNotifications.length > 0 && (
+          <div className="notification-panel__controls">
+            <Flex className="items-center justify-between gap-2">
+              <Select
+                value={selectedTypes}
+                onChange={handleFilterChange}
+                options={filterOptions}
+                multiple={true}
+                compactMode={true}
+                compactIcon="filter"
+                showSelectionCount={false}
+                showSelectAllOption={false}
+                selectAllLabel={t`All`}
+                clearAllLabel={t`Clear`}
+                size="medium"
+                dropdownClassName="panel-select-dropdown"
               />
-            </Tooltip>
-          </Flex>
-        </div>
-      )}
 
-      {/* Notification list */}
-      {isLoading || allNotifications.length === 0 ? (
-        renderEmptyState()
-      ) : (
-        <>
-          {/* Mobile: Use new item list layout */}
-          {isTouchDevice() ? (
-            <div className="mobile-drawer__item-list mobile-drawer__item-list--with-controls">
-              {allNotifications.map((notification) => {
-                const sender = mapSenderToUser(notification.message.content?.senderId);
-                return (
-                  <div
-                    key={`${notification.message.messageId}-${notification.channelId}`}
-                    className="mobile-drawer__item-box mobile-drawer__item-box--interactive"
-                  >
-                    <NotificationItem
-                      notification={notification}
-                      onNavigate={handleNavigate}
-                      displayName={
-                        sender
-                          ? formatResolvedName(
-                              resolveSpaceMemberName({
-                                address: sender.address ?? notification.message.content?.senderId ?? '',
-                                displayName: sender.displayName,
-                                primaryUsername: sender.primaryUsername,
-                                globalDisplayName: sender.globalDisplayName,
-                              }),
-                            )
-                          : t`Unknown User`
-                      }
-                      mapSenderToUser={mapSenderToUser}
-                      spaceRoles={spaceRoles}
-                      spaceChannels={spaceChannels}
-                      compactDate={true}
-                    />
-                  </div>
-                );
-              })}
-            </div>
-          ) : (
-            /* Desktop: card item layout */
-            <div className="notification-panel__list">
-              {allNotifications.map((notification) => {
-                const sender = mapSenderToUser(notification.message.content?.senderId);
-                return (
-                  <div
-                    key={`${notification.message.messageId}-${notification.channelId}`}
-                    className="panel-item-box panel-item-box--interactive"
-                  >
-                    <NotificationItem
-                      notification={notification}
-                      onNavigate={handleNavigate}
-                      displayName={
-                        sender
-                          ? formatResolvedName(
-                              resolveSpaceMemberName({
-                                address: sender.address ?? notification.message.content?.senderId ?? '',
-                                displayName: sender.displayName,
-                                primaryUsername: sender.primaryUsername,
-                                globalDisplayName: sender.globalDisplayName,
-                              }),
-                            )
-                          : t`Unknown User`
-                      }
-                      mapSenderToUser={mapSenderToUser}
-                      spaceRoles={spaceRoles}
-                      spaceChannels={spaceChannels}
-                    />
-                  </div>
-                );
-              })}
-            </div>
-          )}
-        </>
+              <Tooltip
+                id="mark-all-read-tooltip"
+                content={t`Mark all as read`}
+                place="top"
+              >
+                <Button
+                  type="unstyled"
+                  onClick={handleMarkAllRead}
+                  className="notification-panel__mark-read"
+                  iconName="check-circle"
+                  iconOnly
+                />
+              </Tooltip>
+            </Flex>
+          </div>
+        )}
+
+        {/* Notification list */}
+        {isLoading || allNotifications.length === 0 ? (
+          renderEmptyState()
+        ) : (
+          <>
+            {/* Mobile: Use new item list layout */}
+            {isTouchDevice() ? (
+              <div className="mobile-drawer__item-list mobile-drawer__item-list--with-controls">
+                {allNotifications.map((notification) => {
+                  const senderId = notification.message.content?.senderId;
+                  const rowSpaceId = (notification as any).spaceId ?? spaceId;
+                  const sender = global && resolveGlobalSender
+                    ? resolveGlobalSender(rowSpaceId, senderId)
+                    : mapSenderToUser(senderId);
+                  return (
+                    <div
+                      key={`${notification.message.messageId}-${notification.channelId}`}
+                      className="mobile-drawer__item-box mobile-drawer__item-box--interactive"
+                    >
+                      <NotificationItem
+                        notification={notification}
+                        onNavigate={handleNavigate}
+                        displayName={
+                          sender
+                            ? formatResolvedName(
+                                resolveSpaceMemberName({
+                                  address: sender.address ?? notification.message.content?.senderId ?? '',
+                                  displayName: sender.displayName,
+                                  primaryUsername: sender.primaryUsername,
+                                  globalDisplayName: sender.globalDisplayName,
+                                }),
+                              )
+                            : t`Unknown User`
+                        }
+                        mapSenderToUser={mapSenderToUser}
+                        spaceRoles={spaceRoles}
+                        spaceChannels={spaceChannels}
+                        spaceName={global ? (notification as any).spaceName : undefined}
+                        compactDate={true}
+                      />
+                    </div>
+                  );
+                })}
+              </div>
+            ) : (
+              /* Desktop: card item layout */
+              <div className="notification-panel__list">
+                {allNotifications.map((notification) => {
+                  const senderId = notification.message.content?.senderId;
+                  const rowSpaceId = (notification as any).spaceId ?? spaceId;
+                  const sender = global && resolveGlobalSender
+                    ? resolveGlobalSender(rowSpaceId, senderId)
+                    : mapSenderToUser(senderId);
+                  return (
+                    <div
+                      key={`${notification.message.messageId}-${notification.channelId}`}
+                      className="panel-item-box panel-item-box--interactive"
+                    >
+                      <NotificationItem
+                        notification={notification}
+                        onNavigate={handleNavigate}
+                        displayName={
+                          sender
+                            ? formatResolvedName(
+                                resolveSpaceMemberName({
+                                  address: sender.address ?? notification.message.content?.senderId ?? '',
+                                  displayName: sender.displayName,
+                                  primaryUsername: sender.primaryUsername,
+                                  globalDisplayName: sender.globalDisplayName,
+                                }),
+                              )
+                            : t`Unknown User`
+                        }
+                        mapSenderToUser={mapSenderToUser}
+                        spaceRoles={spaceRoles}
+                        spaceChannels={spaceChannels}
+                        spaceName={global ? (notification as any).spaceName : undefined}
+                      />
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </>
+        )}
+
+        {/* Truncation note - only in global mode when results are capped */}
+        {global && globalTruncated && (
+          <div className="notification-panel__truncation-note">
+            {t`Showing the ${GLOBAL_DISPLAY_CAP} most recent notifications`}
+          </div>
+        )}
+      </DropdownPanel>
+
+      {confirm?.modalConfig && (
+        <ConfirmationModal
+          visible={confirm.showModal}
+          title={confirm.modalConfig.title}
+          message={confirm.modalConfig.message}
+          confirmText={confirm.modalConfig.confirmText}
+          cancelText={confirm.modalConfig.cancelText}
+          variant={confirm.modalConfig.variant}
+          busy={confirm.isConfirming}
+          onConfirm={confirm.modalConfig.onConfirm}
+          onCancel={confirm.modalConfig.onCancel}
+        />
       )}
-    </DropdownPanel>
+    </>
   );
 };
 

--- a/src/components/shell/NavRail.scss
+++ b/src/components/shell/NavRail.scss
@@ -214,8 +214,10 @@
 .nav-rail .nav-rail__notif-dot {
   width: $s-2-5;   // 10px — bigger than the base 6px dot
   height: $s-2-5;
-  top: -1px;
-  right: 3px;      // pull inward so it overlaps the bell's top-right corner
+  // Sit on the bell's RIGHT side (not the top): lower it toward the vertical
+  // middle and push it right so it overlaps only the right edge of the glyph.
+  top: 4px;
+  right: 1px;
   left: auto;
   transform: none;
   // Ring lifts the badge off the icon strokes underneath it.

--- a/src/components/shell/NavRail.scss
+++ b/src/components/shell/NavRail.scss
@@ -204,13 +204,21 @@
   text-overflow: ellipsis;
 }
 
-// Unread dot on the notifications bell. The base .icon-unread-dot positions
-// left-of-an-avatar (left: -15px; top: 50%; translateY). Scope under .nav-rail
-// to win on specificity regardless of stylesheet load order, and pin to the
-// bell icon's top-right corner.
+// Unread badge on the notifications bell. The base .icon-unread-dot positions
+// left-of-an-avatar (left: -15px; top: 50%; translateY) and is a tiny 6px dot
+// that blends in with the other unread dots around the app. Here we make it a
+// deliberate badge: larger, sitting OVER the bell's top-right (partially
+// covering the glyph), with a ring in the rail background so it reads as a
+// distinct badge rather than part of the icon. Scoped under .nav-rail to win on
+// specificity regardless of stylesheet load order.
 .nav-rail .nav-rail__notif-dot {
-  top: -2px;
-  right: -2px;
+  width: $s-2-5;   // 10px — bigger than the base 6px dot
+  height: $s-2-5;
+  top: -1px;
+  right: 3px;      // pull inward so it overlaps the bell's top-right corner
   left: auto;
   transform: none;
+  // Ring lifts the badge off the icon strokes underneath it.
+  border: 2px solid var(--color-bg-rail);
+  box-sizing: content-box;
 }

--- a/src/components/shell/NavRail.scss
+++ b/src/components/shell/NavRail.scss
@@ -204,9 +204,11 @@
   text-overflow: ellipsis;
 }
 
-// Unread dot on the notifications bell. Overrides the base .icon-unread-dot
-// (which positions left-of-an-avatar) to sit at the bell icon's top-right.
-.nav-rail__notif-dot {
+// Unread dot on the notifications bell. The base .icon-unread-dot positions
+// left-of-an-avatar (left: -15px; top: 50%; translateY). Scope under .nav-rail
+// to win on specificity regardless of stylesheet load order, and pin to the
+// bell icon's top-right corner.
+.nav-rail .nav-rail__notif-dot {
   top: -2px;
   right: -2px;
   left: auto;

--- a/src/components/shell/NavRail.scss
+++ b/src/components/shell/NavRail.scss
@@ -204,19 +204,12 @@
   text-overflow: ellipsis;
 }
 
-// Unread badge on the notifications bell. The base .icon-unread-dot positions
-// left-of-an-avatar (left: -15px; top: 50%; translateY) and is a tiny 6px dot
-// that blends in with the other unread dots around the app. Here we make it a
-// deliberate badge: larger, sitting OVER the bell's top-right (partially
-// covering the glyph), with a ring in the rail background so it reads as a
-// distinct badge rather than part of the icon. Scoped under .nav-rail to win on
-// specificity regardless of stylesheet load order.
+// Unread badge on the notifications bell.
 .nav-rail .nav-rail__notif-dot {
-  width: $s-2-5;   // 10px — bigger than the base 6px dot
-  height: $s-2-5;
-  // Sit on the bell's RIGHT side (not the top): lower it toward the vertical
-  // middle and push it right so it overlaps only the right edge of the glyph.
-  top: 4px;
+  width: $s-2;   // bigger than the base 6px dot
+  height: $s-2;
+  // Sit on the bell's RIGHT side
+  top: 1px;
   right: 1px;
   left: auto;
   transform: none;

--- a/src/components/shell/NavRail.scss
+++ b/src/components/shell/NavRail.scss
@@ -203,3 +203,12 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
+// Unread dot on the notifications bell. Overrides the base .icon-unread-dot
+// (which positions left-of-an-avatar) to sit at the bell icon's top-right.
+.nav-rail__notif-dot {
+  top: -2px;
+  right: -2px;
+  left: auto;
+  transform: none;
+}

--- a/src/components/shell/NavRail.tsx
+++ b/src/components/shell/NavRail.tsx
@@ -11,8 +11,6 @@ import { useOptionalShellState } from './useShellState';
 import { useSpaces } from '../../hooks/queries/spaces';
 import { useSpaceMentionCounts } from '../../hooks/business/mentions';
 import { useSpaceReplyCounts } from '../../hooks/business/replies';
-import { useGlobalSenderResolver } from '../../hooks/business/notifications';
-import { NotificationPanel } from '../notifications/NotificationPanel';
 import './NavRail.scss';
 
 type RailSectionId = 'dm' | 'spaces' | 'notifications' | 'bookmarks' | 'discover' | 'farcaster' | 'wallet';
@@ -38,12 +36,6 @@ const buildItems = (): RailItemConfig[] => [
     route: '/spaces',
   },
   {
-    id: 'notifications',
-    icon: 'bell',
-    label: t`Notifications`,
-    route: '', // not navigated — opens the global panel
-  },
-  {
     id: 'bookmarks',
     icon: 'bookmark',
     label: t`Bookmarks`,
@@ -67,6 +59,12 @@ const buildItems = (): RailItemConfig[] => [
     label: t`Wallet`,
     route: '/wallet',
   },
+  {
+    id: 'notifications',
+    icon: 'bell',
+    label: t`Notifications`,
+    route: '', // not navigated — opens the global panel
+  },
   // TODO: FAVORITES section — depends on favorites feature
 ];
 
@@ -85,7 +83,7 @@ export const NavRail: React.FunctionComponent<NavRailProps> = ({ collapsed, onTo
   // an empty deps array).
   const items = buildItems();
   const user = usePasskeysContext();
-  const { openUserSettings } = useModalContext();
+  const { openUserSettings, openNotifications } = useModalContext();
   // On phone the rail lives inside the drawer; tapping a section should swap
   // what the sidebar shows (DM list, spaces list) rather than navigate to the
   // last visited leaf, which would close the drawer via the leaf-route
@@ -97,16 +95,16 @@ export const NavRail: React.FunctionComponent<NavRailProps> = ({ collapsed, onTo
   const userIcon = user?.currentPasskeyInfo?.pfpUrl;
   const userAddress = user?.currentPasskeyInfo?.address || '';
 
-  // Global notifications: bell opens a centered panel aggregating across spaces.
-  // `useSpaces` is suspense-backed, matching the sibling SpacesSidebar under the
-  // app-level Suspense boundary (App.tsx) — the cached query won't re-suspend.
-  const [notifOpen, setNotifOpen] = React.useState(false);
+  // Global notifications: the bell opens a centered Modal (rendered by
+  // ModalProvider). NavRail only needs the unread-presence dot — the panel and
+  // its sender resolver live in GlobalNotificationsModal. `useSpaces` is
+  // suspense-backed, matching the sibling SpacesSidebar under the Layout-level
+  // Suspense boundary; the cached query won't re-suspend.
   const { data: spaces = [] } = useSpaces();
   const mentionCounts = useSpaceMentionCounts({ spaces });
   const replyCounts = useSpaceReplyCounts({ spaces });
   const hasUnreadNotifications =
     Object.keys(mentionCounts).length > 0 || Object.keys(replyCounts).length > 0;
-  const resolveGlobalSender = useGlobalSenderResolver(spaces);
 
   // Compute active section from pathname.
   // /discover/* → "discover"; /spaces or /spaces/:id/:id → "spaces"; /messages → "dm".
@@ -122,7 +120,7 @@ export const NavRail: React.FunctionComponent<NavRailProps> = ({ collapsed, onTo
 
   const onItemClick = (item: RailItemConfig) => {
     if (item.id === 'notifications') {
-      setNotifOpen(true);
+      openNotifications();
       return;
     }
     if (item.id === 'dm') {
@@ -297,19 +295,6 @@ export const NavRail: React.FunctionComponent<NavRailProps> = ({ collapsed, onTo
           </div>
         </button>
       )}
-
-      {/* Global notifications panel (centered). spaceId/channelIds/mapSenderToUser
-          are required by the shared props but unused in global mode. */}
-      <NotificationPanel
-        global
-        isOpen={notifOpen}
-        onClose={() => setNotifOpen(false)}
-        spaces={spaces}
-        resolveGlobalSender={resolveGlobalSender}
-        spaceId=""
-        channelIds={[]}
-        mapSenderToUser={() => undefined}
-      />
     </nav>
   );
 };

--- a/src/components/shell/NavRail.tsx
+++ b/src/components/shell/NavRail.tsx
@@ -8,9 +8,14 @@ import { useModalContext } from '../context/ModalProvider';
 import { UserAvatar } from '../user/UserAvatar';
 import { getAddressSuffix } from '../../utils';
 import { useOptionalShellState } from './useShellState';
+import { useSpaces } from '../../hooks/queries/spaces';
+import { useSpaceMentionCounts } from '../../hooks/business/mentions';
+import { useSpaceReplyCounts } from '../../hooks/business/replies';
+import { useGlobalSenderResolver } from '../../hooks/business/notifications';
+import { NotificationPanel } from '../notifications/NotificationPanel';
 import './NavRail.scss';
 
-type RailSectionId = 'dm' | 'spaces' | 'bookmarks' | 'discover' | 'farcaster' | 'wallet';
+type RailSectionId = 'dm' | 'spaces' | 'notifications' | 'bookmarks' | 'discover' | 'farcaster' | 'wallet';
 
 interface RailItemConfig {
   id: RailSectionId;
@@ -31,6 +36,12 @@ const buildItems = (): RailItemConfig[] => [
     icon: 'users-group',
     label: t`Spaces`,
     route: '/spaces',
+  },
+  {
+    id: 'notifications',
+    icon: 'bell',
+    label: t`Notifications`,
+    route: '', // not navigated — opens the global panel
   },
   {
     id: 'bookmarks',
@@ -86,6 +97,17 @@ export const NavRail: React.FunctionComponent<NavRailProps> = ({ collapsed, onTo
   const userIcon = user?.currentPasskeyInfo?.pfpUrl;
   const userAddress = user?.currentPasskeyInfo?.address || '';
 
+  // Global notifications: bell opens a centered panel aggregating across spaces.
+  // `useSpaces` is suspense-backed, matching the sibling SpacesSidebar under the
+  // app-level Suspense boundary (App.tsx) — the cached query won't re-suspend.
+  const [notifOpen, setNotifOpen] = React.useState(false);
+  const { data: spaces = [] } = useSpaces();
+  const mentionCounts = useSpaceMentionCounts({ spaces });
+  const replyCounts = useSpaceReplyCounts({ spaces });
+  const hasUnreadNotifications =
+    Object.keys(mentionCounts).length > 0 || Object.keys(replyCounts).length > 0;
+  const resolveGlobalSender = useGlobalSenderResolver(spaces);
+
   // Compute active section from pathname.
   // /discover/* → "discover"; /spaces or /spaces/:id/:id → "spaces"; /messages → "dm".
   const activeId: RailSectionId | null = React.useMemo(() => {
@@ -99,6 +121,10 @@ export const NavRail: React.FunctionComponent<NavRailProps> = ({ collapsed, onTo
   }, [location.pathname]);
 
   const onItemClick = (item: RailItemConfig) => {
+    if (item.id === 'notifications') {
+      setNotifOpen(true);
+      return;
+    }
     if (item.id === 'dm') {
       // On phone the rail lives in the drawer — land on the DM list so the
       // sidebar swaps content and the drawer stays open. On desktop/tablet
@@ -167,6 +193,9 @@ export const NavRail: React.FunctionComponent<NavRailProps> = ({ collapsed, onTo
             >
               <span className="relative flex-shrink-0">
                 <Icon name={item.icon} size="xl" />
+                {item.id === 'notifications' && hasUnreadNotifications && (
+                  <span className="icon-unread-dot nav-rail__notif-dot" aria-hidden="true" />
+                )}
               </span>
               {!collapsed && (
                 <span className="nav-rail__item-label">{item.label}</span>
@@ -268,6 +297,19 @@ export const NavRail: React.FunctionComponent<NavRailProps> = ({ collapsed, onTo
           </div>
         </button>
       )}
+
+      {/* Global notifications panel (centered). spaceId/channelIds/mapSenderToUser
+          are required by the shared props but unused in global mode. */}
+      <NotificationPanel
+        global
+        isOpen={notifOpen}
+        onClose={() => setNotifOpen(false)}
+        spaces={spaces}
+        resolveGlobalSender={resolveGlobalSender}
+        spaceId=""
+        channelIds={[]}
+        mapSenderToUser={() => undefined}
+      />
     </nav>
   );
 };

--- a/src/dev/tests/hooks/fetchSpaceMentions.unit.test.ts
+++ b/src/dev/tests/hooks/fetchSpaceMentions.unit.test.ts
@@ -26,8 +26,6 @@ function makeMessage(overrides: any = {}) {
 
 function makeDB(over: any = {}) {
   return {
-    getUserConfig: vi.fn().mockResolvedValue({ notificationSettings: {}, mutedChannels: {} }),
-    getSpace: vi.fn().mockResolvedValue(makeSpace()),
     getConversation: vi.fn().mockResolvedValue({ conversation: { lastReadTimestamp: 0 } }),
     getThreadReadTimesForChannel: vi.fn().mockResolvedValue({}),
     getUnreadMentions: vi.fn().mockResolvedValue([makeMessage()]),

--- a/src/dev/tests/hooks/fetchSpaceMentions.unit.test.ts
+++ b/src/dev/tests/hooks/fetchSpaceMentions.unit.test.ts
@@ -1,0 +1,72 @@
+/* globals are injected by vitest (globals: true) — no import needed */
+import { fetchSpaceMentions } from '../../../hooks/business/mentions/fetchSpaceMentions';
+
+const ME = 'QmMeAddr0000000000000000000000000000000000';
+const SENDER = 'QmSender000000000000000000000000000000000';
+
+function makeSpace() {
+  return {
+    spaceId: 'space-1',
+    spaceName: 'Test Space',
+    roles: [],
+    members: {},
+    groups: [{ channels: [{ channelId: 'chan-1', channelName: 'general' }] }],
+  } as any;
+}
+
+function makeMessage(overrides: any = {}) {
+  return {
+    messageId: 'm1',
+    createdDate: 1000,
+    content: { senderId: SENDER, text: 'hey @<' + ME + '>' },
+    mentions: { memberIds: [ME], roleIds: [], everyone: false, channelIds: [] },
+    ...overrides,
+  };
+}
+
+function makeDB(over: any = {}) {
+  return {
+    getUserConfig: vi.fn().mockResolvedValue({ notificationSettings: {}, mutedChannels: {} }),
+    getSpace: vi.fn().mockResolvedValue(makeSpace()),
+    getConversation: vi.fn().mockResolvedValue({ conversation: { lastReadTimestamp: 0 } }),
+    getThreadReadTimesForChannel: vi.fn().mockResolvedValue({}),
+    getUnreadMentions: vi.fn().mockResolvedValue([makeMessage()]),
+    ...over,
+  } as any;
+}
+
+describe('fetchSpaceMentions', () => {
+  it('returns a mention row tagged with spaceId and spaceName', async () => {
+    const db = makeDB();
+    const rows = await fetchSpaceMentions(db, makeSpace(), ME, {
+      enabledTypes: ['mention-you', 'mention-everyone', 'mention-roles'],
+      userRoleIds: [],
+      config: { notificationSettings: {}, mutedChannels: {} } as any,
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].spaceId).toBe('space-1');
+    expect(rows[0].spaceName).toBe('Test Space');
+    expect(rows[0].channelName).toBe('general');
+    expect(rows[0].mentionType).toBe('you');
+  });
+
+  it('returns [] when the space is muted', async () => {
+    const db = makeDB();
+    const rows = await fetchSpaceMentions(db, makeSpace(), ME, {
+      enabledTypes: ['mention-you'],
+      userRoleIds: [],
+      config: { notificationSettings: { 'space-1': { isMuted: true } } } as any,
+    });
+    expect(rows).toEqual([]);
+  });
+
+  it('excludes muted channels', async () => {
+    const db = makeDB();
+    const rows = await fetchSpaceMentions(db, makeSpace(), ME, {
+      enabledTypes: ['mention-you'],
+      userRoleIds: [],
+      config: { notificationSettings: {}, mutedChannels: { 'space-1': ['chan-1'] } } as any,
+    });
+    expect(rows).toEqual([]);
+  });
+});

--- a/src/dev/tests/hooks/fetchSpaceReplies.unit.test.ts
+++ b/src/dev/tests/hooks/fetchSpaceReplies.unit.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest';
+
+const ME = 'QmMeAddr0000000000000000000000000000000000';
+
+function makeSpace() {
+  return {
+    spaceId: 'space-1',
+    spaceName: 'Test Space',
+    roles: [],
+    members: {},
+    groups: [{ channels: [{ channelId: 'chan-1', channelName: 'general' }] }],
+  } as any;
+}
+
+function makeReply() {
+  return {
+    messageId: 'r1',
+    createdDate: 2000,
+    content: { senderId: 'QmSomeoneElse', text: 'reply text' },
+    replyMetadata: { parentAuthor: ME },
+  };
+}
+
+function makeDB(over: any = {}) {
+  return {
+    getConversation: vi.fn().mockResolvedValue({ conversation: { lastReadTimestamp: 0 } }),
+    getThreadReadTimesForChannel: vi.fn().mockResolvedValue({}),
+    getUnreadReplies: vi.fn().mockResolvedValue([makeReply()]),
+    ...over,
+  } as any;
+}
+
+describe('fetchSpaceReplies', () => {
+  it('returns a reply row tagged with spaceId and spaceName when enabled', async () => {
+    const { fetchSpaceReplies } = await import('../../../hooks/business/replies/fetchSpaceReplies');
+    const rows = await fetchSpaceReplies(makeDB(), makeSpace(), ME, {
+      enabled: true,
+      config: { notificationSettings: {}, mutedChannels: {} } as any,
+    });
+    expect(rows).toHaveLength(1);
+    expect((rows[0] as any).spaceId).toBe('space-1');
+    expect((rows[0] as any).spaceName).toBe('Test Space');
+    expect(rows[0].type).toBe('reply');
+  });
+
+  it('returns [] when not enabled', async () => {
+    const { fetchSpaceReplies } = await import('../../../hooks/business/replies/fetchSpaceReplies');
+    const rows = await fetchSpaceReplies(makeDB(), makeSpace(), ME, {
+      enabled: false,
+      config: { notificationSettings: {} } as any,
+    });
+    expect(rows).toEqual([]);
+  });
+
+  it('returns [] when the space is muted', async () => {
+    const { fetchSpaceReplies } = await import('../../../hooks/business/replies/fetchSpaceReplies');
+    const rows = await fetchSpaceReplies(makeDB(), makeSpace(), ME, {
+      enabled: true,
+      config: { notificationSettings: { 'space-1': { isMuted: true } } } as any,
+    });
+    expect(rows).toEqual([]);
+  });
+});

--- a/src/dev/tests/setup.ts
+++ b/src/dev/tests/setup.ts
@@ -1,7 +1,6 @@
 // @ts-ignore - Will be available after installing vitest
 import '@testing-library/jest-dom';
-// @ts-ignore - Will be available after installing vitest
-import { beforeAll, afterEach, afterAll, vi } from 'vitest';
+import { vi } from 'vitest';
 // @ts-ignore - Will be available after installing testing library
 import { cleanup } from '@testing-library/react';
 

--- a/src/dev/tests/utils/resolveGlobalSender.unit.test.ts
+++ b/src/dev/tests/utils/resolveGlobalSender.unit.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+
+const SENDER = 'QmSender000000000000000000000000000000000';
+
+describe('buildGlobalSenderMap / resolveGlobalSender', () => {
+  it('resolves a sender to its member from the matching space (mapped to resolver shape)', async () => {
+    const { buildGlobalSenderMap } = await import('../../../utils/resolveGlobalSender');
+    const resolve = buildGlobalSenderMap({
+      s1: [{ user_address: SENDER, display_name: 'Ada', user_icon: 'icon.png' }],
+    });
+    const user = resolve('s1', SENDER);
+    expect(user?.address).toBe(SENDER);
+    expect(user?.displayName).toBe('Ada');
+    expect(user?.userIcon).toBe('icon.png');
+  });
+
+  it('returns a minimal address-only object when the sender is unknown', async () => {
+    const { buildGlobalSenderMap } = await import('../../../utils/resolveGlobalSender');
+    const resolve = buildGlobalSenderMap({ s1: [] });
+    const user = resolve('s1', SENDER);
+    expect(user?.address).toBe(SENDER);
+    expect(user?.displayName).toBeUndefined();
+  });
+
+  it('returns an address-only object when the space is not in the map', async () => {
+    const { buildGlobalSenderMap } = await import('../../../utils/resolveGlobalSender');
+    const resolve = buildGlobalSenderMap({});
+    const user = resolve('unknown-space', SENDER);
+    expect(user?.address).toBe(SENDER);
+  });
+});

--- a/src/hooks/business/conversations/useUpdateReadTime.ts
+++ b/src/hooks/business/conversations/useUpdateReadTime.ts
@@ -64,6 +64,13 @@ export function useUpdateReadTime({
         queryKey: ['reply-counts', 'space'],
       });
 
+      // 5b. Invalidate notification inbox lists (per-space + global panels).
+      // Bare prefixes match both ['*-notifications', spaceId] and
+      // ['*-notifications', 'global', ...], so reading a channel refreshes the
+      // global panel too.
+      queryClient.invalidateQueries({ queryKey: ['mention-notifications'] });
+      queryClient.invalidateQueries({ queryKey: ['reply-notifications'] });
+
       // 6. Invalidate channel-level unread counts (updates channel unread dots)
       queryClient.invalidateQueries({
         queryKey: ['unread-counts', 'channel', spaceId],

--- a/src/hooks/business/mentions/fetchSpaceMentions.ts
+++ b/src/hooks/business/mentions/fetchSpaceMentions.ts
@@ -1,7 +1,7 @@
 import { isMentionedWithSettings, getDefaultNotificationSettings } from '@quilibrium/quorum-shared';
 import type { Message, Space } from '@quilibrium/quorum-shared';
 import { getMutedChannelsForSpace } from '../../../utils/channelUtils';
-import type { MessageDB } from '../../../db/messages';
+import type { MessageDB, UserConfig } from '../../../db/messages';
 import type { MentionNotification } from './useAllMentions';
 
 function getMentionType(message: Message, userAddress: string): 'you' | 'everyone' | 'roles' {
@@ -11,17 +11,23 @@ function getMentionType(message: Message, userAddress: string): 'you' | 'everyon
   return 'you';
 }
 
+/**
+ * Fetch unread mentions for ONE space (pure; no React).
+ * Replicates the per-space gating from `useAllMentions`. Returns rows in
+ * channel-iteration order — the CALLER sorts (the global hook sorts after
+ * merging across all spaces, so sorting here would be wasted work).
+ */
 export async function fetchSpaceMentions(
-  messageDB: Pick<MessageDB, 'getConversation' | 'getThreadReadTimesForChannel' | 'getUnreadMentions'>,
+  messageDB: MessageDB,
   space: Space,
   userAddress: string,
   opts: {
     enabledTypes?: ('mention-you' | 'mention-everyone' | 'mention-roles')[];
-    userRoleIds: string[];
-    config: any; // UserConfig | undefined
+    userRoleIds?: string[];
+    config: UserConfig | undefined;
   },
 ): Promise<MentionNotification[]> {
-  const { enabledTypes, userRoleIds, config } = opts;
+  const { enabledTypes, userRoleIds = [], config } = opts;
   const settings = config?.notificationSettings?.[space.spaceId];
   if (settings?.isMuted) return [];
 
@@ -37,7 +43,8 @@ export async function fetchSpaceMentions(
   if (typesToCheck.length === 0) return [];
 
   const mutedChannelIds = getMutedChannelsForSpace(space.spaceId, config?.mutedChannels);
-  const channelIds = space.groups.flatMap((g) => g.channels.map((c) => c.channelId));
+  const allChannels = space.groups.flatMap((g) => g.channels);
+  const channelIds = allChannels.map((c) => c.channelId);
   const out: MentionNotification[] = [];
 
   for (const channelId of channelIds) {
@@ -55,9 +62,7 @@ export async function fetchSpaceMentions(
       afterTimestamp: lastReadTimestamp,
       limit: 1000,
     });
-    const channel = space.groups
-      .flatMap((g) => g.channels)
-      .find((c) => c.channelId === channelId);
+    const channel = allChannels.find((c) => c.channelId === channelId);
 
     const unread = messages.filter((message: Message) => {
       if (message.isThreadReply && message.threadId) {

--- a/src/hooks/business/mentions/fetchSpaceMentions.ts
+++ b/src/hooks/business/mentions/fetchSpaceMentions.ts
@@ -1,0 +1,89 @@
+import { isMentionedWithSettings, getDefaultNotificationSettings } from '@quilibrium/quorum-shared';
+import type { Message, Space } from '@quilibrium/quorum-shared';
+import { getMutedChannelsForSpace } from '../../../utils/channelUtils';
+import type { MessageDB } from '../../../db/messages';
+import type { MentionNotification } from './useAllMentions';
+
+function getMentionType(message: Message, userAddress: string): 'you' | 'everyone' | 'roles' {
+  if (message.mentions?.everyone) return 'everyone';
+  if (message.mentions?.roleIds?.length && message.mentions.roleIds.length > 0) return 'roles';
+  if (message.mentions?.memberIds?.includes(userAddress)) return 'you';
+  return 'you';
+}
+
+export async function fetchSpaceMentions(
+  messageDB: Pick<MessageDB, 'getConversation' | 'getThreadReadTimesForChannel' | 'getUnreadMentions'>,
+  space: Space,
+  userAddress: string,
+  opts: {
+    enabledTypes?: ('mention-you' | 'mention-everyone' | 'mention-roles')[];
+    userRoleIds: string[];
+    config: any; // UserConfig | undefined
+  },
+): Promise<MentionNotification[]> {
+  const { enabledTypes, userRoleIds, config } = opts;
+  const settings = config?.notificationSettings?.[space.spaceId];
+  if (settings?.isMuted) return [];
+
+  let typesToCheck: string[];
+  if (enabledTypes) {
+    typesToCheck = enabledTypes;
+  } else {
+    const allTypes =
+      settings?.enabledNotificationTypes ||
+      getDefaultNotificationSettings(space.spaceId).enabledNotificationTypes;
+    typesToCheck = allTypes.filter((tp: string) => tp.startsWith('mention-'));
+  }
+  if (typesToCheck.length === 0) return [];
+
+  const mutedChannelIds = getMutedChannelsForSpace(space.spaceId, config?.mutedChannels);
+  const channelIds = space.groups.flatMap((g) => g.channels.map((c) => c.channelId));
+  const out: MentionNotification[] = [];
+
+  for (const channelId of channelIds) {
+    if (mutedChannelIds.includes(channelId)) continue;
+    const conversationId = `${space.spaceId}/${channelId}`;
+    const { conversation } = await messageDB.getConversation({ conversationId });
+    const lastReadTimestamp = conversation?.lastReadTimestamp || 0;
+    const threadReadTimes = await messageDB.getThreadReadTimesForChannel({
+      spaceId: space.spaceId,
+      channelId,
+    });
+    const messages = await messageDB.getUnreadMentions({
+      spaceId: space.spaceId,
+      channelId,
+      afterTimestamp: lastReadTimestamp,
+      limit: 1000,
+    });
+    const channel = space.groups
+      .flatMap((g) => g.channels)
+      .find((c) => c.channelId === channelId);
+
+    const unread = messages.filter((message: Message) => {
+      if (message.isThreadReply && message.threadId) {
+        const trt = threadReadTimes[message.threadId];
+        if (trt !== undefined && message.createdDate <= trt) return false;
+      } else if (message.createdDate <= lastReadTimestamp) {
+        return false;
+      }
+      return isMentionedWithSettings(message, {
+        userAddress,
+        enabledTypes: typesToCheck,
+        userRoles: userRoleIds,
+        space,
+      });
+    });
+
+    for (const message of unread) {
+      out.push({
+        message,
+        channelId,
+        channelName: channel?.channelName || 'Unknown Channel',
+        mentionType: getMentionType(message, userAddress),
+        spaceId: space.spaceId,
+        spaceName: space.spaceName,
+      });
+    }
+  }
+  return out;
+}

--- a/src/hooks/business/mentions/fetchSpaceMentions.ts
+++ b/src/hooks/business/mentions/fetchSpaceMentions.ts
@@ -25,9 +25,10 @@ export async function fetchSpaceMentions(
     enabledTypes?: ('mention-you' | 'mention-everyone' | 'mention-roles')[];
     userRoleIds?: string[];
     config: UserConfig | undefined;
+    perChannelLimit?: number;
   },
 ): Promise<MentionNotification[]> {
-  const { enabledTypes, userRoleIds = [], config } = opts;
+  const { enabledTypes, userRoleIds = [], config, perChannelLimit = 1000 } = opts;
   const settings = config?.notificationSettings?.[space.spaceId];
   if (settings?.isMuted) return [];
 
@@ -60,7 +61,7 @@ export async function fetchSpaceMentions(
       spaceId: space.spaceId,
       channelId,
       afterTimestamp: lastReadTimestamp,
-      limit: 1000,
+      limit: perChannelLimit,
     });
     const channel = allChannels.find((c) => c.channelId === channelId);
 

--- a/src/hooks/business/mentions/index.ts
+++ b/src/hooks/business/mentions/index.ts
@@ -7,3 +7,5 @@ export { useSpaceMentionCounts } from './useSpaceMentionCounts';
 export { useMentionNotificationSettings } from './useMentionNotificationSettings';
 export { useAllMentions } from './useAllMentions';
 export type { MentionNotification } from './useAllMentions';
+export { useAllMentionsGlobal } from './useAllMentionsGlobal';
+export { fetchSpaceMentions } from './fetchSpaceMentions';

--- a/src/hooks/business/mentions/useAllMentions.ts
+++ b/src/hooks/business/mentions/useAllMentions.ts
@@ -10,6 +10,8 @@ export interface MentionNotification {
   channelId: string;
   channelName: string;
   mentionType: 'you' | 'everyone' | 'roles';
+  spaceId?: string;
+  spaceName?: string;
 }
 
 interface UseAllMentionsProps {

--- a/src/hooks/business/mentions/useAllMentions.ts
+++ b/src/hooks/business/mentions/useAllMentions.ts
@@ -1,9 +1,8 @@
 import { useQuery } from '@tanstack/react-query';
 import { usePasskeysContext } from '@quilibrium/quilibrium-js-sdk-channels';
 import { useMessageDB } from '../../../components/context/useMessageDB';
-import { isMentionedWithSettings, getDefaultNotificationSettings } from '@quilibrium/quorum-shared';
-import { getMutedChannelsForSpace } from '../../../utils/channelUtils';
 import type { Message } from '@quilibrium/quorum-shared';
+import { fetchSpaceMentions } from './fetchSpaceMentions';
 
 export interface MentionNotification {
   message: Message;
@@ -48,119 +47,33 @@ export function useAllMentions({
     queryKey: ['mention-notifications', spaceId, userAddress, ...channelIds.sort(), ...(enabledTypes?.sort() || [])],
     queryFn: async () => {
       if (!userAddress) return [];
-
-      const allMentions: MentionNotification[] = [];
-
       try {
-        // Load user's notification settings for this space
         const config = await messageDB.getUserConfig({ address: userAddress });
-        const settings = config?.notificationSettings?.[spaceId];
-
-        // Check if entire space is muted (takes precedence over individual settings)
-        if (settings?.isMuted) {
-          return []; // Space is muted - no notifications
-        }
-
-        // Determine which mention types to check (unified format)
-        // If enabledTypes provided, use it; otherwise get from settings
-        let typesToCheck: string[];
-        if (enabledTypes) {
-          typesToCheck = enabledTypes;
-        } else {
-          const allTypes = settings?.enabledNotificationTypes || getDefaultNotificationSettings(spaceId).enabledNotificationTypes;
-          // Filter to only mention types (exclude 'reply')
-          typesToCheck = allTypes.filter(t => t.startsWith('mention-'));
-        }
-
-        // If no mention types enabled, return empty
-        if (typesToCheck.length === 0) {
-          return [];
-        }
-
-        // Get muted channels to exclude from notifications
-        const mutedChannelIds = getMutedChannelsForSpace(spaceId, config?.mutedChannels);
-
-        // Get space data to access channel names
         const space = await messageDB.getSpace(spaceId);
+        if (!space) return [];
 
-        // Process each channel (excluding muted ones)
-        for (const channelId of channelIds) {
-          // Skip muted channels - they shouldn't show in notification panel
-          if (mutedChannelIds.includes(channelId)) {
-            continue;
-          }
-          const conversationId = `${spaceId}/${channelId}`;
+        // Preserve the explicit channelIds contract: scope the space's channels
+        // down to the channelIds the caller passed (may be a subset).
+        const allowed = new Set(channelIds);
+        const scoped = {
+          ...space,
+          groups: space.groups.map((g) => ({
+            ...g,
+            channels: g.channels.filter((c) => allowed.has(c.channelId)),
+          })),
+        };
 
-          // Get conversation to find last read timestamp
-          const { conversation } = await messageDB.getConversation({
-            conversationId,
-          });
-
-          const lastReadTimestamp = conversation?.lastReadTimestamp || 0;
-
-          // Fetch thread read times for this channel
-          const threadReadTimes = await messageDB.getThreadReadTimesForChannel({
-            spaceId,
-            channelId,
-          });
-
-          // Use optimized query that returns messages with mentions
-          // (includes thread replies, unlike getMessages which filters them)
-          const messages = await messageDB.getUnreadMentions({
-            spaceId,
-            channelId,
-            afterTimestamp: lastReadTimestamp,
-            limit: 1000,
-          });
-
-          // Get channel name from space data
-          const channel = space?.groups
-            ?.flatMap(g => g.channels)
-            ?.find(c => c.channelId === channelId);
-
-          // Filter messages that mention the user and are unread
-          // Thread replies check against thread read time, not channel read time
-          const unreadMentions = messages.filter((message: Message) => {
-            // Determine the effective read timestamp for this message
-            if (message.isThreadReply && message.threadId) {
-              const threadReadTime = threadReadTimes[message.threadId];
-              // If thread has been read and message is older, skip it
-              if (threadReadTime !== undefined && message.createdDate <= threadReadTime) {
-                return false;
-              }
-              // If no thread read time exists, message is unread (fall through to mention check)
-            } else {
-              // Regular channel message — use channel read time (already filtered by afterTimestamp)
-              if (message.createdDate <= lastReadTimestamp) return false;
-            }
-
-            return isMentionedWithSettings(message, {
-              userAddress,
-              enabledTypes: typesToCheck,
-              userRoles: userRoleIds,
-              space: space ?? undefined,
-            });
-          });
-
-          // Add to results with metadata
-          unreadMentions.forEach((message) => {
-            allMentions.push({
-              message,
-              channelId,
-              channelName: channel?.channelName || 'Unknown Channel',
-              mentionType: getMentionType(message, userAddress),
-            });
-          });
-        }
-
-        // Sort by date (newest first)
-        allMentions.sort((a, b) => b.message.createdDate - a.message.createdDate);
+        const rows = await fetchSpaceMentions(messageDB, scoped, userAddress, {
+          enabledTypes,
+          userRoleIds,
+          config,
+        });
+        rows.sort((a, b) => b.message.createdDate - a.message.createdDate);
+        return rows;
       } catch (error) {
         console.error('[AllMentions] Error fetching mentions:', error);
         return [];
       }
-
-      return allMentions;
     },
     enabled: !!userAddress && channelIds.length > 0,
     staleTime: 30000, // 30 seconds - matches useChannelMentionCounts
@@ -171,12 +84,4 @@ export function useAllMentions({
     mentions: data || [],
     isLoading,
   };
-}
-
-// Helper to determine mention type
-function getMentionType(message: Message, userAddress: string): 'you' | 'everyone' | 'roles' {
-  if (message.mentions?.everyone) return 'everyone';
-  if (message.mentions?.roleIds?.length && message.mentions.roleIds.length > 0) return 'roles';
-  if (message.mentions?.memberIds?.includes(userAddress)) return 'you';
-  return 'you'; // fallback
 }

--- a/src/hooks/business/mentions/useAllMentionsGlobal.ts
+++ b/src/hooks/business/mentions/useAllMentionsGlobal.ts
@@ -1,0 +1,52 @@
+import { useQuery } from '@tanstack/react-query';
+import { usePasskeysContext } from '@quilibrium/quilibrium-js-sdk-channels';
+import { getUserRoles } from '@quilibrium/quorum-shared';
+import type { Space } from '@quilibrium/quorum-shared';
+import { useMessageDB } from '../../../components/context/useMessageDB';
+import { fetchSpaceMentions } from './fetchSpaceMentions';
+import type { MentionNotification } from './useAllMentions';
+import { GLOBAL_PER_CHANNEL_LIMIT } from '../notifications/constants';
+
+interface Props {
+  spaces: Space[];
+  enabledTypes?: ('mention-you' | 'mention-everyone' | 'mention-roles')[];
+}
+
+/**
+ * Aggregate unread mentions across ALL spaces (global notification panel).
+ * Loops every space, delegates per-space gating to `fetchSpaceMentions`, then
+ * sorts the merged set newest-first. Each space's contribution is bounded by
+ * `GLOBAL_PER_CHANNEL_LIMIT` to keep memory in check for heavy users; the
+ * composition hook applies the final display cap.
+ */
+export function useAllMentionsGlobal({ spaces, enabledTypes }: Props) {
+  const user = usePasskeysContext();
+  const { messageDB } = useMessageDB();
+  const userAddress = user.currentPasskeyInfo?.address;
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['mention-notifications', 'global', userAddress, ...spaces.map((s) => s.spaceId).sort(), ...(enabledTypes?.slice().sort() || [])],
+    queryFn: async () => {
+      if (!userAddress) return [] as MentionNotification[];
+      const config = await messageDB.getUserConfig({ address: userAddress });
+      const all: MentionNotification[] = [];
+      for (const space of spaces) {
+        const userRoleIds = getUserRoles(userAddress, space).map((r) => r.roleId);
+        const rows = await fetchSpaceMentions(messageDB, space, userAddress, {
+          enabledTypes,
+          userRoleIds,
+          config,
+          perChannelLimit: GLOBAL_PER_CHANNEL_LIMIT,
+        });
+        all.push(...rows);
+      }
+      all.sort((a, b) => b.message.createdDate - a.message.createdDate);
+      return all;
+    },
+    enabled: !!userAddress && spaces.length > 0,
+    staleTime: 30000,
+    refetchOnWindowFocus: true,
+  });
+
+  return { mentions: data || [], isLoading };
+}

--- a/src/hooks/business/notifications/constants.ts
+++ b/src/hooks/business/notifications/constants.ts
@@ -1,0 +1,2 @@
+export const GLOBAL_PER_CHANNEL_LIMIT = 50; // per-channel getUnreadMentions/Replies cap (global path)
+export const GLOBAL_DISPLAY_CAP = 100; // max rows shown after the global newest-first sort

--- a/src/hooks/business/notifications/index.ts
+++ b/src/hooks/business/notifications/index.ts
@@ -1,4 +1,5 @@
 export { useGlobalNotifications } from './useGlobalNotifications';
+export { useGlobalSenderResolver } from './useGlobalSenderResolver';
 export { GLOBAL_DISPLAY_CAP, GLOBAL_PER_CHANNEL_LIMIT } from './constants';
 export type {
   GlobalNotification,

--- a/src/hooks/business/notifications/index.ts
+++ b/src/hooks/business/notifications/index.ts
@@ -1,0 +1,7 @@
+export { useGlobalNotifications } from './useGlobalNotifications';
+export { GLOBAL_DISPLAY_CAP, GLOBAL_PER_CHANNEL_LIMIT } from './constants';
+export type {
+  GlobalNotification,
+  GlobalMentionNotification,
+  GlobalReplyNotification,
+} from './useGlobalNotifications';

--- a/src/hooks/business/notifications/useGlobalNotifications.ts
+++ b/src/hooks/business/notifications/useGlobalNotifications.ts
@@ -1,0 +1,41 @@
+import { useMemo } from 'react';
+import type { Space } from '@quilibrium/quorum-shared';
+import { useAllMentionsGlobal } from '../mentions/useAllMentionsGlobal';
+import { useAllRepliesGlobal } from '../replies/useAllRepliesGlobal';
+import type { MentionNotification } from '../mentions/useAllMentions';
+import type { ReplyNotification } from '../../../types/notifications';
+import { GLOBAL_DISPLAY_CAP } from './constants';
+
+export type GlobalMentionNotification = MentionNotification & { spaceId: string; spaceName: string };
+export type GlobalReplyNotification = ReplyNotification & { spaceId: string; spaceName: string };
+export type GlobalNotification = GlobalMentionNotification | GlobalReplyNotification;
+
+interface Props {
+  spaces: Space[];
+  enabledTypes: ('mention-you' | 'mention-everyone' | 'mention-roles')[];
+  replyEnabled: boolean;
+}
+
+/**
+ * Compose the global mention + reply streams into one newest-first list for the
+ * global notification panel. Merges, sorts, then slices to `GLOBAL_DISPLAY_CAP`
+ * and exposes a `truncated` flag so the UI can surface "Showing N most recent"
+ * (no silent truncation — see the design's performance section).
+ */
+export function useGlobalNotifications({ spaces, enabledTypes, replyEnabled }: Props) {
+  const { mentions, isLoading: mLoading } = useAllMentionsGlobal({ spaces, enabledTypes });
+  const { replies, isLoading: rLoading } = useAllRepliesGlobal({ spaces, enabled: replyEnabled });
+
+  const { notifications, truncated } = useMemo(() => {
+    const merged = [...(mentions as GlobalMentionNotification[]), ...(replies as GlobalReplyNotification[])]
+      .sort((a, b) => b.message.createdDate - a.message.createdDate);
+    // Slice AFTER the global sort so the cap is order-independent (no bias toward
+    // whichever space was iterated first).
+    return {
+      notifications: merged.slice(0, GLOBAL_DISPLAY_CAP) as GlobalNotification[],
+      truncated: merged.length > GLOBAL_DISPLAY_CAP,
+    };
+  }, [mentions, replies]);
+
+  return { notifications, truncated, isLoading: mLoading || rLoading };
+}

--- a/src/hooks/business/notifications/useGlobalSenderResolver.ts
+++ b/src/hooks/business/notifications/useGlobalSenderResolver.ts
@@ -1,0 +1,39 @@
+import { useQuery } from '@tanstack/react-query';
+import type { Space } from '@quilibrium/quorum-shared';
+import { useMessageDB } from '../../../components/context/useMessageDB';
+import {
+  buildGlobalSenderMap,
+  type ResolvedGlobalSender,
+} from '../../../utils/resolveGlobalSender';
+
+/**
+ * Resolve sender names for the GLOBAL notification panel across all spaces.
+ *
+ * The per-space panel uses Channel's `mapSenderToUser` (built from the channel's
+ * enriched member list). The global panel spans spaces, so it pre-fetches each
+ * space's roster via `messageDB.getSpaceMembers` and builds one synchronous
+ * resolver keyed by `(spaceId, senderId)`. The fetch is cached by React Query
+ * (30s stale) so opening the panel costs one batch of IndexedDB roster reads.
+ */
+export function useGlobalSenderResolver(spaces: Space[]) {
+  const { messageDB } = useMessageDB();
+  const spaceIds = spaces.map((s) => s.spaceId);
+
+  const { data: resolve } = useQuery({
+    queryKey: ['global-sender-resolver', ...spaceIds.slice().sort()],
+    queryFn: async () => {
+      const membersBySpace: Record<string, Awaited<ReturnType<typeof messageDB.getSpaceMembers>>> = {};
+      for (const spaceId of spaceIds) {
+        membersBySpace[spaceId] = await messageDB.getSpaceMembers(spaceId);
+      }
+      return buildGlobalSenderMap(membersBySpace);
+    },
+    enabled: spaceIds.length > 0,
+    staleTime: 30000,
+  });
+
+  // Stable fallback until the rosters load: address-only resolution.
+  return (
+    resolve ?? ((spaceId: string, senderId: string): ResolvedGlobalSender => ({ address: senderId }))
+  );
+}

--- a/src/hooks/business/replies/fetchSpaceReplies.ts
+++ b/src/hooks/business/replies/fetchSpaceReplies.ts
@@ -1,0 +1,66 @@
+import { isNotificationTypeEnabled } from '@quilibrium/quorum-shared';
+import type { Space } from '@quilibrium/quorum-shared';
+import type { ReplyNotification } from '../../../types/notifications';
+import { getMutedChannelsForSpace } from '../../../utils/channelUtils';
+import type { MessageDB, UserConfig } from '../../../db/messages';
+
+/**
+ * Fetch unread replies for ONE space (pure; no React). Replicates the per-space
+ * gating from `useAllReplies`. Returns rows in channel-iteration order — the
+ * CALLER sorts (the global hook sorts after merging across all spaces, so
+ * sorting here would be wasted work).
+ */
+export async function fetchSpaceReplies(
+  messageDB: MessageDB,
+  space: Space,
+  userAddress: string,
+  opts: { enabled: boolean; config: UserConfig | undefined; perChannelLimit?: number },
+): Promise<(ReplyNotification & { spaceId: string; spaceName: string })[]> {
+  const { enabled, config, perChannelLimit = 1000 } = opts;
+  const settings = config?.notificationSettings?.[space.spaceId];
+  if (settings?.isMuted) return [];
+
+  // `enabled` overrides persistent settings (matches old useAllReplies semantics).
+  const shouldFetch = enabled !== undefined ? enabled : isNotificationTypeEnabled(settings, 'reply');
+  if (!shouldFetch) return [];
+
+  const mutedChannelIds = getMutedChannelsForSpace(space.spaceId, config?.mutedChannels);
+  const allChannels = space.groups.flatMap((g) => g.channels);
+  const channelIds = allChannels.map((c) => c.channelId);
+  const out: (ReplyNotification & { spaceId: string; spaceName: string })[] = [];
+
+  for (const channelId of channelIds) {
+    if (mutedChannelIds.includes(channelId)) continue;
+    const conversationId = `${space.spaceId}/${channelId}`;
+    const { conversation } = await messageDB.getConversation({ conversationId });
+    const lastReadTimestamp = conversation?.lastReadTimestamp || 0;
+    const threadReadTimes = await messageDB.getThreadReadTimesForChannel({
+      spaceId: space.spaceId,
+      channelId,
+    });
+    const messages = await messageDB.getUnreadReplies({
+      spaceId: space.spaceId,
+      channelId,
+      userAddress,
+      afterTimestamp: lastReadTimestamp,
+      limit: perChannelLimit,
+    });
+    const channel = allChannels.find((c) => c.channelId === channelId);
+
+    for (const message of messages) {
+      if (message.isThreadReply && message.threadId) {
+        const trt = threadReadTimes[message.threadId];
+        if (trt !== undefined && message.createdDate <= trt) continue;
+      }
+      out.push({
+        message,
+        channelId,
+        channelName: channel?.channelName || 'Unknown Channel',
+        type: 'reply',
+        spaceId: space.spaceId,
+        spaceName: space.spaceName,
+      });
+    }
+  }
+  return out;
+}

--- a/src/hooks/business/replies/index.ts
+++ b/src/hooks/business/replies/index.ts
@@ -1,3 +1,5 @@
 export { useReplyNotificationCounts } from './useReplyNotificationCounts';
 export { useAllReplies } from './useAllReplies';
 export { useSpaceReplyCounts } from './useSpaceReplyCounts';
+export { useAllRepliesGlobal } from './useAllRepliesGlobal';
+export { fetchSpaceReplies } from './fetchSpaceReplies';

--- a/src/hooks/business/replies/useAllReplies.ts
+++ b/src/hooks/business/replies/useAllReplies.ts
@@ -1,9 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { usePasskeysContext } from '@quilibrium/quilibrium-js-sdk-channels';
 import { useMessageDB } from '../../../components/context/useMessageDB';
-import { isNotificationTypeEnabled } from '@quilibrium/quorum-shared';
-import { getMutedChannelsForSpace } from '../../../utils/channelUtils';
-import type { ReplyNotification } from '../../../types/notifications';
+import { fetchSpaceReplies } from './fetchSpaceReplies';
 
 interface UseAllRepliesProps {
   spaceId: string;
@@ -46,97 +44,32 @@ export function useAllReplies({
     queryKey: ['reply-notifications', spaceId, userAddress, ...channelIds.sort(), enabled],
     queryFn: async () => {
       if (!userAddress) return [];
-
-      const allReplies: ReplyNotification[] = [];
-
       try {
-        // Load user's notification settings for this space
         const config = await messageDB.getUserConfig({ address: userAddress });
-        const settings = config?.notificationSettings?.[spaceId];
-
-        // Check if entire space is muted (takes precedence over individual settings)
-        if (settings?.isMuted) {
-          return []; // Space is muted - no notifications
-        }
-
-        // Check if reply notifications are enabled
-        // If enabled parameter provided from UI, use it; otherwise check persistent settings
-        const shouldFetchReplies = enabled !== undefined
-          ? enabled
-          : isNotificationTypeEnabled(settings, 'reply');
-
-        if (!shouldFetchReplies) {
-          return []; // User has disabled reply notifications (either in UI or persistent settings)
-        }
-
-        // Get muted channels to exclude from notifications
-        const mutedChannelIds = getMutedChannelsForSpace(spaceId, config?.mutedChannels);
-
-        // Get space data to access channel names
         const space = await messageDB.getSpace(spaceId);
+        if (!space) return [];
 
-        // Process each channel (excluding muted ones)
-        for (const channelId of channelIds) {
-          // Skip muted channels - they shouldn't show in notification panel
-          if (mutedChannelIds.includes(channelId)) {
-            continue;
-          }
-          const conversationId = `${spaceId}/${channelId}`;
+        // Preserve the explicit channelIds contract: scope the space's channels
+        // down to the channelIds the caller passed (may be a subset).
+        const allowed = new Set(channelIds);
+        const scoped = {
+          ...space,
+          groups: space.groups.map((g) => ({
+            ...g,
+            channels: g.channels.filter((c) => allowed.has(c.channelId)),
+          })),
+        };
 
-          // Get conversation to find last read timestamp
-          const { conversation } = await messageDB.getConversation({
-            conversationId,
-          });
-
-          const lastReadTimestamp = conversation?.lastReadTimestamp || 0;
-
-          // Fetch thread read times for this channel
-          const threadReadTimes = await messageDB.getThreadReadTimesForChannel({
-            spaceId,
-            channelId,
-          });
-
-          // Use optimized database query to get unread replies
-          const messages = await messageDB.getUnreadReplies({
-            spaceId,
-            channelId,
-            userAddress,
-            afterTimestamp: lastReadTimestamp,
-            limit: 1000, // Reasonable limit for notification panel
-          });
-
-          // Get channel name from space data
-          const channel = space?.groups
-            ?.flatMap(g => g.channels)
-            ?.find(c => c.channelId === channelId);
-
-          // Add to results with metadata
-          messages.forEach((message) => {
-            // Thread replies: check against thread read time
-            if (message.isThreadReply && message.threadId) {
-              const threadReadTime = threadReadTimes[message.threadId];
-              if (threadReadTime !== undefined && message.createdDate <= threadReadTime) {
-                return; // Already read in thread, skip
-              }
-            }
-
-            allReplies.push({
-              message,
-              channelId,
-              channelName: channel?.channelName || 'Unknown Channel',
-              type: 'reply',
-            });
-          });
-        }
-
-        // Sort by date (newest first)
-        allReplies.sort((a, b) => b.message.createdDate - a.message.createdDate);
+        const rows = await fetchSpaceReplies(messageDB, scoped, userAddress, {
+          enabled: enabled as boolean,
+          config,
+        });
+        rows.sort((a, b) => b.message.createdDate - a.message.createdDate);
+        return rows;
       } catch (error) {
         console.error('[AllReplies] Error fetching replies:', error);
         return [];
       }
-
-      return allReplies;
     },
     enabled: !!userAddress && channelIds.length > 0,
     staleTime: 30000, // 30 seconds - matches mention system

--- a/src/hooks/business/replies/useAllRepliesGlobal.ts
+++ b/src/hooks/business/replies/useAllRepliesGlobal.ts
@@ -1,0 +1,48 @@
+import { useQuery } from '@tanstack/react-query';
+import { usePasskeysContext } from '@quilibrium/quilibrium-js-sdk-channels';
+import type { Space } from '@quilibrium/quorum-shared';
+import { useMessageDB } from '../../../components/context/useMessageDB';
+import { fetchSpaceReplies } from './fetchSpaceReplies';
+import type { ReplyNotification } from '../../../types/notifications';
+import { GLOBAL_PER_CHANNEL_LIMIT } from '../notifications/constants';
+
+interface Props {
+  spaces: Space[];
+  enabled: boolean;
+}
+
+/**
+ * Aggregate unread replies across ALL spaces (global notification panel).
+ * Loops every space, delegates per-space gating to `fetchSpaceReplies`, then
+ * sorts the merged set newest-first. Each space's contribution is bounded by
+ * `GLOBAL_PER_CHANNEL_LIMIT`; the composition hook applies the final display cap.
+ */
+export function useAllRepliesGlobal({ spaces, enabled }: Props) {
+  const user = usePasskeysContext();
+  const { messageDB } = useMessageDB();
+  const userAddress = user.currentPasskeyInfo?.address;
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['reply-notifications', 'global', userAddress, ...spaces.map((s) => s.spaceId).sort(), enabled],
+    queryFn: async () => {
+      if (!userAddress) return [] as (ReplyNotification & { spaceId: string; spaceName: string })[];
+      const config = await messageDB.getUserConfig({ address: userAddress });
+      const all: (ReplyNotification & { spaceId: string; spaceName: string })[] = [];
+      for (const space of spaces) {
+        const rows = await fetchSpaceReplies(messageDB, space, userAddress, {
+          enabled,
+          config,
+          perChannelLimit: GLOBAL_PER_CHANNEL_LIMIT,
+        });
+        all.push(...rows);
+      }
+      all.sort((a, b) => b.message.createdDate - a.message.createdDate);
+      return all;
+    },
+    enabled: !!userAddress && spaces.length > 0,
+    staleTime: 30000,
+    refetchOnWindowFocus: true,
+  });
+
+  return { replies: data || [], isLoading };
+}

--- a/src/hooks/business/ui/useModalState.ts
+++ b/src/hooks/business/ui/useModalState.ts
@@ -72,6 +72,9 @@ export interface ModalState {
     isOpen: boolean;
     folderId?: string;
   };
+  notifications: {
+    isOpen: boolean;
+  };
 }
 
 // Modal actions
@@ -102,7 +105,9 @@ type ModalAction =
   | { type: 'OPEN_CONVERSATION_SETTINGS'; conversationId: string }
   | { type: 'CLOSE_CONVERSATION_SETTINGS' }
   | { type: 'OPEN_FOLDER_EDITOR'; folderId?: string }
-  | { type: 'CLOSE_FOLDER_EDITOR' };
+  | { type: 'CLOSE_FOLDER_EDITOR' }
+  | { type: 'OPEN_NOTIFICATIONS' }
+  | { type: 'CLOSE_NOTIFICATIONS' };
 
 // Initial state
 const initialModalState: ModalState = {
@@ -117,6 +122,7 @@ const initialModalState: ModalState = {
   blockUser: { isOpen: false },
   conversationSettings: { isOpen: false },
   folderEditor: { isOpen: false },
+  notifications: { isOpen: false },
 };
 
 // Modal reducer
@@ -215,6 +221,11 @@ function modalReducer(state: ModalState, action: ModalAction): ModalState {
       };
     case 'CLOSE_FOLDER_EDITOR':
       return { ...state, folderEditor: { isOpen: false } };
+
+    case 'OPEN_NOTIFICATIONS':
+      return { ...state, notifications: { isOpen: true } };
+    case 'CLOSE_NOTIFICATIONS':
+      return { ...state, notifications: { isOpen: false } };
 
     default:
       return state;
@@ -331,6 +342,15 @@ export const useModalState = () => {
     dispatch({ type: 'CLOSE_FOLDER_EDITOR' });
   }, []);
 
+  // Global Notifications Panel
+  const openNotifications = useCallback(() => {
+    dispatch({ type: 'OPEN_NOTIFICATIONS' });
+  }, []);
+
+  const closeNotifications = useCallback(() => {
+    dispatch({ type: 'CLOSE_NOTIFICATIONS' });
+  }, []);
+
   return {
     // State
     state,
@@ -378,6 +398,10 @@ export const useModalState = () => {
     // Folder Editor
     openFolderEditor,
     closeFolderEditor,
+
+    // Global Notifications Panel
+    openNotifications,
+    closeNotifications,
 
     // Legacy compatibility
     isNewDirectMessageOpen: state.newDirectMessage.isOpen,

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -2102,9 +2102,11 @@ export class MessageService {
       await queryClient.invalidateQueries({
         queryKey: ['mention-counts', 'channel', spaceId],
       });
-      // Also invalidate notification inbox query
+      // Also invalidate notification inbox query (per-space AND global panels).
+      // Bare prefix matches both ['mention-notifications', spaceId] and
+      // ['mention-notifications', 'global', ...].
       await queryClient.invalidateQueries({
-        queryKey: ['mention-notifications', spaceId],
+        queryKey: ['mention-notifications'],
       });
       // Invalidate unread message counts when new messages arrive
       await queryClient.invalidateQueries({
@@ -2126,8 +2128,9 @@ export class MessageService {
       await queryClient.invalidateQueries({
         queryKey: ['reply-counts', 'channel', spaceId],
       });
+      // Per-space AND global panels (bare prefix matches both).
       await queryClient.invalidateQueries({
-        queryKey: ['reply-notifications', spaceId],
+        queryKey: ['reply-notifications'],
       });
     }
 

--- a/src/utils/resolveGlobalSender.ts
+++ b/src/utils/resolveGlobalSender.ts
@@ -1,0 +1,48 @@
+import type { channel } from '@quilibrium/quilibrium-js-sdk-channels';
+
+/**
+ * Member shape consumed by the notification panel's name resolution
+ * (`resolveSpaceMemberName`). Mirrors the per-space `mapSenderToUser` output so
+ * the global panel can reuse the same render path. `primaryUsername` /
+ * `globalDisplayName` come from the public-profile fetch (not the space roster),
+ * so they are optional here — parity with the per-space path when unenriched.
+ */
+export interface ResolvedGlobalSender {
+  address: string;
+  displayName?: string;
+  userIcon?: string;
+  primaryUsername?: string;
+  globalDisplayName?: string;
+}
+
+type SpaceMemberRow = channel.UserProfile & { isKicked?: boolean };
+
+/**
+ * Pure core: given a map of spaceId -> roster (as returned by
+ * `messageDB.getSpaceMembers`), build a synchronous resolver
+ * `(spaceId, senderId) -> ResolvedGlobalSender`. Unknown sender/space falls back
+ * to an address-only object so name resolvers show the address suffix.
+ *
+ * Pure (no React, no IndexedDB) so it is unit-testable in isolation; the
+ * `useGlobalSenderResolver` hook wires the async fetch around it.
+ */
+export function buildGlobalSenderMap(
+  membersBySpace: Record<string, SpaceMemberRow[]>,
+): (spaceId: string, senderId: string) => ResolvedGlobalSender {
+  const bySpace = new Map<string, Map<string, ResolvedGlobalSender>>();
+  for (const [spaceId, rows] of Object.entries(membersBySpace)) {
+    const map = new Map<string, ResolvedGlobalSender>();
+    for (const row of rows) {
+      map.set(row.user_address, {
+        address: row.user_address,
+        displayName: row.display_name,
+        userIcon: row.user_icon,
+      });
+    }
+    bySpace.set(spaceId, map);
+  }
+
+  return (spaceId: string, senderId: string): ResolvedGlobalSender => {
+    return bySpace.get(spaceId)?.get(senderId) ?? { address: senderId };
+  };
+}


### PR DESCRIPTION
Adds a global notification panel: an app-level view (opened from a NavRail bell) that aggregates unread mentions and replies across all spaces, alongside the existing per-space header bell.

## Highlights
- **Shared data layer**: pure `fetchSpaceMentions`/`fetchSpaceReplies` are the single source of truth; per-space hooks and the new global aggregation hooks both delegate to them (gating can never diverge).
- **Global panel**: `useGlobalNotifications` composition hook with a bounded-fetch cap (50/channel, 100 display) and a "showing N most recent" note (no silent truncation).
- **Presentation**: rendered via the Modal primitive through ModalProvider (proper backdrop, z-index, focus); taller layout with longer preview and a single scroll region.
- **Rows (both panels)**: mobile-style redesign — leading type badge (at/bullhorn/shield/reply) + 3-line layout (location / author + preview / relative time).
- **Cross-space mark-all** gated behind a confirmation dialog; cache invalidations broadened to reach the global query keys.
- Per-space title now reads "X notifications in this Space"; bookmarks panel title is context-aware.

## Commits
- Add design spec for global notification panel
- Add implementation plan for global notification panel
- feat(notifications): extract fetchSpaceMentions pure fn
- refactor(notifications): address review feedback on fetchSpaceMentions
- refactor(notifications): useAllMentions delegates to fetchSpaceMentions
- Add bounded-fetch performance cap to global notification panel design/plan
- feat(notifications): extract fetchSpaceReplies, useAllReplies delegates
- feat(notifications): add global mention/reply aggregation hooks
- fix(notifications): broaden inbox invalidations to cover the global panel
- feat(notifications): add useGlobalNotifications composition hook
- feat(notifications): add global sender resolver (getSpaceMembers-based)
- feat(notifications): NotificationItem renders optional space breadcrumb
- feat(notifications): NotificationPanel global mode (centered, breadcrumb, confirm mark-all)
- feat(notifications): NavRail bell opens global panel, unread dot
- docs(notifications): document the global notification panel
- feat(notifications): global panel as modal (backdrop), 2-line rows, bell last, dot top-right
- fix(notifications): compact global modal header, center close button on title bar
- fix(notifications): symmetric close-button alignment in global modal header
- feat(notifications): mobile-style rows (leading type badge, 3-line layout, relative time); per-space title scope; vertical loading state
- fix(notifications): center badge icon; redesign bell unread dot as overlapping badge
- fix(notifications): center badge icon, accent-tint badge bg, bell dot on right side
- fix(notifications): force badge icon centering via grid + fixed svg size
- feat(bookmarks): context-aware panel title (in this Space / in this conversation)
- feat(notifications): taller global panel with longer preview; single scroll region
- docs(notifications): update global panel section for modal shell, mobile-style rows, taller layout