### PR TITLE
feat: proxy prod API through Vite dev server to avoid local CORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ localStorage.removeItem('debug_mock_conversations')
 
 ### Prerequisites
 
-Requires Node.js and `quilibrium-js-sdk-channels` cloned alongside this repository. Running locally in a browser against prod Quorum API requires CORS to be disabled, consult your extensions or settings to perform this (if you disable CORS in your browser, remember to re-enable it as soon as you have finished testing).
+Requires Node.js and `quilibrium-js-sdk-channels` cloned alongside this repository.
+
+When running locally in a browser, calls to the prod Quorum API are routed through the Vite dev server proxy (see `web/vite.config.ts` → `server.proxy`), so the browser only ever talks same-origin and no CORS workaround is needed. You do **not** need to disable browser CORS or install a CORS-unblocking extension. The proxy is dev-only; production and Electron builds call the API directly and are unaffected.
 
 ### Initial Setup
 
@@ -163,4 +165,4 @@ Both apps share code via the `@quilibrium/quorum-shared` package. See [Quorum Ec
 
 ---
 
-_Updated: 2026-01-06_
+_Updated: 2026-06-24_

--- a/src/config/config.quorum.ts
+++ b/src/config/config.quorum.ts
@@ -1,7 +1,28 @@
+// Production targets. The browser blocks direct cross-origin calls from the Vite
+// dev server (localhost) to these, since the API doesn't send CORS headers for
+// localhost. To avoid that during `yarn dev`, we route through Vite's dev proxy
+// (see web/vite.config.ts → server.proxy), which forwards server-side so the
+// browser only ever talks same-origin (localhost → localhost). No CORS involved.
+const PROD_API_URL = 'https://api.quorummessenger.com';
+const PROD_WS_URL = 'wss://api.quorummessenger.com/ws';
+
+// Same-origin paths handled by the Vite dev proxy. Empty baseUrl means request
+// URLs become same-origin (e.g. `/quorum-api/inbox`), which the proxy intercepts.
+const DEV_PROXY_API_URL = '/quorum-api';
+const DEV_PROXY_WS_URL = '/quorum-ws';
+
+// True only when running the app in a browser via `yarn dev`. import.meta.env.DEV
+// is false in production builds; the `window` check excludes Electron's main
+// process (Node), which has no CORS restriction and must use the direct URLs.
+const isDevBrowser =
+  import.meta.env.DEV && typeof window !== 'undefined';
+
 export const getQuorumApiConfig = function () {
   return {
-    quorumApiUrl: 'https://api.quorummessenger.com',
-    quorumWsUrl: 'wss://api.quorummessenger.com/ws',
+    quorumApiUrl: isDevBrowser ? DEV_PROXY_API_URL : PROD_API_URL,
+    quorumWsUrl: isDevBrowser
+      ? `${window.location.origin.replace(/^http/, 'ws')}${DEV_PROXY_WS_URL}`
+      : PROD_WS_URL,
     apiVersion: 'v1',
     langId: 'en-US',
   };

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -121,6 +121,28 @@ export default defineConfig(({ command }): UserConfig => ({
       // Allow serving .agents folder in development (entire dev folder already excluded from prod)
       allow: ['..', '.agents'],
     },
+    // Dev-only CORS workaround. The browser blocks direct calls from this dev
+    // server (localhost) to api.quorummessenger.com because that API doesn't
+    // send CORS headers for localhost. Instead of disabling browser security,
+    // we proxy: the app calls same-origin paths (/quorum-api, /quorum-ws) and
+    // Vite forwards them server-side. `changeOrigin` rewrites the Host/Origin
+    // so the upstream accepts the request. Production and Electron builds are
+    // unaffected — they hit the API directly (see src/config/config.quorum.ts).
+    proxy: {
+      '/quorum-api': {
+        target: 'https://api.quorummessenger.com',
+        changeOrigin: true,
+        secure: true,
+        rewrite: (path) => path.replace(/^\/quorum-api/, ''),
+      },
+      '/quorum-ws': {
+        target: 'wss://api.quorummessenger.com',
+        changeOrigin: true,
+        secure: true,
+        ws: true,
+        rewrite: (path) => path.replace(/^\/quorum-ws/, '/ws'),
+      },
+    },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## What

Running the web app locally in a browser (`yarn dev`) hit CORS errors when calling the prod Quorum API (`api.quorummessenger.com`) directly from `localhost`, because the API doesn't send CORS headers for localhost origins. The previous workaround was to disable browser CORS / install a CORS-unblocking extension.

This replaces that with a **dev-only Vite server proxy**:

- `web/vite.config.ts` adds `server.proxy` entries forwarding `/quorum-api` (HTTP) and `/quorum-ws` (WebSocket, `ws: true`) to the real API with `changeOrigin: true`. The browser only ever talks same-origin, so CORS never fires; Vite forwards server-side.
- `src/config/config.quorum.ts` returns the same-origin proxy paths **only** when running in the dev browser (`import.meta.env.DEV && typeof window !== 'undefined'`). Production builds and Electron's main process call the API directly, unchanged.
- `README.md` updated to document the proxy and remove the "disable CORS / use an extension" instruction.

## Why

Safer and reproducible: no browser-security weakening, no third-party extension, and it's the standard documented Vite approach. Dev-only by construction — production and Electron are unaffected.

## Verification

- `tsc --noEmit` and `eslint` pass on the changed files.
- Confirmed the proxy forwards to the real API (identical response via `/quorum-api/...` and the direct URL) and that the app loads in the browser with no CORS error and the extension disabled.