### PR TITLE
Strip EXIF on all image upload paths

### DIFF
--- a/src/utils/imageProcessing/compressor.ts
+++ b/src/utils/imageProcessing/compressor.ts
@@ -74,7 +74,10 @@ export const compressImage = async (
 
   const originalSize = file.size;
 
-  // Skip compression for GIFs (preserve animation) unless forced
+  // Skip compression for GIFs (preserve animation) unless forced.
+  // GIFs are passed through raw; re-encoding would flatten the animation.
+  // This is an accepted privacy non-gap: the GIF format has no standardized
+  // GPS EXIF field (unlike JPEG), so the location-leak risk does not apply.
   if (file.type === 'image/gif' && !forceGifCompression) {
     return {
       file,
@@ -83,8 +86,12 @@ export const compressImage = async (
     };
   }
 
-  // Skip compression if file is already small and within dimensions
-  if (file.size < skipCompressionThreshold) {
+  // Skip compression if file is already small and within dimensions.
+  // EXIF metadata (incl. GPS) lives in JPEG/TIFF, not PNG/WebP — so JPEGs must
+  // never take the skip path, or a small geotagged photo would upload with its
+  // location intact. Forcing JPEGs through the re-encode below strips it.
+  const carriesExif = file.type === 'image/jpeg' || file.type === 'image/tiff';
+  if (file.size < skipCompressionThreshold && !carriesExif) {
     const withinDimensions = await isWithinDimensions(file, maxWidth, maxHeight);
     if (withinDimensions) {
       return {
@@ -101,6 +108,12 @@ export const compressImage = async (
       quality,
       convertSize: Infinity,
       retainExif: false,
+      // strict:false forces compressorjs to always return the re-encoded canvas
+      // output, even if it ends up marginally larger than the input. With the
+      // default strict:true, an already-compressed JPEG whose re-encode grows
+      // is handed back AS THE ORIGINAL FILE — EXIF (incl. GPS) intact. We always
+      // want the stripped re-encode for privacy. (compressorjs 1.3.0)
+      strict: false,
       mimeType: file.type,
       success(result: Blob) {
         // Convert to File with original name


### PR DESCRIPTION
## What

Photos embed **EXIF metadata** that can include **GPS coordinates**. The image compressor sets `retainExif: false`, but two bypass paths let a raw geotagged file reach the wire un-stripped. This closes both, in the one shared `compressor.ts`, so every surface (avatar, space icon, banner, emoji, sticker, message attachment) is covered at once.

## The fixes (`src/utils/imageProcessing/compressor.ts`)

1. **Skip-compression bypass** — small images already within dimensions skipped compressorjs entirely (so `retainExif:false` never ran). EXIF/GPS lives in **JPEG/TIFF**, so those are now excluded from the skip path and always re-encoded; the perf shortcut is kept for PNG/WebP, which don't carry GPS EXIF.

2. **compressorjs `strict` passthrough** — with the default `strict:true`, when a re-encode comes out larger than the input (common for already-compressed JPEGs) the library hands back the **original file** with EXIF intact. Setting `strict:false` makes it always return the stripped re-encode.

3. **GIFs** — left as raw passthrough and documented in-code as an accepted non-gap: the GIF format has no standardized GPS EXIF field, and re-encoding would flatten the animation.

## Why this shape

Chose the surgical JPEG/TIFF carve-out over dropping `skipCompressionThreshold` to 0, to preserve the skip-compression perf win for the common small-PNG-icon case while still closing the actual GPS-leak path.

## Verification

- Typecheck clean (0 errors), lint clean, full `yarn build` green.
- Suggested dev-env check: upload a geotagged JPEG (small, and an already-compressed one) and confirm with `exiftool` that the stored bytes carry no GPS; confirm PNG icons still upload and GIFs still animate.

## Notes

- Surfaced during the 2026-06-24 image-handling review. Mobile's equivalent gap (Farcaster Cloudflare upload) was already fixed in quorum-mobile #129.