### PR TITLE
feat: jumbo emoji sizing

### DIFF
--- a/src/components/message/MessageMarkdownRenderer.tsx
+++ b/src/components/message/MessageMarkdownRenderer.tsx
@@ -790,7 +790,7 @@ export const MessageMarkdownRenderer: React.FC<MessageMarkdownRendererProps> = (
   }, [content, processMentions, processRoleMentions, processChannelMentions, processMessageLinks]);
 
   // "Jumbo emoji": when a message is nothing but emoji, render them larger.
-  // 1 emoji → largest, 2-3 → smaller-but-large, 4+ → normal inline size.
+  // 1 emoji → 64px, 2-3 → 48px, 4+ → normal inline size (sizes set in _chat.scss).
   // Computed from the raw content (before token processing) so mentions, links,
   // and other text correctly disqualify the message.
   const emojiOnlySize = useMemo(() => getEmojiOnlySize(content), [content]);

--- a/src/components/message/MessageMarkdownRenderer.tsx
+++ b/src/components/message/MessageMarkdownRenderer.tsx
@@ -16,7 +16,7 @@ import {
   getValidInvitePrefixes,
   getValidMessageLinkPrefixes,
 } from '@quilibrium/quorum-shared';
-import { remarkTwemoji } from '../../utils/remarkTwemoji';
+import { remarkTwemoji, getEmojiOnlySize } from '../../utils/remarkTwemoji';
 import { InviteLink } from './InviteLink';
 import { Icon } from '../primitives';
 import type { Role, Channel, PostMessage } from '@quilibrium/quorum-shared';
@@ -789,6 +789,13 @@ export const MessageMarkdownRenderer: React.FC<MessageMarkdownRendererProps> = (
     );
   }, [content, processMentions, processRoleMentions, processChannelMentions, processMessageLinks]);
 
+  // "Jumbo emoji": when a message is nothing but emoji, render them larger.
+  // 1 emoji → largest, 2-3 → smaller-but-large, 4+ → normal inline size.
+  // Computed from the raw content (before token processing) so mentions, links,
+  // and other text correctly disqualify the message.
+  const emojiOnlySize = useMemo(() => getEmojiOnlySize(content), [content]);
+  const emojiSizeClass = emojiOnlySize ? `twemoji-jumbo twemoji-jumbo--${emojiOnlySize}` : '';
+
   // Memoize components to prevent re-creation and YouTube component remounting
   const components = useMemo(() => ({
     // Handle text nodes to render mentions safely
@@ -1124,7 +1131,7 @@ export const MessageMarkdownRenderer: React.FC<MessageMarkdownRendererProps> = (
   }, [onUserClick, onChannelClick, onMessageLinkClick, mapSenderToUser, resolveSender]);
 
   return (
-    <div className={`break-words min-w-0 max-w-full overflow-hidden ${suffix ? 'has-inline-suffix' : ''} ${className || ''}`} onClick={handleClick}>
+    <div className={`break-words min-w-0 max-w-full overflow-hidden ${emojiSizeClass} ${suffix ? 'has-inline-suffix' : ''} ${className || ''}`} onClick={handleClick}>
       <ReactMarkdown
         remarkPlugins={[remarkGfm, remarkBreaks, remarkTwemoji]}
         rehypePlugins={[]}

--- a/src/components/shell/NavRail.tsx
+++ b/src/components/shell/NavRail.tsx
@@ -49,7 +49,7 @@ const buildItems = (): RailItemConfig[] => [
   },
   {
     id: 'farcaster',
-    icon: 'globe',
+    icon: 'world-map',
     label: t`Farcaster`,
     route: '/farcaster',
   },

--- a/src/dev/tests/utils/getEmojiOnlySize.unit.test.ts
+++ b/src/dev/tests/utils/getEmojiOnlySize.unit.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { getEmojiOnlySize } from '../../../utils/remarkTwemoji';
+
+describe('getEmojiOnlySize', () => {
+  it('returns "single" for one emoji', () => {
+    expect(getEmojiOnlySize('😀')).toBe('single');
+  });
+
+  it('returns "few" for two emoji', () => {
+    expect(getEmojiOnlySize('😀😅')).toBe('few');
+  });
+
+  it('returns "few" for three emoji', () => {
+    expect(getEmojiOnlySize('😀😅😂')).toBe('few');
+  });
+
+  it('returns null (normal size) for four emoji', () => {
+    expect(getEmojiOnlySize('😀😅😂🤣')).toBeNull();
+  });
+
+  it('returns null for five or more emoji', () => {
+    expect(getEmojiOnlySize('😀😅😂🤣😊')).toBeNull();
+  });
+
+  it('ignores surrounding and interleaved whitespace', () => {
+    expect(getEmojiOnlySize('  😀  ')).toBe('single');
+    expect(getEmojiOnlySize('😀 😅 😂')).toBe('few');
+    expect(getEmojiOnlySize('\n😀\n')).toBe('single');
+  });
+
+  it('returns null when any non-emoji text is present', () => {
+    expect(getEmojiOnlySize('hi 😀')).toBeNull();
+    expect(getEmojiOnlySize('😀!')).toBeNull();
+    expect(getEmojiOnlySize('😀 lol 😅')).toBeNull();
+  });
+
+  it('returns null for plain text with no emoji', () => {
+    expect(getEmojiOnlySize('hello world')).toBeNull();
+  });
+
+  it('returns null for empty or whitespace-only input', () => {
+    expect(getEmojiOnlySize('')).toBeNull();
+    expect(getEmojiOnlySize('   ')).toBeNull();
+  });
+
+  it('treats a ZWJ sequence as a single emoji', () => {
+    // Family emoji (man + woman + girl + boy joined by ZWJ) is one entity.
+    expect(getEmojiOnlySize('👨‍👩‍👧‍👦')).toBe('single');
+  });
+
+  it('treats a skin-tone modified emoji as a single emoji', () => {
+    expect(getEmojiOnlySize('👍🏽')).toBe('single');
+    expect(getEmojiOnlySize('👍🏽👋🏻')).toBe('few');
+  });
+
+  it('counts flag (regional indicator) emoji correctly', () => {
+    expect(getEmojiOnlySize('🇺🇸')).toBe('single');
+    expect(getEmojiOnlySize('🇺🇸🇮🇹')).toBe('few');
+  });
+});

--- a/src/styles/_chat.scss
+++ b/src/styles/_chat.scss
@@ -174,6 +174,31 @@ img.twemoji {
   margin: 0 0.05em;
 }
 
+// "Jumbo emoji": when a message is nothing but emoji, render them larger.
+// The tier class lives on the renderer's wrapper div (set in
+// MessageMarkdownRenderer). 1 emoji is largest, 2-3 are smaller-but-large,
+// 4+ fall back to normal inline size (no class is applied).
+//
+// max-height caps every emoji image at 128px — the hard upper bound for
+// custom emojis. With the 14px message body font, the em-based heights below
+// resolve well under that (single ≈ 42px, few ≈ 31px); the cap is a safety
+// rail so neither Twemoji nor any future inline custom emoji can blow past it.
+.twemoji-jumbo {
+  img.twemoji {
+    vertical-align: -0.15em;
+    margin: 0 0.08em;
+    max-height: 128px;
+  }
+
+  &--single img.twemoji {
+    height: 3em;
+  }
+
+  &--few img.twemoji {
+    height: 2.2em;
+  }
+}
+
 .message-list {
   flex: 1 1 auto;
   overflow-y: auto;

--- a/src/styles/_chat.scss
+++ b/src/styles/_chat.scss
@@ -179,23 +179,22 @@ img.twemoji {
 // MessageMarkdownRenderer). 1 emoji is largest, 2-3 are smaller-but-large,
 // 4+ fall back to normal inline size (no class is applied).
 //
-// max-height caps every emoji image at 128px — the hard upper bound for
-// custom emojis. With the 14px message body font, the em-based heights below
-// resolve well under that (single ≈ 42px, few ≈ 31px); the cap is a safety
-// rail so neither Twemoji nor any future inline custom emoji can blow past it.
+// Sizes use the shared spacing scale. max-height is capped at $s-32 (128px),
+// the hard upper bound for custom emojis — a safety rail so neither Twemoji
+// nor any future inline custom emoji can blow past it.
 .twemoji-jumbo {
   img.twemoji {
     vertical-align: -0.15em;
     margin: 0 0.08em;
-    max-height: 128px;
+    max-height: $s-32; // 128px
   }
 
   &--single img.twemoji {
-    height: 3em;
+    height: $s-16; // 64px
   }
 
   &--few img.twemoji {
-    height: 2.2em;
+    height: $s-12; // 48px
   }
 }
 

--- a/src/utils/remarkTwemoji.ts
+++ b/src/utils/remarkTwemoji.ts
@@ -24,6 +24,43 @@ function emojiToUnified(emoji: string): string {
 export { emojiToUnified };
 
 /**
+ * Size tier for "jumbo emoji" rendering. When a message contains only emoji
+ * (no other visible text), they render larger than inline size:
+ *   - 'single' (1 emoji)      → largest
+ *   - 'few' (2-3 emoji)       → smaller than single, still large
+ *   - null                    → normal inline size (4+ emoji, or any non-emoji text)
+ */
+export type EmojiOnlySize = 'single' | 'few' | null;
+
+/**
+ * Inspect a raw message string and decide whether it should render with
+ * enlarged ("jumbo") emoji. Returns the size tier, or null when the message
+ * is not emoji-only.
+ *
+ * Emoji-only means: after removing every emoji and all whitespace, nothing
+ * remains. The count drives the tier (1 → 'single', 2-3 → 'few', 4+ → null).
+ */
+export function getEmojiOnlySize(content: string): EmojiOnlySize {
+  if (!content) return null;
+
+  const entities = parseEmoji(content);
+  if (entities.length === 0) return null;
+
+  // Strip every emoji from the text, then check whether only whitespace is left.
+  // Walk entities from the end so the indices stay valid as we splice.
+  let remainder = content;
+  for (let i = entities.length - 1; i >= 0; i--) {
+    const [start, end] = entities[i].indices;
+    remainder = remainder.slice(0, start) + remainder.slice(end);
+  }
+  if (remainder.trim().length > 0) return null;
+
+  if (entities.length === 1) return 'single';
+  if (entities.length <= 3) return 'few';
+  return null;
+}
+
+/**
  * Custom remark plugin that replaces emoji unicode characters with image nodes
  * pointing to self-hosted Twemoji PNGs at /twitter/64/{unified}.png.
  *


### PR DESCRIPTION
## Summary

Enlarge emoji-only messages ("jumbo emoji") and swap the navrail Farcaster icon.

## Highlights

**Jumbo emoji**
- When a message is nothing but emoji, render them larger than inline size: 1 emoji at 64px, 2-3 at 48px, 4+ stay at the normal inline size.
- Detection counts emoji via `@twemoji/parser` (ZWJ sequences, skin tones, and flags each count as one) and disqualifies any message that also contains other visible text (mentions, links, words).
- Emoji image height is capped at 128px (the custom-emoji upper bound) as a safety rail.
- Sizes use the shared spacing tokens from `_variables.scss`.
- Unit tests cover the tier boundaries plus ZWJ, skin-tone, and flag sequences.

**Navrail**
- Swap the Farcaster item icon from `globe` to `world-map`.

## Commits
- Enlarge emoji-only messages (jumbo emoji)
- Swap globe for world-map icon on navrail Farcaster item