### PR TITLE
Consume shared message-preprocessing pipeline in MessageMarkdownRenderer

### DIFF
--- a/.agents/INDEX.md
+++ b/.agents/INDEX.md
@@ -330,8 +330,8 @@ This is the main index for all documentation, bug reports, and task management.
 - [Port-to-mobile — desktop → mobile feature diff](tasks/port-to-mobile/README.md)
 
 ### Quorum Shared Migration
-- [Icon-picker vocabulary — implementation status & PR sequencing](tasks/quorum-shared-migration/2026-06-12-icon-picker-PR-notes.md)
-- [Promote the icon-picker vocabulary to quorum-shared](tasks/quorum-shared-migration/2026-06-12-promote-icon-picker-vocabulary-to-shared.md)
+- [Icon-picker vocabulary — implementation status & PR sequencing](tasks/quorum-shared-migration/.done/2026-06-12-icon-picker-PR-notes.md) ✓ done
+- [Promote the icon-picker vocabulary to quorum-shared](tasks/quorum-shared-migration/.done/2026-06-12-promote-icon-picker-vocabulary-to-shared.md) ✓ done
 - [Promote the message-preprocessing pipeline to quorum-shared](tasks/quorum-shared-migration/2026-06-18-promote-message-preprocessing-to-shared.md)
 - [Cross-repo PR workflow for the quorum-shared migration](tasks/quorum-shared-migration/cross-repo-workflow.md)
 - [Mobile tasks — where to find them](tasks/quorum-shared-migration/mobile-tasks-pending.md)

--- a/.agents/tasks/quorum-shared-migration/.done/2026-06-12-icon-picker-PR-notes.md
+++ b/.agents/tasks/quorum-shared-migration/.done/2026-06-12-icon-picker-PR-notes.md
@@ -1,8 +1,9 @@
 ---
 type: notes
 title: "Icon-picker vocabulary promotion + expansion — PR sequencing & status"
-status: in-progress
+status: done
 created: 2026-06-12
+completed: 2026-06-25
 parent-task: 2026-06-12-promote-icon-picker-vocabulary-to-shared.md
 ---
 

--- a/.agents/tasks/quorum-shared-migration/.done/2026-06-12-promote-icon-picker-vocabulary-to-shared.md
+++ b/.agents/tasks/quorum-shared-migration/.done/2026-06-12-promote-icon-picker-vocabulary-to-shared.md
@@ -1,8 +1,9 @@
 ---
 type: task
 title: "Promote + expand the icon-picker vocabulary (icon set + colors + filled-variant) to quorum-shared"
-status: in-progress
+status: done
 created: 2026-06-12
+completed: 2026-06-25
 runtime-test: not-required (data move; visual smoke on both apps)
 priority: medium (unblocks mobile channel/group icon parity — port-to-mobile rows 31/32)
 source-audit: D:\GitHub\Quilibrium\quorum-desktop\.agents\tasks\port-to-mobile\candidates.md (rows 31/32; "Channel & group icons" detailed entry)
@@ -97,4 +98,10 @@ In progress on branch `promote-icon-picker-vocabulary-to-shared`. Full sequencin
 
 **Checklist status:** shared vocab exported + merged (#39) ✓ · desktop import-swap done (re-exports from shared) ✓ · desktop tsc + lint clean ✓ · expanded picker renders (data validated; layout preview generated) ✓ · picker layout holds (sticky header + scroll + search) ✓ · mobile-tasks-pending row present (7.3, updated for 92 + named-enum) ✓. Remaining: live in-app visual smoke; mobile consumption (row 7.3).
 
-*Last updated: 2026-06-12*
+**Done (2026-06-25):** desktop + shared legs verified complete — `pickerVocabulary.ts`
+lives in shared (exported via Icon → primitives → root barrel), desktop `types.ts`
+re-exports it, tsc + lint clean, PR #39 merged. Moved to `.done/`. Remaining work is
+NOT desktop: live in-app visual smoke + the mobile consumption leg (row 7.3 in
+mobile-tasks-pending.md), which stay tracked there.
+
+*Last updated: 2026-06-25*

--- a/.agents/tasks/quorum-shared-migration/2026-06-18-promote-message-preprocessing-to-shared.md
+++ b/.agents/tasks/quorum-shared-migration/2026-06-18-promote-message-preprocessing-to-shared.md
@@ -1,8 +1,9 @@
 ---
 type: task
 title: "Promote the message-preprocessing pipeline (mention/URL/header/code-fence transforms) to quorum-shared"
-status: open
+status: ready
 created: 2026-06-18
+updated: 2026-06-25
 runtime-test: not-required (logic move; visual smoke on both apps)
 priority: medium (de-dups desktop's inlined pipeline; gives mobile's markdown renderer a shared backbone)
 source: mobile-originated — quorum-mobile Wave 1 Phase 2 wrote a clean pure-function extraction first
@@ -10,9 +11,52 @@ related:
   - quorum-mobile/.agents/tasks/quorum-shared-migration/2026-06-18-adopt-shared-message-preprocessing.md (the mobile consumer leg)
   - quorum-mobile/.agents/tasks/2026-06-18-mentions-and-markdown-renderer.md (Wave 1; where the mobile pipeline was written)
   - quorum-desktop/src/components/message/MessageMarkdownRenderer.tsx (the desktop file holding the inlined copy)
+  - quorum-mobile/utils/messagePreprocessing.ts (the clean draft to start the shared module from)
 ---
 
 # Promote the message-preprocessing pipeline to quorum-shared
+
+## Status snapshot (re-verified 2026-06-25)
+
+Re-checked against all three repos before marking ready. **The task is still worth
+doing and the duplication is real**, but one large chunk it described as *pending* has
+already landed independently, so the remaining work is smaller and cleaner than the
+2026-06-18 draft implied:
+
+- ❌ **Not started:** `quorum-shared/src/utils/messagePreprocessing.ts` does not exist;
+  no test file; desktop still has every function inlined in
+  `MessageMarkdownRenderer.tsx`; mobile still imports its local
+  `utils/messagePreprocessing.ts`. The duplication this task removes is live.
+- ✅ **Already done (was the task's biggest open item):** the **option-B role/channel
+  reconciliation**. Desktop's renderer ALREADY resolves role/channel mentions directly
+  from `spaceRoles: Role[]` / `spaceChannels: Channel[]` with **no
+  `message.mentions.roleIds`/`channelIds` filter** — see
+  `MessageMarkdownRenderer.tsx:364` (`processRoleMentions`) and `:411`
+  (`processChannelMentions`), whose own comments now describe option B. The props are
+  already `spaceRoles`/`spaceChannels` (`:49-50`), not the old `roleMentions: string[]`
+  / `channelMentions: string[]`. **So this is now a pure extraction, not a behavior
+  change.** The whole "Design decision required / option A vs B" debate is settled and
+  shipped; it survives below only as historical context.
+- ✅ **Infra confirmed ready:** shared uses Vitest with 8 existing `src/utils/*.test.ts`
+  files; `src/utils/index.ts` barrel exists; `SpaceMember`/`Role`/`Channel` are all
+  exported from shared; none of the 8 function names collide with existing shared
+  exports; desktop consumes shared via `link:../quorum-shared` (no publish needed for
+  desktop to pick up new code, same as the icon-picker migration).
+
+So: **proceed with the extraction.** The new-vs-draft work is reconciling a handful of
+genuine desktop↔mobile divergences (listed in "Divergences to reconcile" below) — that
+is the real engineering content now, not the filtering decision.
+
+**Independent worth-it review (2026-06-25):** before committing, an independent skeptical
+agent re-read all three repos and graded the migration **"Worth it, medium-high confidence."**
+It confirmed the duplication is real (~320 desktop lines + 383 mobile lines of one algorithm),
+that the `<<<MENTION_*>>>` vocabulary is a genuine load-bearing protocol (`markdownStripping.ts`
++ `.native.ts` already hardcode it to strip those tokens — so a producer divergence is a real
+cross-platform bug, not cosmetic), that it's truly pure (needs no `.native` split), and that
+there are no export-name collisions. It also surfaced **two divergences the original draft
+missed** — now captured as #7 (the `!mapSenderToUser` guard, a token-leak risk) and #8
+(`@<roleId>` role form). Both were independently verified against the code before being added.
+Net: the migration makes sense; #7 is the one item that must not be implemented carelessly.
 
 ## Why
 
@@ -32,9 +76,9 @@ platforms. Any divergence in these transforms = cross-platform render bugs.
 
 **Structurally ready to promote:** 100% pure string→string — no DOM, no native
 APIs, no `unified`. Unlike `markdownStripping` (which forks into `.native.ts`
-because of `unified`/`remark`), this needs **no `.native` split** — one module,
-both platforms. It already depends only on `hasWordBoundaries` + `createIPFSCIDRegex`,
-which are already shared exports.
+because of `unified`/`remark` — confirmed both files still present in shared), this
+needs **no `.native` split** — one module, both platforms. It already depends only
+on `hasWordBoundaries` + `createIPFSCIDRegex`, which are already shared exports.
 
 ## What's already shared (don't re-do)
 
@@ -43,6 +87,7 @@ which are already shared exports.
 - `extractCodeContent`, `shouldUseScrollContainer`, `getScrollContainerMaxHeight` (codeFormatting.ts)
 - `stripMarkdown`/`processMarkdownText` (markdownStripping.ts + .native — a *different* concern: stripping for previews, not tokenizing for rendering)
 - `getRoleColorHex` (roleUtils.ts)
+- `SpaceMember`, `Role`, `Channel` types (all exported from the shared root)
 
 ## What's NOT shared (this task moves it)
 
@@ -51,204 +96,237 @@ The pure pipeline, currently duplicated (desktop inlined + mobile-local):
 - `processMentions` (`@<address>` + `@everyone` → tokens)
 - `processRoleMentions`, `processChannelMentions`
 - `processURLs`, `convertHeadersToH3`, `fixUnclosedCodeBlocks`
-- `getProtectedRegions` / `isInProtectedRegion` (code-region protection — internal)
+- `getProtectedRegions` / `isInProtectedRegion` (code-region protection — internal helper)
 - `hasMarkdown(text)` detector (mobile-only today; useful to both)
-- `prepareMessageContent(text, opts)` orchestrator
+- `prepareMessageContent(text, opts)` orchestrator (mobile-only today; desktop will NOT call it — see step 5)
 
 Mobile's `utils/messagePreprocessing.ts` is already a clean draft of the shared
-module — start from it.
+module — **start from it.** It is the better-factored of the two copies (typed opts,
+JSDoc, named exports).
 
-## Design decision: role-mention filtering — DECIDED (option B)
+## Divergences to reconcile (the actual engineering content)
 
-The one non-mechanical call. **Settled: adopt mobile's filterless behavior on both
-platforms.**
+These are the real desktop↔mobile differences a naive copy would paper over. Resolve
+each deliberately in the shared module; cover each with a test.
 
-Background. Desktop today does NOT tokenize every `@roleTag` it finds — it only
-styles a role mention if that role's id is in the message's pre-extracted mention
-set (`message.mentions.roleIds`). See
-`src/hooks/business/messages/useMessageFormatting.ts:159`
-(`if (role && message.mentions.roleIds.includes(role.roleId))`) and the renderer's
-`roleMentions: string[]` prop fed from `message.mentions?.roleIds`
-(`Message.tsx:1138`). Mobile's `processRoleMentions(text, roles)` has NO such
-filter: it tokenizes any existing role that matches `@roleTag` (or `@<roleId>`).
+1. **`processURLs` — angle-bracket autolink skip (desktop-only).** Desktop's version
+   (`MessageMarkdownRenderer.tsx:179-182`) skips a URL already wrapped as a `<URL>`
+   autolink (`beforeUrl.endsWith('<') && afterUrl.startsWith('>')`). Mobile's
+   (`messagePreprocessing.ts:250`) has **no** such skip. **Keep desktop's behavior** —
+   port the angle-bracket guard into shared. Test: `<https://x.com>` is left untouched;
+   a bare `https://x.com` is wrapped.
 
-**Decision (B): desktop drops the `message.mentions.roleIds` filter and adopts
-mobile's resolve-from-array behavior.** Rationale:
-- **Consistency = better UX.** The exact same text `@admin` renders identically
-  everywhere, instead of being a pill or plain grey depending on invisible state
-  (was it picked from the @ menu? did an edit desync the list?). Inconsistent
-  rendering of identical text is the worse experience.
-- **Still satisfies the hard requirement:** a pill is only ever rendered for a role
-  that ACTUALLY EXISTS in the space — both options check the role list first, so a
-  non-existent `@notarole` never becomes a pill under either. (This requirement is
-  not the discriminator; both pass it.)
-- **Simpler, unified code:** one signature `processRoleMentions(text, roles)` /
-  `processChannelMentions(text, channels)` for both platforms; no filter param to
-  thread through.
+2. **`getProtectedRegions` — markdown-link protection.** Desktop's `getProtectedRegions`
+   (`:86`) protects fenced code, inline code **AND** existing `[text](url)` markdown
+   links. Mobile's `getProtectedRegions` (`:55`) protects only code; it then re-protects
+   md-links *inline inside `processURLs`* (`:254`). Net effect is similar for URL
+   auto-linking but NOT identical for mention tokenization (desktop won't tokenize a
+   mention sitting inside `[text](url)`; mobile would). **Decide one behavior** — desktop's
+   (links are protected everywhere) is the safer superset; adopt it in shared so a
+   `@<addr>` inside a markdown link's text doesn't get tokenized. Test both: a mention
+   and a bare URL inside `[ ]( )` stay untouched.
 
-**Known, accepted trade-off — pill ≠ notification.** On desktop today
-`message.mentions.roleIds` is also the set that decides who gets PINGED, so pill and
-ping coincide. Under B they can diverge: typing `@admin` as casual text (never picked
-from the menu) lights up as a pill but does NOT notify the admin role's members.
-Accepted: the pill means "this names a real role," not "this pinged everyone" (matches
-Discord-style behavior). The notification path is unchanged — only the visual
-tokenization stops consulting `roleIds`.
+3. **`@everyone` parameter shape.** Desktop gates `@everyone` tokenization on a
+   `hasEveryoneMention: boolean` prop (`:305`). Mobile gates on `opts.everyoneAuthorized`
+   (`:101`). Same concept (only tokenize an *authorized* `@everyone`), different param
+   name. **Unify on one name** in the shared signature — `everyoneAuthorized` (mobile's,
+   more precise about meaning) — and have desktop pass its `hasEveryoneMention` value
+   into it. Document that the caller owns the authorization decision (the shared function
+   only tokenizes; it does not decide who's allowed to ping).
 
-Wire-format compatibility verified: mobile's function matches BOTH `@<roleId>` and
-bare `@roleTag`, and desktop's composer writes roles as bare `@roleTag`
-(`MessageComposer.tsx:232`), users as `@<address>`, channels as `#<channelId>`. The
-mobile function already handles desktop's wire format.
+4. **`convertHeadersToH3` regex.** Desktop uses two sequential replaces
+   (`^##\s → "### "`, then `^#\s → "### "`; `:265-267`). Mobile uses one pass
+   (`^(#{1,2})(?!#)(\s+) → "###$2"`; `:290`). Confirm equivalence (they should produce
+   identical output for `#`, `##`, `###+`) and pick the single-pass mobile form. Test:
+   `# h` and `## h` → `### h`; `### h` and `#### h` unchanged; a `#` inside a fence
+   untouched.
+
+5. **Legacy bare-`@address` shim (mobile-only).** Mobile's `processMentions` tolerates a
+   legacy bare `@address` (no brackets), gated on a `members` array
+   (`:138-155`). Desktop never produced bare-format mentions, so it always passes no
+   members → the shim is inert. **Keep it in shared, gated on `members.length > 0`** so
+   it's harmless for desktop. Test: with members supplied, bare `@alice` → token; with
+   none, bare `@alice` stays plain text.
+
+6. **Newline normalization (`\r\n? → \n`).** `prepareMessageContent` does this as its
+   first step (`:323`); the individual functions do NOT. Desktop will call the individual
+   functions (not the orchestrator — see step 5 of Scope), so desktop does NOT inherit
+   normalization — fine, desktop never hit the CR bug (it goes through react-markdown).
+   Just don't silently fold it into an individual function and change desktop's behavior.
+
+7. **⚠️ `!mapSenderToUser` early-return guard (desktop-only — MUST preserve).** Found by
+   the independent worth-it review; the original draft missed it. Desktop's `processMentions`
+   returns `text` unchanged when `mapSenderToUser` is falsy (`MessageMarkdownRenderer.tsx:297`).
+   Mobile's shared `processMentions` has NO such guard — it always tokenizes. `mapSenderToUser`
+   is an **optional** prop, and the renderer is used at callsites that omit it (verified:
+   `BookmarkCard.tsx:121`, plus DirectMessage/BookmarksPanel paths). At those callsites the
+   token→React renderer (`processMentionTokens`) may also not be fully wired — so if the shared
+   function tokenizes unconditionally, a `@<address>` becomes a `<<<MENTION_USER:…>>>` token
+   that can **leak raw to the user** instead of staying plain text. **Fix: keep the guard in
+   desktop's `useCallback` wrapper, NOT in the shared function.** The shared function stays a
+   pure unconditional tokenizer (correct); desktop's wrapper short-circuits:
+   ```ts
+   const processMentions = useCallback((text: string): string => {
+     if (!mapSenderToUser) return text;            // desktop-only caller guard — preserve
+     return sharedProcessMentions(text, [], hasEveryoneMention);
+   }, [mapSenderToUser, hasEveryoneMention]);
+   ```
+   Test the shared function tokenizes unconditionally; assert the guard in the desktop wrapper
+   via the visual-smoke step (a message with `@<addr>` in a context without `mapSenderToUser`
+   must NOT show a raw token).
+
+8. **`@<roleId>` canonical role form (additive for desktop — note, don't block).** Found by
+   the review. Mobile's `processRoleMentions` matches BOTH `@<roleId>` (angle-bracketed UUID,
+   `messagePreprocessing.ts:171-187`) and bare `@roleTag` (`:190-207`). Desktop only matches
+   bare `@roleTag` (`MessageMarkdownRenderer.tsx:385`). Verified desktop's composer writes roles
+   as **bare `@roleTag`, never `@<roleId>`** (`MessageComposer.tsx:233-234`), so for
+   desktop-authored messages the extra `@<roleId>` branch is **inert**. Accept it as additive
+   (harmless), but be aware: a user who types literal `@<some-uuid>` text where the uuid matches
+   a real role's id would now get a pill on desktop where before it stayed plain. Negligible edge
+   case; call it out in the desktop PR description rather than trying to strip the branch.
 
 ## Scope
 
-1. **Create `quorum-shared/src/utils/messagePreprocessing.ts`** from the mobile file.
-   Re-export the public surface (`prepareMessageContent`, `hasMarkdown`, and the
-   individual `process*` functions for callers that want steps à la carte) from the
-   package root barrel.
+1. **Create `quorum-shared/src/utils/messagePreprocessing.ts`** from the mobile file,
+   applying the divergence reconciliations above. Add it to the `src/utils/index.ts`
+   barrel (which the root re-exports), alongside the existing `markdownStripping`/
+   `codeFormatting` lines. Public surface: `prepareMessageContent`, `hasMarkdown`, and the
+   individual `process*` functions (for callers — i.e. desktop — that want steps à la carte).
 
-2. **Reconcile the role/channel API — option B (decided).**
-   - Shared signature: `processRoleMentions(text, roles: Role[])`,
-     `processChannelMentions(text, channels: Channel[])` — filterless, resolve
-     directly from the arrays (mobile's existing shape).
-   - Desktop drops the `roleMentions: string[]` / `channelMentions: string[]` filter
-     props and the `message.mentions.roleIds`/`channelIds` plumbing into the renderer;
-     it passes `spaceRoles` / `spaceChannels` as the resolver arrays instead.
-   - Net desktop behavior change: a `@roleTag` / `#<channelId>` that names an existing
-     role/channel now tokenizes regardless of whether it was in `message.mentions`.
-     Intended (see decided design call above).
+2. **Role/channel API — already option B, just match the signature.** Shared signature:
+   `processRoleMentions(text, roles: Role[])`, `processChannelMentions(text, channels: Channel[])`
+   — filterless, resolve directly from the arrays. **Desktop already uses exactly this shape**
+   (`spaceRoles`/`spaceChannels`, no id filter), so no desktop behavior change is needed here;
+   the refactor just swaps the inlined `useCallback` bodies for shared imports.
 
-3. **Carry the mobile legacy shim.** Mobile's `processMentions` tolerates the legacy
-   bare `@address` (no brackets) format for messages already in storage from old
-   mobile clients. Keep it in shared, gated on a `members` array being supplied
-   (harmless for desktop, which never produced bare-format mentions).
+3. **Carry the mobile legacy shim** (divergence #5) — gated on `members` being supplied.
 
-4. **Decide on the desktop-only steps.** `processInviteLinks`,
-   `processStandaloneYouTubeUrls`, `processMessageLinks` are desktop-only today
-   (mobile defers them to its facade tasks). **Recommend: promote the common core
-   now; leave these three desktop-inlined** (or add to shared behind opt-in flags)
-   until the mobile facades (#5 YouTube, invite cards, message links) land.
+4. **Leave the desktop-only steps inlined.** `processInviteLinks`,
+   `processStandaloneYouTubeUrls`, `processMessageLinks` are desktop-only (mobile defers
+   them to its facade tasks). **Do not move them** — promote the common core now; revisit
+   when the mobile facades (#5 YouTube, invite cards, message links) land. They stay in
+   `MessageMarkdownRenderer.tsx`.
 
 5. **Refactor desktop to consume shared.** Replace the inlined functions in
-   `MessageMarkdownRenderer.tsx` with shared imports. The module-level ones
-   (`processURLs`, `convertHeadersToH3`, `fixUnclosedCodeBlocks`) are an easy lift;
-   the `useCallback` ones need their closed-over args (`mapSenderToUser`,
-   `hasEveryoneMention`, the role/channel arrays) passed as function params, matching
-   the shared signature.
-   - **Do NOT call the `prepareMessageContent` orchestrator on desktop.** Desktop's
-     pipeline interleaves desktop-only steps with the shared ones in a specific order:
+   `MessageMarkdownRenderer.tsx` with shared imports:
+   - Module-level (`processURLs`, plus `getProtectedRegions`/`isInProtectedRegion`) → import from shared.
+   - `useCallback` ones (`processMentions`, `processRoleMentions`, `processChannelMentions`)
+     → call the shared pure functions inside the `useCallback`, passing the closed-over
+     args (`mapSenderToUser`→members not needed for desktop, `hasEveryoneMention`,
+     `spaceRoles`, `spaceChannels`) as function params matching the shared signature. Keep
+     the `useCallback` wrappers (they preserve referential stability for the `processedContent`
+     useMemo deps).
+   - `convertHeadersToH3`, `fixUnclosedCodeBlocks` (currently defined *inside* the component
+     body, `:253`/`:278`) → import from shared.
+   - **Do NOT call `prepareMessageContent` on desktop.** Desktop's pipeline interleaves
+     desktop-only steps with shared ones in a specific order:
      `processInviteLinks` → `processStandaloneYouTubeUrls` → mentions/roles/channels →
-     `processMessageLinks` → `processURLs` → `convertHeadersToH3` →
-     `fixUnclosedCodeBlocks`. Critically `processMessageLinks` MUST run before
-     `processURLs` to avoid double-processing (see the comment at the current
-     `processedContent` useMemo). So desktop calls the **individual** shared functions
-     in its existing order; only mobile uses the `prepareMessageContent` orchestrator.
-   - **Newline normalization:** `prepareMessageContent` does `\r\n? → \n` as its first
-     step; desktop's inlined pipeline does not. If desktop adopts the individual
-     functions (not the orchestrator) it does NOT inherit this — fine, since desktop
-     never hit the CR bug. Just don't reintroduce it silently.
+     `processMessageLinks` → `processURLs` → `convertHeadersToH3` → `fixUnclosedCodeBlocks`
+     (see the `processedContent` useMemo at `:772-790`). Critically `processMessageLinks`
+     MUST run before `processURLs` to avoid double-processing (the comment at `:770` says so).
+     Desktop calls the **individual** shared functions in its existing order; only mobile uses
+     the `prepareMessageContent` orchestrator.
+   - `processMentionTokens` (the token→React renderer, `:569`) is desktop-DOM-specific and
+     stays in the component — it is NOT part of this move.
 
 6. **Mobile consumes** — separate leg, tracked in the mobile task (consumer): bump the
    shared dep, swap `@/utils/messagePreprocessing` → `@quilibrium/quorum-shared`,
-   delete the local file.
+   delete the local file. Its `everyoneAuthorized`/`members`/`roles`/`channels` opts already
+   match the shared signature, so it's a near-drop-in.
 
 ## Tests — ship them in shared with the move
 
 Shared already uses **Vitest** with an established `src/utils/*.test.ts` pattern
-(`mentions.test.ts`, `validation.test.ts`, `roleUtils.test.ts`). Add
-`src/utils/messagePreprocessing.test.ts` in the SAME PR. This is the durable home
-for these tests — they cover desktop AND mobile from one suite.
+(confirmed: `mentions.test.ts`, `validation.test.ts`, `roleUtils.test.ts`,
+`messageGrouping.test.ts`, + 4 more). Add `src/utils/messagePreprocessing.test.ts` in
+the SAME PR. This is the durable home for these tests — they cover desktop AND mobile
+from one suite.
 
 > **Why not test in mobile?** Mobile has no test runner at all (no jest/vitest, no
 > `test` script, zero test files as of 2026-06-18). Desktop's preprocessing functions
 > were never unit-tested (inlined, untestable). So shared is the only place these tests
 > have ever had a home, and the only place they won't go stale when the logic moves.
 
-Test matrix:
-- mention tokenization: `@<address>` → `<<<MENTION_USER:…>>>`; `@everyone` →
-  `<<<MENTION_EVERYONE>>>`; legacy bare `@address` (with members) → token
+Test matrix (each divergence above also gets a test — see that section):
+- mention tokenization: `@<address>` → `<<<MENTION_USER:…>>>`; `@everyone` (authorized) →
+  `<<<MENTION_EVERYONE>>>`; `@everyone` (NOT authorized) → stays plain; legacy bare
+  `@address` (with members) → token; (without members) → plain
 - code-region protection: no tokenization inside `` `inline` `` or ` ```fenced``` `
+- markdown-link protection (divergence #2): mention + bare URL inside `[ ]( )` untouched
 - word-boundary rejection: `x@everyone` must NOT match; mention at string start/end OK
-- role/channel tokenization against the resolver arrays (and case-insensitive role tag)
-- `processURLs`: bare URL → `[url](url)`; skips code + existing markdown links + autolinks
-- `convertHeadersToH3`: `#`/`##` → `###`, leaves `###`+ alone, protects code blocks
+- role/channel tokenization against the resolver arrays (and case-sensitive role tag match per current desktop regex `@${roleTag}(?!\w)`)
+- `processURLs`: bare URL → `[url](url)`; skips code + existing markdown links + `<URL>` autolinks (divergence #1)
+- `convertHeadersToH3`: `#`/`##` → `###`, leaves `###`+ alone, protects code blocks (divergence #4)
 - `fixUnclosedCodeBlocks`: odd fence count gets a closing fence; even is untouched
 - `hasMarkdown`: plain chat line / bare @mention / bare URL → false; `**b**`, `_i_`,
   `~~s~~`, `` `c` ``, fences, `||s||`, `# h`, `> q`, `- list`, `1. ol`, `---` → true
-- emphasis nesting sanity if the inline parser is also promoted (optional — the inline
-  RN renderer is mobile-specific; only the preprocessing is shared)
-
-## Mobile/desktop divergences to account for when sharing (from device testing 2026-06-18)
-
-Device testing of the mobile renderer surfaced where mobile genuinely needs
-different logic than desktop. Keep this split in mind when promoting — the PURE
-pieces are shareable; the RN-RENDERING and a few behavioral bits are not (or need
-to be parameterized).
-
-**Shareable (pure logic — the promotion target):**
-- The whole preprocessing pipeline (mention/role/channel tokenization, URL
-  auto-link, header normalize, fence balance).
-- The **block parser** (text → block AST: paragraph/heading/blockquote/list/
-  code/hr) and the **inline parser** (runs → bold/italic/strike/code/spoiler/
-  mention tokens/emoji/link). These are pure and platform-agnostic. Desktop
-  currently uses `react-markdown` (DOM-only) so it can't reuse a renderer, but a
-  shared **AST producer** could feed both: desktop renders AST→DOM, mobile
-  AST→RN. Worth considering as the real long-term shape.
-
-**Mobile-specific (must NOT be naively shared / needs parameterizing):**
-- **Newline normalization (`\r\n?` → `\n`) before block parsing.** Mobile needs
-  this because pasted text on device carried stray CRs that broke per-line block
-  matching (only the last blockquote/list line survived). Desktop via
-  react-markdown doesn't hit this. If the block parser is shared, this normalize
-  step should live INSIDE it (harmless for desktop, required for mobile).
-- **Spoiler rendering.** Desktop uses a CSS class toggle; mobile renders block
-  glyphs (`█`) when hidden because RN `color: 'transparent'` on nested `<Text>`
-  is unreliable. Pure-logic shareable (detect `||...||`); the reveal/hide
-  RENDERING stays platform-specific.
-- **Pill styling.** Desktop uses a highlighted background pill; mobile uses
-  color-only (bg read too heavy on small screens). Shareable: which runs are
-  pills + their semantic color. NOT shareable: the visual treatment.
-- **Channel mention wire format alignment.** Mobile's composer now inserts
-  `#<channelId>` (matching desktop's shared format) and `MentionableText` parses
-  both `#<id>` and legacy `#name`. This convergence is good — it means a shared
-  channel-tokenizer works for both. Note the legacy `#name` parse is a mobile
-  back-comat concern (old mobile messages stored bare names).
-- **Auto-link truncation (50 chars).** Mobile matches desktop's number; keep the
-  threshold a shared constant so they can't drift.
 
 ## Cross-repo workflow
 
-Follow [cross-repo-workflow.md](cross-repo-workflow.md). Shape:
-1. **quorum-shared PR**: add `messagePreprocessing.ts` + tests, re-export from root,
-   bump version. Additive — no breaking change.
-2. **quorum-desktop PR**: swap `MessageMarkdownRenderer.tsx`'s inlined functions to
-   shared imports; verify the renderer still produces identical output (mentions,
-   spoilers, code, URLs, headers). tsc + lint clean.
+Follow [cross-repo-workflow.md](cross-repo-workflow.md). Shape (driver = shared + desktop;
+consumer = mobile):
+
+1. **quorum-shared PR** (you author; user drives merge + version bump per
+   [feedback_quorum_shared_workflow]): add `messagePreprocessing.ts` + `messagePreprocessing.test.ts`,
+   add the line to `src/utils/index.ts`, `yarn build`, `yarn test:run`. Additive — no breaking
+   change. Bump the `X.Y.Z-N` suffix (currently `2.1.0-34`; do NOT "fix" the suffix to plain
+   SemVer — it's a deliberate lead-dev convention).
+2. **quorum-desktop PR** (this branch): swap `MessageMarkdownRenderer.tsx`'s inlined functions to
+   shared imports; verify the renderer still produces identical output (mentions, spoilers, code,
+   URLs, headers). `npx tsc --noEmit` + `yarn lint` clean. Desktop picks up shared via
+   `link:../quorum-shared` once shared's `dist/` is rebuilt (`yarn build` in shared) — same
+   mechanism as the icon-picker migration; no publish needed for local desktop dev.
 3. **quorum-mobile**: consumer leg — tracked in the mobile task
    ([`2026-06-18-adopt-shared-message-preprocessing.md`](file:///D:/GitHub/Quilibrium/quorum-mobile/.agents/tasks/quorum-shared-migration/2026-06-18-adopt-shared-message-preprocessing.md)).
-   Add the `mobile-tasks-pending.md` signpost is NOT needed (it's a signpost now, per
-   the port-to-mobile README) — the mobile task file is the live status home.
+
+> Reminder ([feedback_dont_break_mobile_on_shared_changes]): the shared change must be
+> **additive** — new module, new exports, no edits to existing shared signatures mobile is
+> pinned to. Mobile consumes on its own schedule via a version bump.
 
 ## Verification
 
 - [ ] quorum-shared: `messagePreprocessing` + tests exported from root; `yarn build` +
-      `vitest` clean.
-- [ ] quorum-desktop: `MessageMarkdownRenderer.tsx` imports from shared; tsc + lint
-      clean; renderer output unchanged (visual smoke: a message with @mention, @role,
-      #channel, `**bold**`, fenced code, `||spoiler||`, a bare URL).
-- [ ] quorum-desktop: role/channel filtering behavior matches the option chosen in the
-      "Design decision required" section — specifically verify a `@roleTag` NOT in
-      `message.mentions.roleIds` renders the same as before (plain under option A;
-      now-styled under option B, which must be intentional).
+      `yarn test:run` clean. Every divergence (#1-#8) has a covering test or documented decision.
+- [ ] quorum-desktop: the `!mapSenderToUser` guard (divergence #7) is preserved in the
+      desktop `useCallback` wrapper — a `@<address>` in a context without `mapSenderToUser`
+      (e.g. a bookmark card) renders as plain text, NOT a raw `<<<MENTION_USER:…>>>` token.
+- [ ] quorum-desktop: `MessageMarkdownRenderer.tsx` imports the pure functions from shared
+      (`processURLs`, `processMentions`, `processRoleMentions`, `processChannelMentions`,
+      `convertHeadersToH3`, `fixUnclosedCodeBlocks`, `getProtectedRegions`/`isInProtectedRegion`);
+      `npx tsc --noEmit` + `yarn lint` clean.
+- [ ] quorum-desktop: renderer output unchanged (visual smoke — a message with @mention, @role,
+      #channel, `**bold**`, fenced code, `||spoiler||`, a bare URL, a `<https://x.com>` autolink,
+      a `[label](url)` markdown link containing an @mention).
 - [ ] quorum-desktop: pipeline step order preserved (`processMessageLinks` before
       `processURLs`); a message link is NOT double-processed into a plain URL.
+- [ ] quorum-desktop: the desktop-only steps (`processInviteLinks`,
+      `processStandaloneYouTubeUrls`, `processMessageLinks`, `processMentionTokens`) remain
+      inlined and unchanged.
 - [ ] No regression on desktop (mentions/spoilers/code/URLs/headers all still render).
 - [ ] Mobile consumer leg opened/linked.
 
+## Historical context — the role/channel filtering decision (NOW MOOT, kept for the record)
+
+The 2026-06-18 draft framed role/channel filtering as an open design decision (option A:
+keep desktop's `message.mentions.roleIds` filter; option B: adopt mobile's filterless
+resolve-from-array). **Option B was chosen AND has since been implemented on desktop**
+independently of this task — `MessageMarkdownRenderer.tsx` already resolves directly from
+`spaceRoles`/`spaceChannels` with no id filter, and its inline comments document the option-B
+rationale (consistency, pill = "names a real role" not "pinged everyone", notification path
+unchanged). So there is nothing to decide or change here anymore; the extraction simply
+matches the signature desktop already uses. The original rationale is preserved in git
+history of this file if needed.
+
 ---
 
-*Last updated: 2026-06-18 — mobile-originated promotion. Driver leg (author shared
-module + tests, refactor desktop). Consumer leg is the mobile task. Added explicit
-role/channel-filtering design decision (option A preserves desktop's
-`message.mentions.roleIds` filter via an optional id param; option B adopts mobile's
-filterless behavior), the orchestrator-vs-individual-functions constraint for desktop,
-and matching verification items.*
+*Last updated: 2026-06-25 — re-verified against all three repos and marked `ready`, then
+hardened with an independent worth-it review. Key correction vs the 2026-06-18 draft: the
+option-B role/channel reconciliation is already shipped on desktop, so this is now a pure
+extraction, not a behavior change. Replaced the stale "design decision required" section
+with a concrete "Divergences to reconcile" list. The independent review confirmed the
+migration is worth doing (medium-high confidence) and added two divergences the draft
+missed: #7 the `!mapSenderToUser` guard (token-leak risk — keep the guard in desktop's
+wrapper, not the shared fn) and #8 the `@<roleId>` role form (additive/inert for desktop,
+verified via `MessageComposer.tsx:233-234`). Confirmed shared test infra (Vitest + 8 suites),
+the `src/utils` barrel, `SpaceMember`/`Role`/`Channel` exports, zero export-name collisions,
+and the `link:../quorum-shared` consume path.*

--- a/src/components/message/MessageMarkdownRenderer.tsx
+++ b/src/components/message/MessageMarkdownRenderer.tsx
@@ -15,6 +15,13 @@ import {
   extractYouTubeVideoId,
   getValidInvitePrefixes,
   getValidMessageLinkPrefixes,
+  // Message-preprocessing pipeline (shared with mobile — single source of truth).
+  processMentions as sharedProcessMentions,
+  processRoleMentions as sharedProcessRoleMentions,
+  processChannelMentions as sharedProcessChannelMentions,
+  processURLs,
+  convertHeadersToH3,
+  fixUnclosedCodeBlocks,
 } from '@quilibrium/quorum-shared';
 import { remarkTwemoji, getEmojiOnlySize } from '../../utils/remarkTwemoji';
 import { InviteLink } from './InviteLink';
@@ -75,118 +82,8 @@ const processInviteLinks = (text: string): string => {
   });
 };
 
-// Helper type for protected regions
-interface ProtectedRegion {
-  start: number;
-  end: number;
-}
-
-// Extract protected regions where mentions/URLs should NOT be processed
-// This includes: fenced code blocks, inline code, and markdown links
-const getProtectedRegions = (text: string): ProtectedRegion[] => {
-  const protectedRegions: ProtectedRegion[] = [];
-
-  // Extract fenced code blocks (```...```)
-  const codeBlockRegex = /```[\s\S]*?```/g;
-  let match;
-  while ((match = codeBlockRegex.exec(text)) !== null) {
-    protectedRegions.push({ start: match.index, end: match.index + match[0].length });
-  }
-
-  // Extract inline code (`...`)
-  const inlineCodeRegex = /`[^`]+`/g;
-  while ((match = inlineCodeRegex.exec(text)) !== null) {
-    const isInsideCodeBlock = protectedRegions.some(
-      r => match!.index >= r.start && match!.index < r.end
-    );
-    if (!isInsideCodeBlock) {
-      protectedRegions.push({ start: match.index, end: match.index + match[0].length });
-    }
-  }
-
-  // Extract markdown links [text](url)
-  const markdownLinkRegex = /\[([^\]]+)\]\(([^)]+)\)/g;
-  while ((match = markdownLinkRegex.exec(text)) !== null) {
-    const isInsideCodeBlock = protectedRegions.some(
-      r => match!.index >= r.start && match!.index < r.end
-    );
-    if (!isInsideCodeBlock) {
-      protectedRegions.push({ start: match.index, end: match.index + match[0].length });
-    }
-  }
-
-  return protectedRegions;
-};
-
-// Check if an index is inside a protected region
-const isInProtectedRegion = (index: number, protectedRegions: ProtectedRegion[]): boolean => {
-  return protectedRegions.some(r => index >= r.start && index < r.end);
-};
-
-// Stable processing functions outside component to prevent re-creation
-const processURLs = (text: string): string => {
-  // Step 1: Build protected regions (code blocks, inline code, existing markdown links)
-  const protectedRegions: { start: number; end: number }[] = [];
-
-  // Extract fenced code blocks (```...```)
-  const codeBlockRegex = /```[\s\S]*?```/g;
-  let match;
-  while ((match = codeBlockRegex.exec(text)) !== null) {
-    protectedRegions.push({ start: match.index, end: match.index + match[0].length });
-  }
-
-  // Extract inline code (`...`)
-  const inlineCodeRegex = /`[^`]+`/g;
-  while ((match = inlineCodeRegex.exec(text)) !== null) {
-    const isInsideCodeBlock = protectedRegions.some(
-      r => match!.index >= r.start && match!.index < r.end
-    );
-    if (!isInsideCodeBlock) {
-      protectedRegions.push({ start: match.index, end: match.index + match[0].length });
-    }
-  }
-
-  // Extract existing markdown links [text](url)
-  const markdownLinkRegex = /\[([^\]]+)\]\(([^)]+)\)/g;
-  while ((match = markdownLinkRegex.exec(text)) !== null) {
-    const isInsideCodeBlock = protectedRegions.some(
-      r => match!.index >= r.start && match!.index < r.end
-    );
-    if (!isInsideCodeBlock) {
-      protectedRegions.push({ start: match.index, end: match.index + match[0].length });
-    }
-  }
-
-  // Step 2: Find all URLs and convert only those not in protected regions
-  const urlRegex = /https?:\/\/[^\s<>"{}|\\^`[\]]+/g;
-  const urlMatches: { index: number; url: string }[] = [];
-  while ((match = urlRegex.exec(text)) !== null) {
-    urlMatches.push({ index: match.index, url: match[0] });
-  }
-
-  // Filter out URLs in protected regions
-  const validUrls = urlMatches.filter(({ index }) => {
-    return !protectedRegions.some(r => index >= r.start && index < r.end);
-  });
-
-  // Step 3: Replace URLs from end to start to avoid index shifting
-  let result = text;
-  for (let i = validUrls.length - 1; i >= 0; i--) {
-    const { index, url } = validUrls[i];
-    const beforeUrl = result.substring(0, index);
-    const afterUrl = result.substring(index + url.length);
-
-    // Additional check: angle bracket autolinks <URL>
-    if (beforeUrl.endsWith('<') && afterUrl.startsWith('>')) {
-      continue; // Don't modify - already in angle bracket autolink
-    }
-
-    // Convert URL to markdown link
-    result = beforeUrl + `[${url}](${url})` + afterUrl;
-  }
-
-  return result;
-};
+// processURLs, getProtectedRegions, isInProtectedRegion now come from
+// @quilibrium/quorum-shared (the shared message-preprocessing pipeline).
 
 const processStandaloneYouTubeUrls = (text: string): string => {
   // Split text into lines first
@@ -249,208 +146,29 @@ export const MessageMarkdownRenderer: React.FC<MessageMarkdownRendererProps> = (
   embeddedMedia,
 }) => {
 
-  // Convert H1 and H2 headers to H3 since only H3 is allowed
-  const convertHeadersToH3 = (text: string): string => {
-    // Don't convert headers inside code blocks
-    const codeBlockRegex = /```[\s\S]*?```/g;
-    const codeBlocks: string[] = [];
+  // convertHeadersToH3 and fixUnclosedCodeBlocks now come from
+  // @quilibrium/quorum-shared (the shared message-preprocessing pipeline).
 
-    // Extract code blocks and replace with placeholders
-    let textWithPlaceholders = text.replace(codeBlockRegex, (match) => {
-      codeBlocks.push(match);
-      return `__CODE_BLOCK_${codeBlocks.length - 1}__`;
-    });
-
-    // Convert H1 and H2 to H3
-    textWithPlaceholders = textWithPlaceholders
-      .replace(/^##\s/gm, '### ')  // H2 to H3
-      .replace(/^#\s/gm, '### ');  // H1 to H3
-
-    // Restore code blocks
-    codeBlocks.forEach((block, index) => {
-      textWithPlaceholders = textWithPlaceholders.replace(`__CODE_BLOCK_${index}__`, block);
-    });
-
-    return textWithPlaceholders;
-  };
-
-  // Fix unclosed code blocks by adding missing closing ```
-  const fixUnclosedCodeBlocks = (text: string): string => {
-    // Split by ``` to analyze the structure
-    const parts = text.split('```');
-
-    // If odd number of parts, we have an unclosed code block
-    if (parts.length % 2 === 0) {
-      // Find the last opening ``` and close it properly
-      const lastPart = parts[parts.length - 1];
-      // Add closing ``` on a new line to ensure proper formatting
-      return text + (lastPart.endsWith('\n') ? '```' : '\n```');
-    }
-
-    return text;
-  };
-
-  // Process mentions to show displayNames with proper styling and click handling
-  // Only process mentions that have word boundaries AND are not inside protected regions
-  // Protected regions: code blocks, inline code, markdown links
+  // Process mentions → tokens. Delegates to the shared pipeline; the desktop
+  // wrapper keeps the `!mapSenderToUser` guard so contexts without a user
+  // resolver (e.g. some bookmark/preview surfaces) leave `@<address>` as plain
+  // text instead of emitting a raw token that wouldn't be rendered. Desktop
+  // never produced legacy bare-`@name` mentions, so it passes no members.
+  // `hasEveryoneMention` is desktop's authorization signal → `everyoneAuthorized`.
   const processMentions = useCallback((text: string): string => {
     if (!mapSenderToUser) return text;
-
-    // Get protected regions (code blocks, inline code, markdown links)
-    const protectedRegions = getProtectedRegions(text);
-
-    let processedText = text;
-
-    // Only style @everyone if the message has mentions.everyone = true and has word boundaries
-    if (hasEveryoneMention) {
-      const everyoneMatches = Array.from(text.matchAll(/@everyone\b/gi));
-
-      // Collect valid matches (not in protected regions and has word boundaries)
-      const validMatches = [];
-      for (const match of everyoneMatches) {
-        if (!isInProtectedRegion(match.index!, protectedRegions) && hasWordBoundaries(text, match)) {
-          validMatches.push(match);
-        }
-      }
-
-      // Replace from end to beginning to avoid index shifting
-      for (let i = validMatches.length - 1; i >= 0; i--) {
-        const match = validMatches[i];
-        const beforeText = processedText.substring(0, match.index);
-        const afterText = processedText.substring(match.index! + match[0].length);
-        processedText = beforeText + '<<<MENTION_EVERYONE>>>' + afterText;
-      }
-    }
-
-    // Replace @<address> with safe placeholder token only if it has word boundaries
-    // Using centralized IPFS CID validation pattern
-    // NOTE: Must match against processedText (not original text) since @everyone replacements change indices
-    const cidPattern = createIPFSCIDRegex().source; // Get the pattern without global flag
-    const userMentionRegex = new RegExp(`@<(${cidPattern})>`, 'g');
-    const userMatches = Array.from(processedText.matchAll(userMentionRegex));
-
-    // Process matches in reverse order to avoid index shifting issues
-    // Filter out matches in protected regions (using original text indices for protected region check)
-    // Note: Protected regions are calculated on original text, but since we only replaced @everyone
-    // with a longer token, protected region checks are still valid (mentions in code blocks stay in code blocks)
-    const validUserMatches = [];
-    for (const match of userMatches) {
-      if (hasWordBoundaries(processedText, match)) {
-        // Check if this position in original text was in a protected region
-        // Since @everyone tokens are longer, we can't use original indices directly
-        // Instead, check if the match content appears to be inside a code block in processedText
-        const isInCodeBlock = isInProtectedRegion(match.index!, getProtectedRegions(processedText));
-        if (!isInCodeBlock) {
-          validUserMatches.push(match);
-        }
-      }
-    }
-
-    // Replace from end to beginning to avoid index shifting
-    for (let i = validUserMatches.length - 1; i >= 0; i--) {
-      const match = validUserMatches[i];
-      const address = match[1];
-      const beforeText = processedText.substring(0, match.index);
-      const afterText = processedText.substring(match.index! + match[0].length);
-      processedText = beforeText + `<<<MENTION_USER:${address}>>>` + afterText;
-    }
-
-    return processedText;
+    return sharedProcessMentions(text, [], hasEveryoneMention);
   }, [mapSenderToUser, hasEveryoneMention]);
 
-  // Process role mentions - render a pill for any @roleTag that names a role
-  // that actually exists in the space (resolved directly from spaceRoles).
-  // Only process mentions that have word boundaries AND are not inside protected regions.
+  // Role mentions → tokens. Resolves directly from spaceRoles (option B —
+  // identical @roleTag text renders consistently; pill = "names a real role").
   const processRoleMentions = useCallback((text: string): string => {
-    if (!spaceRoles || spaceRoles.length === 0) {
-      return text;
-    }
-
-    // Tokenize every existing role's tag. We no longer gate on a pre-extracted
-    // message.mentions.roleIds set: identical @roleTag text renders consistently
-    // regardless of whether it was picked from the @ menu. (Pill = "names a real
-    // role", not "pinged that role" — the notification path is separate.)
-    const roleData = spaceRoles.map(role => ({
-      roleTag: role.roleTag,
-      displayName: role.displayName,
-    }));
-
-    // Replace @roleTag with safe placeholder (only if it has word boundaries and not in protected region)
-    // NOTE: Must re-match and recalculate protected regions after each role replacement
-    // because replacements change string indices
-    let processed = text;
-    roleData.forEach(({ roleTag, displayName }) => {
-      // Recalculate protected regions on current processed text
-      const protectedRegions = getProtectedRegions(processed);
-      const regex = new RegExp(`@${roleTag}(?!\\w)`, 'g');
-      const matches = Array.from(processed.matchAll(regex));
-
-      // Collect valid matches (not in protected regions and has word boundaries)
-      const validMatches = [];
-      for (const match of matches) {
-        if (!isInProtectedRegion(match.index!, protectedRegions) && hasWordBoundaries(processed, match)) {
-          validMatches.push(match);
-        }
-      }
-
-      // Replace from end to beginning to avoid index shifting
-      for (let i = validMatches.length - 1; i >= 0; i--) {
-        const match = validMatches[i];
-        const beforeText = processed.substring(0, match.index);
-        const afterText = processed.substring(match.index! + match[0].length);
-        processed = beforeText + `<<<MENTION_ROLE:${roleTag}:${displayName}>>>` + afterText;
-      }
-    });
-
-    return processed;
+    return sharedProcessRoleMentions(text, spaceRoles);
   }, [spaceRoles]);
 
-  // Process channel mentions - render a pill for any #<channelId> that names a
-  // channel that actually exists in the space (resolved directly from spaceChannels).
-  // Only process mentions that have word boundaries AND are not inside protected regions.
+  // Channel mentions → tokens. Resolves directly from spaceChannels.
   const processChannelMentions = useCallback((text: string): string => {
-    if (!spaceChannels || spaceChannels.length === 0) {
-      return text;
-    }
-
-    // Tokenize every existing channel id. No longer gated on a pre-extracted
-    // message.mentions.channelIds set (see processRoleMentions for the rationale).
-    const channelData = spaceChannels.map(channel => ({
-      channelId: channel.channelId,
-      channelName: channel.channelName,
-    }));
-
-    // Replace #<channelId> with safe placeholder (only if it has word boundaries and not in protected region)
-    // NOTE: Must re-match and recalculate protected regions after each channel replacement
-    // because replacements change string indices
-    let processed = text;
-    channelData.forEach(({ channelId, channelName }) => {
-      // Recalculate protected regions on current processed text
-      const protectedRegions = getProtectedRegions(processed);
-      // Escape special regex characters in channel ID
-      const escapedChannelId = channelId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-
-      const channelRegex = new RegExp(`#<${escapedChannelId}>`, 'g');
-      const matches = Array.from(processed.matchAll(channelRegex));
-
-      // Collect valid matches (not in protected regions and has word boundaries)
-      const validMatches = [];
-      for (const match of matches) {
-        if (!isInProtectedRegion(match.index!, protectedRegions) && hasWordBoundaries(processed, match)) {
-          validMatches.push(match);
-        }
-      }
-
-      // Replace from end to beginning to avoid index shifting
-      for (let i = validMatches.length - 1; i >= 0; i--) {
-        const match = validMatches[i];
-        const beforeText = processed.substring(0, match.index);
-        const afterText = processed.substring(match.index! + match[0].length);
-        processed = beforeText + `<<<MENTION_CHANNEL:${channelId}:${channelName}>>>` + afterText;
-      }
-    });
-
-    return processed;
+    return sharedProcessChannelMentions(text, spaceChannels);
   }, [spaceChannels]);
 
   // Process message links to convert them to styled tokens (same-space only)


### PR DESCRIPTION
## What

Refactors `MessageMarkdownRenderer.tsx` to consume the message-preprocessing pipeline from `@quilibrium/quorum-shared` instead of its inlined copy. Removes ~280 lines of duplication (net **−282**: 305 deleted, 23 added). The `<<<MENTION_*>>>` token vocabulary is a cross-platform protocol now sourced from one place.

## Changes

- Import `processMentions`, `processRoleMentions`, `processChannelMentions`, `processURLs`, `convertHeadersToH3`, `fixUnclosedCodeBlocks`, `getProtectedRegions`/`isInProtectedRegion` from shared.
- Delete the inlined module-level + component-body copies of those functions.
- Thin `useCallback` wrappers delegate to the shared pure functions.

## Desktop-specific behavior preserved

- **`!mapSenderToUser` guard** stays in the desktop wrapper, so contexts without a user resolver (e.g. bookmark/preview surfaces) leave `@<address>` as plain text — never a leaked raw `<<<MENTION_USER:…>>>` token.
- `hasEveryoneMention` maps to the shared `everyoneAuthorized` gate.
- Pipeline order unchanged (`processMessageLinks` before `processURLs`); the desktop-only steps (invite links, standalone YouTube, message links, `processMentionTokens`) stay inlined.

## Verification

- ✅ `npx tsc --noEmit` — exit 0
- ✅ `eslint` on the file — exit 0 (one pre-existing `embeddedMedia` exhaustive-deps warning, present on `main`)
- ✅ `yarn build` — ✓ built in 52s
- ✅ Visual smoke: inline formatting (bold/italic/strike/code) renders correctly. (Full multi-block paste smoke is blocked by a pre-existing, unrelated composer paste bug — see `.agents/bugs/2026-06-25-composer-paste-strips-newlines.md`; the renderer receives already-flattened text in that case.)

## ⚠️ Gated on shared

Depends on **quorum-shared#52** (the producer). Merge that first (with its version bump); then bump `@quilibrium/quorum-shared` here to the published version. Desktop currently resolves shared via `link:../quorum-shared`, so CI needs the published version to build.

Also moves the completed icon-picker migration task files to `.done/` (separate housekeeping commit).