### PR TITLE
fix: composer flattens multi-line input into a single line

### DIFF
--- a/.agents/INDEX.md
+++ b/.agents/INDEX.md
@@ -122,7 +122,6 @@ This is the main index for all documentation, bug reports, and task management.
 - [Desktop shows stale synced config until restart](bugs/2026-06-13-config-not-refetched-stale-until-restart.md)
 - [Space members show truncated address — no `space_members` row](bugs/2026-06-13-space-members-missing-no-join-row.md)
 - [Sync path hardcodes `'post'` in the signature messageId recompute → non-post signatures nulled](bugs/2026-06-14-sync-path-hardcodes-post-type-nulls-nonpost-signatures.md)
-- [Composer flattens multi-line paste into a single line (contentEditable newlines lost) — FIX in progress](bugs/2026-06-25-composer-paste-strips-newlines.md)
 
 ### Solved Issues
 - [Icon Color Not Saving Issue](bugs/.solved/2025-01-15-icon-color-not-saving-issue.md)
@@ -164,6 +163,7 @@ This is the main index for all documentation, bug reports, and task management.
 - [Per-space mention-type filter doesn't sync across devices](bugs/.solved/2026-06-07-mention-type-filter-not-synced.md)
 - [`Save Changes` in Account tab throws "missing inbox configuration"](bugs/.solved/2026-06-07-space-profile-save-missing-inbox.md)
 - [Sync path hardcodes `'post'` in the signature messageId recompute → non-post signatures nulled](bugs/.solved/2026-06-14-sync-path-hardcodes-post-type-nulls-nonpost-signatures.md)
+- [Composer flattens multi-line paste into a single line](bugs/.solved/2026-06-25-composer-paste-strips-newlines.md)
 - [Bug: Emoji Picker Grid Has Empty Space on Right Side in Mobile Drawer](bugs/.solved/emoji-picker-mobile-drawer-empty-space.md)
 - [Channel/Group Save Race Condition](bugs/.solved/channel-group-save-race-condition.md)
 - [Config Save Missing React Query Cache Update Causes Stale allowSync](bugs/.solved/config-save-stale-cache-allowsync.md)
@@ -199,10 +199,6 @@ This is the main index for all documentation, bug reports, and task management.
 - [Application-owned scroll anchoring for the message list (β)](tasks/2026-05-24-virtuoso-application-owned-scroll-anchoring.md)
 - [Unify Account tab's defer-vs-instant control semantics](tasks/2026-06-07-account-tab-defer-save-unification.md)
 - [UserProfile card layout polish pass](tasks/2026-06-08-userprofile-card-layout-polish.md)
-
-### Done Tasks
-- [Move image compression config + orchestration into quorum-shared (desktop side)](tasks/.done/2026-06-24-share-image-compression-config-with-shared.md)
-- [Close EXIF/metadata stripping gaps on image uploads](tasks/.done/2026-06-24-strip-image-exif-metadata-gaps.md)
 
 ### .Archived
 - [🚀 Search Performance Optimization - Revised Implementation Plan](tasks/.archived/2025-11-12-search-performance-optimization-original.md)
@@ -331,8 +327,6 @@ This is the main index for all documentation, bug reports, and task management.
 - [Port-to-mobile — desktop → mobile feature diff](tasks/port-to-mobile/README.md)
 
 ### Quorum Shared Migration
-- [Icon-picker vocabulary — implementation status & PR sequencing](tasks/quorum-shared-migration/.done/2026-06-12-icon-picker-PR-notes.md) ✓ done
-- [Promote the icon-picker vocabulary to quorum-shared](tasks/quorum-shared-migration/.done/2026-06-12-promote-icon-picker-vocabulary-to-shared.md) ✓ done
 - [Promote the message-preprocessing pipeline to quorum-shared](tasks/quorum-shared-migration/2026-06-18-promote-message-preprocessing-to-shared.md)
 - [Cross-repo PR workflow for the quorum-shared migration](tasks/quorum-shared-migration/cross-repo-workflow.md)
 - [Mobile tasks — where to find them](tasks/quorum-shared-migration/mobile-tasks-pending.md)
@@ -351,6 +345,8 @@ This is the main index for all documentation, bug reports, and task management.
 - [useTwoStepConfirm — extract two-step confirmation primitive to shared](tasks/quorum-shared-migration/.done/2026-05-28-migrate-use-two-step-confirm.md)
 - [Validation hooks — move logic to shared with errorKey i18n pattern](tasks/quorum-shared-migration/.done/2026-05-28-migrate-validation-hooks.md)
 - [Extract role-mutation pure helpers to `@quilibrium/quorum-shared`](tasks/quorum-shared-migration/.done/2026-05-29-migrate-role-mutation-helpers.md)
+- [Icon-picker vocabulary — implementation status & PR sequencing](tasks/quorum-shared-migration/.done/2026-06-12-icon-picker-PR-notes.md)
+- [Promote the icon-picker vocabulary to quorum-shared](tasks/quorum-shared-migration/.done/2026-06-12-promote-icon-picker-vocabulary-to-shared.md)
 
 ### Quorum Shared Migration Designs
 - [Utilities Migration Design](tasks/quorum-shared-migration/designs/2026-03-18-utils-design.md)
@@ -465,6 +461,8 @@ This is the main index for all documentation, bug reports, and task management.
 - [Global Notification Panel (Desktop) — Design](tasks/.done/2026-06-23-global-notification-panel-design.md)
 - [Global Notification Panel (Desktop) Implementation Plan](tasks/.done/2026-06-23-global-notification-panel-plan.md)
 - [Notification-type settings: stale read in the settings modal (+ clobber-on-save)](tasks/.done/2026-06-23-notification-settings-stale-read-and-clobber.md)
+- [Move image compression config + orchestration into quorum-shared (desktop side)](tasks/.done/2026-06-24-share-image-compression-config-with-shared.md)
+- [Close EXIF/metadata stripping gaps on image uploads](tasks/.done/2026-06-24-strip-image-exif-metadata-gaps.md)
 - [AccentColorSwitcher Cross-Platform Migration + Persistence](tasks/.done/accent-color-switcher-cross-platform-migration.md)
 - [Add Context to Desktop Notifications](tasks/.done/rich-desktop-notifications-context.md)
 - [Add DM-Specific Action Queue Handlers](tasks/.done/dm-action-queue-handlers.md)
@@ -655,4 +653,4 @@ This is the main index for all documentation, bug reports, and task management.
 
 ---
 
-**Last Updated**: 2026-06-24 10:02:52
+**Last Updated**: 2026-06-25 11:03:31

--- a/.agents/INDEX.md
+++ b/.agents/INDEX.md
@@ -122,6 +122,7 @@ This is the main index for all documentation, bug reports, and task management.
 - [Desktop shows stale synced config until restart](bugs/2026-06-13-config-not-refetched-stale-until-restart.md)
 - [Space members show truncated address — no `space_members` row](bugs/2026-06-13-space-members-missing-no-join-row.md)
 - [Sync path hardcodes `'post'` in the signature messageId recompute → non-post signatures nulled](bugs/2026-06-14-sync-path-hardcodes-post-type-nulls-nonpost-signatures.md)
+- [Composer flattens multi-line paste into a single line (contentEditable newlines lost) — FIX in progress](bugs/2026-06-25-composer-paste-strips-newlines.md)
 
 ### Solved Issues
 - [Icon Color Not Saving Issue](bugs/.solved/2025-01-15-icon-color-not-saving-issue.md)

--- a/.agents/bugs/.solved/2026-06-25-composer-paste-strips-newlines.md
+++ b/.agents/bugs/.solved/2026-06-25-composer-paste-strips-newlines.md
@@ -1,9 +1,11 @@
 ---
 type: bug
 title: "Composer flattens multi-line paste into a single line (contentEditable newlines lost)"
-status: open
+status: solved
 severity: medium
 created: 2026-06-25
+solved: 2026-06-25
+fixed-in: src/utils/mentionPillDom.ts (extractStorageTextFromEditor — newline reconstruction)
 area: message composer
 component: src/components/message/MessageComposer.tsx
 related:
@@ -11,6 +13,25 @@ related:
   - src/hooks/business/mentions/useMentionPillEditor.ts (wraps the serializer)
   - src/components/message/MessageMarkdownRenderer.tsx (the renderer — NOT the cause; receives already-flattened text)
 ---
+
+## RESOLVED 2026-06-25
+
+Fixed by reconstructing newlines in `extractStorageTextFromEditor`
+(`src/utils/mentionPillDom.ts`): emit `\n` for `<br>` and at block-element
+(`<div>`/`<p>`) boundaries, skipping the trailing filler `<br>` / `<div><br></div>`
+empty-line case to avoid double newlines. Covered by
+`src/dev/tests/utils/mentionPillDom.unit.test.ts` (13 cases).
+
+Both reported symptoms verified fixed in-app by the user:
+1. Multi-line messages no longer collapse onto one line.
+2. A pasted unclosed code fence now renders correctly (was an empty code box —
+   same root cause: with newlines restored, the fence sits on its own line, so
+   `fixUnclosedCodeBlocks` sees valid input and the content is no longer misread
+   as the code language identifier).
+
+Both symptoms shared the single newline-flattening root cause; one fix resolved
+both. The shared `fixUnclosedCodeBlocks` was never wrong — it only received
+pre-flattened input.
 
 # Composer flattens multi-line paste into a single line
 

--- a/.agents/bugs/2026-06-25-composer-paste-strips-newlines.md
+++ b/.agents/bugs/2026-06-25-composer-paste-strips-newlines.md
@@ -1,0 +1,158 @@
+---
+type: bug
+title: "Composer flattens multi-line paste into a single line (contentEditable newlines lost)"
+status: open
+severity: medium
+created: 2026-06-25
+area: message composer
+component: src/components/message/MessageComposer.tsx
+related:
+  - src/utils/mentionPillDom.ts (extractStorageTextFromEditor — the serializer that drops newlines)
+  - src/hooks/business/mentions/useMentionPillEditor.ts (wraps the serializer)
+  - src/components/message/MessageMarkdownRenderer.tsx (the renderer — NOT the cause; receives already-flattened text)
+---
+
+# Composer flattens multi-line paste into a single line
+
+## Symptom
+
+Pasting multi-line / multi-block markdown into the message composer and sending
+it produces a message where every line is concatenated onto one line. Block
+structure collapses: headers, lists, blockquotes, and tables all run together
+into a single paragraph. Inline formatting (`**bold**`, `*italic*`, `~~strike~~`,
+`` `code` ``) still renders correctly — only the line breaks between blocks are
+lost.
+
+Observed 2026-06-25 while smoke-testing the markdown renderer: a multi-block test
+message rendered as
+`Header (already H3)**Bold text** and ... Blockquote with bold inside- Unordered list item 1...`
+— one flowed line. (Screenshot in session.)
+
+## Root cause (confirmed in code)
+
+The composer is a `contentEditable` `<div>`, not a `<textarea>`. Its content is
+serialized back to a storage string by `extractStorageTextFromEditor` in
+`src/utils/mentionPillDom.ts:142`. That walker handles three cases:
+
+- text node → append `textContent`
+- mention pill element → append the `@<addr>` / `#<id>` / `@roleTag` token
+- any other element → **recurse into its children** (line 165)
+
+It **never emits a `\n` for block-level elements**. When the browser pastes
+multi-line text into a `contentEditable`, it represents line breaks as `<div>`
+wrappers and/or `<br>` elements. The walker recurses through `<div>`s and ignores
+`<br>`s, so all line breaks are dropped and the result is a single line.
+
+The paste handler itself (`MessageComposer.tsx:315-320`) is not the culprit — it
+does `e.clipboardData.getData('text/plain')` (which still contains the `\n`s) and
+inserts via `document.execCommand('insertText', …)`. The newlines survive into
+the DOM as block elements; they're lost only when the DOM is serialized back out
+by `extractStorageTextFromEditor`.
+
+## Regression window (when it was introduced)
+
+This is a **regression**, not a day-one limitation. The composer has two input
+modes gated by the `ENABLE_MENTION_PILLS` feature flag:
+
+- **Flag OFF / pre-pills:** a plain `<TextArea>` whose `.value` preserves `\n`
+  natively. Multi-line messages worked.
+- **Flag ON:** a `contentEditable` `<div>` whose content must be serialized to a
+  string by hand via `extractStorageTextFromEditor` (introduced in commit
+  `36292659` "refactor: extract mention pills into shared utilities", 2026-01-09,
+  which consolidated the pre-existing pill/contentEditable logic into
+  `mentionPillDom.ts` + `useMentionPillEditor`).
+
+The newline loss appears when the contentEditable pills path is active. The
+serializer never handled block-element newlines, so enabling pills (or that path
+becoming the default) is the regression point. There is no prior newline-aware
+serializer to restore — the fix is to add `\n` reconstruction to the walker.
+
+A secondary nit: the serializer ends with `return text.trim()` (line 171), which
+also strips leading/trailing blank lines, but that's minor next to the
+intra-message flattening.
+
+## NOT related to the shared message-preprocessing migration
+
+This was found during testing of the renderer refactor (consume shared
+`messagePreprocessing` in `MessageMarkdownRenderer.tsx`), but it is independent
+and pre-existing:
+
+- The bug is in the **composer's DOM→string serialization**, upstream of the
+  renderer. The renderer only ever sees the already-flattened string.
+- The shared preprocessing functions perform **zero** newline-touching
+  operations on the desktop path (verified: no `\n`-stripping `replace`/`split`
+  in `messagePreprocessing.ts`; the only `\r\n?→\n` normalize lives in
+  `prepareMessageContent`, which desktop does not call). So the refactor cannot
+  add or remove this behavior.
+- It reproduces identically on `main` (the serializer is unchanged by the
+  refactor).
+
+## Knock-on symptom: pasted fenced code blocks render EMPTY
+
+A sharper failure mode of the same root cause, confirmed 2026-06-25. Pasting a
+fenced code block:
+
+```​
+this fence is never closed
+the renderer should still treat it as code
+```​
+
+flattens to a single line ` ``` this fence is never closed … code`. react-markdown
+then reads the text after the opening ` ``` ` on the same line as the code block's
+**info string (language identifier)**, not as content — so the body is empty and
+the renderer shows an empty code box. The content is silently swallowed into a
+bogus "language" tag.
+
+This is NOT a bug in `fixUnclosedCodeBlocks` (shared
+`messagePreprocessing.ts`) — that function is correct: given the un-flattened
+multi-line input it produces a properly-closed block with content intact
+(verified by tracing the function directly). It only misbehaves because it
+receives already-flattened single-line input from the composer. Fixing the
+newline serialization fixes this too.
+
+When the serializer fix lands, re-verify this exact fenced-code paste case — the
+info-string corruption is a distinct, easy-to-miss symptom beyond "lines run
+together."
+
+## Likely fix (to validate when we tackle it)
+
+In `extractStorageTextFromEditor` (`mentionPillDom.ts`), emit `\n` for block
+boundaries during the walk:
+
+- Append `\n` when encountering a `<br>` element.
+- Append `\n` between block-level child containers (`<div>`, `<p>`) — browsers
+  wrap each visual line of a `contentEditable` in its own `<div>` after the
+  first, so a `\n` before each non-first block `<div>` reconstructs the line
+  structure.
+
+Care needed:
+- Don't double-count (`<div><br></div>` is a common empty-line representation —
+  emitting `\n` for both the div boundary and the `<br>` would produce two
+  newlines for one empty line).
+- Preserve the existing pill/text/`@everyone` serialization exactly (wire format
+  must not change).
+- Re-check the trailing `.trim()` — switch to trimming only outer blank lines if
+  intentional leading/trailing structure matters, otherwise leave as-is.
+- Cross-check `extractVisualText` (uses `textContent`, same newline-loss) if any
+  caller relies on it for multi-line.
+
+Add a unit test for the serializer with a multi-`<div>` / `<br>` fixture once the
+fix lands (the function is pure DOM→string and testable with jsdom).
+
+## Repro
+
+1. Copy a multi-line markdown block (e.g. a header line + blank line + a list).
+2. Paste into the composer in any channel/DM.
+3. Send.
+4. Observed: one flowed line. Expected: blocks render on separate lines.
+
+## Workaround for testing the renderer in the meantime
+
+Send one small block at a time as separate messages (single header, single
+mention, single URL each), so no message needs internal line breaks to survive.
+
+Note: it is NOT yet verified whether *typed* multi-line input (Enter / Shift+Enter
+in the composer) survives serialization — typed line breaks also become
+`<div>`/`<br>` in the contentEditable, so the same serializer may flatten them too.
+Confirm this when tackling the fix; until then, the only reliable workaround is
+one-block-per-message.

--- a/.agents/docs/features/messages/markdown-renderer.md
+++ b/.agents/docs/features/messages/markdown-renderer.md
@@ -53,6 +53,7 @@ Messages automatically detect markdown patterns and render with enhanced formatt
 
 - `src/components/message/MessageMarkdownRenderer.tsx` - Main renderer component
 - `src/components/message/MarkdownToolbar.tsx` - Discord-style formatting toolbar
+- `@quilibrium/quorum-shared` (`src/utils/messagePreprocessing.ts`) - **Shared message-preprocessing pipeline** (moved to shared 2026-06-25, single source of truth with mobile): `processMentions`, `processRoleMentions`, `processChannelMentions`, `processURLs`, `convertHeadersToH3`, `fixUnclosedCodeBlocks`, `getProtectedRegions`/`isInProtectedRegion`, `hasMarkdown`, `prepareMessageContent`. Desktop imports the individual functions; mobile uses the `prepareMessageContent` orchestrator.
 - `@quilibrium/quorum-shared` (`src/utils/youtubeUtils.ts`) - Centralized YouTube URL utilities (moved to shared package)
 - `src/utils/codeFormatting.ts` - Code block analysis utilities
 - `src/utils/markdownFormatting.ts` - Markdown formatting functions for toolbar
@@ -74,13 +75,18 @@ The message rendering system maintains **two independent rendering paths** for r
 
 **Supported Features**:
 - ✅ Markdown formatting (`**bold**`, `*italic*`, code blocks, tables, etc.)
-- ✅ User mentions (`@<address>`) via safe placeholder tokens with display name lookup
-- ✅ Role mentions (`@role`) via safe placeholder tokens
-- ✅ Channel mentions (`#<channelId>`) via safe placeholder tokens with channel name lookup
+- ✅ User mentions (`@<address>`) via safe placeholder tokens, display name resolved at render time
+- ✅ Role mentions (`@roleTag`) via safe placeholder tokens, resolved filterless from `spaceRoles`
+- ✅ Channel mentions (`#<channelId>`) via safe placeholder tokens, resolved filterless from `spaceChannels`
 - ✅ YouTube embeds (standalone URLs) and links (inline URLs)
 - ✅ Regular URL auto-linking
 - ✅ Invite links (via placeholder tokens)
-- ✅ Security hardened (no HTML injection, XSS protection, display name security)
+- ✅ Security hardened (no HTML injection, XSS protection, render-time name resolution)
+
+> The mention/URL/header/fence preprocessing comes from the **shared** module
+> (`@quilibrium/quorum-shared` → `messagePreprocessing.ts`); the desktop-only
+> steps (invite links, standalone YouTube, message links) and the token→React
+> renderer (`processMentionTokens`) remain in `MessageMarkdownRenderer.tsx`.
 
 **Security Architecture**:
 - Uses placeholder token system (`<<<TOKEN>>>`) for dynamic content
@@ -90,7 +96,7 @@ The message rendering system maintains **two independent rendering paths** for r
 
 ### System 2: Token-Based Rendering (Fallback Path)
 
-**Location**: `src/components/message/Message.tsx` (lines 664-744)
+**Location**: `src/components/message/Message.tsx` (the `else` branch after the `ENABLE_MARKDOWN && shouldUseMarkdown()` check, ~line 1209+)
 **Activation**: When `ENABLE_MARKDOWN === false` OR `shouldUseMarkdown()` returns false
 **Current behavior**: Unreachable code (kept for emergency fallback)
 
@@ -107,6 +113,24 @@ The message rendering system maintains **two independent rendering paths** for r
 2. **Backward compatibility**: Existing code path maintained for safety
 3. **Feature completeness**: Includes invite link support that was later added to MessageMarkdownRenderer
 4. **Testing**: Useful for comparing rendering behavior
+
+> ⚠️ **System 1 / System 2 divergence — role & channel resolution.** The two
+> paths use independent engines, so their mention behavior differs:
+> - **System 1** (MessageMarkdownRenderer, active): role/channel mentions resolve
+>   **filterless** from the `spaceRoles`/`spaceChannels` arrays (option B,
+>   2026-06-25, via the shared `messagePreprocessing` functions). Any `@roleTag` /
+>   `#<channelId>` that names a role/channel existing in the space becomes a pill.
+> - **System 2** (token-based fallback, unreachable): still resolves via
+>   `useMessageFormatting.ts` `processTextToken()`, which only styles a role/channel
+>   if its id is in the message's pre-extracted `message.mentions.roleIds` /
+>   `channelIds` set.
+>
+> This is invisible today because `shouldUseMarkdown()` always returns `true`, so
+> System 2 never runs. But if `ENABLE_MARKDOWN` is ever flipped to `false`, the same
+> message could render role/channel pills differently between the two paths. If the
+> fallback is ever reactivated, align `processTextToken()` to the filterless
+> behavior (or accept the difference deliberately). System 2 was NOT updated during
+> the 2026-06-25 preprocessing-to-shared migration — only System 1 was.
 
 ### Routing Decision Flow
 
@@ -148,48 +172,54 @@ if (ENABLE_MARKDOWN && formatting.shouldUseMarkdown()) {
 
 ## Architecture
 
-### **Processing Pipeline (Security Hardened 2025-11-07)**
+### **Processing Pipeline (Security Hardened 2025-11-07; preprocessing moved to shared 2026-06-25)**
+
+The pure string→string preprocessing transforms now live in
+`@quilibrium/quorum-shared` (`src/utils/messagePreprocessing.ts`) and are shared
+with mobile — they are the single canonical producer of the `<<<MENTION_*>>>`
+token protocol that `markdownStripping` also consumes. Desktop imports the
+**individual** functions and calls them in its own order (it does NOT call the
+shared `prepareMessageContent` orchestrator, because it interleaves desktop-only
+steps and must run `processMessageLinks` before `processURLs`).
 
 ```typescript
-// Stable processing functions (outside component scope)
-const processURLs = (text: string): string => {
-  /* Convert URLs to markdown links (protects code blocks, inline code, existing md links) */
-};
+// Imported from @quilibrium/quorum-shared (shared with mobile):
+//   processMentions, processRoleMentions, processChannelMentions,
+//   processURLs, convertHeadersToH3, fixUnclosedCodeBlocks,
+//   getProtectedRegions / isInProtectedRegion, hasMarkdown
+// (the renderer aliases the mention ones, e.g. sharedProcessMentions)
 
-const processStandaloneYouTubeUrls = (text: string): string => {
-  /* Detect standalone YouTube URLs and convert to markdown image syntax */
-  /* Inline YouTube URLs remain as plain URLs for link processing */
-};
+// Still DESKTOP-INLINED in MessageMarkdownRenderer.tsx (mobile defers these to
+// its facade tasks, so they were intentionally NOT promoted):
+//   processInviteLinks, processStandaloneYouTubeUrls, processMessageLinks,
+//   processMentionTokens (the token → React renderer)
 
-const processMentions = (text: string): string => {
-  /* Replace @mentions with safe placeholder tokens: <<<MENTION_USER:address>>> */
-  /* Prevents markdown interpretation and XSS attacks */
-};
+// Thin desktop wrappers delegate to the shared pure functions:
+const processMentions = useCallback((text: string): string => {
+  if (!mapSenderToUser) return text;                    // desktop-only guard (see below)
+  return sharedProcessMentions(text, [], hasEveryoneMention);
+}, [mapSenderToUser, hasEveryoneMention]);
 
-const processRoleMentions = (text: string): string => {
-  /* Replace @role mentions with safe placeholders */
-};
+const processRoleMentions = useCallback(
+  (text: string) => sharedProcessRoleMentions(text, spaceRoles),    // filterless (option B)
+  [spaceRoles],
+);
+const processChannelMentions = useCallback(
+  (text: string) => sharedProcessChannelMentions(text, spaceChannels),
+  [spaceChannels],
+);
 
-const processChannelMentions = (text: string): string => {
-  /* Replace #channel mentions with safe placeholders */
-};
-
-const processMessageLinks = (text: string): string => {
-  /* Replace message URLs with <<<MESSAGE_LINK:channelId:messageId:channelName>>> */
-  /* Same-space only, protects code blocks/inline code/markdown links */
-};
-
-// Processing pipeline (order matters!)
+// Processing pipeline (order matters! — processMessageLinks BEFORE processURLs)
 const processedContent = useMemo(() => {
   return fixUnclosedCodeBlocks(
     convertHeadersToH3(
       processURLs(                    // Last: convert remaining URLs to links
-        processMessageLinks(          // Before URLs: extract message links
+        processMessageLinks(          // Before URLs: extract message links (desktop-only)
           processChannelMentions(
             processRoleMentions(
               processMentions(
-                processStandaloneYouTubeUrls(
-                  processInviteLinks(content)
+                processStandaloneYouTubeUrls(   // desktop-only
+                  processInviteLinks(content)   // desktop-only
                 )
               )
             )
@@ -200,6 +230,13 @@ const processedContent = useMemo(() => {
   );
 }, [content, processMentions, processRoleMentions, processChannelMentions, processMessageLinks]);
 ```
+
+> **`!mapSenderToUser` guard (desktop-only):** the shared `processMentions`
+> always tokenizes. Desktop's wrapper keeps an early `return text` when no user
+> resolver is wired, so surfaces without one (e.g. some bookmark/preview
+> contexts) leave `@<address>` as plain text rather than emitting a token that
+> wouldn't be rendered. This guard is a caller concern and intentionally lives in
+> the desktop wrapper, not in the shared function.
 
 ### **Component Rendering Flow (Updated 2025-11-07)**
 
@@ -219,9 +256,9 @@ const processedContent = useMemo(() => {
 
 ### **Performance Optimizations**
 
-- **Stable functions:** Processing functions moved outside component scope
-- **Memoized components:** `useMemo(() => ({ ... }), [])` prevents re-creation
-- **Minimal dependencies:** Only `content` triggers re-processing
+- **Shared pure functions:** The preprocessing transforms are pure module-level functions in `@quilibrium/quorum-shared` (stable references). Desktop's mention wrappers are `useCallback`-memoized so `processedContent`'s `useMemo` deps stay stable.
+- **Memoized components:** `useMemo(() => ({ ... }), [...])` prevents re-creation
+- **Minimal dependencies:** `processedContent` re-runs only when `content` or the resolver arrays (`spaceRoles`/`spaceChannels`) change
 - **Persistent state:** YouTube video state survives component re-renders
 
 ## Disabled Features (Design Decisions)
@@ -332,16 +369,13 @@ MessageMarkdownRenderer uses special tokens to safely render dynamic content lik
 - **Example**: `"https://invite.url"` → `"![invite-card](https://invite.url)"` → Invite card
 
 ### User Mentions
-- **Token Pattern**: `<<<MENTION_USER:address:displayName>>>`
-- **Creation**: `processMentions()` converts `@<address>` format to safe tokens
-- **Format**: Only `@<Qm...>` is supported
-- **Rendering**: `text` and `p` components catch tokens and render styled spans
+- **Token Pattern**: `<<<MENTION_USER:address>>>` (the token carries ONLY the address; the display name is resolved at render time, not stored in the token)
+- **Creation**: shared `processMentions()` converts `@<address>` format to safe tokens
+- **Format**: `@<Qm...>` is the canonical form. The shared function also tolerates a legacy bare `@name` ONLY when a `members` array is supplied (mobile back-compat); desktop passes no members, so the shim is inert on desktop.
+- **Rendering**: `text`/`p`/`h3`/`li` components catch tokens and render styled spans via `processMentionTokens()`
 - **Security**: Prevents markdown interpretation and XSS attacks
-- **Display Name Handling**: ALWAYS uses `mapSenderToUser()` lookup for security
-  - Extracts address → lookup real display name from space data
-  - Prevents name-spoofing and impersonation attacks
-  - See [useMessageFormatting.ts:157-175](src/hooks/business/messages/useMessageFormatting.ts#L157-L175)
-- **Example**: `"Hey @<Qm123>"` → `"Hey <<<MENTION_USER:Qm123:displayName>>>"` → Styled mention with lookup name
+- **Display Name Handling**: resolved at RENDER time in `processMentionTokens` (MessageMarkdownRenderer.tsx), via `resolveSender`/`mapSenderToUser` then `resolveSpaceMemberName`. A resolved user shows their name and is clickable; an unresolved address shows a non-interactive truncated-address pill. The lookup is always fresh (no name baked into the token) to prevent spoofing.
+- **Example**: `"Hey @<Qm123>"` → `"Hey <<<MENTION_USER:Qm123>>>"` → styled pill, name looked up at render
 
 ### Everyone Mentions
 - **Token Pattern**: `<<<MENTION_EVERYONE>>>`
@@ -350,8 +384,9 @@ MessageMarkdownRenderer uses special tokens to safely render dynamic content lik
 
 ### Role Mentions
 - **Token Pattern**: `<<<MENTION_ROLE:roleTag:displayName>>>`
-- **Creation**: `processRoleMentions()` converts `@roleTag` to safe tokens
-- **Rendering**: `text` and `p` components render styled role mention spans
+- **Creation**: shared `processRoleMentions(text, spaceRoles)` converts `@roleTag` (and the canonical `@<roleId>` form) to safe tokens
+- **Resolution (option B, 2026-06-25)**: resolves **filterless directly from the `spaceRoles` array** — a pill is rendered for ANY `@roleTag` that names a role existing in the space, regardless of whether the role id was in `message.mentions.roleIds`. This replaces the previous behavior that only styled a role if its id was in the pre-extracted mention set. A pill means "this names a real role," NOT "this pinged the role" — the notification path is separate and unchanged. Identical `@admin` text now renders consistently everywhere (matches mobile).
+- **Rendering**: `text`/`p`/`h3`/`li` components render styled role mention spans
 
 **Why Tokens?**
 - Prevents markdown parser from interpreting dynamic content incorrectly
@@ -360,16 +395,13 @@ MessageMarkdownRenderer uses special tokens to safely render dynamic content lik
 - Security: No raw HTML injection possible
 
 ### Channel Mentions
-- **Token Pattern**: `<<<MENTION_CHANNEL:channelId:channelName:displayName>>>`
-- **Creation**: `processChannelMentions()` converts `#<channelId>` format to safe tokens
+- **Token Pattern**: `<<<MENTION_CHANNEL:channelId:channelName>>>`
+- **Creation**: shared `processChannelMentions(text, spaceChannels)` converts `#<channelId>` format to safe tokens
 - **Format**: Only `#<ch-abc123>` is supported
-- **Rendering**: `text` and `p` components catch tokens and render clickable channel spans
+- **Resolution (option B, 2026-06-25)**: resolves **filterless directly from the `spaceChannels` array** (same rationale as role mentions — no longer gated on `message.mentions.channelIds`). The real channel name is read from the matched `spaceChannels` entry and embedded in the token, so the rendered name always reflects current space data (anti-spoofing).
+- **Rendering**: `text`/`p`/`h3`/`li` components catch tokens and render clickable channel spans
 - **Navigation**: Click handler navigates to the referenced channel
-- **Display Name Handling**: ALWAYS looks up channel name from `spaceChannels` array for security
-  - Extracts channelId → lookup real channel name from space data
-  - Prevents spoofing attacks
-  - See [useMessageFormatting.ts:196-218](src/hooks/business/messages/useMessageFormatting.ts#L196-L218)
-- **Example**: `"Check #<ch-123>"` → `"<<<MENTION_CHANNEL:ch-123:channelName:displayName>>>"` → Clickable span showing lookup name
+- **Example**: `"Check #<ch-123>"` → `"<<<MENTION_CHANNEL:ch-123:channelName>>>"` → clickable span showing the channel name
 
 ### Message Links (Discord-style)
 - **Token Pattern**: `<<<MESSAGE_LINK:channelId:messageId:channelName>>>`
@@ -539,11 +571,12 @@ All user-controlled content now follows this pattern:
 - [Bookmarks](bookmarks.md) - Hybrid preview rendering for bookmarks
 
 ---
-**Last Updated**: 2026-05-20 — staleness audit fixes
-**Security Hardening**: Complete (rehype-raw removed, XSS vulnerabilities fixed, word boundary validation added, display name lookup for security)
+**Last Updated**: 2026-06-25 — preprocessing pipeline promoted to quorum-shared
+**Preprocessing Pipeline**: Moved to `@quilibrium/quorum-shared` (`messagePreprocessing.ts`) — single source of truth with mobile. Desktop imports the individual functions; `processInviteLinks`/`processStandaloneYouTubeUrls`/`processMessageLinks`/`processMentionTokens` stay desktop-inlined.
+**Role/Channel Resolution**: Option B — filterless, resolved directly from `spaceRoles`/`spaceChannels` (no longer gated on `message.mentions.roleIds`/`channelIds`).
+**Security Hardening**: Complete (rehype-raw removed, XSS vulnerabilities fixed, word boundary validation, render-time name resolution)
 **Performance Optimization**: Complete
-**Mention Formats**: Only `@<address>` and `#<channelId>` supported (display names looked up from space data for security)
+**Mention Formats**: `@<address>` (user), `@roleTag`/`@<roleId>` (role), `#<channelId>` (channel), `@everyone`. Tokens: `<<<MENTION_USER:address>>>`, `<<<MENTION_ROLE:roleTag:displayName>>>`, `<<<MENTION_CHANNEL:channelId:channelName>>>`, `<<<MENTION_EVERYONE>>>`.
 **Message Links**: Complete (Discord-style rendering with same-space validation)
 **Spoilers**: Complete (plain text only, dot pattern styling, keyboard accessible)
 **Keyboard Shortcuts**: Complete (Bold, Italic, Strikethrough, Inline Code)
-**Recent Changes**: Updated documentation to reflect current mention format support (no enhanced formats with embedded names)

--- a/src/dev/tests/utils/mentionPillDom.unit.test.ts
+++ b/src/dev/tests/utils/mentionPillDom.unit.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Unit tests for extractStorageTextFromEditor — the contentEditable → storage
+ * string serializer used by the message composer and the edit textarea.
+ *
+ * Focus: newline reconstruction (regression — multi-line messages were
+ * flattened to a single line because the walker ignored block elements and
+ * <br>). Browsers represent contentEditable line breaks as either <br> nodes or
+ * by wrapping each line after the first in its own <div>/<p>; both shapes are
+ * exercised here. See .agents/bugs/2026-06-25-composer-paste-strips-newlines.md.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect } from 'vitest';
+import { extractStorageTextFromEditor } from '../../../utils/mentionPillDom';
+
+/** Build a contentEditable editor div from an HTML string. */
+function editor(html: string): HTMLElement {
+  const el = document.createElement('div');
+  el.setAttribute('contenteditable', 'true');
+  el.innerHTML = html;
+  return el;
+}
+
+/** Build a mention pill span the way the composer does. */
+function pill(type: 'user' | 'role' | 'channel' | 'everyone', address: string, label: string): string {
+  return `<span data-mention-type="${type}" data-mention-address="${address}">${label}</span>`;
+}
+
+describe('extractStorageTextFromEditor — basic content', () => {
+  it('returns plain single-line text unchanged', () => {
+    expect(extractStorageTextFromEditor(editor('hello world'))).toBe('hello world');
+  });
+
+  it('serializes a user pill to @<address>', () => {
+    const html = `hi ${pill('user', 'QmAddr123', '@Alice')} there`;
+    expect(extractStorageTextFromEditor(editor(html))).toBe('hi @<QmAddr123> there');
+  });
+
+  it('serializes role / channel / everyone pills', () => {
+    expect(extractStorageTextFromEditor(editor(pill('role', 'admin', '@admin')))).toBe('@admin');
+    expect(extractStorageTextFromEditor(editor(pill('channel', 'chan-1', '#general')))).toBe('#<chan-1>');
+    expect(extractStorageTextFromEditor(editor(pill('everyone', 'everyone', '@everyone')))).toBe('@everyone');
+  });
+});
+
+describe('extractStorageTextFromEditor — newline reconstruction (the regression)', () => {
+  it('reconstructs newlines from <br> elements', () => {
+    expect(extractStorageTextFromEditor(editor('line1<br>line2<br>line3'))).toBe('line1\nline2\nline3');
+  });
+
+  it('reconstructs newlines from per-line <div> wrapping (Chrome paste shape)', () => {
+    // First line is bare text; each subsequent line is its own <div>.
+    const html = 'line1<div>line2</div><div>line3</div>';
+    expect(extractStorageTextFromEditor(editor(html))).toBe('line1\nline2\nline3');
+  });
+
+  it('handles an all-div shape (every line wrapped)', () => {
+    const html = '<div>line1</div><div>line2</div>';
+    // Leading <div> opens line 2 relative to an empty line 1 → one newline between.
+    expect(extractStorageTextFromEditor(editor(html))).toBe('line1\nline2');
+  });
+
+  it('represents an empty line as a single newline (<div><br></div>)', () => {
+    // "a", blank line, "b" → a\n\nb
+    const html = 'a<div><br></div><div>b</div>';
+    expect(extractStorageTextFromEditor(editor(html))).toBe('a\n\nb');
+  });
+
+  it('does not double-count a trailing filler <br> inside a block', () => {
+    const html = 'a<div>b<br></div>';
+    expect(extractStorageTextFromEditor(editor(html))).toBe('a\nb');
+  });
+
+  it('preserves newlines around mention pills', () => {
+    const html = `${pill('user', 'QmX', '@X')}<div>second line</div>`;
+    expect(extractStorageTextFromEditor(editor(html))).toBe('@<QmX>\nsecond line');
+  });
+
+  it('reconstructs a multi-block paste (header + blank + list lines)', () => {
+    // Mimics pasting:  # Title\n\n- one\n- two
+    const html = '# Title<div><br></div><div>- one</div><div>- two</div>';
+    expect(extractStorageTextFromEditor(editor(html))).toBe('# Title\n\n- one\n- two');
+  });
+
+  it('keeps an unclosed code fence on its own line (the empty-code-box repro)', () => {
+    const html = '```<div>code line 1</div><div>code line 2</div>';
+    expect(extractStorageTextFromEditor(editor(html))).toBe('```\ncode line 1\ncode line 2');
+  });
+});
+
+describe('extractStorageTextFromEditor — trimming', () => {
+  it('trims outer whitespace but keeps internal newlines', () => {
+    expect(extractStorageTextFromEditor(editor('  hello<br>world  '))).toBe('hello\nworld');
+  });
+
+  it('returns empty string for an empty editor', () => {
+    expect(extractStorageTextFromEditor(editor(''))).toBe('');
+  });
+});

--- a/src/utils/mentionPillDom.ts
+++ b/src/utils/mentionPillDom.ts
@@ -142,32 +142,83 @@ export function createPillElement(pillData: PillData, onClick?: () => void): HTM
 export function extractStorageTextFromEditor(editorElement: HTMLElement): string {
   let text = '';
 
-  const walk = (node: Node) => {
+  // Block-level tags a contentEditable uses to represent visual lines. Browsers
+  // keep the first line as inline/text content of the editor and wrap each
+  // subsequent line in its own block element, so a `\n` must be emitted at the
+  // start of every block boundary to reconstruct the original line breaks.
+  const BLOCK_TAGS = new Set(['DIV', 'P']);
+
+  // Walk the editor's DOM and serialize to storage text.
+  // `isBlock` marks a node that opens a new visual line (a block element that is
+  // not the editor's first child) so we can prefix it with a newline.
+  const walk = (node: Node, isBlock: boolean) => {
     if (node.nodeType === Node.TEXT_NODE) {
       text += node.textContent;
-    } else if (node.nodeType === Node.ELEMENT_NODE) {
-      const el = node as HTMLElement;
-      if (el.dataset?.mentionType && el.dataset?.mentionAddress) {
-        const prefix = el.dataset.mentionType === 'channel' ? '#' : '@';
-
-        // Use simple format for storage: @<address> or #<id>
-        if (el.dataset.mentionType === 'role') {
-          // Roles always use @roleTag format (no brackets)
-          text += `@${el.dataset.mentionAddress}`;
-        } else if (el.dataset.mentionType === 'everyone') {
-          // @everyone always same format
-          text += '@everyone';
-        } else {
-          // Legacy format: @<address> or #<channelId>
-          text += `${prefix}<${el.dataset.mentionAddress}>`;
-        }
-      } else {
-        node.childNodes.forEach(walk);
-      }
+      return;
     }
+    if (node.nodeType !== Node.ELEMENT_NODE) return;
+
+    const el = node as HTMLElement;
+
+    // A <br> is an explicit line break.
+    if (el.tagName === 'BR') {
+      text += '\n';
+      return;
+    }
+
+    // Mention pills serialize to their storage token (no newline).
+    if (el.dataset?.mentionType && el.dataset?.mentionAddress) {
+      const prefix = el.dataset.mentionType === 'channel' ? '#' : '@';
+      if (el.dataset.mentionType === 'role') {
+        // Roles always use @roleTag format (no brackets)
+        text += `@${el.dataset.mentionAddress}`;
+      } else if (el.dataset.mentionType === 'everyone') {
+        // @everyone always same format
+        text += '@everyone';
+      } else {
+        // Legacy format: @<address> or #<channelId>
+        text += `${prefix}<${el.dataset.mentionAddress}>`;
+      }
+      return;
+    }
+
+    // Other element: open a line break if this is a block boundary, then recurse.
+    if (isBlock) {
+      text += '\n';
+    }
+
+    const children = Array.from(el.childNodes);
+    children.forEach((child, i) => {
+      // A trailing <br> that is the sole/last child of a block is the filler
+      // browsers insert into an otherwise-empty line; the block's own leading
+      // newline already represents that line, so skip it to avoid a double `\n`.
+      const isTrailingFillerBr =
+        child.nodeType === Node.ELEMENT_NODE &&
+        (child as HTMLElement).tagName === 'BR' &&
+        i === children.length - 1 &&
+        BLOCK_TAGS.has(el.tagName);
+      if (isTrailingFillerBr) return;
+
+      const childOpensBlock =
+        child.nodeType === Node.ELEMENT_NODE &&
+        BLOCK_TAGS.has((child as HTMLElement).tagName);
+      walk(child, childOpensBlock);
+    });
   };
 
-  editorElement.childNodes.forEach(walk);
+  // Top-level children: the first child continues the first line (no leading
+  // newline); each subsequent block-level child opens a new line.
+  const topChildren = Array.from(editorElement.childNodes);
+  topChildren.forEach((child, i) => {
+    const opensBlock =
+      i > 0 &&
+      child.nodeType === Node.ELEMENT_NODE &&
+      BLOCK_TAGS.has((child as HTMLElement).tagName);
+    walk(child, opensBlock);
+  });
+
+  // Trim outer whitespace (matches the original behavior); the reconstruction
+  // above only adds INTERNAL newlines, which trim() leaves intact.
   return text.trim();
 }
 


### PR DESCRIPTION
## What

Fixes a regression where multi-line messages (pasted or typed in the pills-enabled composer) collapsed onto a single line. `extractStorageTextFromEditor` walked the contentEditable DOM but never emitted newlines for block elements, so headers, lists, blockquotes, and tables ran together — and a pasted unclosed code fence rendered as an empty box (its content was read as the code language because the fence ended up on the same line as the text).

## Fix

In `src/utils/mentionPillDom.ts`, reconstruct newlines during the DOM walk:
- emit `\n` for `<br>`
- emit `\n` at block boundaries (`<div>`/`<p>` after the first line)
- skip the trailing filler `<br>` and the `<div><br></div>` empty-line case to avoid double newlines

Regression came from enabling mention pills (a contentEditable replaced the plain `<textarea>`, whose `.value` preserved newlines natively). Fixes both the composer and the edit textarea, which share this serializer.

## Tests

Adds `src/dev/tests/utils/mentionPillDom.unit.test.ts` — 13 cases covering `<br>`, per-line `<div>`, empty lines, mention pills, multi-block paste, and the unclosed-fence repro.

## Docs

Syncs the markdown-renderer doc with the recent preprocessing-to-shared migration: documents the shared pipeline source, the option-B filterless role/channel resolution, corrected token formats, and a System 1 / System 2 fallback divergence note. Marks the paste bug solved.

## Commits
- Fix composer flattening multi-line input into a single line
- docs: sync markdown-renderer doc with shared preprocessing migration