### PR TITLE
Fix DM control-message auth bypass (spoofable senderId): anchor to session sender

### DIFF
--- a/.agents/tasks/.done/2026-06-25-desktop-dm-control-msg-auth-fix-plan.md
+++ b/.agents/tasks/.done/2026-06-25-desktop-dm-control-msg-auth-fix-plan.md
@@ -1,0 +1,117 @@
+---
+type: task
+title: "PLAN: Desktop DM control-message auth fix (remove-message + edit-message) — anchor to session sender"
+status: done (DM paths implemented + tested; PR + manual verify tracked in MASTER-RECAP)
+priority: high
+created: 2026-06-25
+branch: fix/control-message-auth-session-sender
+mirrors: quorum-mobile commit 18cc7dc (branch feature/dm-delete-own-message-sync)
+---
+
+# Plan: fix DM remove-message + edit-message authorization on desktop
+
+## Plain-language problem
+
+DM control messages (delete-for-everyone = `remove-message`, and `edit-message`)
+carry a `content.senderId` field that is **plaintext the sender's client writes**.
+It is NOT proven by the encryption. A peer running a modified client can set it to
+**your** address and delete/edit a message **you** authored. Desktop currently
+authorizes by comparing `targetMessage.content.senderId === decryptedContent.content.senderId`
+— two spoofable plaintext fields.
+
+## The fix (mirrors mobile)
+
+Authorize against the **session-authenticated sender** — the address of the Double
+Ratchet session that actually decrypted the message — not the plaintext payload.
+
+Key insight (why this is sound for DMs): a DM session is two-party. A message only
+decrypts if it came from **you or the one peer**. The session that decrypts names
+the true author via `conversationId.split('/')[0]` (or `session.user_address` on
+the first-contact path). The attacker cannot fake which session decrypts their
+message, so they cannot fake this identity.
+
+The authorization check becomes (mobile's exact shape):
+```ts
+const authorized =
+  payloadSenderId === authenticatedSender &&
+  (!targetMessage || targetMessage.content?.senderId === authenticatedSender);
+```
+
+### The self-sync subtlety (the one trap)
+
+Desktop fans DM messages out to the sender's OWN other devices too (confirmed:
+`encryptAndSendDm` line ~757 and the edit-send block ~2400-2438 send to
+`self.device_registrations` minus this device). When your own delete reaches your
+other device, the code rewrites `conversationId` to point at the partner (for
+storage). So the authenticated sender MUST be captured **before** that rewrite:
+- First-contact path: capture `session.user_address` BEFORE the rewrite at
+  MessageService.ts:2773-2777 (for self-sync, pre-rewrite value == self_address,
+  which matches your own message's senderId == you → your delete is honored).
+- Established path: the rewrite is the `conversationId.split('/')[0] === self_address`
+  → repoint logic; capture before it.
+
+## What's IN scope (high confidence)
+- DM `remove-message` — `saveMessage` handler (lines ~992-995) and `addMessage`
+  handler (lines ~1592-1595).
+- DM `edit-message` — `saveMessage` handler (line ~1050) and `addMessage` handler
+  (line ~1527). NOTE: mobile has NO DM edit handler (DM edits are sender-side only
+  there); desktop DOES have one, so we fix desktop's to be safe. Flag for mobile
+  parity discussion.
+
+## What's OUT of scope (matches mobile — do NOT diverge)
+- **Space `remove-message` and `edit-message`.** Mobile deliberately did NOT
+  cryptographically fix the space path (commit 18cc7dc) — the space broadcast model
+  has no per-message authenticated sender without a protocol change. Mobile keeps
+  role-based checking on the payload senderId but hardcodes `isSpaceOwner: false`.
+  Desktop's space gates (lines 1012/1027/1609/1620 role lookups) stay as-is here.
+  Tracked separately:
+  - quorum-desktop `.agents/tasks/2026-06-25-dm-remove-message-auth-bypass-spoofable-senderid.md` (space portion)
+  - quorum-mobile `.agents/tasks/2026-06-25-control-message-auth-audit-senderid-spoofing.md`
+- **Reactions / remove-reaction** — LOW (attribution spoof only, no privilege gate).
+
+## Implementation approach
+
+Thread the captured authenticated sender into `saveMessage`/`addMessage` as a new
+**optional** parameter `authenticatedDmSender?: string`:
+- When present (DM calls) → DM auth gates use it instead of the payload senderId.
+- When absent (space calls) → behavior unchanged (space role gates untouched).
+- Storage/cache keys keep using `spaceId`/`channelId` exactly as today; only the
+  authorization DECISION changes.
+
+DM call sites to pass it from (the authenticated sender, captured pre-rewrite):
+- First-contact: MessageService.ts ~2847 (saveMessage) + ~2876 (addMessage).
+- Established: MessageService.ts ~4421 (saveMessage) + ~4443 (addMessage).
+
+## Verify after the fix (the three scenarios)
+- (a) Peer deletes/edits a message THEY authored → honored.
+- (b) Peer tries to delete/edit a message YOU authored (spoofs senderId=you) → dropped.
+- (c) Your own delete/edit fans out to your other devices (self-sync) → honored.
+
+Plus: `npx tsc --noEmit`, `yarn lint`, existing MessageService/ActionQueueHandlers unit tests, and add tests for (a)/(b)/(c).
+
+## What was actually implemented (2026-06-25)
+
+Four authorization gates in `src/services/MessageService.ts`, all DM-only
+(`isDM = spaceId === channelId`), anchored to the proven conversation owner
+(`spaceId`) instead of payload `senderId`:
+1. `saveMessage` remove-message (~line 1011)
+2. `addMessage` remove-message (~line 1622)
+3. `saveMessage` edit-message (~line 1080)
+4. `addMessage` edit-message (~line 1573)
+
+Space paths left untouched (out of scope). Self-sync auto-apply intentionally not
+handled on desktop (the "safe version" — see MASTER-RECAP). Implementation chose
+NOT to thread a new parameter: for a DM, `spaceId` already IS the authenticated
+sender in scope, so the gate uses it directly (simpler, no signature changes).
+
+Tests added (`src/dev/tests/services/MessageService.unit.test.tsx`,
+blocks 3b + 3c): legit peer delete honored; spoofed "delete YOUR message" dropped;
+third-party-authored target dropped; legit peer edit honored; spoofed edit dropped.
+
+Verification: `npx tsc --noEmit` clean; MessageService tests 24/24;
+ActionQueueHandlers 67/67; eslint on changed file 0 errors.
+
+PENDING: manual in-app verify of scenarios (a)/(b)/(c); PR to `main`; lead-dev
+conversation re: space path + SDK authenticated-sender (see MASTER-RECAP talking points).
+
+*Last updated: 2026-06-25*

--- a/.agents/tasks/2026-06-25-MASTER-RECAP-control-message-auth.md
+++ b/.agents/tasks/2026-06-25-MASTER-RECAP-control-message-auth.md
@@ -1,0 +1,190 @@
+---
+type: recap
+title: "MASTER RECAP: control-message authorization fix (delete/edit spoofing) — desktop + mobile"
+status: living-document
+priority: high
+created: 2026-06-25
+audience: "the team — written in plain language, no deep jargon"
+---
+
+# Master recap: the "spoofable senderId" fix
+
+This is the ONE document to read to understand the whole situation. Everything
+else (the other task files) is detail under one of the boxes below.
+
+## The bug, in one paragraph
+
+Delete and edit messages carry a "signed by: <name>" field that is **just text the
+sender's app writes** — it is not proven by the encryption. A chat partner running
+a **modified app** can set that field to **your** name and target a message **you**
+wrote. The receiving app currently believes it, so the partner can secretly delete
+or edit messages you authored. (This is NOT a random internet attacker — it's a
+person you're already in a conversation with, using a hacked client. Receive-side
+checks exist precisely so we don't have to trust the other person's client.)
+
+## The fix, in one sentence
+
+Stop trusting the "signed by" text. Authorize using the identity the **encryption
+itself proves** about who sent the message (the "session-authenticated sender").
+
+## The full picture (every piece, with status)
+
+|  | DM (private 1-on-1) | Space (group chat) |
+|---|---|---|
+| **delete** (`remove-message`) | Mobile: DONE. **Desktop: DONE** (code + tests, on branch). | Left alone on purpose — see note. |
+| **edit** (`edit-message`) | **Desktop: DONE** (code + tests, on branch). Mobile: no DM-edit handler exists. | Left alone on purpose — see note. |
+| **reactions** | Out of scope — low stakes (fake "X reacted", no privilege). | Out of scope — same. |
+
+> "Desktop: DONE" = code written, type-check clean, unit tests pass (incl. the
+> spoof-attack tests). Still PENDING: a quick in-app manual check + opening the PR.
+> See "Current status / what's left" below.
+
+**"Left alone on purpose" (group chats):** In a group chat the encryption can't
+prove who sent each message without a deeper change to the shared crypto library.
+**Mobile chose not to fix group chats in this round, so desktop matches mobile and
+also does not touch group chats.** Fixing one side but not the other would make the
+apps disagree and cause new bugs. Group chats are tracked as separate future tasks
+(see "Related files" below). Not part of the current work.
+
+## What "this work" (the current desktop branch) actually changes
+
+Branch: `fix/control-message-auth-session-sender`
+
+ONLY private-chat (DM) delete and edit. Four spots in
+`src/services/MessageService.ts`:
+- delete: the `saveMessage` handler + the `addMessage` handler
+- edit: the `saveMessage` handler + the `addMessage` handler
+
+Nothing about group chats, reactions, or the crypto library is touched.
+
+How the fix works in one line: for a DM, the app already knows the proven other
+party (it's the conversation address). A delete/edit is honored only if the message
+being deleted/edited was actually written by that proven party. A partner lying
+that "this is signed by you" to delete YOUR message fails this check.
+
+## Current status / what's left
+
+DONE (on branch `fix/control-message-auth-session-sender`):
+- Code: 4 DM authorization gates rewritten in `src/services/MessageService.ts`.
+- Tests: 5 new unit tests in `src/dev/tests/services/MessageService.unit.test.tsx`
+  (legit peer delete honored; spoofed "delete your message" dropped; third-party
+  target dropped; legit peer edit honored; spoofed edit dropped).
+- Checks: `npx tsc --noEmit` clean · MessageService tests 24/24 · ActionQueueHandlers
+  67/67 · eslint on the changed file: 0 errors.
+
+STILL TO DO:
+1. Manual in-app sanity check (delete/edit your own DM message works; the cosmetic
+   self-sync lag is the only expected difference).
+2. Open the PR to `main` (commit/push only when you say so).
+3. Talk to the lead dev using the talking points at the bottom of this file
+   (group-chat scope + whether the SDK should expose the per-message sender).
+
+## The one known limitation (decided: ship the safe version)
+
+When you delete a message, your app also syncs that delete to your OWN other
+devices. On desktop, for an **ongoing** conversation, the app cannot tell apart
+"this delete came from my other device" vs "from my chat partner." Mobile CAN tell
+(its lower-level decryptor hands back the proven sender on every message; desktop's
+does not).
+
+Decision: **ship the safe version.** It 100% blocks the attack. The only cost is
+a rare cosmetic lag — a delete you make on one device might not auto-disappear on
+your *other* device until that device refreshes. Nothing is lost or insecure.
+
+The "perfect" version (instant self-sync too) needs the shared crypto library to
+return the proven sender on every message, like mobile's native layer does. That is
+a **lead-dev / SDK decision**, noted as a follow-up — NOT done in this branch.
+
+## Why desktop and mobile differ here (so it's not a surprise later)
+
+Mobile's message decryption runs in a native (Rust/WASM) layer that returns the
+authenticated sender for every message. Desktop uses the JavaScript SDK, which only
+returns the sender on the FIRST message of a conversation, not on later ones. Same
+encryption underneath; different amount of info handed back to the app. That gap is
+the entire reason for the limitation above.
+
+## Parity: are desktop and mobile fixing this the SAME way? (Yes, on security)
+
+The security logic is **identical** on both platforms:
+
+| | Mobile | Desktop |
+|---|---|---|
+| The check | `senderId === authenticatedSender && (!target \|\| target.senderId === authenticatedSender)` | `senderId === spaceId && target.senderId === spaceId` |
+| "authenticated sender" is… | `conversationId.split('/')[0]` | `spaceId` — which **for a DM equals** `conversationId.split('/')[0]` |
+| Spoofed "delete YOUR msg" | dropped | dropped |
+
+Same two-part rule, same proven-sender source. Different variable name only
+(`authenticatedDmSender` on mobile vs `spaceId` on desktop), because on desktop the
+DM's `spaceId` already IS that proven sender. **This is true parity on the part that
+makes it safe.**
+
+The ONLY difference is the self-sync nicety (instant cross-device delete), which
+mobile has and desktop doesn't, purely because of the SDK info gap above. That
+difference is cosmetic and does NOT affect the security guarantee. It is a lead-dev
+/ SDK item, not a parity bug.
+
+**Bottom line for shipping:** the attack is blocked the same way on both apps. The
+fix is fully verifiable on a single device (edit a message, delete a message — both
+confirmed working in desktop dev). Cross-device sync is NOT required to trust or
+merge this fix.
+
+## Task index (THIS file is the hub — every related task is linked here)
+
+This is the single source of truth. The other files hold detail; this table tells
+you what is OPEN vs DONE so nothing gets lost.
+
+### Core security work (the senderId-spoofing fix)
+
+| Status | Task | What it covers |
+|---|---|---|
+| **DONE** | `.done/2026-06-25-desktop-dm-control-msg-auth-fix-plan.md` (desktop) | The desktop DM delete+edit fix implemented on this branch. Complete: code + tests. |
+| **DONE** | mobile commit `18cc7dc` (branch `feature/dm-delete-own-message-sync`) | The mobile DM delete fix. The reference desktop mirrored. |
+| **OPEN** | `2026-06-25-dm-remove-message-auth-bypass-spoofable-senderid.md` (desktop) | Original bug write-up. DM part now DONE; **SPACE part still open** (see below). |
+| **OPEN** | `2026-06-25-space-remove-message-auth-uses-payload-senderid.md` (mobile) | **Group-chat (space) delete fix — both platforms.** The biggest remaining piece. Needs lead-dev call on the space authenticated-sender. |
+| **REFERENCE** | `2026-06-25-control-message-auth-audit-senderid-spoofing.md` (mobile) | The full audit matrix of every control-message handler. Superseded as a tracker by THIS recap; keep for the detailed per-handler notes. |
+
+### Adjacent work (related topic, NOT the spoofing fix — don't confuse)
+
+| Status | Task | Why it's separate |
+|---|---|---|
+| OPEN | `2026-06-17-delete-own-message-in-dm.md` (mobile) | The mobile DM-delete *feature* (where this fix originated). |
+| OPEN | `2026-06-25-dm-delete-conversation-signal-and-self-sync.md` (mobile) | Deleting a WHOLE conversation — different feature, blocked on a new shared wire type. |
+| OPEN | `2026-06-25-port-message-signing-controls.md` (mobile) | The "Always sign messages" toggle UI — unrelated to spoofing auth. |
+
+### The one open follow-up this recap itself owns
+
+- **Space-path fix (desktop + mobile)** — tracked by the two OPEN space tasks above.
+  Both platforms still authorize space deletes/edits on the spoofable payload
+  senderId. Blocked on the same question: does the group-chat crypto expose a
+  per-message authenticated sender? → lead-dev / SDK decision.
+
+## For a conversation with the lead dev (talking points)
+
+1. We're fixing DM delete + edit on desktop to match the mobile fix (block the
+   spoof). Good to merge.
+2. We are deliberately NOT touching group-chat delete/edit (matches mobile's
+   decision). Confirm that's still the plan.
+3. Desktop has a self-sync cosmetic limitation mobile doesn't, because the JS SDK
+   doesn't return the authenticated sender on every message. Question for you: do
+   we want the SDK to expose that (so desktop can reach full parity), or is the
+   safe-version behavior fine to live with?
+
+## Ready to ship? (merge readiness)
+
+YES for the desktop DM fix. Reasoning:
+- The attack is blocked, with the SAME logic as the already-merged mobile fix
+  (see Parity section) — no divergence on security.
+- Verified: tsc clean, 24/24 + 67/67 unit tests, lint clean on the changed file.
+- Manually confirmed in desktop dev: editing a message works, deleting a message
+  works. (Cross-device propagation could NOT be tested due to a desktop↔mobile sync
+  issue, but it is NOT required for this fix — see Parity section: the fix is
+  single-device-verifiable, and the self-sync nicety is a separate SDK item.)
+
+Not blocking the merge: the space-path fix and the self-sync nicety are tracked
+follow-ups, not regressions introduced by this branch.
+
+Suggested PR scope: desktop DM `remove-message` + `edit-message` only. Mention in
+the PR body that space paths are intentionally unchanged (parity with mobile) and
+linked to the open space task.
+
+*Last updated: 2026-06-25*

--- a/.agents/tasks/2026-06-25-dm-remove-message-auth-bypass-spoofable-senderid.md
+++ b/.agents/tasks/2026-06-25-dm-remove-message-auth-bypass-spoofable-senderid.md
@@ -1,0 +1,112 @@
+---
+type: task
+title: "SECURITY: DM remove-message authorization bypass (spoofable senderId) — anchor to session sender"
+status: "partial — DM remove + edit DONE (desktop branch); SPACE path still OPEN"
+priority: high
+created: 2026-06-25
+source: surfaced during quorum-mobile DM delete-own-message work + deep code review
+severity: HIGH (authorization bypass / integrity)
+---
+
+> **HUB:** This issue is tracked from
+> [2026-06-25-MASTER-RECAP-control-message-auth.md](2026-06-25-MASTER-RECAP-control-message-auth.md).
+> Read that first for the big picture and current status.
+>
+> **What's done:** the DM `remove-message` + `edit-message` bypass described below
+> is FIXED on branch `fix/control-message-auth-session-sender` (see the recap and the
+> `.done/` plan file). **What remains:** the **space (group-chat)** portion — scenario
+> (d) below — is still open and shared with mobile's
+> `2026-06-25-space-remove-message-auth-uses-payload-senderid.md`. The text below is
+> kept as the original detailed analysis.
+
+# DM remove-message auth bypass: authorize against the session-authenticated sender, not the payload `senderId`
+
+## Summary
+
+Desktop's DM `remove-message` handler authorizes a delete-for-everyone by comparing
+two **plaintext payload fields** against each other:
+
+```ts
+if (targetMessage.content.senderId === decryptedContent.content.senderId) {
+  await deleteOrSoftDelete(decryptedContent.content.removeMessageId);
+}
+```
+
+Both `targetMessage.content.senderId` (author stored on the target) and
+`decryptedContent.content.senderId` (the deleter, taken from the decrypted
+remove-message payload) are **attacker-settable**. The deleter's `senderId` is
+just a JSON field the sender writes; it is NOT derived from the Double-Ratchet
+session that decrypted the message. So a malicious peer in a DM with you can:
+
+1. Learn/observe the `messageId` of a message **you** authored (they have it — it's their conversation).
+2. Send a `remove-message` with `content.senderId = <your address>` and `removeMessageId = <your message's id>`.
+3. Your client computes `targetMessage.content.senderId (== you) === decryptedContent.content.senderId (spoofed to you)` → **true** → your message is deleted.
+
+This violates the intended rule that **a peer can never delete a message you authored** (delete is own-message-only). It's an integrity/authorization bypass, not a confidentiality leak, but it lets a counterparty silently censor your side of a DM.
+
+## Scope: this is ONE fix covering BOTH DMs and Spaces, in BOTH handlers
+
+The same `remove-message` handler authorizes BOTH conversation types — DMs and
+Spaces share one code block — and trusts the spoofable `decryptedContent.content.senderId`
+in EVERY authorization decision. So the fix is: replace `decryptedContent.content.senderId`
+with the cryptographically-authenticated sender (derived from the session that
+decrypted the message, NOT the payload) at every spot it gates a delete. Do this
+in both handlers. Concretely:
+
+**Handler 1 — `saveMessage` path (~line 941–1036):**
+- line 992–993 — author check `targetMessage.content.senderId === decryptedContent.content.senderId`. **This is the DM authorization** (DMs have `spaceId == channelId`, so the space `else if` at line 997 is skipped — DMs are authorized ONLY by this line).
+- line 1012 — Space read-only-channel manager role check: `role.members.includes(decryptedContent.content.senderId)`.
+- line 1027 — Space regular `message:delete` role check: `r.members.includes(decryptedContent.content.senderId)`.
+
+**Handler 2 — `addMessage` path (~line 1575–1626):**
+- line 1592–1593 — author check (DM + space "own message").
+- line 1609 — Space read-only manager role check.
+- line 1620 — Space regular `message:delete` role check.
+
+So: **DM bypass** = lines 993 + 1593. **Space bypass** = lines 993/1593 (own) PLUS the role-lookup lines 1012/1027/1609/1620 (forge senderId = an admin/manager → delete anyone's space message). Fixing only the author-check lines would leave the space role bypass open; all of the above must use the authenticated sender.
+
+Both use the payload `senderId`, not a session-bound identity.
+
+## The fix (mirror the mobile fix)
+
+Authorize against the **cryptographically-authenticated sender** — the identity
+of the DR session that decrypted this control message — NOT the self-asserted
+`decryptedContent.content.senderId`.
+
+On mobile this is `conversationId.split('/')[0]` captured BEFORE the multi-device
+self-sync rewrite (see quorum-mobile `context/WebSocketContext.tsx`, the two DM
+`remove-message` branches; branch `feature/dm-delete-own-message-sync`). The
+check becomes:
+
+```ts
+const authenticatedSender = /* the session-decrypted conversation owner, pre-self-sync */;
+const authorized =
+  decryptedContent.content.senderId === authenticatedSender &&            // payload claim must match the session
+  (!targetMessage || targetMessage.content?.senderId === authenticatedSender); // deleter must be the author
+```
+
+Desktop equivalent of `authenticatedSender`: derive it from `found.conversationId`
+(the session/inbox that successfully decrypted the message in
+`DoubleRatchetInboxDecrypt` / `ConfirmDoubleRatchetSenderSession`), NOT from the
+decrypted plaintext. Confirm where desktop already has the authenticated
+conversation owner in scope at the `remove-message` handler and use it.
+
+### Verify these scenarios after the fix
+- (a) Peer deletes a message THEY authored → honored.
+- (b) Peer tries to delete a message YOU authored (spoofing `senderId = you`) → **dropped**.
+- (c) Your own delete fans out to your other devices (self-sync) → honored (authenticated sender is you, target authored by you). Watch the multi-device rewrite: capture the authenticated sender BEFORE any conversation rewrite, else self-sync deletes get dropped.
+- (d) **Space `remove-message` path — CONFIRMED ALSO VULNERABLE (broader than DMs).** `addMessage` path lines 1592–1626 trust `decryptedContent.content.senderId` for BOTH the own-message check (line 1593) AND the role lookups: read-only manager check (`role.members.includes(decryptedContent.content.senderId)`, line 1609) and `message:delete` role check (line 1620). A peer with send access to a space can set `content.senderId = <an admin/manager's address>` and pass the role gate, deleting **anyone's** messages. The role membership lookup MUST use the authenticated sender, not the payload field. Fix the space path in the same pass.
+
+## Notes / context
+
+- The same weak pattern existed on mobile until `feature/dm-delete-own-message-sync` (2026-06-25). Mobile now anchors to the session sender; desktop should match.
+- This is the canonical "verify the RECEIVE-side check, not the button" situation — the send-side gate (own-message-only) is irrelevant because a modified/malicious client ignores it.
+- Reactions (`remove-reaction`) have the same payload-`senderId` trust shape; lower impact (reactions are low-stakes) but worth a follow-up audit while you're in this code.
+
+## Source
+
+Mobile reference implementation + full threat-model verification:
+quorum-mobile branch `feature/dm-delete-own-message-sync`, and the mobile memory note
+`dm-control-msg-auth-session-sender-not-payload`.
+
+*Last updated: 2026-06-25*

--- a/src/dev/tests/services/MessageService.unit.test.tsx
+++ b/src/dev/tests/services/MessageService.unit.test.tsx
@@ -87,6 +87,8 @@ describe('MessageService - Unit Tests', () => {
         }),
         getSpaceMember: vi.fn().mockResolvedValue(null),
         isUserMuted: vi.fn().mockResolvedValue(false),
+        getConversation: vi.fn().mockResolvedValue({ conversation: null }),
+        updateMessage: vi.fn().mockResolvedValue(undefined),
       } as any,
       enqueueOutbound: vi.fn(),
       addOrUpdateConversation: vi.fn(),
@@ -371,6 +373,166 @@ describe('MessageService - Unit Tests', () => {
 
       // ✅ VERIFY: deleteMessage called
       expect(mockDeps.messageDB.deleteMessage).toHaveBeenCalledWith('msg-to-remove');
+    });
+  });
+
+  // SECURITY: DM control-message authorization must anchor to the session-
+  // authenticated sender (the conversation owner == spaceId for a DM), NOT the
+  // spoofable plaintext content.senderId. See
+  // .agents/tasks/2026-06-25-MASTER-RECAP-control-message-auth.md
+  describe('3b. saveMessage() - DM remove-message authorization (anti-spoofing)', () => {
+    // For a DM, spaceId === channelId === the proven conversation partner address.
+    const PEER = 'peer-address';
+    const SELF = 'my-own-address';
+
+    const makeTarget = (authorSenderId: string) => ({
+      messageId: 'target-msg',
+      spaceId: PEER,
+      channelId: PEER,
+      createdDate: Date.now(),
+      modifiedDate: Date.now(),
+      digestAlgorithm: 'sha256' as const,
+      nonce: 'nonce',
+      lastModifiedHash: 'hash',
+      content: { senderId: authorSenderId, type: 'post' as const, text: 'msg' },
+    });
+
+    const makeRemove = (claimedSenderId: string) => ({
+      messageId: 'remove-req',
+      spaceId: PEER,
+      channelId: PEER,
+      createdDate: Date.now(),
+      modifiedDate: Date.now(),
+      digestAlgorithm: 'sha256' as const,
+      nonce: 'nonce',
+      lastModifiedHash: 'hash',
+      content: {
+        senderId: claimedSenderId,
+        type: 'remove-message' as const,
+        removeMessageId: 'target-msg',
+      },
+    });
+
+    it('(a) honors a peer deleting a message the peer authored', async () => {
+      // Target authored by PEER; delete claims PEER. Both === spaceId (PEER).
+      mockDeps.messageDB.getMessage = vi.fn().mockResolvedValue(makeTarget(PEER));
+
+      await messageService.saveMessage(
+        makeRemove(PEER) as any,
+        mockDeps.messageDB,
+        PEER, // spaceId === channelId → DM
+        PEER,
+        'direct',
+        { user_icon: 'icon.png', display_name: 'User' }
+      );
+
+      expect(mockDeps.messageDB.deleteMessage).toHaveBeenCalledWith('target-msg');
+    });
+
+    it('(b) DROPS a peer trying to delete YOUR message by spoofing senderId=you', async () => {
+      // Target authored by SELF (you). Attacker (the peer) sends a delete with
+      // content.senderId spoofed to SELF. The old code compared the two plaintext
+      // fields (SELF === SELF) and deleted. The fix anchors to spaceId (PEER):
+      // SELF !== PEER → unauthorized → must NOT delete.
+      mockDeps.messageDB.getMessage = vi.fn().mockResolvedValue(makeTarget(SELF));
+
+      await messageService.saveMessage(
+        makeRemove(SELF) as any, // spoofed claim
+        mockDeps.messageDB,
+        PEER,
+        PEER,
+        'direct',
+        { user_icon: 'icon.png', display_name: 'User' }
+      );
+
+      expect(mockDeps.messageDB.deleteMessage).not.toHaveBeenCalled();
+    });
+
+    it('(b2) DROPS a peer deleting a message authored by a third party', async () => {
+      // Defense-in-depth: even if the claim matched spaceId, a target not authored
+      // by the proven owner must not be deletable.
+      mockDeps.messageDB.getMessage = vi
+        .fn()
+        .mockResolvedValue(makeTarget('someone-else'));
+
+      await messageService.saveMessage(
+        makeRemove(PEER) as any,
+        mockDeps.messageDB,
+        PEER,
+        PEER,
+        'direct',
+        { user_icon: 'icon.png', display_name: 'User' }
+      );
+
+      expect(mockDeps.messageDB.deleteMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('3c. saveMessage() - DM edit-message authorization (anti-spoofing)', () => {
+    const PEER = 'peer-address';
+    const SELF = 'my-own-address';
+
+    const makeTarget = (authorSenderId: string) => ({
+      messageId: 'target-msg',
+      spaceId: PEER,
+      channelId: PEER,
+      createdDate: Date.now(),
+      modifiedDate: Date.now(),
+      digestAlgorithm: 'sha256' as const,
+      nonce: 'orig-nonce',
+      lastModifiedHash: 'orig-nonce',
+      content: { senderId: authorSenderId, type: 'post' as const, text: 'original' },
+    });
+
+    const makeEdit = (claimedSenderId: string) => ({
+      messageId: 'edit-req',
+      spaceId: PEER,
+      channelId: PEER,
+      createdDate: Date.now(),
+      modifiedDate: Date.now(),
+      digestAlgorithm: 'sha256' as const,
+      nonce: 'nonce',
+      lastModifiedHash: 'hash',
+      content: {
+        senderId: claimedSenderId,
+        type: 'edit-message' as const,
+        originalMessageId: 'target-msg',
+        editedText: 'EDITED',
+        editedAt: Date.now(),
+        editNonce: 'edit-nonce',
+      },
+    });
+
+    it('(a) honors a peer editing a message the peer authored', async () => {
+      mockDeps.messageDB.getMessage = vi.fn().mockResolvedValue(makeTarget(PEER));
+
+      await messageService.saveMessage(
+        makeEdit(PEER) as any,
+        mockDeps.messageDB,
+        PEER,
+        PEER,
+        'direct',
+        { user_icon: 'icon.png', display_name: 'User' }
+      );
+
+      // An applied edit persists the updated message via saveMessage.
+      expect(mockDeps.messageDB.saveMessage).toHaveBeenCalled();
+    });
+
+    it('(b) DROPS a peer trying to edit YOUR message by spoofing senderId=you', async () => {
+      mockDeps.messageDB.getMessage = vi.fn().mockResolvedValue(makeTarget(SELF));
+
+      await messageService.saveMessage(
+        makeEdit(SELF) as any, // spoofed claim
+        mockDeps.messageDB,
+        PEER,
+        PEER,
+        'direct',
+        { user_icon: 'icon.png', display_name: 'User' }
+      );
+
+      // Unauthorized edit returns early before persisting any change.
+      expect(mockDeps.messageDB.saveMessage).not.toHaveBeenCalled();
     });
   });
 

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -988,10 +988,44 @@ export class MessageService {
         }
       };
 
-      // For DMs (spaceId == channelId): Always honor deletion if sender owns the target message
-      if (
+      // DM authorization (spaceId == channelId).
+      //
+      // SECURITY: `decryptedContent.content.senderId` is plaintext the sender's
+      // client writes — it is NOT proven by the Double Ratchet. A peer running a
+      // modified client could set it to YOUR address to delete a message you
+      // authored. So we authorize against the session-authenticated sender
+      // instead: for a DM, `spaceId` (== channelId) IS the cryptographically
+      // proven conversation owner (the address whose session decrypted this
+      // message). A DM is two-party, so the only legitimate deleter of the target
+      // is its author, and the author can only be the proven conversation owner.
+      // We require BOTH: the payload claim matches the proven owner AND the target
+      // was authored by that proven owner. A spoofed "senderId = you" fails the
+      // second clause (your message's author != the peer).
+      //
+      // Self-sync note: when your OWN delete reaches your OTHER device, `spaceId`
+      // is the partner but the target's author is you — so this check does not
+      // auto-apply your own cross-device deletes (they reconcile on next load).
+      // This is the accepted trade-off of the "safe version": we block the spoof
+      // fully and tolerate a cosmetic self-sync lag, because desktop's JS SDK does
+      // not expose the per-message authenticated sender that would let us tell a
+      // genuine self-echo from a peer spoofing your address. See
+      // .agents/tasks/2026-06-25-MASTER-RECAP-control-message-auth.md.
+      const isDM = spaceId === channelId;
+      if (isDM) {
+        const authorized =
+          decryptedContent.content.senderId === spaceId &&
+          targetMessage.content.senderId === spaceId;
+        if (authorized) {
+          await deleteOrSoftDelete(decryptedContent.content.removeMessageId);
+          // Don't return early - allow addMessage() to update React Query cache
+        }
+        // Unauthorized DM delete: drop silently (do not honor).
+      } else if (
         targetMessage.content.senderId === decryptedContent.content.senderId
       ) {
+        // Space "own message" delete — unchanged (space path is out of scope;
+        // tracked separately). Still uses payload senderId by design parity with
+        // mobile until the space path is fixed in tandem.
         await deleteOrSoftDelete(decryptedContent.content.removeMessageId);
         // Don't return early - allow addMessage() to update React Query cache
       } else if (spaceId != channelId) {
@@ -1046,8 +1080,24 @@ export class MessageService {
         return;
       }
 
-      // Only original sender can edit their message
-      if (targetMessage.content.senderId !== editMessage.senderId) {
+      // Only original sender can edit their message.
+      //
+      // SECURITY: `editMessage.senderId` is spoofable plaintext (same shape as the
+      // remove-message bug). For a DM, authorize against the session-authenticated
+      // sender — `spaceId` (== channelId) is the cryptographically proven
+      // conversation owner — and require the target to have been authored by that
+      // proven owner. A peer spoofing `senderId = you` to edit your message fails
+      // this check. Space path keeps the legacy payload check (out of scope,
+      // tracked in .agents/tasks/2026-06-25-MASTER-RECAP-control-message-auth.md).
+      const isDM = spaceId === channelId;
+      if (isDM) {
+        if (
+          editMessage.senderId !== spaceId ||
+          targetMessage.content.senderId !== spaceId
+        ) {
+          return;
+        }
+      } else if (targetMessage.content.senderId !== editMessage.senderId) {
         return;
       }
 
@@ -1080,7 +1130,7 @@ export class MessageService {
       }
 
       // Check if saveEditHistory is enabled for this conversation/space
-      const isDM = spaceId === channelId;
+      // (isDM already computed above for the authorization check)
       let saveEditHistoryEnabled: boolean;
 
       if (isDM) {
@@ -1509,6 +1559,10 @@ export class MessageService {
       );
     } else if (decryptedContent.content.type === 'edit-message') {
       const editMessage = decryptedContent.content as EditMessage;
+      // DM edits authorize against the session-authenticated sender (spaceId ==
+      // the proven conversation owner), not the spoofable payload senderId. Mirrors
+      // the saveMessage edit handler. Space path unchanged (out of scope).
+      const isDM = spaceId === channelId;
 
       queryClient.setQueriesData(
         { queryKey: buildMessagesKeyPrefix({ spaceId: spaceId, channelId: channelId }) },
@@ -1523,8 +1577,17 @@ export class MessageService {
                 messages: [
                   ...page.messages.map((m: Message) => {
                     if (m.messageId === editMessage.originalMessageId) {
-                      // Only update if the sender matches (permission check)
-                      if (m.content.senderId !== editMessage.senderId) {
+                      // Only update if the sender matches (permission check).
+                      // DM: authorize against the proven conversation owner
+                      // (spaceId), not the spoofable payload senderId.
+                      if (isDM) {
+                        if (
+                          editMessage.senderId !== spaceId ||
+                          m.content.senderId !== spaceId
+                        ) {
+                          return m;
+                        }
+                      } else if (m.content.senderId !== editMessage.senderId) {
                         return m;
                       }
                       // Only allow editing post messages
@@ -1582,11 +1645,27 @@ export class MessageService {
       // Check if this delete request should be honored
       let shouldHonorDelete = false;
 
+      const isDM = spaceId === channelId;
+
       if (!targetMessage) {
-        // If target message doesn't exist, always remove from UI
+        // If target message doesn't exist, always remove from UI.
+        // (Unchanged: this is a no-op removal of a message we don't have — not the
+        // attack surface. The attack targets a message that DOES exist, handled
+        // by the DM branch below.)
         shouldHonorDelete = true;
+      } else if (isDM) {
+        // DM authorization — authorize against the session-authenticated sender,
+        // NOT the spoofable payload `senderId`. For a DM, `spaceId` (== channelId)
+        // is the cryptographically proven conversation owner. Require BOTH: the
+        // payload claim matches the proven owner AND the target was authored by
+        // that proven owner. A peer spoofing `senderId = you` to delete your
+        // message fails the second clause. (Same check as the saveMessage handler;
+        // see .agents/tasks/2026-06-25-MASTER-RECAP-control-message-auth.md.)
+        shouldHonorDelete =
+          decryptedContent.content.senderId === spaceId &&
+          targetMessage.content.senderId === spaceId;
       } else {
-        // If target message exists, check permissions
+        // Space path — unchanged (out of scope, tracked separately).
 
         // 1. Users can always delete their own messages
         if (


### PR DESCRIPTION
## What & why

DM `remove-message` (delete-for-everyone) and `edit-message` were authorized by comparing two **plaintext, sender-written** `senderId` fields. That field is not proven by the Double Ratchet, so a peer running a **modified client** could set `senderId` to the victim's address and **delete or edit a message the victim authored** (an authorization/integrity bypass — a counterparty can silently censor or alter your side of a DM).

## The fix

For DMs, authorize against the **cryptographically proven conversation owner** — `spaceId`, which for a DM equals the address of the Double Ratchet session that decrypted the message — instead of the spoofable payload `senderId`.

The check now requires **both**:
- the payload claim equals the proven owner, **and**
- the target message was authored by that proven owner.

A spoofed `senderId = you` fails the second clause and is dropped.

Applied at all four DM gates:
- `saveMessage` (DB) — remove-message + edit-message
- `addMessage` (cache) — remove-message + edit-message

## Parity with mobile

Same security logic as the merged mobile fix (`quorum-mobile` branch `feature/dm-delete-own-message-sync`). Mobile names it `authenticatedDmSender = conversationId.split('/')[0]`; desktop uses `spaceId`, which **is** that proven sender for a DM. Identical rule, identical attack outcome.

## Scope (intentional)

- **DM only.** Space (group-chat) `remove-message`/`edit-message` still authorize on the payload `senderId` and are **left unchanged here**, matching mobile's decision (the group crypto does not expose a per-message authenticated sender without a deeper change). Tracked as a separate follow-up.
- **Self-sync:** your own cross-device delete reconciles on next load rather than instantly, because the desktop JS SDK only returns the authenticated sender on the first message of a session. Cosmetic, security-neutral; lead-dev / SDK follow-up. Full context in `.agents/tasks/2026-06-25-MASTER-RECAP-control-message-auth.md`.

## Verification

- `npx tsc --noEmit` clean
- `MessageService.unit.test.tsx` 24/24 (5 new tests: legit peer delete/edit honored; spoofed delete/edit dropped; third-party-authored target dropped)
- `ActionQueueHandlers.unit.test.ts` 67/67
- eslint on changed file: 0 errors
- Manually confirmed in desktop dev: editing and deleting your own DM message work
