### PR TITLE
docs: move space-path auth tracking to a private issue

### DIFF
--- a/.agents/tasks/2026-06-25-MASTER-RECAP-control-message-auth.md
+++ b/.agents/tasks/2026-06-25-MASTER-RECAP-control-message-auth.md
@@ -38,6 +38,20 @@ itself proves** about who sent the message (the "session-authenticated sender").
 > "Desktop: DONE" = code written, type-check clean, unit tests pass (incl. the
 > spoof-attack tests). Still PENDING: a quick in-app manual check + opening the PR.
 > See "Current status / what's left" below.
+>
+> **Mobile "DONE" status (2026-06-25):** code complete on branch
+> `feature/dm-delete-own-message-sync`, **uncommitted working tree**, verified
+> static (tsc + lint clean; reaction send unchanged; normal receive unaffected;
+> desktop honors a legit cross-account delete — traced). The mobile branch ALSO
+> carries two delivery-reliability fixes the desktop side doesn't need: (1) the
+> delete sends via the all-devices transport (`sendEncryptedMessageToAllDevices`),
+> not the single-session reaction transport, so it reaches every device a normal
+> message does; (2) the send no longer bails on a transient `!isConnected` (it
+> enqueues and flushes on reconnect) — that was silently dropping deletes. These
+> are mobile-transport fixes, separate from the shared security logic. Live
+> mobile↔desktop propagation could not be confirmed: blocked by the pre-existing
+> desktop↔mobile delivery sync issue (affects normal messages too), NOT the auth
+> fix. Detail: mobile `.agents/docs/features/dm-delete-own-message.md`.
 
 **"Left alone on purpose" (group chats):** In a group chat the encryption can't
 prove who sent each message without a deeper change to the shared crypto library.
@@ -139,9 +153,8 @@ you what is OPEN vs DONE so nothing gets lost.
 |---|---|---|
 | **DONE** | `.done/2026-06-25-desktop-dm-control-msg-auth-fix-plan.md` (desktop) | The desktop DM delete+edit fix implemented on this branch. Complete: code + tests. |
 | **DONE** | mobile commit `18cc7dc` (branch `feature/dm-delete-own-message-sync`) | The mobile DM delete fix. The reference desktop mirrored. |
-| **OPEN** | `2026-06-25-dm-remove-message-auth-bypass-spoofable-senderid.md` (desktop) | Original bug write-up. DM part now DONE; **SPACE part still open** (see below). |
-| **OPEN** | `2026-06-25-space-remove-message-auth-uses-payload-senderid.md` (mobile) | **Group-chat (space) delete fix — both platforms.** The biggest remaining piece. Needs lead-dev call on the space authenticated-sender. |
-| **REFERENCE** | `2026-06-25-control-message-auth-audit-senderid-spoofing.md` (mobile) | The full audit matrix of every control-message handler. Superseded as a tracker by THIS recap; keep for the detailed per-handler notes. |
+| **OPEN** | `2026-06-25-dm-remove-message-auth-bypass-spoofable-senderid.md` (desktop) | Original DM bug write-up. DM part now DONE. (Space portion redacted — see private issue.) |
+| **OPEN** | **PRIVATE:** quorum-app-prod#1 + quorum-mobile gitignored `.agents/` | **Group-chat (space) authorization — the remaining work.** Detail is kept OUT of this public repo. |
 
 ### Adjacent work (related topic, NOT the spoofing fix — don't confuse)
 
@@ -153,10 +166,11 @@ you what is OPEN vs DONE so nothing gets lost.
 
 ### The one open follow-up this recap itself owns
 
-- **Space-path fix (desktop + mobile)** — tracked by the two OPEN space tasks above.
-  Both platforms still authorize space deletes/edits on the spoofable payload
-  senderId. Blocked on the same question: does the group-chat crypto expose a
-  per-message authenticated sender? → lead-dev / SDK decision.
+- **Space-path fix (desktop + mobile)** — this is an UNPATCHED authorization concern
+  for group chats, so its specifics are kept OUT of this public repo. Tracked
+  privately at **https://github.com/QuilibriumNetwork/quorum-app-prod/issues/1**, with
+  the design/decision doc in quorum-mobile's gitignored `.agents/`. Awaiting a
+  lead-dev direction decision. Do NOT re-add space exploit detail to this public repo.
 
 ## For a conversation with the lead dev (talking points)
 

--- a/.agents/tasks/2026-06-25-dm-remove-message-auth-bypass-spoofable-senderid.md
+++ b/.agents/tasks/2026-06-25-dm-remove-message-auth-bypass-spoofable-senderid.md
@@ -44,28 +44,28 @@ session that decrypted the message. So a malicious peer in a DM with you can:
 
 This violates the intended rule that **a peer can never delete a message you authored** (delete is own-message-only). It's an integrity/authorization bypass, not a confidentiality leak, but it lets a counterparty silently censor your side of a DM.
 
-## Scope: this is ONE fix covering BOTH DMs and Spaces, in BOTH handlers
+## Scope: DM portion (this doc) — Space portion tracked privately
 
-The same `remove-message` handler authorizes BOTH conversation types — DMs and
-Spaces share one code block — and trusts the spoofable `decryptedContent.content.senderId`
-in EVERY authorization decision. So the fix is: replace `decryptedContent.content.senderId`
-with the cryptographically-authenticated sender (derived from the session that
-decrypted the message, NOT the payload) at every spot it gates a delete. Do this
-in both handlers. Concretely:
+This document covers the **DM** `remove-message` / `edit-message` fix, which is
+DONE and merged (PR #220). The DM handler authorizes by comparing the spoofable
+`decryptedContent.content.senderId`; the fix replaces it with the
+cryptographically-authenticated session sender (see "The fix" below).
 
-**Handler 1 — `saveMessage` path (~line 941–1036):**
-- line 992–993 — author check `targetMessage.content.senderId === decryptedContent.content.senderId`. **This is the DM authorization** (DMs have `spaceId == channelId`, so the space `else if` at line 997 is skipped — DMs are authorized ONLY by this line).
-- line 1012 — Space read-only-channel manager role check: `role.members.includes(decryptedContent.content.senderId)`.
-- line 1027 — Space regular `message:delete` role check: `r.members.includes(decryptedContent.content.senderId)`.
+> The **Space (group-chat)** portion of this issue is intentionally NOT detailed
+> here. It is an unpatched authorization concern and its specifics are kept out of
+> this public repo. Tracked privately:
+> **https://github.com/QuilibriumNetwork/quorum-app-prod/issues/1**
+> (design notes live in quorum-mobile's gitignored `.agents/`). Do not re-add Space
+> exploit specifics to this file.
 
-**Handler 2 — `addMessage` path (~line 1575–1626):**
-- line 1592–1593 — author check (DM + space "own message").
-- line 1609 — Space read-only manager role check.
-- line 1620 — Space regular `message:delete` role check.
+**DM handler — `saveMessage` path (~line 941–1036):**
+- the DM author check `targetMessage.content.senderId === decryptedContent.content.senderId`
+  (DMs have `spaceId == channelId`, so DMs are authorized ONLY by this line).
 
-So: **DM bypass** = lines 993 + 1593. **Space bypass** = lines 993/1593 (own) PLUS the role-lookup lines 1012/1027/1609/1620 (forge senderId = an admin/manager → delete anyone's space message). Fixing only the author-check lines would leave the space role bypass open; all of the above must use the authenticated sender.
+**DM handler — `addMessage` path (~line 1575–1626):**
+- the DM author check (same shape).
 
-Both use the payload `senderId`, not a session-bound identity.
+Both used the payload `senderId`, not a session-bound identity — now fixed for DMs.
 
 ## The fix (mirror the mobile fix)
 
@@ -95,7 +95,9 @@ conversation owner in scope at the `remove-message` handler and use it.
 - (a) Peer deletes a message THEY authored → honored.
 - (b) Peer tries to delete a message YOU authored (spoofing `senderId = you`) → **dropped**.
 - (c) Your own delete fans out to your other devices (self-sync) → honored (authenticated sender is you, target authored by you). Watch the multi-device rewrite: capture the authenticated sender BEFORE any conversation rewrite, else self-sync deletes get dropped.
-- (d) **Space `remove-message` path — CONFIRMED ALSO VULNERABLE (broader than DMs).** `addMessage` path lines 1592–1626 trust `decryptedContent.content.senderId` for BOTH the own-message check (line 1593) AND the role lookups: read-only manager check (`role.members.includes(decryptedContent.content.senderId)`, line 1609) and `message:delete` role check (line 1620). A peer with send access to a space can set `content.senderId = <an admin/manager's address>` and pass the role gate, deleting **anyone's** messages. The role membership lookup MUST use the authenticated sender, not the payload field. Fix the space path in the same pass.
+- (d) **Space path** — a related authorization concern exists for group chats; it is
+  tracked privately (see the note above:
+  https://github.com/QuilibriumNetwork/quorum-app-prod/issues/1). Not described here.
 
 ## Notes / context
 


### PR DESCRIPTION
Moves the group-chat (space) authorization follow-up to private tracking. These desktop task files now point to the private issue instead of holding the detail inline. Docs-only; no code change.