### PR TITLE
fix: dm conversation keyed by qns name

### DIFF
--- a/src/components/modals/NewDirectMessageModal.tsx
+++ b/src/components/modals/NewDirectMessageModal.tsx
@@ -29,6 +29,7 @@ const NewDirectMessageModal: React.FunctionComponent<
 > = (props) => {
   const {
     address,
+    effectiveAddress,
     handleAddressChange,
     handleSubmit,
     buttonText,
@@ -60,14 +61,19 @@ const NewDirectMessageModal: React.FunctionComponent<
   // Override handleSubmit to save conversation settings (only for new conversations)
   const handleSubmitWithSettings = React.useCallback(async () => {
     // Only save conversation record for NEW conversations
-    // For existing conversations, just navigate (don't overwrite their data)
-    if (address && !existingConversation) {
+    // For existing conversations, just navigate (don't overwrite their data).
+    // Key the row on the RESOLVED Qm… address (effectiveAddress), never the raw
+    // typed input: typing a @username would otherwise persist a row keyed by the
+    // QNS name (e.g. "alice/alice") while navigation goes to the resolved Qm…,
+    // splitting one partner into two contacts — and the name-keyed one is broken
+    // (no registration, can't send, can't be re-resolved).
+    if (effectiveAddress && !existingConversation) {
       // Persist the conversation record with the selected non-repudiability
       const now = Date.now();
       try {
         await messageDB.saveConversation({
-          conversationId: address + '/' + address,
-          address: address,
+          conversationId: effectiveAddress + '/' + effectiveAddress,
+          address: effectiveAddress,
           icon: DefaultImages.UNKNOWN_USER,
           displayName: t`Unknown User`,
           type: 'direct',
@@ -80,7 +86,7 @@ const NewDirectMessageModal: React.FunctionComponent<
       }
     }
     handleSubmit();
-  }, [address, existingConversation, nonRepudiable, messageDB, handleSubmit]);
+  }, [effectiveAddress, existingConversation, nonRepudiable, messageDB, handleSubmit]);
 
   return (
     <Modal

--- a/src/db/messages.ts
+++ b/src/db/messages.ts
@@ -1,4 +1,4 @@
-import { logger } from '@quilibrium/quorum-shared';
+import { logger, isValidIPFSCID } from '@quilibrium/quorum-shared';
 import { channel } from '@quilibrium/quilibrium-js-sdk-channels';
 import type { Conversation, Message, Space, Bookmark, BroadcastSpaceTag, ChannelThread, UserNote, FarcasterLink } from '@quilibrium/quorum-shared';
 import { BOOKMARKS_CONFIG } from '@quilibrium/quorum-shared';
@@ -998,6 +998,30 @@ export class MessageDB {
 
   async saveConversation(conversation: Conversation): Promise<void> {
     await this.init();
+
+    // Guard: a direct conversation must be keyed by the partner's Qm… address
+    // ("<Qm…>/<Qm…>"), never a QNS @username. Persisting a name-keyed row splits
+    // one partner into two contacts and leaves the name-keyed one unusable (no
+    // registration → can't send, can't re-resolve). Reject loudly so a leaking
+    // call site is caught instead of silently corrupting the contact list.
+    if (conversation.type === 'direct') {
+      const [a, b] = String(conversation.conversationId).split('/');
+      const keyedByAddress =
+        !!a && a === b && isValidIPFSCID(a, true);
+      if (!keyedByAddress) {
+        logger.error(
+          '[messageDB] Refusing to save direct conversation not keyed by a Qm… address',
+          { conversationId: conversation.conversationId, address: conversation.address },
+        );
+        return Promise.reject(
+          new Error(
+            'Direct conversation must be keyed by a Qm… address, got: ' +
+              conversation.conversationId,
+          ),
+        );
+      }
+    }
+
     return new Promise((resolve, reject) => {
       const transaction = this.db!.transaction('conversations', 'readwrite');
       const store = transaction.objectStore('conversations');

--- a/src/hooks/business/conversations/useDirectMessageCreation.ts
+++ b/src/hooks/business/conversations/useDirectMessageCreation.ts
@@ -100,6 +100,11 @@ export const useDirectMessageCreation = () => {
   return {
     // `address` keeps the field controlled by what the user typed.
     address: input,
+    // The resolved Qm… address everything downstream should key on: the QNS
+    // lookup result for @usernames, the raw input for Qm… addresses. Empty
+    // until an @username resolves. Persisting/navigating MUST use this, never
+    // `address` (the raw name), or a DM gets keyed by the QNS name and breaks.
+    effectiveAddress,
     handleAddressChange,
     handleSubmit,
     buttonText,


### PR DESCRIPTION
Starting a DM by typing a QNS @username persisted the conversation row keyed by the raw name (e.g. `name/name`) while navigation went to the resolved Qm… address. This split one partner into two contacts, and the name-keyed row was unusable: no registration to encrypt against (messages could not send), and `getUser(name)` returned 400 so it could never be re-resolved or have its profile fetched.

## Fix
- **Creation hook** now exposes the resolved `effectiveAddress` (the QNS lookup result for usernames, raw input for Qm… addresses) alongside the raw typed input.
- **New DM modal** keys the persisted conversation row on `effectiveAddress`, never the raw name.
- **MessageDB.saveConversation** gains a defense-in-depth guard that refuses to persist a direct conversation whose id is not `<Qm…>/<Qm…>`, logging loudly so any future leaking call site is caught instead of silently corrupting the contact list.

Mobile was checked and is not affected: its new-conversation flow already resolves the name to an address before saving.

## Commits
- fix(dm): key new DM conversations by resolved address, not QNS name