### PR TITLE
fix: show truncated address for never-replied DM contacts

### DIFF
--- a/src/components/direct/DirectMessage.tsx
+++ b/src/components/direct/DirectMessage.tsx
@@ -235,17 +235,23 @@ const DirectMessage: React.FC<{}> = () => {
     if (conversation?.conversation) {
       // Priority 1: Use conversation data from IndexedDB (available offline).
       // Fall through to public profile only when local fields are empty/unknown.
+      // When neither the local row nor the public profile carries an identity
+      // (a never-replied, non-public contact), leave displayName/userIcon
+      // undefined. The name resolver then falls through to the truncated
+      // address and the avatar to address-derived initials — matching mobile
+      // and preserving privacy: no name/pfp is shown until the peer replies or
+      // has opted into a public profile.
       const localName = conversation.conversation.displayName;
       const localIcon = conversation.conversation.icon;
       m[address!] = {
         displayName:
           localName && localName !== t`Unknown User`
             ? localName
-            : pubName ?? t`Unknown User`,
+            : pubName,
         userIcon:
           localIcon && localIcon !== DefaultImages.UNKNOWN_USER
             ? localIcon
-            : pubIcon ?? DefaultImages.UNKNOWN_USER,
+            : pubIcon,
         primaryUsername: pubQns,
         address: address!,
       };
@@ -254,16 +260,16 @@ const DirectMessage: React.FC<{}> = () => {
       // Registration has no display name; public profile is the only naming
       // source available at this priority.
       m[registration.registration.user_address] = {
-        displayName: pubName ?? t`Unknown User`,
-        userIcon: pubIcon ?? DefaultImages.UNKNOWN_USER,
+        displayName: pubName,
+        userIcon: pubIcon,
         primaryUsername: pubQns,
         address: registration.registration.user_address,
       };
     } else {
       // Priority 3: Offline fallback - use address as identifier.
       m[address!] = {
-        displayName: pubName ?? t`Unknown User`,
-        userIcon: pubIcon ?? DefaultImages.UNKNOWN_USER,
+        displayName: pubName,
+        userIcon: pubIcon,
         primaryUsername: pubQns,
         address: address!,
       };
@@ -329,8 +335,10 @@ const DirectMessage: React.FC<{}> = () => {
   // wins; public-profile bio is the fallback for users who opted in.
   const otherUser = useMemo(() => {
     const base = members[address!] || {
-      displayName: t`Unknown User`,
-      userIcon: DefaultImages.UNKNOWN_USER,
+      // No identity yet — leave name/icon undefined so the resolver falls
+      // through to the truncated address and the avatar to address-initials.
+      displayName: undefined,
+      userIcon: undefined,
       address: address!,
     };
     const localBio = conversation?.conversation?.bio;
@@ -703,8 +711,10 @@ const DirectMessage: React.FC<{}> = () => {
     (senderId: string) => {
       return (
         members[senderId] || {
-          displayName: t`Unknown User`,
-          userIcon: DefaultImages.UNKNOWN_USER,
+          // No known identity — undefined name/icon lets the resolver fall
+          // through to the truncated address and the avatar to initials.
+          displayName: undefined,
+          userIcon: undefined,
         }
       );
     },

--- a/src/hooks/business/conversations/useDirectMessageData.ts
+++ b/src/hooks/business/conversations/useDirectMessageData.ts
@@ -3,8 +3,6 @@ import { useParams } from 'react-router';
 import { usePasskeysContext } from '@quilibrium/quilibrium-js-sdk-channels';
 import { useRegistration } from '../../queries/registration/useRegistration';
 import { useConversation } from '../../queries/conversation/useConversation';
-import { DefaultImages } from '../../../utils';
-import { t } from '@lingui/core/macro';
 
 export interface DirectMessageMember {
   displayName?: string;
@@ -45,17 +43,20 @@ export function useDirectMessageData(): UseDirectMessageDataReturn {
   const members = useMemo(() => {
     const m: { [address: string]: DirectMessageMember } = {};
 
-    // Other user
+    // Other user. Leave displayName/userIcon undefined when no identity is
+    // known so callers fall through to the truncated address (name) and
+    // address-derived initials (avatar) — matching mobile and not revealing a
+    // name/pfp until the peer replies or has a public profile.
     if (conversation?.conversation) {
       m[address!] = {
-        displayName: conversation.conversation.displayName ?? t`Unknown User`,
-        userIcon: conversation.conversation.icon ?? DefaultImages.UNKNOWN_USER,
+        displayName: conversation.conversation.displayName ?? undefined,
+        userIcon: conversation.conversation.icon ?? undefined,
         address: address!,
       };
     } else if (registration?.registration) {
       m[registration.registration.user_address] = {
-        displayName: t`Unknown User`,
-        userIcon: DefaultImages.UNKNOWN_USER,
+        displayName: undefined,
+        userIcon: undefined,
         address: registration.registration.user_address,
       };
     }
@@ -72,8 +73,8 @@ export function useDirectMessageData(): UseDirectMessageDataReturn {
 
   // Helper getters for easier access
   const otherUser = members[address!] || {
-    displayName: t`Unknown User`,
-    userIcon: DefaultImages.UNKNOWN_USER,
+    displayName: undefined,
+    userIcon: undefined,
     address: address!,
   };
 


### PR DESCRIPTION
Aligns the desktop DM identity fallback to mobile.

When a DM contact has **neither replied nor opted into a public profile**, the header and avatar previously showed the literal "Unknown User" string and a `?` placeholder. This changes the fallback to render the **truncated address** as the name and **address-derived initials** as the avatar, matching mobile exactly.

## How

The root cause was injecting the literal `"Unknown User"` string as the display name (and the `UNKNOWN_USER` placeholder as the icon), which the name resolver treats as a real name and renders verbatim, never reaching the address fallback. Leaving `displayName`/`userIcon` **undefined** when no identity is known lets the existing resolver chain fall through to the truncated address for the name and to address-derived initials for the avatar.

## Privacy behavior (unchanged in direction)

| State | Name | Avatar |
|---|---|---|
| Never replied, no public profile | truncated address | address initial |
| Never replied, has public profile | public display name | public pfp |
| Replied (public or not) | name from reply envelope | pfp from reply envelope |

Identity is still only revealed by the peer sending a message (consent) or by deliberately publishing a public profile.

## Files
- `src/components/direct/DirectMessage.tsx` — members / otherUser / mapSenderToUser fallbacks
- `src/hooks/business/conversations/useDirectMessageData.ts` — parallel hook aligned