### PR TITLE
Fix per-space avatar clears and hydrate user settings display name

### DIFF
--- a/src/hooks/business/spaces/useSpaceProfile.ts
+++ b/src/hooks/business/spaces/useSpaceProfile.ts
@@ -199,12 +199,24 @@ export const useSpaceProfile = (
       return `data:${currentFile.type};base64,${Buffer.from(fileData).toString('base64')}`;
     }
 
-    // Check if member has per-space avatar
-    if (currentMember?.user_icon && !currentMember.user_icon.includes(DefaultImages.UNKNOWN_USER)) {
-      return currentMember.user_icon;
+    // Three-state per-space avatar (matches the avatar clear/absent/value
+    // design — see WebSocketContext/useMembersWithPublicProfileFallback):
+    //   - real image  -> show it
+    //   - '' (cleared) -> the user DELIBERATELY removed their per-space avatar,
+    //                     so show initials and do NOT fall back to the global
+    //                     avatar (a truthy check here wrongly resurrected it)
+    //   - undefined    -> no per-space override -> fall back to the global avatar
+    const perSpaceIcon = currentMember?.user_icon;
+    if (perSpaceIcon !== undefined) {
+      // Explicit per-space value (including '' = cleared). Only a real,
+      // non-sentinel image is renderable; '' / sentinel -> default (initials).
+      if (perSpaceIcon && !perSpaceIcon.includes(DefaultImages.UNKNOWN_USER)) {
+        return perSpaceIcon;
+      }
+      return 'var(--unknown-icon)';
     }
 
-    // Fallback to global avatar
+    // No per-space override at all -> fall back to global avatar
     if (
       currentPasskeyInfo?.pfpUrl &&
       !currentPasskeyInfo.pfpUrl.includes(DefaultImages.UNKNOWN_USER)

--- a/src/hooks/business/user/useMembersWithPublicProfileFallback.ts
+++ b/src/hooks/business/user/useMembersWithPublicProfileFallback.ts
@@ -128,7 +128,16 @@ export function useMembersWithPublicProfileFallback(
       merged[addr] = {
         ...(local ?? { address: addr }),
         displayName: local?.displayName || pub.display_name || undefined,
-        userIcon: local?.userIcon || pub.profile_image || undefined,
+        // Distinguish "no per-space avatar → backfill from public profile"
+        // (userIcon === undefined) from "deliberately cleared the per-space
+        // avatar" (userIcon === ''). A truthy `||` here would resurrect the
+        // sender's global avatar over an intentional clear. useChannelData
+        // maps the never-set/UNKNOWN_USER case to undefined and a real clear
+        // to '', so `!== undefined` is the correct discriminator.
+        userIcon:
+          local?.userIcon !== undefined
+            ? local.userIcon
+            : pub.profile_image || undefined,
         // Bio uses the same per-field merge — a populated per-space bio
         // wins, otherwise we surface the global public-profile bio so
         // users we don't share a space with still show an About section.

--- a/src/hooks/business/user/useUserSettings.ts
+++ b/src/hooks/business/user/useUserSettings.ts
@@ -129,6 +129,15 @@ export const useUserSettings = (
         setTypingIndicatorsDM(config?.typingIndicatorsDM ?? false);
         setTypingIndicatorsSpaces(config?.typingIndicatorsSpaces ?? false);
         setGenerateYouTubePreviews(config?.generateYouTubePreviews ?? false);
+        // Hydrate the display name from config (saveChanges writes it as
+        // `name`). Without this the field only reflected
+        // currentPasskeyInfo.displayName at mount and stayed empty whenever
+        // that was blank — even though the name was set and synced elsewhere.
+        // Only overwrite when config actually carries a name, so we don't blank
+        // a good passkey-seeded value with an empty config.
+        if (config?.name !== undefined) {
+          setDisplayName(config.name);
+        }
         setBio(config?.bio ?? '');
         setIsProfilePublic(config?.isProfilePublic ?? false);
         setSpaceTagId(config?.spaceTagId ?? undefined);

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -1340,12 +1340,18 @@ export class MessageService {
       // block profile updates after any key rotation.
       //
       // Upsert-aware merge: omitted field = no change, empty string = clear.
-      // displayName + bio use `!== undefined` (clearing propagates); userIcon
-      // keeps the truthy guard.
+      // displayName, bio AND userIcon use `!== undefined` so an explicit clear
+      // ('') propagates. An emptied userIcon is stored as '' and the avatar
+      // components treat '' as "no image" (isLikelyRenderableImage('') === false),
+      // falling back to initials — the same as the UNKNOWN_USER sentinel. Senders
+      // that mean "no change" omit the field; the all-spaces rebroadcast sends the
+      // UNKNOWN_USER sentinel (never ''), so this does not clobber. The public-
+      // profile backfill (useMembersWithPublicProfileFallback) also honors '' as
+      // a deliberate clear, so it won't resurrect the sender's global avatar.
       if (decryptedContent.content.displayName !== undefined) {
         participant.display_name = decryptedContent.content.displayName;
       }
-      if (decryptedContent.content.userIcon) {
+      if (decryptedContent.content.userIcon !== undefined) {
         participant.user_icon = decryptedContent.content.userIcon;
       }
       if (decryptedContent.content.bio !== undefined) {
@@ -1900,10 +1906,12 @@ export class MessageService {
       // Upsert-aware merge (mirrors mobile WebSocketContext.tsx:1841-1854):
       // see the same block in saveMessage above for the full rationale.
       // Presence semantics: omitted = no change, explicit empty = clear.
+      // userIcon uses `!== undefined` too so an emptied avatar ('') propagates
+      // and falls back to initials (see the saveMessage block above).
       if (decryptedContent.content.displayName !== undefined) {
         participant.display_name = decryptedContent.content.displayName;
       }
-      if (decryptedContent.content.userIcon) {
+      if (decryptedContent.content.userIcon !== undefined) {
         participant.user_icon = decryptedContent.content.userIcon;
       }
       if (decryptedContent.content.bio !== undefined) {


### PR DESCRIPTION
Makes cleared avatars propagate correctly and fixes the user settings display-name field. Applies the same empty-vs-cleared model as the paired quorum-mobile PR.

## Changes
- **Receive honors a cleared avatar:** an empty-string `userIcon` in an incoming `update-profile` is now treated as a deliberate clear instead of being dropped by a truthy check, at both receive sites. A cleared avatar falls back to initials (the render layer already treats `''` as no image).
- **No resurrection via backfill:** `useMembersWithPublicProfileFallback` no longer resurrects a cleared per-space avatar from the sender's global public profile — an explicit empty local value wins; only an absent (`undefined`) value backfills.
- **Space Settings avatar preview:** a cleared per-space avatar shows initials instead of falling through to the global avatar.
- **User Settings display name:** hydrate the field from config on open. It was never populated, so it showed empty even when a name was set, and a save risked writing an empty name over the real one.

## Model
Three states, discriminated by presence not truthiness: `undefined` = no change (backfill allowed), `''` = deliberate clear (wins, shows initials), value = the image.

## Testing
Mobile→desktop verified 2026-07-15: clearing an avatar on another device now clears here (member rows and Space Settings preview) and shows initials; no type errors.

Paired with quorum-mobile PR (fix-space-profile-updates).