### PR TITLE
Keep per-space profile settings in sync with synced member updates

### DIFF
--- a/src/hooks/business/spaces/useSpaceProfile.ts
+++ b/src/hooks/business/spaces/useSpaceProfile.ts
@@ -1,11 +1,13 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useDropzone, FileRejection } from 'react-dropzone';
 import { usePasskeysContext } from '@quilibrium/quilibrium-js-sdk-channels';
 import { t } from '@lingui/core/macro';
 import { DefaultImages } from '../../../utils';
 import { processAvatarImage, FILE_SIZE_LIMITS } from '../../../utils/imageProcessing';
 import { useMessageDB } from '../../../components/context/useMessageDB';
-import { useQueryClient } from '@tanstack/react-query';
+import { useQueryClient, useQuery } from '@tanstack/react-query';
+import { buildSpaceMembersKey } from '../../queries/spaceMembers/buildSpaceMembersKey';
+import { buildSpaceMembersFetcher } from '../../queries/spaceMembers/buildSpaceMembersFetcher';
 import { showError } from '../../../utils/toast';
 import { useDisplayNameValidation, validateUserBio } from '../validation';
 
@@ -74,36 +76,55 @@ export const useSpaceProfile = (
   const bioErrors = validateUserBio(bio);
   const hasValidationError = !!displayNameError || bioErrors.length > 0;
 
-  // Load current member data
+  // Load the member from the REACTIVE space-members query (same cache the
+  // channel/message rows use), not a one-shot read. A profile update synced
+  // from another device (e.g. a per-space name change made on mobile) writes
+  // the member row and invalidates this query, so opening this modal before
+  // that write lands no longer shows a stale/empty field that never refreshes.
+  // Plain useQuery (not the suspense variant) so no Suspense boundary is needed
+  // here; it shares the same queryKey/cache, so it stays in sync.
+  const { data: spaceMembers } = useQuery({
+    queryKey: buildSpaceMembersKey({ spaceId }),
+    queryFn: buildSpaceMembersFetcher({ spaceId, messageDB }),
+    enabled: !!spaceId && !!currentPasskeyInfo?.address,
+    networkMode: 'always', // IndexedDB, not network
+  });
+
+  const ownMember = useMemo(() => {
+    const addr = currentPasskeyInfo?.address;
+    if (!addr || !spaceMembers) return undefined;
+    return spaceMembers.find(
+      (m) =>
+        (m as { user_address?: string }).user_address === addr ||
+        (m as { address?: string }).address === addr
+    );
+  }, [spaceMembers, currentPasskeyInfo?.address]);
+
+  // Hydrate the editable fields from the member — but ONLY while the field is
+  // still pristine (its current value equals the last-loaded baseline). Once
+  // the user edits, the field diverges from baseline and we stop overwriting,
+  // so a live sync update never clobbers in-progress typing. When the member
+  // updates and the user hasn't touched the form, the field refreshes live.
   useEffect(() => {
     if (!currentPasskeyInfo?.address) return;
-
-    (async () => {
-      try {
-        const member = await messageDB.getSpaceMember(spaceId, currentPasskeyInfo.address);
-        setCurrentMember(member);
-        // Per-space name is an optional override: init from the member's name
-        // only, NOT the global name (that made an unset override look set and
-        // defeated clearing). Empty = use my global / QNS name here.
-        const initialDisplayName = member?.display_name ?? '';
-        const initialBio = member?.bio ?? '';
-        const initialUserIcon = member?.user_icon ?? '';
-        setDisplayName(initialDisplayName);
-        setBio(initialBio);
-        setBaseline({
-          displayName: initialDisplayName,
-          bio: initialBio,
-          userIcon: initialUserIcon,
-        });
-      } catch (error) {
-        console.error('Failed to load space member:', error);
-        // Fallback to global profile
-        setDisplayName(currentPasskeyInfo.displayName || '');
-        setBio('');
-        setBaseline({ displayName: currentPasskeyInfo.displayName || '', bio: '', userIcon: '' });
-      }
-    })();
-  }, [spaceId, currentPasskeyInfo?.address, messageDB]);
+    // Per-space name/bio are optional overrides: init from the member only,
+    // NOT the global name (that made an unset override look set and defeated
+    // clearing). Empty = use my global / QNS name here.
+    const memberDisplayName = ownMember?.display_name ?? '';
+    const memberBio = ownMember?.bio ?? '';
+    const memberUserIcon = ownMember?.user_icon ?? '';
+    setCurrentMember(ownMember ?? null);
+    setDisplayName((cur) => (cur === baseline.displayName ? memberDisplayName : cur));
+    setBio((cur) => (cur === baseline.bio ? memberBio : cur));
+    setBaseline({
+      displayName: memberDisplayName,
+      bio: memberBio,
+      userIcon: memberUserIcon,
+    });
+    // baseline is intentionally omitted from deps: it's updated here and the
+    // pristine check reads the latest value via the functional setState above.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ownMember, currentPasskeyInfo?.address]);
 
   // Dropzone for avatar upload
   const { getRootProps, getInputProps, isDragActive: isAvatarDragActive } = useDropzone({

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -4357,6 +4357,19 @@ export class MessageService {
                   }
                 }
 
+                // A synced batch may include an update-profile that saveMessage
+                // wrote to the member store above. This bulk-sync path refetched
+                // messages but not the members query, so a per-space profile
+                // change synced from another device (e.g. a name/avatar edit on
+                // mobile) landed in IndexedDB but never refreshed the live
+                // SpaceMembers cache — leaving stale member data (empty name /
+                // old avatar) until a manual refetch. Refetch it once per batch.
+                queryClient.refetchQueries({
+                  queryKey: buildSpaceMembersKey({
+                    spaceId: conversationId.split('/')[0],
+                  }),
+                });
+
                 noteSyncActivity();
               }
             }


### PR DESCRIPTION
The Space Settings Account tab read the current member once on mount with no reactivity, so a per-space name/avatar change synced from another device could show a stale or empty field that never refreshed until the modal was reopened. Saving from that stale state could also fall back to the global name.

## Changes
- Source the member from the reactive `SpaceMembers` query (the same cache the channel/message rows use) instead of a one-shot read. Re-hydrate the form fields only while they are pristine, so a live update never clobbers in-progress edits.
- Refetch the `SpaceMembers` query after the bulk message-sync path, which previously refreshed only the messages cache. A profile update arriving via sync now updates the live member data instead of sitting unseen in IndexedDB.

## Testing
Verified: a per-space name changed on another device now shows correctly in Space Settings and updates on reopen; no type or lint regressions. Mobile does not need this change (it reads members directly from storage and re-reads on modal open).