### PR TITLE
feat: per-space profile follows global unless overridden

### DIFF
--- a/.agents/INDEX.md
+++ b/.agents/INDEX.md
@@ -35,6 +35,7 @@ This is the main index for all documentation, bug reports, and task management.
 - [Dropdown Panels](docs/features/dropdown-panels.md)
 - [Input & Textarea Validation Reference](docs/features/input-validation-reference.md)
 - [Invite System Documentation](docs/features/invite-system-analysis.md)
+- [Identity resolution and profile sync (canonical model)](docs/features/identity-resolution-and-profile-sync.md)
 - [Kick User System Documentation](docs/features/kick-user-system.md)
 - [Mention Pills UI System](docs/features/mention-pills-ui-system.md)
 - [Message Search Feature](docs/features/search-feature.md)

--- a/.agents/INDEX.md
+++ b/.agents/INDEX.md
@@ -200,6 +200,8 @@ This is the main index for all documentation, bug reports, and task management.
 - [Application-owned scroll anchoring for the message list (β)](tasks/2026-05-24-virtuoso-application-owned-scroll-anchoring.md)
 - [Unify Account tab's defer-vs-instant control semantics](tasks/2026-06-07-account-tab-defer-save-unification.md)
 - [UserProfile card layout polish pass](tasks/2026-06-08-userprofile-card-layout-polish.md)
+- [update-profile receive: add per-slot staleness guard (parity with mobile)](tasks/2026-07-16-update-profile-receive-per-slot-timestamp-guard.md)
+- [quorum-shared: type the two-slot global identity fields (retire casts)](tasks/2026-07-16-quorum-shared-type-two-slot-global-identity-fields.md)
 
 ### .Archived
 - [🚀 Search Performance Optimization - Revised Implementation Plan](tasks/.archived/2025-11-12-search-performance-optimization-original.md)

--- a/.agents/docs/features/identity-resolution-and-profile-sync.md
+++ b/.agents/docs/features/identity-resolution-and-profile-sync.md
@@ -205,8 +205,17 @@ global identity on the next reconnect.
   `.agents/bugs/2026-07-02-dm-message-delivery-unreliable-master.md`). The DM
   path is UNTOUCHED by this work; DM verification is parked on that transport
   issue, not on this feature.
-- **Mobile↔desktop:** blocked by the same transport flakiness this session.
-  Verify once transport is healthy.
+- **Mobile→desktop global propagation:** CONFIRMED 2026-07-16. A display-name
+  changed on mobile propagated to desktop once the (flaky) transport recovered
+  and messages started landing — the name update rode in with the space
+  messages, exactly as the shared-transport model predicts. Validates the full
+  chain: mobile send → wire field parse → separate-global-slot store → render.
+  The earlier "not landing" was the pre-existing transport flakiness, not this
+  feature.
+- **Rapid two-device LWW race** (near-simultaneous renames on two devices →
+  strictly-latest wins everywhere): not yet exercised behaviorally; the
+  independent per-slot timestamp guards were verified by review. Low residual
+  risk.
 - **Static confidence:** three independent code reviews (delivery-safety, LWW
   correctness, regressions) found no delivery risk and two minor bugs, both
   fixed (desktop optimistic-cache override wipe; mobile stale-message drop

--- a/.agents/docs/features/identity-resolution-and-profile-sync.md
+++ b/.agents/docs/features/identity-resolution-and-profile-sync.md
@@ -1,0 +1,172 @@
+---
+type: doc
+title: "Identity resolution and profile sync (canonical model)"
+status: done
+ai_generated: true
+created: 2026-07-16
+updated: 2026-07-16
+related_docs:
+  - "qns-username-display.md"
+  - "user-config-sync.md"
+  - "../config-sync-system.md"
+related_tasks:
+  - ".agents/tasks/port-from-mobile/.done/2026-06-08-port-public-profile.md"
+  - ".agents/tasks/.done/2026-06-10-space-message-list-public-profile-fallback.md"
+---
+
+# Identity resolution and profile sync (canonical model)
+
+> **⚠️ AI-Generated**: May contain errors. Verify before use.
+> Applies to BOTH apps (desktop + mobile). Written 2026-07-16 during the
+> per-space-profile follow-global work, after tracing every write/read path
+> in both codebases. This is the one place that explains how a user's
+> name/avatar/bio flows through the system. Read this BEFORE touching any
+> profile, member-roster, or public-profile code.
+
+## The question this answers
+
+"Which name/avatar/bio does user X show, on which surface, and how does a
+change made on one device reach everyone else?"
+
+## The three storage channels
+
+A user's identity lives in three places. Each has ONE job. Most historical
+bugs came from these three competing instead of layering.
+
+| # | Channel | What it is | Audience | How it moves |
+|---|---------|-----------|----------|--------------|
+| A | **Encrypted UserConfig** (`name`, `profile_image`, `bio`) | Your private, encrypted settings blob on the Quorum API | **Your own other devices** | `saveConfig` on edit; `getConfig` on startup/login (timestamp LWW). No live push — other devices see it on restart or incidental re-pull. |
+| B | **Published public profile** (`GET/POST /users/:addr/public-profile`) | Signed plaintext record: `display_name`, `profile_image`, `bio`, `primary_username` | **Everyone else** — both strangers (DM headers, lookups) AND spacemates (as the global fallback in the precedence ladder) | Published on global-profile save when `isProfilePublic=true`; fetched on demand with a 1h React Query cache (`publicProfileQueryKey`). Opt-in. |
+| C | **Space member roster** (`SpaceMember.display_name` / `user_icon` / `bio`) | Per-space member rows, one per (space, member) | **Members of that space** | `update-profile` messages sent into the space; receivers upsert with a `profileTimestamp` staleness guard (skip if `existing >= msg.createdDate`). |
+
+Plus render-only inputs: QNS `primary_username` (travels ONLY in B, never in
+messages) and the truncated address as final fallback.
+
+## What the public-profile feature IS (and is not)
+
+It is the **opt-in "be discoverable" feature**: when ON, people who do NOT
+share a space with you (a stranger DMing you, an address lookup) see your
+name/avatar/bio instead of your raw address. It is also the only carrier of
+`primary_username` (the `.q` name) and of your **global** display name as
+data that the precedence ladder can fall back to inside spaces.
+
+It is NOT the primary mechanism by which spacemates see your name — that is
+the space roster (channel C), fed by `update-profile` messages. The
+public-profile server is consulted for a spacemate only as a FALLBACK when
+their roster entry lacks a field (see precedence below).
+
+The toggle does NOT gate reachability (QNS resolution is public); it only
+gates whether Quorum displays your profile data to non-spacemates.
+
+## The precedence ladder (render time)
+
+From `qns-username-display.md`, implemented by the shared
+`resolveDisplayName` + per-app adapters (`resolveSpaceMemberName` /
+`resolveMemberName` on desktop; mobile merges via
+`useMembersWithPublicProfileFallback.pickField`):
+
+```
+custom per-space name (C, deliberate)  →  QNS primary username .q (B)
+  →  global display name (B)  →  truncated address
+```
+
+- **Space surfaces:** deliberate per-space override wins; else QNS; else
+  global; else address.
+- **DM / global surfaces** (no per-space concept): QNS → global → address.
+- Avatar and bio follow the same "override else global" idea (no QNS step).
+
+## The two-state per-space model (follow-global, 2026-07-15/16)
+
+A per-space field is an OPTIONAL OVERRIDE with exactly two states:
+- **absent/empty = follow global** (default): the space renders your current
+  global value, dynamically.
+- **non-empty = override**: replaces the global value in that space only.
+
+There is NO per-space "explicitly blank" state. Wire semantics for
+`update-profile` fields: **omitted = no change; `''` = deliberate clear
+(revert to follow-global); value = set override.**
+
+### Why: the roster-stamping problem
+
+Historically BOTH apps copied the user's global name/avatar into the space
+roster (channel C) at join, at space creation, on every reconnect
+rebroadcast, and on every global save. Consequences:
+
+1. Roster rows couldn't distinguish "deliberate per-space name" from
+   "copied global default" — desktop built the comparison trick in
+   `resolveSpaceMemberName` (roster == global ⇒ treat as default) to guess.
+2. Global changes did NOT propagate to spaces (rows were frozen copies).
+3. "Clear my per-space name" was inexpressible (clearing re-showed the
+   global, which then got re-stamped).
+4. Your own devices raced each other: each device's global save re-stamped
+   every space with ITS value; last device to save/reconnect won the roster.
+
+The follow-global work removes the stamping so a non-empty roster field
+means a REAL override. De-stamped so far (2026-07-16, branch
+`follow-global-profile` in both repos): the on-connect/tag-rotation
+rebroadcasts, space creation, and (desktop) the editor save. STILL STAMPING
+as of this writing: the global-profile save path on both apps (desktop
+`MessageDB.updateUserProfile` all-spaces loop; mobile
+`UnifiedProfileEditModal.saveQuorum` per-space loop) — removing that is the
+remaining planned change. Once removed, the comparison trick becomes a
+legacy safety net rather than load-bearing.
+
+## How a global profile change propagates (target model)
+
+User edits global name/avatar/bio on device D1:
+
+1. **Local + channel A:** update local user state; `saveConfig` (encrypted,
+   timestamped). D2 picks it up on restart/next pull (no live push — known
+   gap, acceptable).
+2. **Channel B:** if `isProfilePublic`, publish the signed public profile
+   (server keeps latest by timestamp = LWW across devices). Local
+   `publicProfileQueryKey` cache is optimistically updated + invalidated on
+   the saving device.
+3. **Channel C:** NOTHING (after the remaining de-stamping change lands).
+   Spacemates see the new global value via the precedence ladder: their
+   roster row for you is empty (no override) → falls to B on their next
+   profile fetch (1h cache, so up to ~1h staleness for them; DM partners
+   still get the live DM identity broadcast).
+4. **DMs:** unchanged — DM identity is pushed to partners via the existing
+   DM profile broadcast (global value; DMs have no override concept).
+
+Per-space override edit (Space Settings → Account) is the ONLY thing that
+writes channel C: value / `''` / omitted per the wire semantics above.
+
+## Known limitations (accepted)
+
+- **Channel A has no live cross-device push** — your own second device
+  learns a global change on restart/incidental pull. (Historical; see
+  `config-blob-syncs-only-on-restart-not-live` behavior.)
+- **Channel B 1h cache** — OTHER users can render your old global identity
+  for up to ~1h after a rename (documented in qns-username-display.md).
+  The renaming device refreshes its own cache immediately.
+- **`Date.now()` LWW** — B and C timestamps come from the writing device's
+  clock; severe clock skew can make an older edit win. Accepted (2026-07-16
+  decision) — normal skew is seconds.
+- **Non-public users** (`isProfilePublic=false`) have no channel B: to
+  spacemates they render their per-space override if any, else placeholder/
+  address; to strangers always the address. This is the privacy-consistent
+  reading of the opt-in.
+- **Legacy stamped rosters**: rows stamped with old global values before the
+  de-stamping look like deliberate overrides until manually cleared in that
+  space's settings. Decision 2026-07-16: NO auto-migration (tiny user base,
+  manual clear is easy).
+
+## File map (where each piece lives)
+
+| Piece | Desktop | Mobile |
+|---|---|---|
+| Global editor save | `src/hooks/business/user/useUserSettings.ts` | `components/UnifiedProfileEditModal.tsx` (`saveQuorum`) |
+| Publish/unpublish B | `src/services/PublicProfileService.ts` | `services/profile/publicProfile.ts` |
+| B fetch hook (1h cache) | `src/hooks/business/user/useUserPublicProfile.ts` | `hooks/useUserPublicProfile.ts` |
+| Member fallback (precedence merge) | `src/hooks/business/user/useMembersWithPublicProfileFallback.ts` | `hooks/useMembersWithPublicProfileFallback.ts` |
+| Name resolvers | `src/utils/resolveMemberName.ts` (+ shared `resolveDisplayName`) | merged inside the fallback hook (`pickField`) |
+| Space editor (override) | `useSpaceProfile.ts` + `SpaceSettingsModal/Account.tsx` | `components/SpaceSettingsModal.tsx` |
+| C receive/upsert | `MessageService.ts` (update-profile handler) | `context/WebSocketContext.tsx` (~2100, ~3578) |
+| On-connect rebroadcast | `MessageService.ts` (~577, tag rotation) | `context/WebSocketContext.tsx` (~4770) |
+| Global-save space broadcast (TO BE REMOVED) | `MessageDB.tsx` `updateUserProfile` (~421) | `UnifiedProfileEditModal.tsx` `saveQuorum` space loop |
+| Channel A sync | `src/services/ConfigService.ts` | `services/config/configService.ts` |
+
+---
+*Last updated: 2026-07-16*

--- a/.agents/docs/features/identity-resolution-and-profile-sync.md
+++ b/.agents/docs/features/identity-resolution-and-profile-sync.md
@@ -66,14 +66,17 @@ From `qns-username-display.md`, implemented by the shared
 `useMembersWithPublicProfileFallback.pickField`):
 
 ```
-custom per-space name (C, deliberate)  →  QNS primary username .q (B)
-  →  global display name (B)  →  truncated address
+custom per-space name (C override)  →  QNS primary username .q (B)
+  →  global display name (C global slot, else B)  →  truncated address
 ```
 
-- **Space surfaces:** deliberate per-space override wins; else QNS; else
-  global; else address.
+- **Space surfaces:** deliberate per-space override wins; else QNS; else the
+  member's global name (from the roster GLOBAL SLOT if present — the live push,
+  works for non-public users — else the public profile); else address.
 - **DM / global surfaces** (no per-space concept): QNS → global → address.
-- Avatar and bio follow the same "override else global" idea (no QNS step).
+- Avatar and bio follow the same "override → global slot → public" idea (no QNS
+  step). The global slot is the tier added by the two-slot model (below); it
+  sits between the override and the public profile.
 
 ## The two-state per-space model (follow-global, 2026-07-15/16)
 
@@ -101,37 +104,65 @@ rebroadcast, and on every global save. Consequences:
 4. Your own devices raced each other: each device's global save re-stamped
    every space with ITS value; last device to save/reconnect won the roster.
 
-The follow-global work removes the stamping so a non-empty roster field
-means a REAL override. De-stamped so far (2026-07-16, branch
-`follow-global-profile` in both repos): the on-connect/tag-rotation
-rebroadcasts, space creation, and (desktop) the editor save. STILL STAMPING
-as of this writing: the global-profile save path on both apps (desktop
-`MessageDB.updateUserProfile` all-spaces loop; mobile
-`UnifiedProfileEditModal.saveQuorum` per-space loop) — removing that is the
-remaining planned change. Once removed, the comparison trick becomes a
-legacy safety net rather than load-bearing.
+The follow-global work removes the OVERRIDE-field stamping so a non-empty
+override roster field means a REAL override. This SHIPPED 2026-07-16 (branch
+`follow-global-profile`, both repos): the on-connect/tag-rotation rebroadcasts,
+space creation, and the editor saves no longer write the global value into the
+override fields. The `resolveSpaceMemberName` comparison trick is now a legacy
+safety net (it neutralizes old stamped rows for free) rather than load-bearing.
 
-## How a global profile change propagates (target model)
+## The TWO-SLOT wire model (what actually shipped)
 
-User edits global name/avatar/bio on device D1:
+Rather than remove the global-save space broadcast entirely (which would have
+left spacemates dependent on channel B's 1h cache, and broken it for
+non-public users), `update-profile` messages carry TWO clearly-labeled groups
+of fields, stored SEPARATELY on the member row:
+
+- **Override slot** — `displayName` / `userIcon` / `bio` (wire) →
+  `display_name` / `user_icon`(desktop) or `profile_image`(mobile) / `bio`
+  (storage). A deliberate per-space override. Guarded by `profileTimestamp`.
+- **Global slot** — `globalDisplayName` / `globalUserIcon` / `globalBio` (wire)
+  → `global_display_name` / `global_user_icon`(desktop) or
+  `global_profile_image`(mobile) / `global_bio` (storage). The sender's current
+  global identity. Guarded (mobile) by a SEPARATE `globalProfileTimestamp`.
+
+The wire field names are identical across apps (byte-for-byte); only the local
+STORAGE field names differ (desktop `global_user_icon` vs mobile
+`global_profile_image` — each app reads its own storage). The global* fields
+are additive; old clients ignore them; the message signature is unaffected
+(`canonicalize` only hashes `type + displayName + userIcon`).
+
+> Not yet in the shared `UpdateProfileMessage` type — carried via casts. See
+> the follow-up task `2026-07-16-quorum-shared-type-two-slot-global-identity-fields`.
+
+## How a global profile change propagates (shipped model)
+
+User edits global name/avatar/bio on device D1 (`UnifiedProfileEditModal.
+saveQuorum` on mobile / `useUserSettings` → `MessageDB.updateUserProfile` on
+desktop):
 
 1. **Local + channel A:** update local user state; `saveConfig` (encrypted,
-   timestamped). D2 picks it up on restart/next pull (no live push — known
-   gap, acceptable).
+   timestamped). D2 picks it up on restart/next pull (no live push — known gap).
 2. **Channel B:** if `isProfilePublic`, publish the signed public profile
    (server keeps latest by timestamp = LWW across devices). Local
    `publicProfileQueryKey` cache is optimistically updated + invalidated on
    the saving device.
-3. **Channel C:** NOTHING (after the remaining de-stamping change lands).
-   Spacemates see the new global value via the precedence ladder: their
-   roster row for you is empty (no override) → falls to B on their next
-   profile fetch (1h cache, so up to ~1h staleness for them; DM partners
-   still get the live DM identity broadcast).
+3. **Channel C — GLOBAL SLOT (the live push):** send an `update-profile` to
+   every space carrying ONLY the global* slot (never the override fields).
+   Spacemates store it in the separate global slot and render it via the
+   precedence ladder immediately — no dependence on B's 1h cache, and it works
+   for NON-PUBLIC users too. The editing device also writes its own roster
+   global slots locally for instant self-render.
 4. **DMs:** unchanged — DM identity is pushed to partners via the existing
-   DM profile broadcast (global value; DMs have no override concept).
+   `dm-update-profile` broadcast (global value; DMs have no override concept).
 
-Per-space override edit (Space Settings → Account) is the ONLY thing that
-writes channel C: value / `''` / omitted per the wire semantics above.
+A per-space override edit (Space Settings → Account) is the ONLY thing that
+writes the OVERRIDE slot: value / `''` (clear = follow global) / omitted (no
+change) per the wire semantics above.
+
+The on-connect / tag-rotation rebroadcasts send the override-or-omit fields AND
+the current global slot, so a spacemate who missed a live save still learns the
+global identity on the next reconnect.
 
 ## Known limitations (accepted)
 
@@ -144,14 +175,42 @@ writes channel C: value / `''` / omitted per the wire semantics above.
 - **`Date.now()` LWW** — B and C timestamps come from the writing device's
   clock; severe clock skew can make an older edit win. Accepted (2026-07-16
   decision) — normal skew is seconds.
-- **Non-public users** (`isProfilePublic=false`) have no channel B: to
-  spacemates they render their per-space override if any, else placeholder/
-  address; to strangers always the address. This is the privacy-consistent
-  reading of the opt-in.
+- **Non-public users** (`isProfilePublic=false`) have no channel B, but they DO
+  reach spacemates: their global identity is pushed via the channel-C GLOBAL
+  SLOT (that's the whole point of the two-slot design). Only STRANGERS (no
+  shared space) see the address for a non-public user. Privacy-consistent: the
+  public toggle governs stranger visibility, not what spacemates see.
+- **Bio to DMs vs spaces**: global bio propagates to SPACEMATES ungated (via the
+  global slot). The DM identity broadcast still gates bio on `isProfilePublic`
+  (legacy DM behavior, unchanged). So a non-public user shows their bio to
+  spacemates but not to DM-only partners — accepted asymmetry.
+- **Channel B 1h cache** — still relevant for STRANGERS (people with no shared
+  space) and for the QNS `.q` name, which travels only in B. Spacemates no
+  longer depend on it for name/avatar/bio (the global slot is the live push).
+- **`Date.now()` LWW** — B and C timestamps come from the writing device's
+  clock; severe clock skew can make an older edit win. Accepted (2026-07-16).
 - **Legacy stamped rosters**: rows stamped with old global values before the
   de-stamping look like deliberate overrides until manually cleared in that
-  space's settings. Decision 2026-07-16: NO auto-migration (tiny user base,
-  manual clear is easy).
+  space's settings. Decision 2026-07-16: NO auto-migration (tiny user base).
+  Side effect: such a row can render a different name on desktop vs mobile
+  (desktop's comparison trick demotes a roster==global name to QNS; mobile
+  doesn't) until cleared — folds into the same accepted limitation.
+
+## Verification status (2026-07-16)
+
+- **Spaces, desktop↔desktop:** CONFIRMED working by the user — space text lands
+  and per-space + global profile updates render correctly.
+- **DM profile propagation:** BLOCKED by a pre-existing, unrelated DM-transport
+  delivery issue (~6 months old; master bug
+  `.agents/bugs/2026-07-02-dm-message-delivery-unreliable-master.md`). The DM
+  path is UNTOUCHED by this work; DM verification is parked on that transport
+  issue, not on this feature.
+- **Mobile↔desktop:** blocked by the same transport flakiness this session.
+  Verify once transport is healthy.
+- **Static confidence:** three independent code reviews (delivery-safety, LWW
+  correctness, regressions) found no delivery risk and two minor bugs, both
+  fixed (desktop optimistic-cache override wipe; mobile stale-message drop
+  guard). Both repos typecheck clean.
 
 ## File map (where each piece lives)
 
@@ -163,9 +222,11 @@ writes channel C: value / `''` / omitted per the wire semantics above.
 | Member fallback (precedence merge) | `src/hooks/business/user/useMembersWithPublicProfileFallback.ts` | `hooks/useMembersWithPublicProfileFallback.ts` |
 | Name resolvers | `src/utils/resolveMemberName.ts` (+ shared `resolveDisplayName`) | merged inside the fallback hook (`pickField`) |
 | Space editor (override) | `useSpaceProfile.ts` + `SpaceSettingsModal/Account.tsx` | `components/SpaceSettingsModal.tsx` |
-| C receive/upsert | `MessageService.ts` (update-profile handler) | `context/WebSocketContext.tsx` (~2100, ~3578) |
-| On-connect rebroadcast | `MessageService.ts` (~577, tag rotation) | `context/WebSocketContext.tsx` (~4770) |
-| Global-save space broadcast (TO BE REMOVED) | `MessageDB.tsx` `updateUserProfile` (~421) | `UnifiedProfileEditModal.tsx` `saveQuorum` space loop |
+| C receive/upsert (two-slot merge) | `MessageService.ts` (update-profile handlers + `applyGlobalProfileSlots`) | `context/WebSocketContext.tsx` (~2100 JS path, ~3589 batch path) |
+| C wire send (both slots) | `MessageService.ts` rebroadcast + `MessageDB.updateUserProfile` | `services/space/spaceMessageService.ts` (`sendUpdateProfileMessage`) |
+| On-connect rebroadcast (override-or-omit + global slot) | `MessageService.ts` (~595, tag rotation) | `context/WebSocketContext.tsx` (~4783) |
+| Global-save space broadcast (GLOBAL SLOT only) | `MessageDB.tsx` `updateUserProfile` | `UnifiedProfileEditModal.tsx` `saveQuorum` space loop |
+| useChannelData (surfaces global slots) | `src/hooks/business/channels/useChannelData.ts` | (mobile reads slots directly in the fallback hook) |
 | Channel A sync | `src/services/ConfigService.ts` | `services/config/configService.ts` |
 
 ---

--- a/.agents/tasks/2026-07-16-quorum-shared-type-two-slot-global-identity-fields.md
+++ b/.agents/tasks/2026-07-16-quorum-shared-type-two-slot-global-identity-fields.md
@@ -1,0 +1,78 @@
+---
+type: task
+title: "quorum-shared: type the two-slot global identity fields (retire casts)"
+status: todo
+priority: low
+created: 2026-07-16
+related_docs:
+  - ".agents/docs/features/identity-resolution-and-profile-sync.md"
+related_files:
+  - "src/services/MessageService.ts"
+  - "src/components/context/MessageDB.tsx"
+  - "src/hooks/business/user/useMembersWithPublicProfileFallback.ts"
+  - "src/hooks/business/channels/useChannelData.ts"
+---
+
+# quorum-shared: type the two-slot global identity fields
+
+> Housed in the desktop repo (its `.agents/` is git-tracked/synced) but the
+> actual code change lands in **quorum-shared**, then both apps swap their casts
+> to the typed fields on the next shared bump. Coordinate with the shared lead.
+
+## Context
+
+The two-slot identity design (see identity-resolution-and-profile-sync doc)
+shipped 2026-07-16 on branch `follow-global-profile` in both apps. It adds a
+GLOBAL identity slot to `update-profile` messages and to member rows, stored
+separately from the per-space OVERRIDE fields. To ship without waiting on a
+shared publish, both apps carry the new fields **untyped via casts**:
+
+- Wire (`UpdateProfileMessage`): `globalDisplayName` / `globalUserIcon` /
+  `globalBio`. Desktop casts with `as unknown as UpdateProfileMessage`
+  (`MessageDB.tsx`); mobile casts the content `as MessageContent`
+  (`spaceMessageService.ts`).
+- Member row: `global_display_name` / `global_user_icon` (`global_profile_image`
+  on mobile) / `global_bio`, plus a `globalProfileTimestamp` (mobile). Read via
+  `(x as any)` / helper casts on both sides.
+
+This works — old clients ignore unknown wire fields, and the fields round-trip
+untyped — but it means zero TypeScript safety on the new fields and a drift
+risk if the two apps' field names diverge.
+
+## What to do
+
+1. **quorum-shared** — add, additively and optional:
+   - `UpdateProfileMessage`: `globalDisplayName?: string`, `globalUserIcon?:
+     string`, `globalBio?: string`.
+   - `SpaceMember` / `UserProfile` (whichever the member row extends):
+     `global_display_name?`, `global_user_icon?`, `global_bio?`,
+     `globalProfileTimestamp?: number`. (Confirm the canonical avatar field
+     name — mobile stores `global_profile_image`, desktop reads
+     `global_user_icon`; pick ONE in the shared type and align both apps.)
+   - Publish.
+2. **Desktop** — remove the `as unknown as UpdateProfileMessage` cast in
+   `MessageDB.updateUserProfile`, the `as MessageContent`-style casts, and the
+   `(curr as any).global_*` reads in `useChannelData` / the
+   `applyGlobalProfileSlots` helper; use the typed fields.
+3. **Mobile** — same: drop the `content as MessageContent` cast in
+   `sendUpdateProfileMessage`, the `as never` member-row writes, and the
+   `(local as {...})` reads in `useMembersWithPublicProfileFallback`.
+
+## Gotcha: canonical avatar field name
+
+Mobile's member row uses `global_profile_image`; desktop reads
+`global_user_icon` (mirroring its existing `user_icon` vs mobile's
+`profile_image` split). This is fine untyped because each app reads its own
+storage, but the WIRE field is shared (`globalUserIcon`) and both apps already
+agree on it. Only the local storage field names differ. When typing the member
+row in shared, decide whether to unify or keep the per-app split documented.
+
+## Sequencing
+
+Do this AFTER the cross-device behavior is confirmed working (no point typing a
+wire shape that might still change). Pairs naturally with
+`2026-07-16-update-profile-receive-per-slot-timestamp-guard.md` (that guard also
+needs the timestamp fields on the shared member type).
+
+---
+*Last updated: 2026-07-16*

--- a/.agents/tasks/2026-07-16-update-profile-receive-per-slot-timestamp-guard.md
+++ b/.agents/tasks/2026-07-16-update-profile-receive-per-slot-timestamp-guard.md
@@ -1,0 +1,63 @@
+---
+type: task
+title: "update-profile receive: add per-slot staleness guard (parity with mobile)"
+status: todo
+priority: low
+created: 2026-07-16
+related_docs:
+  - ".agents/docs/features/identity-resolution-and-profile-sync.md"
+related_files:
+  - "src/services/MessageService.ts"
+---
+
+# update-profile receive: add per-slot staleness guard
+
+## Context
+
+The two-slot identity design (see identity-resolution-and-profile-sync doc)
+split `update-profile` into a per-space OVERRIDE slot
+(`displayName`/`userIcon`/`bio`) and a GLOBAL slot
+(`globalDisplayName`/`globalUserIcon`/`globalBio`), stored separately on the
+member row. It shipped 2026-07-16 on branch `follow-global-profile`.
+
+**Mobile** guards each slot with its own timestamp: `profileTimestamp` for the
+override slot and `globalProfileTimestamp` for the global slot, applying a slot
+only when the incoming message's `createdDate` is newer than the stored value
+for THAT slot (see `quorum-mobile/context/WebSocketContext.tsx` ~2130/~3600).
+
+**Desktop does NOT guard by timestamp at all.** Both receive handlers
+(`MessageService.ts`, the `saveMessage` path ~1366 and the standalone path
+~1931) apply profile fields whenever present. This was already true for the
+override fields BEFORE the two-slot work — the gap is pre-existing, not a
+regression — but it means out-of-order `update-profile` messages can let an
+OLDER value win until the next broadcast corrects it.
+
+## Symptom (theoretical, not yet observed)
+
+A reconnect rebroadcast carrying an older global identity arrives after a newer
+one (network reordering, a slow device catching up) and briefly overwrites the
+newer value. Self-corrects on the next broadcast. Low probability, low harm,
+but real — and the reason mobile added the guards.
+
+## Fix
+
+Add `profileTimestamp` + `globalProfileTimestamp` fields to the desktop member
+row and, in both receive handlers, apply the override fields only when
+`message.createdDate > existing.profileTimestamp` and the global fields only
+when `message.createdDate > existing.globalProfileTimestamp`. Mirror mobile's
+two-guard structure. Stamp the applied slot's timestamp on save.
+
+Do this alongside the additive shared-type work (the `global_*` fields need to
+land on the shared/desktop member type anyway), so it's one typed pass rather
+than another `as`-cast layer.
+
+## How to confirm it's needed
+
+Before implementing, reproduce the reorder: send two global renames close
+together from two devices (or replay an old rebroadcast after a new one) and
+check whether the older value ever sticks on desktop. If it never reproduces in
+practice, this can stay low-priority/wontfix. Mobile added the guard
+defensively, not from an observed desktop-style failure.
+
+---
+*Last updated: 2026-07-16*

--- a/src/components/context/MessageDB.tsx
+++ b/src/components/context/MessageDB.tsx
@@ -435,23 +435,26 @@ const MessageDBProvider: FC<MessageDBContextProps> = ({ children }) => {
     ) => {
       const spaces = await messageDB.getSpaces();
       for (const space of spaces) {
-        // Per-space bio overrides are applied via useSpaceProfile; the global
-        // bio is broadcast here so members of every space pick up the
-        // current global value. Receivers use upsert-aware merge — an
-        // explicit empty string clears the bio (matches what the user did
-        // in the User Settings → General editor); undefined leaves the
-        // receiver's stored bio untouched.
+        // Two-slot design (see identity-resolution doc): the global editor
+        // broadcasts the user's GLOBAL identity via the global* slots, NOT the
+        // per-space override fields. Sending the override fields here is what
+        // used to freeze every space to the global value and fake per-space
+        // overrides. Receivers store global* separately and render
+        // override-else-global. Empty string = deliberate global clear.
         submitChannelMessage(
           space.spaceId,
           space.defaultChannelId,
           {
             type: 'update-profile',
-            displayName,
-            userIcon,
             senderId: currentPasskeyInfo.address,
-            ...(bio !== undefined ? { bio } : {}),
+            globalDisplayName: displayName,
+            globalUserIcon: userIcon,
+            ...(bio !== undefined ? { globalBio: bio } : {}),
             ...(spaceTag ? { spaceTag } : {}),
-          } as UpdateProfileMessage,
+            // Cast via unknown: global* slots are additive, not yet on the shared
+            // UpdateProfileMessage type (additive shared PR pending). Override
+            // fields are intentionally absent — this is a global-only broadcast.
+          } as unknown as UpdateProfileMessage,
           queryClient,
           currentPasskeyInfo,
           undefined, // inReplyTo

--- a/src/components/modals/SpaceSettingsModal/Account.tsx
+++ b/src/components/modals/SpaceSettingsModal/Account.tsx
@@ -51,6 +51,7 @@ interface AccountProps {
   markedForDeletion: boolean;
   markForDeletion: () => void;
   getProfileImageUrl: () => string;
+  currentMember: unknown;
   onSave: () => void;
   isSaving: boolean;
   hasValidationError: boolean;
@@ -83,6 +84,7 @@ const Account: React.FunctionComponent<AccountProps> = ({
   markedForDeletion,
   markForDeletion,
   getProfileImageUrl,
+  currentMember,
   onSave,
   isSaving,
   hasValidationError,
@@ -156,6 +158,19 @@ const Account: React.FunctionComponent<AccountProps> = ({
             const avatarUrl = getProfileImageUrl();
             const showImage = hasAvatar && avatarUrl !== 'var(--unknown-icon)';
 
+            // The revert control ("Use my main avatar") only makes sense when a
+            // per-space OVERRIDE exists — either a fresh upload staged in this
+            // session, or a stored non-empty per-space user_icon. When merely
+            // FOLLOWING the global avatar (no override), showing a "remove"
+            // control is the misleading affordance this effort removes: there is
+            // nothing per-space to revert. (Follow-global design.)
+            const hasFreshUpload = !!fileData;
+            const perSpaceIcon = (currentMember as { user_icon?: string })?.user_icon;
+            const hasStoredOverride =
+              !!perSpaceIcon && !perSpaceIcon.includes(DefaultImages.UNKNOWN_USER);
+            const hasOverride =
+              (hasFreshUpload || hasStoredOverride) && !markedForDeletion;
+
             return (
               <>
                 <div
@@ -166,8 +181,8 @@ const Account: React.FunctionComponent<AccountProps> = ({
                 >
                   <input {...getInputProps()} />
                   {!showImage && <Icon name="image" size="2xl" className="icon" />}
-                  {showImage && (
-                    <Tooltip id="space-profile-avatar-delete" content={t`Delete this image`} place="bottom">
+                  {showImage && hasOverride && (
+                    <Tooltip id="space-profile-avatar-delete" content={t`Use my main avatar`} place="bottom">
                       <button
                         type="button"
                         className="image-upload-delete-btn"
@@ -175,7 +190,7 @@ const Account: React.FunctionComponent<AccountProps> = ({
                           e.stopPropagation();
                           markForDeletion();
                         }}
-                        aria-label={t`Delete this image`}
+                        aria-label={t`Use my main avatar`}
                       >
                         <Icon name="trash" size="sm" />
                       </button>

--- a/src/components/modals/SpaceSettingsModal/SpaceSettingsModal.tsx
+++ b/src/components/modals/SpaceSettingsModal/SpaceSettingsModal.tsx
@@ -499,6 +499,7 @@ const SpaceSettingsModal: React.FunctionComponent<{
                           markedForDeletion={spaceProfile.markedForDeletion}
                           markForDeletion={spaceProfile.markForDeletion}
                           getProfileImageUrl={spaceProfile.getProfileImageUrl}
+                          currentMember={spaceProfile.currentMember}
                           onSave={spaceProfile.onSave}
                           isSaving={spaceProfile.isSaving}
                           hasValidationError={spaceProfile.hasValidationError}

--- a/src/hooks/business/channels/useChannelData.ts
+++ b/src/hooks/business/channels/useChannelData.ts
@@ -73,6 +73,15 @@ export function useChannelData({ spaceId, channelId }: UseChannelDataProps) {
             // Per-space bio override; flows into UserProfile's "About"
             // section. Empty string means the user explicitly cleared it.
             bio: (curr as any).bio as string | undefined,
+            // Roster GLOBAL slots (two-slot design): the sender's current global
+            // identity, pushed separately from the per-space override fields.
+            // Consumed by the fallback resolver as the tier between override and
+            // public profile. See identity-resolution-and-profile-sync doc.
+            globalDisplayName: (curr as any).global_display_name as string | undefined,
+            globalUserIcon: (curr as any).global_user_icon?.includes(DefaultImages.UNKNOWN_USER)
+              ? undefined
+              : ((curr as any).global_user_icon as string | undefined),
+            globalBio: (curr as any).global_bio as string | undefined,
             isKicked: curr.isKicked || false,
             spaceTag: (curr as any).spaceTag as BroadcastSpaceTag | undefined,
             joinedAt: curr.joinedAt,
@@ -84,6 +93,9 @@ export function useChannelData({ spaceId, channelId }: UseChannelDataProps) {
           userIcon?: string;
           displayName?: string;
           bio?: string;
+          globalDisplayName?: string;
+          globalUserIcon?: string;
+          globalBio?: string;
           isKicked?: boolean;
           spaceTag?: BroadcastSpaceTag;
           joinedAt?: number;

--- a/src/hooks/business/spaces/useSpaceProfile.ts
+++ b/src/hooks/business/spaces/useSpaceProfile.ts
@@ -6,6 +6,7 @@ import { DefaultImages } from '../../../utils';
 import { processAvatarImage, FILE_SIZE_LIMITS } from '../../../utils/imageProcessing';
 import { useMessageDB } from '../../../components/context/useMessageDB';
 import { useQueryClient, useQuery } from '@tanstack/react-query';
+import type { UpdateProfileMessage } from '@quilibrium/quorum-shared';
 import { buildSpaceMembersKey } from '../../queries/spaceMembers/buildSpaceMembersKey';
 import { buildSpaceMembersFetcher } from '../../queries/spaceMembers/buildSpaceMembersFetcher';
 import { showError } from '../../../utils/toast';
@@ -305,9 +306,12 @@ export const useSpaceProfile = (
         throw new Error('Space not found');
       }
 
-      // Include a field only when changed (mirrors bio): omitted displayName =
-      // no change, empty = clear the per-space name. userIcon stays required by
-      // the type, so fall back to baseline (overwrite-with-same is harmless).
+      // Include a field ONLY when it changed. Two-state model: a per-space
+      // field is sent only when the user set/changed an OVERRIDE; omitting it
+      // means "no change / follow global". Do NOT send userIcon unconditionally
+      // (it previously fell back to baseline, re-stamping the global value into
+      // the per-space row on every save and faking an override). All three
+      // fields now behave identically: send on change, omit otherwise.
       await submitChannelMessage(
         spaceId,
         space.defaultChannelId,
@@ -317,9 +321,11 @@ export const useSpaceProfile = (
           ...(changed.displayName !== undefined
             ? { displayName: changed.displayName }
             : {}),
-          userIcon: changed.userIcon ?? baseline.userIcon,
+          ...(changed.userIcon !== undefined
+            ? { userIcon: changed.userIcon }
+            : {}),
           ...(changed.bio !== undefined ? { bio: changed.bio } : {}),
-        },
+        } as UpdateProfileMessage,
         queryClient,
         currentPasskeyInfo,
         undefined, // inReplyTo

--- a/src/hooks/business/spaces/useSpaceProfile.ts
+++ b/src/hooks/business/spaces/useSpaceProfile.ts
@@ -221,24 +221,19 @@ export const useSpaceProfile = (
       return `data:${currentFile.type};base64,${Buffer.from(fileData).toString('base64')}`;
     }
 
-    // Three-state per-space avatar (matches the avatar clear/absent/value
-    // design — see WebSocketContext/useMembersWithPublicProfileFallback):
-    //   - real image  -> show it
-    //   - '' (cleared) -> the user DELIBERATELY removed their per-space avatar,
-    //                     so show initials and do NOT fall back to the global
-    //                     avatar (a truthy check here wrongly resurrected it)
-    //   - undefined    -> no per-space override -> fall back to the global avatar
+    // Two-state per-space avatar (follow-global model — supersedes the earlier
+    // three-state '' = "cleared, show initials" concept):
+    //   - non-empty per-space value -> OVERRIDE -> show it
+    //   - '' or absent              -> follow global -> fall back to the
+    //                                  global avatar (there is no per-space
+    //                                  "blank"; only the global avatar can be
+    //                                  empty, and its absence flows here)
     const perSpaceIcon = currentMember?.user_icon;
-    if (perSpaceIcon !== undefined) {
-      // Explicit per-space value (including '' = cleared). Only a real,
-      // non-sentinel image is renderable; '' / sentinel -> default (initials).
-      if (perSpaceIcon && !perSpaceIcon.includes(DefaultImages.UNKNOWN_USER)) {
-        return perSpaceIcon;
-      }
-      return 'var(--unknown-icon)';
+    if (perSpaceIcon && !perSpaceIcon.includes(DefaultImages.UNKNOWN_USER)) {
+      return perSpaceIcon;
     }
 
-    // No per-space override at all -> fall back to global avatar
+    // No per-space override -> fall back to the global (public-profile) avatar
     if (
       currentPasskeyInfo?.pfpUrl &&
       !currentPasskeyInfo.pfpUrl.includes(DefaultImages.UNKNOWN_USER)

--- a/src/hooks/business/user/useMembersWithPublicProfileFallback.ts
+++ b/src/hooks/business/user/useMembersWithPublicProfileFallback.ts
@@ -44,11 +44,16 @@ interface MemberRecord {
    *  the public-profile fallback so members we don't share fresh data with
    *  still show their verified name. */
   primaryUsername?: string;
-  /** The member's GLOBAL display name from their public profile (as opposed to
-   *  `displayName`, which is the roster name and may be a per-space custom
-   *  name). resolveSpaceMemberName compares the two to decide whether the
+  /** The member's GLOBAL display name (roster global slot if present, else the
+   *  public profile). Kept SEPARATE from `displayName` (the roster override
+   *  name) so resolveSpaceMemberName can compare the two to decide whether the
    *  roster name was deliberately set for the space. */
   globalDisplayName?: string;
+  /** Roster GLOBAL avatar/bio slots (two-slot design) — the live-pushed global
+   *  identity, consumed as the tier between the per-space override and the
+   *  public profile. */
+  globalUserIcon?: string;
+  globalBio?: string;
   // Additional fields preserved opaquely (isKicked, spaceTag, joinedAt, etc).
   [extra: string]: unknown;
 }
@@ -121,33 +126,36 @@ export function useMembersWithPublicProfileFallback(
     const merged: MemberMap = { ...members };
     addressesToFetch.forEach((addr, i) => {
       const pub = dataRefs[i];
-      if (!pub) return;
       const local = members[addr];
-      // Per-field merge. A populated local field wins; an empty local
-      // field falls back to the public profile.
+      // Roster GLOBAL slots (two-slot design) — the live-pushed global identity,
+      // the tier between the per-space override and the public profile. Works
+      // for non-public users (no public profile). See identity-resolution doc.
+      const rosterGlobalName = local?.globalDisplayName as string | undefined;
+      const rosterGlobalIcon = (local as { globalUserIcon?: string } | undefined)?.globalUserIcon;
+      const rosterGlobalBio = (local as { globalBio?: string } | undefined)?.globalBio;
+      // The member's effective GLOBAL identity: prefer the live roster slot,
+      // else the public profile. Used both as the render fallback below and
+      // (as globalDisplayName) by resolveSpaceMemberName's custom-name compare.
+      const effectiveGlobalName = rosterGlobalName || pub?.display_name || undefined;
+      // Nothing to add for this member (no public profile AND no roster global
+      // slots) — leave the local record untouched.
+      if (!pub && !rosterGlobalName && !rosterGlobalIcon && !rosterGlobalBio) return;
+      // Per-field precedence: per-space OVERRIDE → roster global slot →
+      // public profile.
       merged[addr] = {
         ...(local ?? { address: addr }),
-        displayName: local?.displayName || pub.display_name || undefined,
-        // Per-space profile is two-state: a per-space OVERRIDE (non-empty
-        // value) wins; otherwise the field follows the member's GLOBAL value
-        // from their public profile. Empty per-space avatar = "follow global"
-        // (there is no per-space "blank" — that only exists globally), so an
-        // empty local userIcon falls back to the global avatar, same as
-        // name/bio. See per-space-profile-follow-global design.
-        userIcon: local?.userIcon || pub.profile_image || undefined,
-        // Bio uses the same per-field merge — a populated per-space bio
-        // wins, otherwise we surface the global public-profile bio so
-        // users we don't share a space with still show an About section.
-        bio: (local?.bio as string | undefined) || pub.bio || undefined,
-        // QNS primary username: only the public profile carries it, so the
-        // fallback is the only source. Rendered as "name.q" by the UI.
+        displayName: local?.displayName || rosterGlobalName || pub?.display_name || undefined,
+        userIcon: local?.userIcon || rosterGlobalIcon || pub?.profile_image || undefined,
+        bio: (local?.bio as string | undefined) || rosterGlobalBio || pub?.bio || undefined,
+        // QNS primary username: only the public profile carries it.
         primaryUsername:
           (local?.primaryUsername as string | undefined) ||
-          pub.primary_username ||
+          pub?.primary_username ||
           undefined,
         // The member's global display name, kept SEPARATE from the roster
-        // `displayName` so the space resolver can compare the two.
-        globalDisplayName: pub.display_name || undefined,
+        // `displayName` so the space resolver can compare the two (custom-name
+        // detection). Prefers the live roster global slot over the public one.
+        globalDisplayName: effectiveGlobalName,
       };
     });
     result = merged;

--- a/src/hooks/business/user/useMembersWithPublicProfileFallback.ts
+++ b/src/hooks/business/user/useMembersWithPublicProfileFallback.ts
@@ -128,16 +128,13 @@ export function useMembersWithPublicProfileFallback(
       merged[addr] = {
         ...(local ?? { address: addr }),
         displayName: local?.displayName || pub.display_name || undefined,
-        // Distinguish "no per-space avatar → backfill from public profile"
-        // (userIcon === undefined) from "deliberately cleared the per-space
-        // avatar" (userIcon === ''). A truthy `||` here would resurrect the
-        // sender's global avatar over an intentional clear. useChannelData
-        // maps the never-set/UNKNOWN_USER case to undefined and a real clear
-        // to '', so `!== undefined` is the correct discriminator.
-        userIcon:
-          local?.userIcon !== undefined
-            ? local.userIcon
-            : pub.profile_image || undefined,
+        // Per-space profile is two-state: a per-space OVERRIDE (non-empty
+        // value) wins; otherwise the field follows the member's GLOBAL value
+        // from their public profile. Empty per-space avatar = "follow global"
+        // (there is no per-space "blank" — that only exists globally), so an
+        // empty local userIcon falls back to the global avatar, same as
+        // name/bio. See per-space-profile-follow-global design.
+        userIcon: local?.userIcon || pub.profile_image || undefined,
         // Bio uses the same per-field merge — a populated per-space bio
         // wins, otherwise we surface the global public-profile bio so
         // users we don't share a space with still show an About section.

--- a/src/hooks/business/user/useUserSettings.ts
+++ b/src/hooks/business/user/useUserSettings.ts
@@ -12,6 +12,8 @@ import { useUploadRegistration } from '../../mutations/useUploadRegistration';
 import { BackupService } from '../../../services/BackupService';
 import { PublicProfileService } from '../../../services/PublicProfileService';
 import { QuorumApiClient } from '../../../api/baseTypes';
+import type { PublicProfileResponse } from '../../../api/baseTypes';
+import { publicProfileQueryKey } from './useUserPublicProfile';
 import { getDeviceName } from '../../../utils/deviceInfo';
 import { showError } from '../../../utils/toast';
 import { normalizePrivateKeyHex } from '../../../utils/privateKey';
@@ -395,6 +397,24 @@ export const useUserSettings = (
       buildConfigKey({ userAddress: currentPasskeyInfo.address }),
       newConfig
     );
+
+    // Refresh our own public-profile cache: non-overridden spaces render our
+    // name/avatar from it (1h staleTime), so a global change wouldn't reach
+    // already-rendered messages otherwise. Set optimistically; refetch only when
+    // public (a private profile 404s to null and would blank the value).
+    {
+      const key = publicProfileQueryKey(currentPasskeyInfo.address);
+      queryClient.setQueryData<PublicProfileResponse | null>(key, (prev) => ({
+        ...(prev ?? { signature: '' }),
+        display_name: displayName,
+        profile_image: profileImageUrl ?? '',
+        bio: isProfilePublic ? bio.trim() : (prev?.bio ?? ''),
+        timestamp: Date.now(),
+      }) as PublicProfileResponse);
+      if (isProfilePublic) {
+        void queryClient.invalidateQueries({ queryKey: key });
+      }
+    }
 
     // Public profile publish/unpublish: best-effort. The local
     // isProfilePublic setting is the source of truth — server publish

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -573,35 +573,50 @@ export class MessageService {
       ? { ...currentTag, spaceId: space.spaceId }
       : undefined;
 
-    // 7. Read display name + icon + bio from config
-    const displayName = config.name ?? '';
-    const userIcon = config.profile_image ?? DefaultImages.UNKNOWN_USER;
-    const bio = config.bio;
-
-    // 8. Broadcast update-profile to all spaces
+    // 7. Broadcast update-profile to all spaces
     const allSpaces = await this.messageDB.getSpaces();
     this.enqueueOutbound(async () => {
       const outbounds: string[] = [];
 
       for (const s of allSpaces) {
         try {
+          // Per-space profile follows the sender's global value unless a
+          // deliberate OVERRIDE was set in this space. The stored member
+          // row carries an override iff its field is a non-empty value;
+          // empty/absent = follow global. We must NOT stamp the global
+          // config value as a per-space field (that froze the space to a
+          // stale global and broke "clear the override" — the bug this
+          // whole effort removes). So: send the per-space override if one
+          // exists, else OMIT the field so receivers fall back to the
+          // sender's global (public-profile) value via the render fallback.
+          // (See per-space-profile-empty-follows-global design.)
+          const ownMember = await this.messageDB.getSpaceMember(
+            s.spaceId,
+            selfAddress
+          );
+          const nameOverride = ownMember?.display_name || undefined;
+          // Member avatar lives on `user_icon` (typed UserProfile field);
+          // some rows also carry `profile_image` from other write paths, so
+          // read both defensively (mirrors the fallback at line ~4479).
+          const iconOverride =
+            ownMember?.user_icon ||
+            (ownMember as { profile_image?: string })?.profile_image ||
+            undefined;
+          const bioOverride = ownMember?.bio || undefined;
+
           const nonce = crypto.randomUUID();
-          const updateProfileMessage: UpdateProfileMessage = {
+          const updateProfileMessage = {
             type: 'update-profile',
-            displayName,
-            userIcon,
             senderId: selfAddress,
-            // Carry the global bio along on tag-rotation rebroadcasts so
-            // receivers who joined after the user last edited still pick
-            // it up. Only included when the user has a bio set —
-            // omitting it lets each receiver keep whatever bio it already
-            // has (the receive-side upsert merge treats absent fields as
-            // "no change"). An explicit empty-string bio here would
-            // instead CLEAR the receiver's stored bio, which is the
-            // wrong semantic for an incidental tag-rotation event.
-            ...(bio ? { bio } : {}),
+            // Omit any field with no per-space override — the receiver's
+            // upsert merge treats absent fields as "no change" and its
+            // render fallback surfaces the sender's global value. Only a
+            // real per-space override goes on the wire.
+            ...(nameOverride !== undefined ? { displayName: nameOverride } : {}),
+            ...(iconOverride !== undefined ? { userIcon: iconOverride } : {}),
+            ...(bioOverride !== undefined ? { bio: bioOverride } : {}),
             ...(resolvedTag ? { spaceTag: resolvedTag } : {}),
-          };
+          } as UpdateProfileMessage;
 
           const messageId = await crypto.subtle.digest(
             'SHA-256',

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -5340,11 +5340,20 @@ export class MessageService {
           currentPasskeyInfo.address
         );
         if (participant) {
-          participant.display_name = updateProfileMessage.displayName;
-          participant.user_icon = updateProfileMessage.userIcon;
-          participant.spaceTag = updateProfileMessage.spaceTag;
-          // Apply any global slots present (harmless for pure override edits,
-          // where they're undefined). Two-slot design.
+          // Presence-checked: only apply OVERRIDE fields the message actually
+          // carries. A global-save message omits these (it uses the global*
+          // slots below), so an unconditional assignment would wipe a real
+          // per-space override with undefined. Matches the receive-side rule.
+          if (updateProfileMessage.displayName !== undefined) {
+            participant.display_name = updateProfileMessage.displayName;
+          }
+          if (updateProfileMessage.userIcon !== undefined) {
+            participant.user_icon = updateProfileMessage.userIcon;
+          }
+          if (updateProfileMessage.spaceTag !== undefined) {
+            participant.spaceTag = updateProfileMessage.spaceTag;
+          }
+          // Apply any global slots present (undefined for pure override edits).
           applyGlobalProfileSlots(participant, updateProfileMessage);
           await this.messageDB.saveSpaceMember(spaceId, participant);
 

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -5366,19 +5366,18 @@ export class MessageService {
           applyGlobalProfileSlots(participant, updateProfileMessage);
           await this.messageDB.saveSpaceMember(spaceId, participant);
 
-          // Update query cache for immediate UI refresh
+          // Update query cache for immediate UI refresh. Use the already-merged
+          // `participant` (which the presence-checked writes above produced), NOT
+          // the raw message fields — spreading raw `updateProfileMessage.display_name`
+          // etc. would write `undefined` on a global-only save and briefly wipe the
+          // user's own per-space override in the UI until the next refetch.
           queryClient.setQueryData(
             buildSpaceMembersKey({ spaceId }),
             (oldData: secureChannel.UserProfile[]) => {
               if (!oldData) return oldData;
               return oldData.map((member) =>
                 member.user_address === currentPasskeyInfo.address
-                  ? {
-                      ...member,
-                      display_name: updateProfileMessage.displayName,
-                      user_icon: updateProfileMessage.userIcon,
-                      spaceTag: updateProfileMessage.spaceTag,
-                    }
+                  ? participant
                   : member
               );
             }

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -104,6 +104,28 @@ export interface MessageServiceDependencies {
   handleSyncManifest: (spaceId: string, targetInbox: string, payload: any) => Promise<void>;
 }
 
+// Two-slot design (see identity-resolution-and-profile-sync doc): copy the
+// sender's GLOBAL identity fields from an update-profile message onto a member
+// row, stored separately from the per-space override fields
+// (display_name/user_icon/bio). Presence semantics: omitted = no change,
+// '' = deliberate global clear. Read untyped — global* are additive to the
+// shared UpdateProfileMessage (additive shared PR pending, non-blocking).
+function applyGlobalProfileSlots(participant: object, content: unknown): void {
+  const c = content as {
+    globalDisplayName?: string;
+    globalUserIcon?: string;
+    globalBio?: string;
+  };
+  const p = participant as {
+    global_display_name?: string;
+    global_user_icon?: string;
+    global_bio?: string;
+  };
+  if (c.globalDisplayName !== undefined) p.global_display_name = c.globalDisplayName;
+  if (c.globalUserIcon !== undefined) p.global_user_icon = c.globalUserIcon;
+  if (c.globalBio !== undefined) p.global_bio = c.globalBio;
+}
+
 export class MessageService {
   private messageDB: MessageDB;
   private enqueueOutbound: (action: () => Promise<string[]>) => void;
@@ -1372,6 +1394,11 @@ export class MessageService {
       if (decryptedContent.content.bio !== undefined) {
         participant.bio = decryptedContent.content.bio;
       }
+      // GLOBAL identity slots (two-slot design — see identity-resolution doc).
+      // Stored separately from the override fields above so the sender's global
+      // rename reaches spacemates without being mistaken for a per-space
+      // override. Read untyped: additive to the shared UpdateProfileMessage.
+      applyGlobalProfileSlots(participant, decryptedContent.content);
       participant.inbox_address = inboxAddress;
       // Validate inbound spaceTag — reject SVG data URIs (XSS) and oversized payloads
       const inboundTag = decryptedContent.content.spaceTag;
@@ -1932,6 +1959,9 @@ export class MessageService {
       if (decryptedContent.content.bio !== undefined) {
         participant.bio = decryptedContent.content.bio;
       }
+      // GLOBAL identity slots (two-slot design) — stored separately from the
+      // override fields above. See identity-resolution doc.
+      applyGlobalProfileSlots(participant, decryptedContent.content);
       participant.inbox_address = inboxAddress;
       // Validate inbound spaceTag — reject SVG data URIs (XSS) and oversized payloads
       const inboundTag = decryptedContent.content.spaceTag;
@@ -5313,6 +5343,9 @@ export class MessageService {
           participant.display_name = updateProfileMessage.displayName;
           participant.user_icon = updateProfileMessage.userIcon;
           participant.spaceTag = updateProfileMessage.spaceTag;
+          // Apply any global slots present (harmless for pure override edits,
+          // where they're undefined). Two-slot design.
+          applyGlobalProfileSlots(participant, updateProfileMessage);
           await this.messageDB.saveSpaceMember(spaceId, participant);
 
           // Update query cache for immediate UI refresh

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -627,6 +627,12 @@ export class MessageService {
           const bioOverride = ownMember?.bio || undefined;
 
           const nonce = crypto.randomUUID();
+          // Current GLOBAL identity from config — carried in the global* slots
+          // so members who missed the global save learn it on our tag-rotation
+          // rebroadcast. Separate from the override fields. (Two-slot design.)
+          const globalName = config.name || undefined;
+          const globalIcon = config.profile_image || undefined;
+          const globalBioVal = config.bio || undefined;
           const updateProfileMessage = {
             type: 'update-profile',
             senderId: selfAddress,
@@ -637,6 +643,9 @@ export class MessageService {
             ...(nameOverride !== undefined ? { displayName: nameOverride } : {}),
             ...(iconOverride !== undefined ? { userIcon: iconOverride } : {}),
             ...(bioOverride !== undefined ? { bio: bioOverride } : {}),
+            ...(globalName !== undefined ? { globalDisplayName: globalName } : {}),
+            ...(globalIcon !== undefined ? { globalUserIcon: globalIcon } : {}),
+            ...(globalBioVal !== undefined ? { globalBio: globalBioVal } : {}),
             ...(resolvedTag ? { spaceTag: resolvedTag } : {}),
           } as UpdateProfileMessage;
 

--- a/src/services/SpaceService.ts
+++ b/src/services/SpaceService.ts
@@ -416,10 +416,11 @@ export class SpaceService {
       ),
     });
     await this.messageDB.saveSpace(space);
+    // Follow-global: don't stamp the creator's global name/avatar into their
+    // per-space row (empty = follow global). Peers learn identity from the join
+    // envelope; this row only records membership.
     await this.messageDB.saveSpaceMember(spaceAddress, {
       user_address: registration.user_address,
-      user_icon: userIcon,
-      display_name: userDisplayName,
       inbox_address: inboxAddress,
     });
     // Defensive: ensure creator is present in member list
@@ -430,8 +431,6 @@ export class SpaceService {
     if (!ensuredMember) {
       await this.messageDB.saveSpaceMember(spaceAddress, {
         user_address: registration.user_address,
-        user_icon: userIcon,
-        display_name: userDisplayName,
         inbox_address: inboxAddress,
       });
     }


### PR DESCRIPTION
Makes a member's per-space display name, avatar, and bio **follow their global profile unless they set a deliberate per-space override**, and makes a global profile change reach spacemates reliably. Companion to the matching quorum-mobile PR.

## Why
Previously the app copied a user's global name/avatar into every space's member row (at join, space creation, on reconnect, and on every global save). That froze each space to a stale copy: changing your global name didn't reach spaces, "clear my per-space name" was impossible, and two of your own devices could overwrite each other's rows. This PR removes that stamping and replaces it with an explicit two-channel model.

## What changed
- **Follow-global rendering**: an empty per-space name/avatar/bio now renders the member's global value; a non-empty value is a real per-space override.
- **Global identity is broadcast on its own labeled fields** (separate from the per-space override fields), so a global rename propagates to everyone in a space live, works for users who haven't made their profile public, and can never be mistaken for a deliberate per-space override. Receivers store the two independently.
- **Editor**: the per-space avatar revert control ("Use my main avatar") only appears when an override exists; the effective global value shows as a placeholder when following global.
- **Space creation** no longer stamps the creator's global identity into their own member row.
- Refreshes the editing user's own public-profile cache on save so their name updates immediately, and fixes the optimistic cache so a global save can't briefly blank the user's own per-space override.
- Adds a canonical design doc (`.agents/docs/features/identity-resolution-and-profile-sync.md`) plus two tracked follow-up tasks.

## Verification
Space propagation confirmed working desktop↔desktop and mobile→desktop. Reviewed for message-delivery safety (the normal message transport is untouched) and last-write-wins correctness. The wire change is additive and interoperates with older clients; land close to the mobile PR.
