### PR TITLE
feat(profile): type two-slot global identity fields + per-slot LWW guard

### DIFF
--- a/.agents/INDEX.md
+++ b/.agents/INDEX.md
@@ -33,9 +33,9 @@ This is the main index for all documentation, bug reports, and task management.
 - [Delete Confirmation System](docs/features/delete-confirmation-system.md)
 - [Desktop Notifications Feature](docs/features/desktop-notifications.md)
 - [Dropdown Panels](docs/features/dropdown-panels.md)
+- [Identity resolution and profile sync (canonical model)](docs/features/identity-resolution-and-profile-sync.md)
 - [Input & Textarea Validation Reference](docs/features/input-validation-reference.md)
 - [Invite System Documentation](docs/features/invite-system-analysis.md)
-- [Identity resolution and profile sync (canonical model)](docs/features/identity-resolution-and-profile-sync.md)
 - [Kick User System Documentation](docs/features/kick-user-system.md)
 - [Mention Pills UI System](docs/features/mention-pills-ui-system.md)
 - [Message Search Feature](docs/features/search-feature.md)
@@ -123,6 +123,7 @@ This is the main index for all documentation, bug reports, and task management.
 - [Desktop shows stale synced config until restart](bugs/2026-06-13-config-not-refetched-stale-until-restart.md)
 - [Space members show truncated address — no `space_members` row](bugs/2026-06-13-space-members-missing-no-join-row.md)
 - [Sync path hardcodes `'post'` in the signature messageId recompute → non-post signatures nulled](bugs/2026-06-14-sync-path-hardcodes-post-type-nulls-nonpost-signatures.md)
+- [DM message delivery is unreliable (master report)](bugs/2026-07-02-dm-message-delivery-unreliable-master.md)
 
 ### Solved Issues
 - [Icon Color Not Saving Issue](bugs/.solved/2025-01-15-icon-color-not-saving-issue.md)
@@ -200,8 +201,8 @@ This is the main index for all documentation, bug reports, and task management.
 - [Application-owned scroll anchoring for the message list (β)](tasks/2026-05-24-virtuoso-application-owned-scroll-anchoring.md)
 - [Unify Account tab's defer-vs-instant control semantics](tasks/2026-06-07-account-tab-defer-save-unification.md)
 - [UserProfile card layout polish pass](tasks/2026-06-08-userprofile-card-layout-polish.md)
-- [update-profile receive: add per-slot staleness guard (parity with mobile)](tasks/2026-07-16-update-profile-receive-per-slot-timestamp-guard.md)
-- [quorum-shared: type the two-slot global identity fields (retire casts)](tasks/2026-07-16-quorum-shared-type-two-slot-global-identity-fields.md)
+- [DM remove-message auth bypass: authorize against the session-authenticated sender, not the payload `senderId`](tasks/2026-06-25-dm-remove-message-auth-bypass-spoofable-senderid.md)
+- [Master recap: the "spoofable senderId" fix](tasks/2026-06-25-MASTER-RECAP-control-message-auth.md)
 
 ### .Archived
 - [🚀 Search Performance Optimization - Revised Implementation Plan](tasks/.archived/2025-11-12-search-performance-optimization-original.md)
@@ -262,6 +263,8 @@ This is the main index for all documentation, bug reports, and task management.
 - [Polls in Spaces — v1 Implementation Plan](tasks/.todo/2026-06-01-polls-plan.md)
 - [Spaces Highlights Feed — Design Spec](tasks/.todo/2026-06-04-spaces-highlights-feed-design.md)
 - [Spaces Highlights Feed Implementation Plan](tasks/.todo/2026-06-04-spaces-highlights-feed-plan.md)
+- [Coalesce replayed space-manifest during history replay (stop flicker) — DEFERRED](tasks/.todo/2026-06-28-coalesce-replay-space-manifest-flicker.md)
+- [Coalesce replayed update-profile during history replay (stop flicker) — DEFERRED](tasks/.todo/2026-06-28-coalesce-replay-state-updates-flicker.md)
 
 ### Messagedb
 - [handleNewMessage Decomposition — Reconsidered](tasks/messagedb/handleNewMessage-reconsidered.md)
@@ -324,6 +327,9 @@ This is the main index for all documentation, bug reports, and task management.
 - [QNS Usernames on Desktop — Implementation Plan](tasks/port-from-mobile/.done/2026-06-10-qns-username-display-plan.md)
 - [Port — paste private key on import + copy private key in settings](tasks/port-from-mobile/.done/2026-06-11-port-key-paste-import-and-copy-export.md)
 - [QNS username overrides display name everywhere + mentions by QNS name](tasks/port-from-mobile/.done/2026-06-11-qns-username-overrides-display-name-plan.md)
+- [Design: per-message indicators on grouped (continuation) messages](tasks/port-from-mobile/.done/2026-06-28-grouped-message-indicators-design.md)
+- [Grouped/continuation messages drop per-message indicators (desktop + mobile)](tasks/port-from-mobile/.done/2026-06-28-grouped-message-indicators-missing.md)
+- [Implementation plan: per-message indicators on grouped (continuation) messages — DESKTOP](tasks/port-from-mobile/.done/2026-07-15-grouped-message-indicators-plan.md)
 
 ### Port To Mobile
 - [Port-to-mobile candidates](tasks/port-to-mobile/candidates.md)
@@ -466,6 +472,9 @@ This is the main index for all documentation, bug reports, and task management.
 - [Notification-type settings: stale read in the settings modal (+ clobber-on-save)](tasks/.done/2026-06-23-notification-settings-stale-read-and-clobber.md)
 - [Move image compression config + orchestration into quorum-shared (desktop side)](tasks/.done/2026-06-24-share-image-compression-config-with-shared.md)
 - [Close EXIF/metadata stripping gaps on image uploads](tasks/.done/2026-06-24-strip-image-exif-metadata-gaps.md)
+- [Plan: fix DM remove-message + edit-message authorization on desktop](tasks/.done/2026-06-25-desktop-dm-control-msg-auth-fix-plan.md)
+- [quorum-shared: type the two-slot global identity fields](tasks/.done/2026-07-16-quorum-shared-type-two-slot-global-identity-fields.md)
+- [update-profile receive: add per-slot staleness guard](tasks/.done/2026-07-16-update-profile-receive-per-slot-timestamp-guard.md)
 - [AccentColorSwitcher Cross-Platform Migration + Persistence](tasks/.done/accent-color-switcher-cross-platform-migration.md)
 - [Add Context to Desktop Notifications](tasks/.done/rich-desktop-notifications-context.md)
 - [Add DM-Specific Action Queue Handlers](tasks/.done/dm-action-queue-handlers.md)
@@ -656,4 +665,4 @@ This is the main index for all documentation, bug reports, and task management.
 
 ---
 
-**Last Updated**: 2026-06-25 11:03:31
+**Last Updated**: 2026-07-16 13:36:59

--- a/.agents/tasks/.done/2026-07-16-quorum-shared-type-two-slot-global-identity-fields.md
+++ b/.agents/tasks/.done/2026-07-16-quorum-shared-type-two-slot-global-identity-fields.md
@@ -1,9 +1,10 @@
 ---
 type: task
 title: "quorum-shared: type the two-slot global identity fields (retire casts)"
-status: todo
+status: done
 priority: low
 created: 2026-07-16
+completed: 2026-07-16
 related_docs:
   - ".agents/docs/features/identity-resolution-and-profile-sync.md"
 related_files:
@@ -75,4 +76,43 @@ wire shape that might still change). Pairs naturally with
 needs the timestamp fields on the shared member type).
 
 ---
+
+## Done — 2026-07-16 (shared PR #57 merged to master; desktop branch `feat/two-slot-identity-types-and-timestamp-guard`)
+
+Implemented together with the per-slot timestamp guard task in one typed pass.
+
+**quorum-shared (PR #57, merged):**
+- Added `globalDisplayName?` / `globalUserIcon?` / `globalBio?` to
+  `UpdateProfileMessage` (additive, optional; canonicalize unaffected). ✅
+- **Deviation — member-row fields NOT added to shared's `SpaceMember`.** Recon
+  found desktop's member row is typed off `channel.UserProfile` (the SDK type),
+  NOT shared's `SpaceMember`, so adding `global_*`/timestamp fields to shared's
+  `SpaceMember` would not retire desktop's storage casts. Instead a desktop-local
+  `SpaceMemberRow` type (in `src/db/messages.ts`) is now the single source of
+  truth for those fields. If mobile later wants a shared member-row type, that's
+  a separate, additive step — not required to retire desktop's casts.
+- **NOT published / NOT version-bumped** (deliberate — held for the next publish
+  batch per the user). Desktop consumes the change via the local symlink today;
+  mobile will only see it after a future publish + bump.
+
+**Desktop (branch, not yet PR'd at time of writing):**
+- Retired `as unknown as UpdateProfileMessage` in `MessageDB.updateUserProfile`
+  → single `as UpdateProfileMessage` cast (matches the tag-rotation rebroadcast
+  site; the remaining cast only papers over the pre-existing required-`userIcon`
+  field on a global-only broadcast, unrelated to this task). ✅
+- Retired the `(curr as any).global_*` reads in `useChannelData` and the
+  `(local as {...})` reads in `useMembersWithPublicProfileFallback` — both now
+  read typed fields off `SpaceMemberRow` / the existing `MemberRecord`. ✅
+- Replaced the `applyGlobalProfileSlots` helper with a typed, guard-aware
+  `applyProfileUpdate` (see the timestamp-guard task). ✅
+
+**Mobile — NOT done (out of scope this session).** Step 3 (drop mobile's
+`content as MessageContent` cast, `as never` member-row writes, and the
+`(local as {...})` reads) still stands. It only becomes possible after shared is
+published + mobile bumps to a version carrying the new `UpdateProfileMessage`
+fields. Track as a mobile-side follow-up once shared is published. The canonical
+avatar-field-name gotcha is resolved by keeping the per-app storage split
+(desktop `global_user_icon` vs mobile `global_profile_image`); only the WIRE
+name (`globalUserIcon`) is shared and identical — documented, not unified.
+
 *Last updated: 2026-07-16*

--- a/.agents/tasks/.done/2026-07-16-update-profile-receive-per-slot-timestamp-guard.md
+++ b/.agents/tasks/.done/2026-07-16-update-profile-receive-per-slot-timestamp-guard.md
@@ -1,9 +1,10 @@
 ---
 type: task
 title: "update-profile receive: add per-slot staleness guard (parity with mobile)"
-status: todo
+status: done
 priority: low
 created: 2026-07-16
+completed: 2026-07-16
 related_docs:
   - ".agents/docs/features/identity-resolution-and-profile-sync.md"
 related_files:
@@ -60,4 +61,34 @@ practice, this can stay low-priority/wontfix. Mobile added the guard
 defensively, not from an observed desktop-style failure.
 
 ---
+
+## Done — 2026-07-16 (desktop branch `feat/two-slot-identity-types-and-timestamp-guard`)
+
+Implemented alongside the shared-type task in one typed pass.
+
+- Added `profileTimestamp?` + `globalProfileTimestamp?` to the desktop member
+  row (`SpaceMemberRow` in `src/db/messages.ts`). ✅
+- New `applyProfileUpdate(participant, content, createdDate)` helper in
+  `MessageService.ts` replaces `applyGlobalProfileSlots`. It mirrors mobile's
+  `applyOverride` / `applyGlobal` structure: each slot (override vs global) is
+  applied only when the incoming `createdDate` is newer than that slot's stored
+  timestamp, and stamps the applied slot's timestamp on save. ✅
+- Wired into BOTH receive handlers (the `saveMessage` path and the standalone
+  path) and the send-side self-apply (the editing device's own immediate local
+  write). Self-apply uses its own send `createdDate`, so the user's latest edit
+  always wins locally AND is protected from a later out-of-order echo of an
+  older edit. ✅
+- **Guard only — no inbox delete.** Mobile deletes the space-inbox message when
+  both slots are stale; desktop does NOT, because desktop's P2P transport has no
+  per-space server inbox to acknowledge. That cleanup belongs to the future
+  hub-log migration (confirmed coming to desktop), at the transport layer, not
+  in this handler. Noted in an `applyProfileUpdate` code comment so the future
+  migrator wires the inbox-ack at the transport layer — the guard itself is
+  transport-agnostic and needs no change.
+
+**Verification:** desktop `tsc` clean, eslint 0 errors, MessageService unit
+tests 24/24 pass. The rapid two-device LWW reorder was NOT reproduced
+behaviorally (per "How to confirm it's needed" — the guard is defensive parity
+with mobile, matching the doc's low-residual-risk assessment).
+
 *Last updated: 2026-07-16*

--- a/src/components/context/MessageDB.tsx
+++ b/src/components/context/MessageDB.tsx
@@ -451,10 +451,10 @@ const MessageDBProvider: FC<MessageDBContextProps> = ({ children }) => {
             globalUserIcon: userIcon,
             ...(bio !== undefined ? { globalBio: bio } : {}),
             ...(spaceTag ? { spaceTag } : {}),
-            // Cast via unknown: global* slots are additive, not yet on the shared
-            // UpdateProfileMessage type (additive shared PR pending). Override
-            // fields are intentionally absent — this is a global-only broadcast.
-          } as unknown as UpdateProfileMessage,
+            // Global-only broadcast: the override fields (incl. the required
+            // `userIcon`) are intentionally absent. Single cast to satisfy that
+            // one required field, matching the tag-rotation rebroadcast site.
+          } as UpdateProfileMessage,
           queryClient,
           currentPasskeyInfo,
           undefined, // inReplyTo

--- a/src/db/messages.ts
+++ b/src/db/messages.ts
@@ -118,6 +118,30 @@ export type UserConfig = {
 
 export type { UserNote } from '@quilibrium/quorum-shared';
 
+// The desktop space-member row as stored in IndexedDB: the SDK UserProfile plus
+// the local-only fields. Single source of truth for the shape — the two-slot
+// GLOBAL identity slots (global_*) and the per-slot LWW timestamps used to be
+// read via `as any` casts scattered across the receive handlers and hooks.
+// Storage names mirror the existing user_icon/profile_image split (desktop uses
+// *_user_icon); the WIRE names (globalUserIcon) are shared and identical.
+export type SpaceMemberRow = channel.UserProfile & {
+  inbox_address: string;
+  isKicked?: boolean;
+  spaceTag?: BroadcastSpaceTag;
+  joinedAt?: number;
+  bio?: string;
+  // GLOBAL identity slot (two-slot model) — the sender's current global
+  // identity, kept separate from the per-space override fields above.
+  global_display_name?: string;
+  global_user_icon?: string;
+  global_bio?: string;
+  // Per-slot last-write-wins guards: the override fields and the global slot
+  // each track the createdDate of the newest update-profile that set them, so
+  // an out-of-order rebroadcast can't let an older value win. Mirrors mobile.
+  profileTimestamp?: number;
+  globalProfileTimestamp?: number;
+};
+
 export interface SearchableMessage {
   id: string;
   messageId: string;
@@ -1113,13 +1137,7 @@ export class MessageDB {
 
   async saveSpaceMember(
     spaceId: string,
-    userProfile: channel.UserProfile & {
-      inbox_address: string;
-      isKicked?: boolean;
-      spaceTag?: BroadcastSpaceTag;
-      joinedAt?: number;
-      bio?: string;
-    }
+    userProfile: SpaceMemberRow
   ): Promise<void> {
     await this.init();
     return new Promise((resolve, reject) => {
@@ -1135,9 +1153,7 @@ export class MessageDB {
   async getSpaceMember(
     spaceId: string,
     user_address: string
-  ): Promise<
-    channel.UserProfile & { inbox_address: string; isKicked?: boolean; spaceTag?: BroadcastSpaceTag; joinedAt?: number; bio?: string }
-  > {
+  ): Promise<SpaceMemberRow> {
     await this.init();
     return new Promise((resolve, reject) => {
       const transaction = this.db!.transaction('space_members', 'readonly');
@@ -1154,9 +1170,7 @@ export class MessageDB {
 
   async getSpaceMembers(
     spaceId: string
-  ): Promise<
-    (channel.UserProfile & { inbox_address: string; isKicked?: boolean; spaceTag?: BroadcastSpaceTag; joinedAt?: number; bio?: string })[]
-  > {
+  ): Promise<SpaceMemberRow[]> {
     await this.init();
     return new Promise((resolve, reject) => {
       const transaction = this.db!.transaction('space_members', 'readonly');

--- a/src/dev/tests/services/MessageService.applyProfileUpdate.unit.test.ts
+++ b/src/dev/tests/services/MessageService.applyProfileUpdate.unit.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi } from 'vitest';
+import { applyProfileUpdate } from '@/services/MessageService';
+import type { SpaceMemberRow } from '@/db/messages';
+import type { UpdateProfileMessage } from '@quilibrium/quorum-shared';
+
+// MessageService.ts imports the native SDK at module load; stub it so this
+// pure-logic helper can be imported without the real WASM channel module.
+vi.mock('@quilibrium/quilibrium-js-sdk-channels', () => ({
+  channel: {},
+  channel_raw: {},
+}));
+
+const SENDER = 'QmSender000000000000000000000000000000000';
+
+function row(overrides: Partial<SpaceMemberRow> = {}): SpaceMemberRow {
+  return { user_address: SENDER, inbox_address: 'inbox', ...overrides };
+}
+
+// UpdateProfileMessage.userIcon is required on the wire type, but the real
+// senders OMIT it entirely on a global-only / no-icon-override broadcast (they
+// cast the object). We model that faithfully: userIcon is only present when a
+// test passes it, so a "no override" message genuinely has no override fields.
+// The cast mirrors the send-path cast that papers over the required field.
+function msg(content: Partial<UpdateProfileMessage>): UpdateProfileMessage {
+  return { senderId: SENDER, type: 'update-profile', ...content } as UpdateProfileMessage;
+}
+
+describe('applyProfileUpdate — two-slot per-slot LWW guard', () => {
+  it('applies both slots and stamps timestamps when the row has none (legacy row = always apply)', () => {
+    const p = row();
+    applyProfileUpdate(
+      p,
+      msg({ displayName: 'Ada', globalDisplayName: 'Ada Global' } as Partial<UpdateProfileMessage>),
+      1000
+    );
+    expect(p.display_name).toBe('Ada');
+    expect(p.global_display_name).toBe('Ada Global');
+    expect(p.profileTimestamp).toBe(1000);
+    expect(p.globalProfileTimestamp).toBe(1000);
+  });
+
+  it('does NOT clobber a newer stored value with an older message (override slot)', () => {
+    const p = row({ display_name: 'New', profileTimestamp: 2000 });
+    applyProfileUpdate(p, msg({ displayName: 'Old' } as Partial<UpdateProfileMessage>), 1000);
+    expect(p.display_name).toBe('New'); // older message rejected
+    expect(p.profileTimestamp).toBe(2000); // timestamp unchanged
+  });
+
+  it('applies a strictly-newer message (override slot)', () => {
+    const p = row({ display_name: 'Old', profileTimestamp: 1000 });
+    applyProfileUpdate(p, msg({ displayName: 'New' } as Partial<UpdateProfileMessage>), 2000);
+    expect(p.display_name).toBe('New');
+    expect(p.profileTimestamp).toBe(2000);
+  });
+
+  it('treats an equal timestamp as a no-op (self-echo case)', () => {
+    const p = row({ display_name: 'Mine', profileTimestamp: 1500 });
+    applyProfileUpdate(p, msg({ displayName: 'Echo' } as Partial<UpdateProfileMessage>), 1500);
+    expect(p.display_name).toBe('Mine'); // >= guard rejects the equal-ts echo
+    expect(p.profileTimestamp).toBe(1500);
+  });
+
+  it('applies slots independently: a stale global-only message cannot block a fresh override', () => {
+    // Global slot is fresh (ts 3000); an OLDER override message (ts 1000) arrives.
+    const p = row({ global_display_name: 'G', globalProfileTimestamp: 3000 });
+    applyProfileUpdate(p, msg({ displayName: 'Override' } as Partial<UpdateProfileMessage>), 1000);
+    // Override applied on its own (undefined override ts = always apply)...
+    expect(p.display_name).toBe('Override');
+    expect(p.profileTimestamp).toBe(1000);
+    // ...and the fresh global slot is untouched.
+    expect(p.global_display_name).toBe('G');
+    expect(p.globalProfileTimestamp).toBe(3000);
+  });
+
+  it('applies slots independently: a stale override-only message cannot block a fresh global', () => {
+    const p = row({ display_name: 'O', profileTimestamp: 3000 });
+    applyProfileUpdate(
+      p,
+      msg({ globalDisplayName: 'Global New' } as Partial<UpdateProfileMessage>),
+      1000
+    );
+    expect(p.global_display_name).toBe('Global New');
+    expect(p.globalProfileTimestamp).toBe(1000);
+    expect(p.display_name).toBe('O'); // fresh override untouched
+    expect(p.profileTimestamp).toBe(3000);
+  });
+
+  it("honors '' as a deliberate clear (presence check, not truthy)", () => {
+    const p = row({ display_name: 'Ada', bio: 'hi', profileTimestamp: 1000 });
+    applyProfileUpdate(p, msg({ displayName: '', bio: '' } as Partial<UpdateProfileMessage>), 2000);
+    expect(p.display_name).toBe(''); // cleared, not left as 'Ada'
+    expect(p.bio).toBe('');
+  });
+
+  it('leaves an untouched slot alone when only the other slot is present', () => {
+    const p = row({ display_name: 'Keep', profileTimestamp: 1000 });
+    applyProfileUpdate(
+      p,
+      msg({ globalDisplayName: 'GN' } as Partial<UpdateProfileMessage>),
+      2000
+    );
+    // No override fields on the message → override slot (and its ts) untouched.
+    expect(p.display_name).toBe('Keep');
+    expect(p.profileTimestamp).toBe(1000);
+    expect(p.global_display_name).toBe('GN');
+  });
+
+  it('falls back to Date.now() when createdDate is 0/falsy', () => {
+    const before = Date.now();
+    const p = row();
+    applyProfileUpdate(p, msg({ displayName: 'Ada' } as Partial<UpdateProfileMessage>), 0);
+    expect(p.profileTimestamp).toBeGreaterThanOrEqual(before);
+  });
+});

--- a/src/hooks/business/channels/useChannelData.ts
+++ b/src/hooks/business/channels/useChannelData.ts
@@ -4,6 +4,7 @@ import { useSpaceMembers } from '../../queries/spaceMembers/useSpaceMembers';
 import { i18n } from '@lingui/core';
 import { DefaultImages } from '../../../utils';
 import type { BroadcastSpaceTag } from '@quilibrium/quorum-shared';
+import type { SpaceMemberRow } from '../../../db/messages';
 
 // Safe development-only testing - automatically disabled in production
 const ENABLE_MOCK_USERS =
@@ -46,9 +47,11 @@ export function useChannelData({ spaceId, channelId }: UseChannelDataProps) {
   }, [mockUtils]);
 
   // Add mock users for testing virtualization performance
-  const enhancedSpaceMembers = useMemo(() => {
+  const enhancedSpaceMembers = useMemo<SpaceMemberRow[]>(() => {
     if (ENABLE_MOCK_USERS) {
-      return [...spaceMembers, ...mockUsers];
+      // mockUsers is dev-only `any[]`; cast the merged array once so members
+      // stay typed as SpaceMemberRow at the reduce below.
+      return [...spaceMembers, ...mockUsers] as SpaceMemberRow[];
     }
     return spaceMembers;
   }, [spaceMembers, mockUsers]);
@@ -72,18 +75,18 @@ export function useChannelData({ spaceId, channelId }: UseChannelDataProps) {
             displayName: curr.display_name,
             // Per-space bio override; flows into UserProfile's "About"
             // section. Empty string means the user explicitly cleared it.
-            bio: (curr as any).bio as string | undefined,
+            bio: curr.bio,
             // Roster GLOBAL slots (two-slot design): the sender's current global
             // identity, pushed separately from the per-space override fields.
             // Consumed by the fallback resolver as the tier between override and
             // public profile. See identity-resolution-and-profile-sync doc.
-            globalDisplayName: (curr as any).global_display_name as string | undefined,
-            globalUserIcon: (curr as any).global_user_icon?.includes(DefaultImages.UNKNOWN_USER)
+            globalDisplayName: curr.global_display_name,
+            globalUserIcon: curr.global_user_icon?.includes(DefaultImages.UNKNOWN_USER)
               ? undefined
-              : ((curr as any).global_user_icon as string | undefined),
-            globalBio: (curr as any).global_bio as string | undefined,
+              : curr.global_user_icon,
+            globalBio: curr.global_bio,
             isKicked: curr.isKicked || false,
-            spaceTag: (curr as any).spaceTag as BroadcastSpaceTag | undefined,
+            spaceTag: curr.spaceTag,
             joinedAt: curr.joinedAt,
           },
         }),

--- a/src/hooks/business/user/useMembersWithPublicProfileFallback.ts
+++ b/src/hooks/business/user/useMembersWithPublicProfileFallback.ts
@@ -130,9 +130,9 @@ export function useMembersWithPublicProfileFallback(
       // Roster GLOBAL slots (two-slot design) — the live-pushed global identity,
       // the tier between the per-space override and the public profile. Works
       // for non-public users (no public profile). See identity-resolution doc.
-      const rosterGlobalName = local?.globalDisplayName as string | undefined;
-      const rosterGlobalIcon = (local as { globalUserIcon?: string } | undefined)?.globalUserIcon;
-      const rosterGlobalBio = (local as { globalBio?: string } | undefined)?.globalBio;
+      const rosterGlobalName = local?.globalDisplayName;
+      const rosterGlobalIcon = local?.globalUserIcon;
+      const rosterGlobalBio = local?.globalBio;
       // The member's effective GLOBAL identity: prefer the live roster slot,
       // else the public profile. Used both as the render fallback below and
       // (as globalDisplayName) by resolveSpaceMemberName's custom-name compare.

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -118,7 +118,8 @@ export interface MessageServiceDependencies {
 // are stale — desktop's P2P transport has no per-space inbox to acknowledge.
 // That cleanup step belongs to the future hub-log migration, at the transport
 // layer, not here. See project docs / the two-slot task file.
-function applyProfileUpdate(
+// Exported for unit testing (pure logic, no dependencies).
+export function applyProfileUpdate(
   participant: SpaceMemberRow,
   content: UpdateProfileMessage,
   createdDate: number

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -17,6 +17,7 @@ import {
   RATE_LIMITS,
 } from '@quilibrium/quorum-shared';
 import { MessageDB, EncryptionState, EncryptedMessage } from '../db/messages';
+import type { SpaceMemberRow } from '../db/messages';
 import type {
   Message,
   ReactionMessage,
@@ -104,26 +105,56 @@ export interface MessageServiceDependencies {
   handleSyncManifest: (spaceId: string, targetInbox: string, payload: any) => Promise<void>;
 }
 
-// Two-slot design (see identity-resolution-and-profile-sync doc): copy the
-// sender's GLOBAL identity fields from an update-profile message onto a member
-// row, stored separately from the per-space override fields
-// (display_name/user_icon/bio). Presence semantics: omitted = no change,
-// '' = deliberate global clear. Read untyped — global* are additive to the
-// shared UpdateProfileMessage (additive shared PR pending, non-blocking).
-function applyGlobalProfileSlots(participant: object, content: unknown): void {
-  const c = content as {
-    globalDisplayName?: string;
-    globalUserIcon?: string;
-    globalBio?: string;
-  };
-  const p = participant as {
-    global_display_name?: string;
-    global_user_icon?: string;
-    global_bio?: string;
-  };
-  if (c.globalDisplayName !== undefined) p.global_display_name = c.globalDisplayName;
-  if (c.globalUserIcon !== undefined) p.global_user_icon = c.globalUserIcon;
-  if (c.globalBio !== undefined) p.global_bio = c.globalBio;
+// Apply an update-profile message onto a member row (two-slot model — see
+// identity-resolution-and-profile-sync doc). The OVERRIDE fields
+// (display_name/user_icon/bio) and the GLOBAL slot (global_*) are stored
+// separately and each carry their own last-write-wins timestamp, so an
+// out-of-order rebroadcast carrying an older value for one slot can't clobber a
+// newer value in the other. Presence semantics: omitted = no change,
+// '' = deliberate clear. Mirrors mobile WebSocketContext (applyOverride/
+// applyGlobal). `createdDate` is the wire message's timestamp.
+//
+// NOTE: unlike mobile, this does NOT delete the inbox message when both slots
+// are stale — desktop's P2P transport has no per-space inbox to acknowledge.
+// That cleanup step belongs to the future hub-log migration, at the transport
+// layer, not here. See project docs / the two-slot task file.
+function applyProfileUpdate(
+  participant: SpaceMemberRow,
+  content: UpdateProfileMessage,
+  createdDate: number
+): void {
+  const ts = createdDate || Date.now();
+
+  const hasOverride =
+    content.displayName !== undefined ||
+    content.userIcon !== undefined ||
+    content.bio !== undefined;
+  const hasGlobal =
+    content.globalDisplayName !== undefined ||
+    content.globalUserIcon !== undefined ||
+    content.globalBio !== undefined;
+
+  const applyOverride =
+    hasOverride &&
+    !(participant.profileTimestamp && participant.profileTimestamp >= ts);
+  const applyGlobal =
+    hasGlobal &&
+    !(participant.globalProfileTimestamp && participant.globalProfileTimestamp >= ts);
+
+  // OVERRIDE slot — presence check ('' is a deliberate per-space clear).
+  if (applyOverride) {
+    if (content.displayName !== undefined) participant.display_name = content.displayName;
+    if (content.userIcon !== undefined) participant.user_icon = content.userIcon;
+    if (content.bio !== undefined) participant.bio = content.bio;
+    participant.profileTimestamp = ts;
+  }
+  // GLOBAL slot — the sender's current global identity, never mistaken for an override.
+  if (applyGlobal) {
+    if (content.globalDisplayName !== undefined) participant.global_display_name = content.globalDisplayName;
+    if (content.globalUserIcon !== undefined) participant.global_user_icon = content.globalUserIcon;
+    if (content.globalBio !== undefined) participant.global_bio = content.globalBio;
+    participant.globalProfileTimestamp = ts;
+  }
 }
 
 export class MessageService {
@@ -1376,38 +1407,21 @@ export class MessageService {
         spaceId,
         decryptedContent.content.senderId
       );
-      const participant = existing ?? ({
+      const participant: SpaceMemberRow = existing ?? {
         user_address: decryptedContent.content.senderId,
         inbox_address: inboxAddress,
-      } as secureChannel.UserProfile & { inbox_address: string; isKicked?: boolean });
+      };
 
       // update-profile is itself a key rotation announcement — accept inbox address changes.
       // Signature was already verified upstream; rejecting on mismatch would permanently
       // block profile updates after any key rotation.
       //
-      // Upsert-aware merge: omitted field = no change, empty string = clear.
-      // displayName, bio AND userIcon use `!== undefined` so an explicit clear
-      // ('') propagates. An emptied userIcon is stored as '' and the avatar
-      // components treat '' as "no image" (isLikelyRenderableImage('') === false),
-      // falling back to initials — the same as the UNKNOWN_USER sentinel. Senders
-      // that mean "no change" omit the field; the all-spaces rebroadcast sends the
-      // UNKNOWN_USER sentinel (never ''), so this does not clobber. The public-
-      // profile backfill (useMembersWithPublicProfileFallback) also honors '' as
-      // a deliberate clear, so it won't resurrect the sender's global avatar.
-      if (decryptedContent.content.displayName !== undefined) {
-        participant.display_name = decryptedContent.content.displayName;
-      }
-      if (decryptedContent.content.userIcon !== undefined) {
-        participant.user_icon = decryptedContent.content.userIcon;
-      }
-      if (decryptedContent.content.bio !== undefined) {
-        participant.bio = decryptedContent.content.bio;
-      }
-      // GLOBAL identity slots (two-slot design — see identity-resolution doc).
-      // Stored separately from the override fields above so the sender's global
-      // rename reaches spacemates without being mistaken for a per-space
-      // override. Read untyped: additive to the shared UpdateProfileMessage.
-      applyGlobalProfileSlots(participant, decryptedContent.content);
+      // Two-slot, per-slot-LWW merge (see applyProfileUpdate). Presence
+      // semantics: omitted = no change, '' = deliberate clear (falls back to
+      // initials for an emptied icon). The public-profile backfill
+      // (useMembersWithPublicProfileFallback) also honors '' as a deliberate
+      // clear, so it won't resurrect the sender's global avatar.
+      applyProfileUpdate(participant, decryptedContent.content, decryptedContent.createdDate);
       participant.inbox_address = inboxAddress;
       // Validate inbound spaceTag — reject SVG data URIs (XSS) and oversized payloads
       const inboundTag = decryptedContent.content.spaceTag;
@@ -1940,37 +1954,19 @@ export class MessageService {
         spaceId,
         decryptedContent.content.senderId
       );
-      const participant =
-        existing ??
-        ({
-          user_address: decryptedContent.content.senderId,
-          inbox_address: inboxAddress,
-        } as secureChannel.UserProfile & {
-          inbox_address: string;
-          isKicked?: boolean;
-        });
+      const participant: SpaceMemberRow = existing ?? {
+        user_address: decryptedContent.content.senderId,
+        inbox_address: inboxAddress,
+      };
 
       // update-profile is itself a key rotation announcement — accept inbox address changes.
       // Signature was already verified upstream; rejecting on mismatch would permanently
       // block profile updates after any key rotation.
       //
-      // Upsert-aware merge (mirrors mobile WebSocketContext.tsx:1841-1854):
-      // see the same block in saveMessage above for the full rationale.
-      // Presence semantics: omitted = no change, explicit empty = clear.
-      // userIcon uses `!== undefined` too so an emptied avatar ('') propagates
-      // and falls back to initials (see the saveMessage block above).
-      if (decryptedContent.content.displayName !== undefined) {
-        participant.display_name = decryptedContent.content.displayName;
-      }
-      if (decryptedContent.content.userIcon !== undefined) {
-        participant.user_icon = decryptedContent.content.userIcon;
-      }
-      if (decryptedContent.content.bio !== undefined) {
-        participant.bio = decryptedContent.content.bio;
-      }
-      // GLOBAL identity slots (two-slot design) — stored separately from the
-      // override fields above. See identity-resolution doc.
-      applyGlobalProfileSlots(participant, decryptedContent.content);
+      // Two-slot, per-slot-LWW merge (see applyProfileUpdate + the saveMessage
+      // block above for the full rationale). Presence semantics: omitted =
+      // no change, '' = deliberate clear.
+      applyProfileUpdate(participant, decryptedContent.content, decryptedContent.createdDate);
       participant.inbox_address = inboxAddress;
       // Validate inbound spaceTag — reject SVG data URIs (XSS) and oversized payloads
       const inboundTag = decryptedContent.content.spaceTag;
@@ -5311,14 +5307,15 @@ export class MessageService {
           )
         );
 
+        const createdDate = Date.now();
         const message = {
           spaceId: spaceId,
           channelId: channelId,
           messageId: Buffer.from(messageId).toString('hex'),
           digestAlgorithm: 'SHA-256',
           nonce: nonce,
-          createdDate: Date.now(),
-          modifiedDate: Date.now(),
+          createdDate,
+          modifiedDate: createdDate,
           lastModifiedHash: '',
           content: {
             ...updateProfileMessage,
@@ -5349,21 +5346,15 @@ export class MessageService {
           currentPasskeyInfo.address
         );
         if (participant) {
-          // Presence-checked: only apply OVERRIDE fields the message actually
-          // carries. A global-save message omits these (it uses the global*
-          // slots below), so an unconditional assignment would wipe a real
-          // per-space override with undefined. Matches the receive-side rule.
-          if (updateProfileMessage.displayName !== undefined) {
-            participant.display_name = updateProfileMessage.displayName;
-          }
-          if (updateProfileMessage.userIcon !== undefined) {
-            participant.user_icon = updateProfileMessage.userIcon;
-          }
+          // Self-apply our own just-sent edit locally (don't wait for echo).
+          // Same two-slot, presence-checked, per-slot-LWW merge as the receive
+          // handlers — a global-only save omits the override fields, so they're
+          // left untouched rather than wiped. `createdDate` is our own send
+          // timestamp, so our latest edit always wins over our stored value.
+          applyProfileUpdate(participant, updateProfileMessage, createdDate);
           if (updateProfileMessage.spaceTag !== undefined) {
             participant.spaceTag = updateProfileMessage.spaceTag;
           }
-          // Apply any global slots present (undefined for pure override edits).
-          applyGlobalProfileSlots(participant, updateProfileMessage);
           await this.messageDB.saveSpaceMember(spaceId, participant);
 
           // Update query cache for immediate UI refresh. Use the already-merged


### PR DESCRIPTION
Consumes the newly-typed `UpdateProfileMessage` global fields (quorum-shared PR #57) and adds the per-slot staleness guard the desktop `update-profile` receive handlers were missing.

## What changed
- **`SpaceMemberRow`** (`src/db/messages.ts`) — single source of truth for the member row: SDK `UserProfile` + local fields + the two-slot `global_*` slots + per-slot `profileTimestamp` / `globalProfileTimestamp`. Replaces three repeated inline intersections in the storage methods.
- **`applyProfileUpdate`** replaces `applyGlobalProfileSlots` — applies the OVERRIDE slot (display_name/user_icon/bio) and the GLOBAL slot (global_*) **independently**, each only when the incoming `createdDate` is newer than that slot's stored timestamp, then stamps it. Mirrors mobile's `applyOverride`/`applyGlobal`. Wired into both receive handlers **and** the send-side self-apply.
- **Guard only — no inbox delete.** Desktop's P2P transport has no per-space inbox to acknowledge; mobile's `deleteSpaceInboxMessages` step belongs to the future hub-log migration (at the transport layer), not this handler. Documented in-code. The guard itself is transport-agnostic.
- **Retired casts** the missing shared type forced: `as unknown as UpdateProfileMessage` in `MessageDB` (now a single cast for the required `userIcon`, matching the rebroadcast site), the `(curr as any).global_*` reads in `useChannelData`, and the `(local as {...})` reads in the fallback hook.

## Why the guard
Out-of-order `update-profile` rebroadcasts (network reordering, a slow device catching up on reconnect) could let an OLDER profile value briefly win until the next broadcast corrected it. Mobile already guards each slot by its own timestamp; this brings desktop to parity. Low probability, low harm, but real — and it's exactly the reorder that the coming hub-log replay makes more likely.

## Verification
- `tsc` clean, eslint 0 errors.
- **New unit test** (`MessageService.applyProfileUpdate.unit.test.ts`, 9 tests) — older-doesn't-clobber-newer, equal-timestamp self-echo no-op, per-slot independence (both directions), legacy undefined-timestamp rows always-apply, `''` deliberate-clear.
- MessageService suite 24/24 pass.
- Independent code review (fresh context) confirmed the core logic sound, no critical issues.

## Follow-ups (tracked, out of scope here)
- Mobile cast cleanup — blocked on publishing shared PR #57 (task filed in the mobile repo).
- Making `UpdateProfileMessage.userIcon` optional in shared (the reviewer's type-lie finding) — the deeper fix, tracked with the shared-type task.