### PR TITLE
fix: space avatar profile mobile drawer

### DIFF
--- a/src/components/message/Message.tsx
+++ b/src/components/message/Message.tsx
@@ -17,7 +17,6 @@ const EmojiPicker = React.lazy(() =>
   import('../emoji-picker/EmojiPicker').then((m) => ({ default: m.default }))
 );
 import type { EmojiData } from '../emoji-picker/types';
-import UserProfile from '../user/UserProfile';
 import { FloatingPopover, rectAnchor } from '../ui';
 import { SpaceTag } from '../space/SpaceTag';
 import { useParams } from 'react-router';
@@ -161,8 +160,6 @@ type MessageProps = {
   stickers?: { [key: string]: Sticker };
   message: MessageType;
   messageList: MessageType[];
-  senderRoles: Role[];
-  canEditRoles?: boolean;
   canDeleteMessages?: boolean;
   canPinMessages?: boolean;
   channel?: Channel;
@@ -220,8 +217,6 @@ export const Message = React.memo(
     stickers,
     message,
     messageList,
-    senderRoles,
-    canEditRoles,
     canDeleteMessages,
     canPinMessages,
     channel,
@@ -277,13 +272,10 @@ export const Message = React.memo(
     );
 
     // Component state that needs to be available to hooks
-    const [showUserProfile, setShowUserProfile] = useState<boolean>(false);
     const [editingMessageId, setEditingMessageId] = useState<string | null>(null);
     const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
     const contextMenuClosedAt = useRef(0);
     const [isShowingGifAnimation, setIsShowingGifAnimation] = useState(false);
-    // Anchor for the touch-path UserProfile card (positioned via FloatingPopover).
-    const userProfileAnchorRef = useRef<HTMLElement | null>(null);
 
     // Modal contexts
     const { showImageModal } = useImageModal();
@@ -358,7 +350,6 @@ export const Message = React.memo(
       message,
       hoverTarget,
       setHoverTarget,
-      setShowUserProfile,
       onCloseEmojiPickers: emojiPicker.closeEmojiPickers,
       onMobileActionsDrawer: (config) => {
         // For touch devices, always show confirmation (shiftKey = false)
@@ -367,10 +358,6 @@ export const Message = React.memo(
           ...buildDrawerConfig(),
           ...config,
         });
-      },
-      onEmojiPickerUserProfileClick: (clientY: number, onProfileClick: () => void) => {
-        // Direction is now handled by FloatingPopover's flip() middleware.
-        emojiPicker.handleUserProfileClick(clientY, onProfileClick);
       },
       onReply: messageActions.handleReply,
       isEditing: editingMessageId === message.messageId,
@@ -745,25 +732,6 @@ export const Message = React.memo(
           <Flex
             className="message-body w-full font-[11pt] px-[16px] items-start"
           >
-            {spaceId && (
-              <FloatingPopover
-                open={showUserProfile}
-                onClose={() => setShowUserProfile(false)}
-                anchor={userProfileAnchorRef.current}
-                placement="right-start"
-                closeOnScroll
-              >
-                <UserProfile
-                  spaceId={message.spaceId}
-                  canEditRoles={canEditRoles}
-                  roles={senderRoles}
-                  user={sender}
-                  dismiss={() => {
-                    setShowUserProfile(false);
-                  }}
-                />
-              </FloatingPopover>
-            )}
             {isCompact ? (
               <div className="message-sender-spacer">
                 <span className="compact-timestamp">
@@ -777,34 +745,30 @@ export const Message = React.memo(
                 address={sender.address}
                 size={44}
                 className="message-sender-icon"
-                onClick={
-                  isTouchDevice()
-                    ? (event: React.MouseEvent) => {
-                        // Capture the avatar element so FloatingPopover can
-                        // anchor the touch-path profile card to it.
-                        userProfileAnchorRef.current =
-                          event.currentTarget as HTMLElement;
-                        interactions.handleUserProfileClick(event);
+                onClick={(event: React.MouseEvent) => {
+                  // Single profile-open path for every input (mouse and touch):
+                  // hand off to the container's userProfileModal, which renders
+                  // the card on desktop and the drawer below 1024px. Previously
+                  // touch devices used a separate, viewport-agnostic popover in
+                  // this component — that always showed the desktop card (even on
+                  // phones / in device emulation) and is now removed.
+                  event.stopPropagation();
+                  if (onUserClick) {
+                    onUserClick(
+                      {
+                        address: sender.address,
+                        displayName: sender.displayName,
+                        userIcon: sender.userIcon,
+                        bio: sender.bio,
+                      },
+                      event,
+                      {
+                        type: 'message-avatar',
+                        element: event.currentTarget as HTMLElement,
                       }
-                    : (event: React.MouseEvent) => {
-                        event.stopPropagation();
-                        if (onUserClick) {
-                          onUserClick(
-                            {
-                              address: sender.address,
-                              displayName: sender.displayName,
-                              userIcon: sender.userIcon,
-                              bio: sender.bio,
-                            },
-                            event,
-                            {
-                              type: 'message-avatar',
-                              element: event.currentTarget as HTMLElement,
-                            }
-                          );
-                        }
-                      }
-                }
+                    );
+                  }
+                }}
               />
             )}
             <div className="message-content">

--- a/src/components/message/MessageList.tsx
+++ b/src/components/message/MessageList.tsx
@@ -378,7 +378,6 @@ export const MessageList = forwardRef<MessageListRef, MessageListProps>(
             )}
             {displayInfo.needsNewMessagesSeparator && <NewMessagesSeparator />}
             <Message
-              senderRoles={roles}
               spaceRoles={roles}
               stickers={stickers}
               emojiPickerOpen={emojiPickerOpen}
@@ -396,7 +395,6 @@ export const MessageList = forwardRef<MessageListRef, MessageListProps>(
               setInReplyTo={setInReplyTo}
               editorRef={editor.current}
               height={height}
-              canEditRoles={isSpaceOwner}
               canDeleteMessages={canDeleteMessages(message)}
               canPinMessages={
                 canPinMessages ? canPinMessages(message) : undefined

--- a/src/components/space/Channel.tsx
+++ b/src/components/space/Channel.tsx
@@ -110,6 +110,13 @@ const Channel: React.FC<ChannelProps> = ({
     useResponsiveLayoutContext();
   const shell = useOptionalShellState();
   const isPhone = shell?.viewport === 'phone';
+  // Single source of truth for the card-vs-drawer split. The shell viewport is
+  // the app's authoritative responsive signal (it drives the nav rail, sidebars
+  // and the members drawer); keying the profile modal off the same value keeps
+  // it from disagreeing with the surrounding layout. Falls back to the
+  // window-width layout hook only if this Channel ever renders outside the shell
+  // (useOptionalShellState → null). 'desktop' is ≥1024, matching isDesktop.
+  const isDesktopLayout = shell ? shell.viewport === 'desktop' : isDesktop;
   const queryClient = useQueryClient();
   const user = usePasskeysContext();
   const { showRightSidebar: showUsers, setShowRightSidebar: setShowUsers } =
@@ -1950,7 +1957,7 @@ const Channel: React.FC<ChannelProps> = ({
           the anchored row's DOM node — a popover that tried to follow the anchor
           would stick to a stale node and then fail to reopen. Closing on scroll
           (Discord/Slack-style) avoids that. */}
-      {isDesktop && (
+      {isDesktopLayout && (
         <FloatingPopover
           open={userProfileModal.isOpen && !!userProfileModal.selectedUser}
           onClose={handleUserProfileClose}
@@ -1975,8 +1982,37 @@ const Channel: React.FC<ChannelProps> = ({
         </FloatingPopover>
       )}
 
+      {/* User Profile drawer - below 1024px. The FloatingPopover above is
+          desktop-only (a card anchored to a virtualized message/sidebar row
+          detaches on scroll on narrow widths), so on tablet/narrow viewports
+          the same profile content is shown in a MobileDrawer instead — driven
+          by the identical userProfileModal state. Without this, clicking a
+          message avatar / mention / member row below 1024px set the modal
+          state but rendered nothing. Mirrors the DM view's pattern. */}
+      {!isDesktopLayout && (
+        <MobileDrawer
+          isOpen={userProfileModal.isOpen && !!userProfileModal.selectedUser}
+          onClose={handleUserProfileClose}
+          showCloseButton={false}
+          enableSwipeToClose={true}
+          ariaLabel={t`User profile`}
+        >
+          {userProfileModal.selectedUser && (
+            <UserProfile
+              key={userProfileModal.selectedUser.address}
+              spaceId={spaceId}
+              canEditRoles={isSpaceOwner}
+              roles={roles || []}
+              user={userProfileModal.selectedUser}
+              dismiss={handleUserProfileClose}
+              variant="drawer"
+            />
+          )}
+        </MobileDrawer>
+      )}
+
       {/* Mobile drawer for user list below 1024px */}
-      {!isDesktop && (
+      {!isDesktopLayout && (
         <MobileDrawer
           isOpen={showUsers}
           onClose={() => setShowUsers(false)}

--- a/src/components/user/UserProfile.scss
+++ b/src/components/user/UserProfile.scss
@@ -29,6 +29,70 @@
   }
 }
 
+// Drawer variant: rendered inside a full-width MobileDrawer below 1024px. The
+// drawer owns the surface, border and scrolling, so the profile drops its own
+// card chrome (fixed width / border / shadow) and fills the drawer width
+// instead of floating as a narrow card inside it.
+.user-profile--drawer {
+  width: 100%;
+  border: none;
+  box-shadow: none;
+  border-radius: 0;
+  // The drawer body already paints the modal surface; keep transparent so the
+  // header band and content sit directly on it without a nested surface step.
+  background: transparent;
+
+  // Flatten the header and footer surfaces into the drawer body. In the card
+  // these carry their own tinted bands (--color-bg-modal-sidebar / -modal) to
+  // read as distinct header/footer zones; inside the drawer that shows up as
+  // two mismatched stripes against the drawer surface, so make them transparent.
+  // Rules here are nested under .user-profile--drawer so they win over the base
+  // single-class .user-profile-* rules regardless of source order.
+  .user-profile-header {
+    border-radius: 0;
+    background: transparent;
+
+    // Centered identity block (big avatar, name and address stacked and
+    // centered below it), mirroring the DM profile drawer.
+    flex-direction: column;
+    align-items: center;
+    gap: $s-2;
+    padding: $s-6 $s-4 $s-4;
+    min-height: 0;
+  }
+
+  .user-profile-username {
+    padding-right: 0; // no close button to clear in the drawer
+    max-width: 100%;
+    text-align: center;
+    // Let a long name wrap and center instead of truncating to an ellipsis.
+    white-space: normal;
+    overflow: visible;
+  }
+
+  .user-profile-action-footer {
+    background: transparent;
+  }
+
+  // Consistent 16px ($s-4) horizontal gutters for every content section, matching
+  // the header and the app's MobileDrawer standard (its header rows/sections all
+  // use $s-4). The card layout inherits 8px gutters from a 330px floating card,
+  // which read as cramped and misaligned against the 16px header once the profile
+  // fills a full-width drawer. Vertical padding on each section is left intact;
+  // only the left/right is normalised here.
+  //
+  // Roles block: the JSX wrapper is a bare `p-2` div (first child of the section
+  // container that follows the header), so target it structurally.
+  > div > .p-2,
+  .user-profile-bio-section,
+  .user-profile-note-section,
+  .user-profile-note-trigger,
+  .user-profile-action-footer {
+    padding-left: $s-4;
+    padding-right: $s-4;
+  }
+}
+
 .user-profile-header {
   // Subtle header band, offset from the card body (--color-bg-modal = surface-2).
   // This resolves to surface-1 which matches the chat background, but the card's

--- a/src/components/user/UserProfile.tsx
+++ b/src/components/user/UserProfile.tsx
@@ -38,6 +38,13 @@ const UserProfile: React.FunctionComponent<{
   canEditRoles?: boolean;
   user: any;
   dismiss?: () => void;
+  /**
+   * Presentation variant. Default 'card' is the floating popover card
+   * (fixed width, own border/shadow). 'drawer' fills its container and drops
+   * the card chrome — used inside the MobileDrawer below 1024px so the profile
+   * reads as full-width drawer content, not a narrow card floating in a drawer.
+   */
+  variant?: 'card' | 'drawer';
 }> = (props) => {
   const { currentPasskeyInfo } = usePasskeysContext();
   const { messageDB } = useMessageDB();
@@ -217,10 +224,14 @@ const UserProfile: React.FunctionComponent<{
 
   return (
     <div
-      className="user-profile"
+      className={
+        'user-profile' + (props.variant === 'drawer' ? ' user-profile--drawer' : '')
+      }
       onClick={(e: React.MouseEvent) => e.stopPropagation()}
     >
-      {props.dismiss && (
+      {/* Close X is only for the floating card; the drawer variant is dismissed
+          by swipe/tap-out, so it has no in-card close button. */}
+      {props.dismiss && props.variant !== 'drawer' && (
         <div
           className="absolute right-3 top-3 cursor-pointer text-subtle hover:text-main z-10"
           onClick={props.dismiss}
@@ -228,28 +239,20 @@ const UserProfile: React.FunctionComponent<{
           <Icon name="close" />
         </div>
       )}
-      <div
-        className={
-          'user-profile-header ' +
-          (currentPasskeyInfo!.address === props.user.address &&
-          userRoles.length === 0 &&
-          !props.canEditRoles
-            ? 'rounded-b-xl'
-            : '')
-        }
-      >
-        <UserAvatar
-          userIcon={props.user.userIcon}
-          displayName={props.user.displayName}
-          address={props.user.address}
-          size={44}
-          className="user-profile-icon"
-        />
-        <div className="user-profile-text">
+      {props.variant === 'drawer' ? (
+        // Drawer header: centered identity block (big avatar, name and address
+        // stacked below) — mirrors the DM profile drawer layout.
+        <div className="user-profile-header">
+          <UserAvatar
+            userIcon={props.user.userIcon}
+            displayName={props.user.displayName}
+            address={props.user.address}
+            size={96}
+          />
           <div className="user-profile-username">
             <ResolvedName resolved={resolvedName} />
           </div>
-          <Flex className="py-1 text-subtle">
+          <Flex className="text-subtle justify-center items-center">
             <span className="text-xs text-subtle">
               {formatAddress(props.user.address)}
             </span>
@@ -263,16 +266,54 @@ const UserProfile: React.FunctionComponent<{
               <></>
             </ClickToCopyContent>
           </Flex>
-          <div className="user-profile-state">
-            {/* TODO: Re-enable when online/offline status is implemented
-                See .agents/tasks/todo/user-status.md for implementation plan
-                Phase 1: Show current user's connection state
-                Phase 2: Show all users' online/offline status via presence system
-            <UserOnlineStateIndicator user={props.user} />
-            */}
+        </div>
+      ) : (
+        <div
+          className={
+            'user-profile-header ' +
+            (currentPasskeyInfo!.address === props.user.address &&
+            userRoles.length === 0 &&
+            !props.canEditRoles
+              ? 'rounded-b-xl'
+              : '')
+          }
+        >
+          <UserAvatar
+            userIcon={props.user.userIcon}
+            displayName={props.user.displayName}
+            address={props.user.address}
+            size={44}
+            className="user-profile-icon"
+          />
+          <div className="user-profile-text">
+            <div className="user-profile-username">
+              <ResolvedName resolved={resolvedName} />
+            </div>
+            <Flex className="py-1 text-subtle">
+              <span className="text-xs text-subtle">
+                {formatAddress(props.user.address)}
+              </span>
+              <ClickToCopyContent
+                className="ml-2"
+                tooltipText={t`Copy address`}
+                text={props.user.address}
+                tooltipLocation="top"
+                iconClassName="text-xs text-subtle hover:text-surface-7"
+              >
+                <></>
+              </ClickToCopyContent>
+            </Flex>
+            <div className="user-profile-state">
+              {/* TODO: Re-enable when online/offline status is implemented
+                  See .agents/tasks/todo/user-status.md for implementation plan
+                  Phase 1: Show current user's connection state
+                  Phase 2: Show all users' online/offline status via presence system
+              <UserOnlineStateIndicator user={props.user} />
+              */}
+            </div>
           </div>
         </div>
-      </div>
+      )}
 
       <div>
         {(userRoles.length > 0 || props.canEditRoles) && (

--- a/src/hooks/business/messages/useMessageInteractions.ts
+++ b/src/hooks/business/messages/useMessageInteractions.ts
@@ -9,13 +9,8 @@ interface UseMessageInteractionsOptions {
   message: MessageType;
   hoverTarget: string | undefined;
   setHoverTarget: React.Dispatch<React.SetStateAction<string | undefined>>;
-  setShowUserProfile: React.Dispatch<React.SetStateAction<boolean>>;
   onCloseEmojiPickers: () => void;
   onMobileActionsDrawer: (config: any) => void;
-  onEmojiPickerUserProfileClick: (
-    clientY: number,
-    onProfileClick: () => void
-  ) => void;
   /** Callback to trigger reply - used for double-click to reply on desktop */
   onReply?: () => void;
   /** Whether the message is currently being edited */
@@ -27,10 +22,8 @@ export function useMessageInteractions(options: UseMessageInteractionsOptions) {
     message,
     hoverTarget,
     setHoverTarget,
-    setShowUserProfile,
     onCloseEmojiPickers,
     onMobileActionsDrawer,
-    onEmojiPickerUserProfileClick,
     onReply,
     isEditing,
   } = options;
@@ -129,7 +122,6 @@ export function useMessageInteractions(options: UseMessageInteractionsOptions) {
       }
 
       // Common click behaviors
-      setShowUserProfile(false);
       onCloseEmojiPickers();
     },
     [
@@ -139,26 +131,8 @@ export function useMessageInteractions(options: UseMessageInteractionsOptions) {
       message.messageId,
       setHoverTarget,
       setActionsVisibleOnTap,
-      setShowUserProfile,
       onCloseEmojiPickers,
     ]
-  );
-
-  // Handle user profile icon click
-  const handleUserProfileClick = useCallback(
-    (e: React.MouseEvent) => {
-      onEmojiPickerUserProfileClick(e.clientY, () => setShowUserProfile(true));
-      e.stopPropagation();
-    },
-    [onEmojiPickerUserProfileClick, setShowUserProfile]
-  );
-
-  // Handle background click to close user profile
-  const handleUserProfileBackgroundClick = useCallback(
-    (e: React.MouseEvent) => {
-      setShowUserProfile(false);
-    },
-    [setShowUserProfile]
   );
 
   // Handle double-click to reply (desktop only)
@@ -212,7 +186,5 @@ export function useMessageInteractions(options: UseMessageInteractionsOptions) {
     handleMouseOut,
     handleMessageClick,
     handleDoubleClick,
-    handleUserProfileClick,
-    handleUserProfileBackgroundClick,
   };
 }


### PR DESCRIPTION
## Summary

Below 1024px, clicking a user avatar (or mention, or member row) in a space did nothing: the profile card was gated to desktop only, so the click set the modal state but rendered no surface. This adds a drawer for the sub-1024px viewport and unifies the profile-open path so every input behaves the same.

## Changes

**Profile drawer below 1024px**
- Render `UserProfile` inside a `MobileDrawer` on tablet/phone viewports, mirroring the DM profile drawer. Above 1024px the floating card is unchanged.

**Single profile-open path on the message avatar**
- Touch devices previously used a separate, viewport-agnostic popover inside `Message` that always showed the desktop card, even on phones and in device emulation. All avatar clicks now route through the shared `userProfileModal`, which picks card vs. drawer by viewport.
- Removed the dead local popover, its state/ref, and the now-unused `senderRoles` / `canEditRoles` prop-drilling through `MessageList` and `useMessageInteractions`.

**One responsive source of truth**
- The card-vs-drawer split now keys off the shell viewport (the app's authoritative responsive signal used by the nav rail, sidebars and members drawer) instead of a parallel window-width hook, so the profile modal can't disagree with the surrounding layout.

**Drawer layout**
- Centered identity header (large avatar, name and address stacked), flat surface (no nested card chrome), and consistent 16px content gutters, matching the DM profile drawer.

The DM profile drawer was already correct and is unchanged.