### PR TITLE
feat: Reset Encryption Session action in DM settings

### DIFF
--- a/src/components/modals/ConversationSettingsModal.tsx
+++ b/src/components/modals/ConversationSettingsModal.tsx
@@ -402,27 +402,36 @@ const ConversationSettingsModal: React.FC<ConversationSettingsModalProps> = ({
 
         <Spacer spaceBefore="lg" spaceAfter="md" border direction="vertical" />
 
-        {/* Reset Session Section */}
-        <Flex direction="column" align="center" className="mb-3">
+        {/* Reset Session — quiet, understated utility link (neutral) */}
+        <Flex justify="center" align="center" className="mb-3">
           <Button
             type="unstyled"
-            className="text-label-strong hover:text-main"
+            className="text-subtle hover:text-main cursor-pointer"
             onClick={(e: React.MouseEvent) => {
               if (!resetConfirmation.isConfirming) handleResetSessionClick(e);
             }}
           >
-            {t`Reset Encryption Session`}
+            <Flex align="center" gap="xs">
+              <Icon name="refresh" size="sm" />
+              {t`Reset Encryption Session`}
+            </Flex>
           </Button>
-          <div className="text-xs text-subtle">
-            {t`Reset if messages fail to send/decrypt`}
-          </div>
+          <Tooltip
+            id="conv-reset-session-tooltip"
+            content={t`Reset the encryption session if messages fail to send or decrypt. The next message will establish a fresh secure connection.`}
+            maxWidth={260}
+            className="!text-left !max-w-[260px]"
+            place="top"
+          >
+            <Icon name="info-circle" size="sm" className="ml-2 text-subtle" />
+          </Tooltip>
         </Flex>
 
-        {/* Delete Section */}
+        {/* Delete — destructive action, kept isolated as its own centered link */}
         <Flex justify="center" align="center">
           <Button
             type="unstyled"
-            className="text-danger hover:text-danger-hover"
+            className="text-danger hover:text-danger-hover cursor-pointer"
             onClick={(e: React.MouseEvent) => {
               if (!deleteConfirmation.isConfirming) handleDeleteClick(e);
             }}


### PR DESCRIPTION
## What

Adds a **Reset Encryption Session** action to the DM Conversation Settings modal, matching the mobile app's existing "Reset Session" feature (`DMSettingsSheet` → `resetDMSession`).

It deletes the local Double Ratchet encryption states for the conversation (message history and inbox mappings are untouched). The next outgoing message re-establishes a fresh session via a new init envelope; when the counterparty receives it, their side replaces the stale session for that device pair automatically, so one side resetting heals both directions.

## Why

DM conversations can reach a state where messages stop being delivered with no error surfaced to either user (a decrypt failure on one side tears down the session; subsequent messages are silently dropped). Mobile already ships a manual reset for exactly this; desktop had no equivalent, leaving affected conversations with no recovery path.

## Scope / honesty note

This is a **manual mitigation**, not the root-cause fix. It gives users (and us, while testing) a way to recover a broken conversation on demand. The underlying "session destroyed on decrypt failure" bug is tracked separately and will be fixed on its own branch.

## UI

- Reset presented as a quiet, centered link with a refresh icon and an info tooltip (neutral styling), sitting above the isolated red "Delete Conversation" link.
- Confirmation dialog mirrors mobile's wording.

## Commits

- `feat`: add Reset Encryption Session action to DM conversation settings
- `refactor`: present Reset Session as a quiet centered link with tooltip