### PR TITLE
fix: preserve DM session on decrypt failure (Double Ratchet spec compliance)

### DIFF
--- a/.agents/bugs/2026-07-17-dm-aead-error-frame-drops.md
+++ b/.agents/bugs/2026-07-17-dm-aead-error-frame-drops.md
@@ -1,0 +1,99 @@
+---
+type: bug
+title: "DM individual frames fail to decrypt (aead::Error) and drop — remaining half of the delivery bug"
+status: open — session-death half fixed & shipped 2026-07-17; this is the frame-generation half. Not yet root-caused. HAND-OFF doc for next session / more powerful model.
+created: 2026-07-17
+severity: high
+repo: quorum-desktop (mobile likely same)
+area: DM delivery / Double Ratchet / retry / dedupe
+related:
+  - ".agents/bugs/2026-07-17-dm-decrypt-failure-destroys-session-FIX-SPEC.md (Fix 1 — SHIPPED, stops session destruction)"
+  - ".agents/bugs/2026-07-02-dm-message-delivery-unreliable-master.md (full diagnosis archive)"
+---
+
+# DM frames still drop with `aead::Error` (remaining half of the delivery bug)
+
+## Read this first — what is and isn't fixed
+
+The DM delivery bug had **two mechanisms**:
+
+1. **Session destruction (FIXED, shipped 2026-07-17).** A single decrypt failure used to tear
+   down the whole encryption session → conversation direction permanently dead. Fix: stop
+   deleting the session on decrypt failure (Double Ratchet spec compliance). Confirmed live —
+   the conversation now survives decrypt failures and keeps delivering past them.
+
+2. **Frame generation (THIS DOC, still open).** Individual DM frames still fail to decrypt with
+   `Decryption failed: aead::Error` and are dropped. With Fix 1 in place these are now *isolated
+   single-message losses* (the conversation keeps working), not a dead direction — but a
+   messenger that silently loses individual messages is still broken. We need to stop the bad
+   frames being produced.
+
+## Confirmed symptom (live, 2026-07-17, after Fix 1)
+
+Two desktop accounts (Brave ↔ Gatopardo), fresh session via reset. Messages flow, then
+occasional numbered messages fail to land in one or both directions (e.g. Brave→Gatopardo "13"
+dropped; Gatopardo→Brave "12" and "13" dropped) while surrounding messages arrive fine. On the
+receiver console: `[MessageService] DM decrypt failed (DoubleRatchetInboxDecrypt) — skipping
+frame, keeping session` with `SyntaxError: Unexpected token 'D', "Decryption"... is not valid
+JSON` (the WASM returns the string `Decryption failed: aead::Error` in `result.message`; JSON
+parsing it throws). `aead::Error` = AEAD authentication failure = the ratchet message key used
+to encrypt didn't match what the receiver derived for that frame.
+
+## Leading hypothesis (NOT yet proven) — retry collisions
+
+`aead::Error` on a per-frame basis means sender and receiver ratchet states diverged for that
+one frame. The most concrete suspected source is the **automatic retry**:
+
+- `MessageService.retryDirectMessage` (~line 5554) and `retryMessage` (~line 5450) re-encrypt and
+  re-send a message when no delivery receipt arrives in time.
+- Re-encrypting advances/uses ratchet state. If a retry re-encrypts from a DB state that has
+  moved on (or races the original send's state save), it can emit a frame whose key the receiver
+  can't derive → `aead::Error`.
+- This fits the timing: drops cluster during active back-and-forth (when receipts and retries are
+  in flight), and the receipt traffic itself is low-volume and retry-prone.
+
+Other candidates to rule out (from the master report): two-tabs/two-devices state races; a
+duplicate/redelivery from the network inbox re-handed after the ratchet advanced; the receipt
+control-message path specifically (delivery-ack / read-ack are sent as their own DM frames and
+could be the ones failing).
+
+## How to investigate (evidence-first — do NOT patch blind)
+
+The `[DMTRACE]` kit on branch `debug/dm-delivery-trace` already has a `⚠️ REDELIVERY` detector
+and per-frame timestamps. For this bug, extend it to answer:
+
+1. **Is the failing frame a retry?** Tag every send with its origin (original vs retry) and its
+   ratchet-state identity; when an `aead::Error` fires, report whether that (inbox, timestamp)
+   was sent more than once, and whether a retry preceded it.
+2. **Is it a receipt frame?** Log the decrypted `type` the sender intended (post vs delivery-ack
+   vs read-ack) for the failing frame — cross-check against whether receipt frames fail
+   disproportionately (the read-receipt asymmetry seen earlier hints they might).
+3. **Is it a state-save race?** Check for concurrent `saveEncryptionState` on the same session
+   around the failure (two sends interleaving).
+
+Pass criterion for a fix: sustained several-minute back-and-forth with NO dropped messages
+(not just no dead direction).
+
+## Candidate fixes (after root cause confirmed)
+
+- **Fix 2 — dedupe before decrypt:** track recently-processed (inbox, timestamp); skip+ack
+  duplicates so redelivered/retried frames never reach the ratchet. Directly neutralizes the
+  redelivery/retry-collision class. Keep the logic PURE (extractable to quorum-shared later).
+- **Retry hardening:** don't let a retry re-encrypt from stale state; serialize send+state-save
+  so a retry can't race the original; or make retries idempotent at the frame level.
+- **Receipt path review:** if receipt frames are the disproportionate failers, look at how
+  standalone acks are encrypted/sent (`ActionQueueHandlers.sendReadAck` /
+  `encryptAndSendDm`) vs piggybacked ones.
+
+## Note for the next session / model
+
+Fix 1 shipped separately and is safe. This is the harder, genuinely-uncertain half — worth a
+recon spike against the real retry/receipt code before proposing a fix, and worth confirming the
+retry hypothesis with instrumentation before writing any patch. There is also a **separate,
+possibly-related read-receipt asymmetry bug** (Gatopardo reads Brave's messages but Brave never
+sees the read indicator) that was being investigated with `[RCPT]` logs when this was parked —
+those logs were removed from the tree but the tracing points are documented in git history on
+branch context; may share a root cause with the receipt-frame failures here.
+
+---
+*Created: 2026-07-17*

--- a/.agents/bugs/2026-07-17-dm-decrypt-failure-destroys-session-FIX-SPEC.md
+++ b/.agents/bugs/2026-07-17-dm-decrypt-failure-destroys-session-FIX-SPEC.md
@@ -1,0 +1,97 @@
+---
+type: bug
+title: "DM decrypt failure destroys the whole session (root cause of 6-month delivery bug) — FIX SPEC"
+status: root cause PROVEN live 2026-07-17; fix not yet implemented
+created: 2026-07-17
+severity: high
+repo: quorum-desktop (mobile has the same disease — see cross-platform note)
+area: DM delivery / Double Ratchet / MessageService receive pipeline
+supersedes-as-actionable: ".agents/bugs/2026-07-02-dm-message-delivery-unreliable-master.md (the full 6-month diagnosis archive; read it for evidence, work from THIS doc for the fix)"
+related:
+  - ".agents/tasks/2026-07-17-dm-session-reset-and-delivery-fix-plan.md (button shipped PR #234; systemic proposal)"
+---
+
+# FIX SPEC: DM decrypt failure destroys the session
+
+This is the **short, actionable** spec for the core fix. The giant master report
+(`2026-07-02-...-master.md`) is the diagnosis archive — 5 instrumented live rounds proving the
+mechanism. Do not re-read all of it to act; everything needed to implement the fix is here.
+
+## The bug in three sentences
+
+When a single incoming DM frame fails to decrypt (observed live: WASM returns
+`Decryption failed: aead::Error` — a one-off ratchet key mismatch from a duplicate/retry/race,
+NOT a broken session), the receive pipeline **deletes the entire encryption session and the
+server copy of the message**. The sender still holds its session and keeps encrypting into an
+inbox the receiver no longer listens to, so every subsequent message is silently dropped
+(`!found` branch), with zero error to either user. Result: the conversation direction is dead
+permanently until a manual session reset — which itself gets re-killed within minutes of active
+use (confirmed twice, 2026-07-17).
+
+## Why this is the real fix (not the reset button)
+
+The Double Ratchet **tolerates a lost/bad frame by design** — later messages use later keys and
+decrypt fine. So destroying the session on one failure is pure self-harm: the captured
+`aead::Error` frame would have cost exactly one frame (a receipt) and been invisible to the user
+if the code had simply skipped it. The reset button (shipped PR #234) is a manual unstick, not a
+cure — it re-establishes a session that the same reaction then destroys again.
+
+## The exact drop sites (current `main`, `src/services/MessageService.ts`)
+
+Two catch blocks in the DM receive section do the damage:
+
+1. **D1 — `DoubleRatchetInboxDecrypt` catch** (~line 3174):
+   ```ts
+   } catch (decryptError) {
+     logger.error('[MessageService] DM decrypt failed (DoubleRatchetInboxDecrypt)', decryptError);
+     await this.deleteInboxMessages(keys.receiving_inbox, [message.timestamp], this.apiClient); // deletes server copy
+     await this.messageDB.deleteEncryptionState(found);  // ← DESTROYS THE SESSION. This is the bug.
+     return;
+   }
+   ```
+2. **D2 — `ConfirmDoubleRatchetSenderSession` catch** (~line 3121): identical shape — deletes
+   server message + `deleteEncryptionState(found)`.
+
+Also relevant (silent aftermath, not the trigger):
+- **D3b — `if (!found)`** (~line 3073): message for an inbox with no state → deleted unread,
+  no log. This is where post-destruction messages vanish. Make it log-and-leave, don't
+  delete-and-forget.
+
+## The fix (surgical, minimal — Fix 1)
+
+In both D1 and D2 catch blocks: **do NOT call `deleteEncryptionState(found)`.** Keep the session.
+Skip the one bad frame. Decision to make (small):
+- Deleting the *server copy* of the poison frame (`deleteInboxMessages`) is arguably fine to keep
+  — a frame that can't be decrypted is useless and leaving it invites redelivery→refail loops.
+  Recommend: KEEP the server-delete, DROP the session-delete. That's the whole Fix 1.
+- Log loudly (keep the `logger.error`) so the skip is visible.
+
+That single change (remove two `deleteEncryptionState` calls) is expected to stop the
+every-few-minutes death entirely, because a transient `aead::Error` stops being fatal.
+
+## Follow-on fixes (separate, optional, after Fix 1 proves out)
+
+- **Fix 2 — dedupe before decrypt:** track recently-processed (inbox, timestamp) pairs; skip +
+  ack duplicates so retry/redelivery frames never reach the ratchet. Kills the trigger class.
+- **Fix 3 — auto-heal:** after N *consecutive* failures on one session (true de-sync, not a
+  one-off), do what the reset button does automatically (delete state → next msg re-inits).
+- **Fix 4 — un-silence D3b / D3a** (log-and-leave).
+
+Keep Fix 2/3 decision logic PURE (no storage/transport) so it can later be extracted to
+quorum-shared if the lead-dev wants mobile parity (see the fix plan doc). Desktop-local for now.
+
+## Test criteria (using the `[DMTRACE]` kit on branch `debug/dm-delivery-trace`)
+
+Two browser profiles, chat numbered messages. Pass = when a `🔴 decrypt failed` fires,
+subsequent messages on the SAME session **keep being delivered** (no `NO STATE` cascade, no
+dead direction). Before Fix 1 the session dies; after, it survives the bad frame. This is
+directly observable without deep log reading — messages simply keep landing.
+
+## Cross-platform note
+
+Mobile has the identical destroy-on-failure behavior (its Reset Session button is the proof the
+team has met this). Fixes 1-4 are transport-agnostic receive logic and apply conceptually to
+mobile too; propose to lead-dev after Fix 1 is validated on desktop.
+
+---
+*Created: 2026-07-17*

--- a/.agents/bugs/2026-07-17-dm-decrypt-failure-destroys-session-FIX-SPEC.md
+++ b/.agents/bugs/2026-07-17-dm-decrypt-failure-destroys-session-FIX-SPEC.md
@@ -36,6 +36,24 @@ decrypt fine. So destroying the session on one failure is pure self-harm: the ca
 if the code had simply skipped it. The reset button (shipped PR #234) is a manual unstick, not a
 cure — it re-establishes a session that the same reaction then destroys again.
 
+### Spec confirmation (verified 2026-07-17, not inference)
+
+A security-motivated reading of the current code is "decrypt/AEAD failure could mean tampering,
+so tear the session down (fail closed)." The Signal **Double Ratchet specification explicitly
+rejects this** for the `RatchetDecrypt` operation:
+
+> "If an exception is raised (e.g. message authentication failure) then the message is discarded
+> and changes to the state object are discarded. Otherwise, the decrypted plaintext is accepted
+> and changes to the state object are stored."
+> — Signal Double Ratchet spec, https://signal.org/docs/specifications/doubleratchet/
+
+So the spec-correct behavior on failure is: **discard the message, leave the saved session state
+untouched.** Rejecting the frame IS the complete defense against a tampered/injected message;
+destroying the session adds no security (the attacker gains nothing from you keeping the session)
+and breaks the protocol's documented tolerance for out-of-order / transient failures. The current
+code does the opposite — it persists a mutation (deletes the session) on failure — which is
+*non-compliant*. Our fix brings the code INTO spec, it does not weaken it.
+
 ## The exact drop sites (current `main`, `src/services/MessageService.ts`)
 
 Two catch blocks in the DM receive section do the damage:

--- a/.agents/bugs/2026-07-17-dm-decrypt-failure-destroys-session-FIX-SPEC.md
+++ b/.agents/bugs/2026-07-17-dm-decrypt-failure-destroys-session-FIX-SPEC.md
@@ -1,7 +1,7 @@
 ---
 type: bug
 title: "DM decrypt failure destroys the whole session (root cause of 6-month delivery bug) — FIX SPEC"
-status: root cause PROVEN live 2026-07-17; fix not yet implemented
+status: SHIPPED 2026-07-17 (branch fix/dm-decrypt-failure-preserve-session). Fix 1 done — session no longer destroyed on decrypt failure, confirmed live (conversation survived decrypt failures that previously killed it). Remaining: individual frames still fail to decrypt (aead::Error) and drop — tracked in 2026-07-17-dm-aead-error-frame-drops.md (Fix 2+).
 created: 2026-07-17
 severity: high
 repo: quorum-desktop (mobile has the same disease — see cross-platform note)

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -3119,13 +3119,19 @@ export class MessageService {
             return;
           }
         } catch (decryptError) {
-          logger.error('[MessageService] DM decrypt failed (ConfirmDoubleRatchetSenderSession)', decryptError);
+          // Double Ratchet spec: on a decrypt/authentication failure, discard the
+          // message but LEAVE the session state untouched — a single bad/duplicate/
+          // out-of-order frame does not mean the session is broken, and later frames
+          // decrypt fine. Destroying the session here was the root cause of the
+          // long-standing "DM direction goes permanently dead" bug: the sender kept
+          // encrypting to a session the receiver had torn down.
+          // (https://signal.org/docs/specifications/doubleratchet/)
+          logger.error('[MessageService] DM decrypt failed (ConfirmDoubleRatchetSenderSession) — skipping frame, keeping session', decryptError);
           await this.deleteInboxMessages(
             keys.receiving_inbox,
             [message.timestamp],
             this.apiClient
           );
-          await this.messageDB.deleteEncryptionState(found);
           return;
         }
       } else {
@@ -3172,13 +3178,19 @@ export class MessageService {
             return;
           }
         } catch (decryptError) {
-          logger.error('[MessageService] DM decrypt failed (DoubleRatchetInboxDecrypt)', decryptError);
+          // Double Ratchet spec: on a decrypt/authentication failure, discard the
+          // message but LEAVE the session state untouched — a single bad/duplicate/
+          // out-of-order frame does not mean the session is broken, and later frames
+          // decrypt fine. Destroying the session here was the root cause of the
+          // long-standing "DM direction goes permanently dead" bug: the sender kept
+          // encrypting to a session the receiver had torn down.
+          // (https://signal.org/docs/specifications/doubleratchet/)
+          logger.error('[MessageService] DM decrypt failed (DoubleRatchetInboxDecrypt) — skipping frame, keeping session', decryptError);
           await this.deleteInboxMessages(
             keys.receiving_inbox,
             [message.timestamp],
             this.apiClient
           );
-          await this.messageDB.deleteEncryptionState(found);
           return;
         }
       }


### PR DESCRIPTION
## What

On a DM decrypt/authentication failure, stop deleting the encryption session. The failed frame is still discarded from the network inbox and logged; the session is preserved so subsequent frames continue to decrypt normally.

Two catch blocks in the DM receive path (`ConfirmDoubleRatchetSenderSession`, `DoubleRatchetInboxDecrypt`) previously called `deleteEncryptionState(found)` on failure. Those two calls are removed.

## Why

This is the root cause of the long-standing (~6 month) bug where a DM direction goes **permanently dead** with no error to either user: one transient decrypt failure (observed live as `aead::Error` — a duplicate/retry/out-of-order frame) tore down the whole session, after which the sender kept encrypting into an inbox the receiver no longer listened to, and every subsequent message was silently dropped.

## Spec compliance (not a security tradeoff)

The Signal Double Ratchet spec requires this exact behavior for `RatchetDecrypt`:

> "If an exception is raised (e.g. message authentication failure) then the message is discarded and changes to the state object are discarded. Otherwise, the decrypted plaintext is accepted and changes to the state object are stored."
> — https://signal.org/docs/specifications/doubleratchet/

Rejecting the frame is the complete defense against a tampered/injected message; destroying the session adds no security and breaks the protocol's designed tolerance for out-of-order/transient failures. The old code was **non-compliant** (it persisted a state mutation — session deletion — on failure). This change brings it into spec.

## Scope — this is HALF the fix (honest note)

- ✅ Fixes: conversation direction dying **permanently**. Confirmed live — a conversation now survives decrypt failures that previously killed it and keeps delivering.
- ⏳ Does NOT fix: individual frames still occasionally fail to decrypt (`aead::Error`) and drop. With this change those are now isolated single-message losses, not a dead direction. Tracked in `.agents/bugs/2026-07-17-dm-aead-error-frame-drops.md` (leading theory: retry collisions; needs its own investigation).

## Verification

Live desktop↔desktop test: with the fix, receiver console shows `DM decrypt failed … — skipping frame, keeping session` and the conversation continues delivering past the failure (previously it went permanently silent). `tsc` clean.

## Cross-platform

Mobile has the same destroy-on-failure behavior (its Reset Session button is the manual workaround). This receive-pipeline logic applies conceptually to mobile too — worth proposing to lead-dev.