### PR TITLE
fix: refuse stale init envelopes that silently replaced healthy DM sessions

### DIFF
--- a/.agents/bugs/.solved/2026-07-02-dm-message-delivery-unreliable-master.md
+++ b/.agents/bugs/.solved/2026-07-02-dm-message-delivery-unreliable-master.md
@@ -1,7 +1,7 @@
 ---
 type: bug
 title: "DM messages between users intermittently never arrive (master report)"
-status: RESOLVED 2026-07-17 — both mechanisms fixed and live-verified. (1) Session destruction on decrypt failure: fixed, PR #235. (2) aead::Error frame drops from unserialized ratchet state: fixed on branch fix/dm-ratchet-serialization, live-verified 10/10 messages per direction with receipts + typing on. This report is the consolidated summary + diagnosis archive.
+status: RESOLVED 2026-07-17 — THREE mechanisms found, fixed, and live-verified. (1) Session destruction on decrypt failure: fixed, PR #235. (2) Unserialized ratchet state read-modify-write: fixed, PR #236/#237. (3) Stale init-envelope redelivery silently replacing healthy sessions — THE DOMINANT killer, explains the recurring "reset works, then dies on refresh" pattern: fixed on branch chore/dm-reset-signal-logging (staleness guard). Residual: isolated single-frame wire loss with no auto-resend — tracked in the auto-heal task. This report is the consolidated summary + diagnosis archive.
 created: 2026-07-02
 severity: high
 repo: quorum-desktop (primary; mobile has the same patterns — see "Remaining gaps")
@@ -19,8 +19,8 @@ related:
 
 **One-line:** for ~6 months, DMs intermittently never arrived, with no error, no retry, and no
 signal to either user; once a conversation direction "went bad" it stayed dead until a manual
-session reset. Root-caused and fixed 2026-07-17 as two cooperating defects, both in
-`src/services/MessageService.ts`.
+session reset — and freshly reset conversations died again within minutes. Root-caused and
+fixed 2026-07-17 as THREE cooperating defects in the DM receive/send pipeline.
 
 ---
 
@@ -29,19 +29,26 @@ session reset. Root-caused and fixed 2026-07-17 as two cooperating defects, both
 | # | Mechanism | Effect | Fix | Status |
 |---|---|---|---|---|
 | 1 | **Session destruction on decrypt failure.** One bad frame → the receive pipeline deleted the entire Double Ratchet session (and the server copy of the frame). The sender kept encrypting into an inbox the receiver no longer had state for → every later message silently deleted (`!found` branch). | Conversation direction permanently dead | Both decrypt-failure catch blocks skip the frame and KEEP the session (Signal spec compliance) | SHIPPED, PR #235, live-verified |
-| 2 | **Unserialized ratchet state read-modify-write.** Five paths (receive decrypt, text send/edit, retry, receipt sends, typing sends) each did read-state → ratchet-op → save-state with no coordination. Concurrent ops read the same snapshot; the losing save erased the winner's advance → the peer could no longer derive keys → `aead::Error` on subsequent frames; one bad collision forked the session permanently ("msg 1 & 2 land, from msg 3 nothing lands"). | Individual frames dropped; under receipts, full one-direction death within ~3 messages | Per-conversation FIFO mutex (`src/utils/keyedMutex.ts`) around every ratchet critical section + receive path re-reads state inside the lock and saves immediately after decrypt | SHIPPED, branch `fix/dm-ratchet-serialization`, live-verified |
+| 2 | **Unserialized ratchet state read-modify-write.** Five paths (receive decrypt, text send/edit, retry, receipt sends, typing sends) each did read-state → ratchet-op → save-state with no coordination. Concurrent ops read the same snapshot; the losing save erased the winner's advance → the peer could no longer derive keys → `aead::Error`. Receipts amplified it: every received message fired a send inside the receive handler's huge read-to-save window. | Isolated frame drops; occasional session forks under receipt/typing load | Per-conversation FIFO mutex (`KeyedMutex`, now in quorum-shared) around every ratchet critical section + receive path re-reads state inside the lock and saves immediately after decrypt | SHIPPED, PR #236 + #237 (+ quorum-shared #59/#60), live-verified |
+| 3 | **Stale init-envelope redelivery — THE DOMINANT KILLER.** An init envelope replaces the receiver's session for its device tag, unconditionally and silently. The server redelivers any frame whose ack-by-delete failed (`POST /inbox/delete` 502s observed live), so every past reset left potential mines on the device inbox. On any reconnect/hard refresh the mines were replayed and each replaced the CURRENT healthy session with a zombie the sender no longer held. Observed live: redelivered envelopes up to 60 DAYS old killing a fresh session on every refresh. Explains the entire recurring pattern: reset → works → dies minutes later, because each reset planted the seed of the next death. | Fresh sessions silently died on the next reconnect; receiver console completely silent (frames to unknown inboxes never even reach the app) | `isStaleInitEnvelope` guard: refuse envelopes not strictly newer than the session rows they would replace (exact-timestamp match = redelivery; older than newest row beyond 2-min skew tolerance = zombie); refused envelopes are deleted server-side (mine defused). Also: drop malformed envelopes (undefined sender), loud logs on every session replacement, reset signal, and failed inbox delete | SHIPPED, branch `chore/dm-reset-signal-logging`, live-verified (hard refreshes no longer kill the session) |
 
-**Why receipts "caused" it:** they didn't — they amplified mechanism 2. The delivery/read
-receipt feature fires an encrypted send within milliseconds of every received message, exactly
-inside the receive handler's read-to-save window (which spanned ~1,400 lines of awaited code).
-A race that previously needed coincidence (typing + send + receive overlapping, two tabs)
-became near-deterministic. One 6-month-old bug, not two; receipts made it reproducible.
+**Attribution, honestly stated:** mechanisms 1 and 2 are real, spec-backed defects and their
+fixes stand on their own (2 was proven by a red/green concurrency test; 1 by the Signal spec
+and live survival of bad frames). But the recurring session DEATHS — the user-visible disease —
+were dominated by mechanism 3, which is why the conversation kept dying even after 1 and 2
+shipped. Nothing about mechanism 3 ever *failed*: old frames were processed *successfully*,
+which is why it survived every failure-focused investigation until the replacement site was
+instrumented.
 
-**Live verification (2026-07-17):** fresh session reset, receipts + typing ON, 10 numbered
-messages per direction: all 20 landed, nothing stuck at "Sending…", no dead direction. The old
-code reliably died at message 3 under the same protocol. Frames encrypted against a pre-reset
-session fail once with `skipping frame, keeping session` and drain harmlessly — expected noise,
-not loss.
+**Live verification (2026-07-17):** after the staleness guard: multiple hard refreshes on both
+clients (previously instantly fatal — a wall of `SESSION REPLACED` with 60-day-old envelopes,
+then silence), session survives, messages keep landing. Stale frames from old epochs fail once
+with `skipping frame, keeping session` and drain harmlessly.
+
+**Known residual (tracked, not a session-death bug):** isolated single-frame wire loss (one
+message vanishes, conversation continues, sender sees the missing delivery checkmark) with no
+automatic resend. Observed once post-fix. Recovery design:
+`.agents/tasks/2026-07-17-dm-dead-session-autoheal.md` (resend on missing delivery receipt).
 
 **Also shipped along the way:**
 - **Reset Session button** (PR #234) — manual recovery valve, still useful.
@@ -68,9 +75,26 @@ not loss.
 4. **Never hold the ratchet lock across delivery.** The outbound queue only drains on an open
    socket and its callbacks take the same lock; awaiting delivery inside the lock is a
    circular wait.
+5. **Never install an init envelope that is not strictly newer than the session it replaces.**
+   The server redelivers frames whose ack-by-delete failed, and successful re-processing of an
+   old init envelope silently resurrects a zombie session. `isStaleInitEnvelope`
+   (`src/utils/initEnvelopeGuard.ts`, pure, tested) is the gate; refused envelopes are deleted
+   server-side. Frame deletions can fail (502) — a refused mine that survives deletion is
+   refused again next time, harmlessly.
+6. **"Successfully processed" is not the same as "should have been processed."** This bug
+   survived five instrumented rounds because every investigation looked for FAILURES; the
+   killer was old frames being accepted successfully. When a session dies with a completely
+   silent console, suspect state replacement, not state corruption.
 
 ## 3. Remaining known gaps (for lead dev)
 
+- **No automatic resend (highest-value follow-up):** an isolated frame lost on the wire stays
+  lost; the sender sees the missing delivery checkmark but nothing retries. Design:
+  `.agents/tasks/2026-07-17-dm-dead-session-autoheal.md` (detect via missing delivery
+  receipts, resend unacked, auto-repair dead sessions).
+- **Failed inbox deletes (502 Bad Gateway on POST /inbox/delete, server side):** the root
+  enabler of mechanism 3 — every failed delete leaves a redelivery mine. Client now guards
+  and logs; the server-side 502s deserve their own investigation.
 - **Two tabs / same account:** two JS contexts race each other; the in-process mutex cannot
   arbitrate. Needs Web Locks API or single-instance enforcement. Pre-existing, low priority.
 - **Session reset not under the lock:** `deleteEncryptionStates` racing an in-flight decrypt
@@ -78,8 +102,12 @@ not loss.
 - **Mobile parity (verified in mobile code 2026-07-17):** mobile does NOT have the
   destroy-on-failure bug (its decrypt failure already returns null without persisting), but
   it DOES have the unserialized read-modify-write gap (no lock, awaited native decrypt
-  between read and write, receipts ride the ratchet). Tasks created:
-  `.agents/tasks/2026-07-17-quorum-shared-add-keyedmutex.md` (shared util) and
+  between read and write, receipts ride the ratchet). For mechanism 3, mobile is PARTIALLY
+  protected by design: its init handling checks an ephemeral-key cache and tries the existing
+  session first, so redelivery of the CURRENT envelope cannot nuke the session; an OLDER
+  distinct envelope falling through to fresh X3DH may still replace a newer session — recon
+  item in the mobile task. Tasks:
+  `.agents/tasks/.done/2026-07-17-quorum-shared-add-keyedmutex.md` (shared util, DONE) and
   `quorum-mobile/.agents/tasks/2026-07-17-serialize-dm-ratchet-state-keyedmutex.md`.
 - **Redelivery duplicates:** the server re-pushes undeleted frames on re-listen; duplicates
   always fail AEAD (key already consumed), get skipped and deleted. Harmless but noisy; a

--- a/.agents/docs/dm-ratchet-upstream-divergences.md
+++ b/.agents/docs/dm-ratchet-upstream-divergences.md
@@ -115,6 +115,38 @@ advance.
 
 ---
 
+## Divergence 3 — stale init envelopes are refused instead of installed
+
+**Shipped:** branch `chore/dm-reset-signal-logging` (2026-07-17).
+
+**Original behavior:** an incoming initialization envelope (the "here is our new session"
+message that establishes or re-establishes a DM session) unconditionally replaced the
+receiver's existing session for that device tag, in complete silence.
+
+**New behavior:** an init envelope is installed only if it is strictly newer than the session
+rows it would replace. Concretely (`src/utils/initEnvelopeGuard.ts`, pure and unit-tested):
+an envelope whose timestamp exactly matches an existing row is a redelivery of an
+already-processed envelope and is refused; an envelope older than the newest existing row
+beyond a 2-minute clock-skew tolerance is refused. Refused envelopes are deleted from the
+server. Malformed envelopes with no resolvable sender address are also dropped. Every
+replacement, refusal, and reset signal is now logged at warning level.
+
+**Why this was necessary — this was the dominant cause of the 6-month delivery bug.** The
+server retains every inbox frame until the client explicitly deletes it, and those deletions
+can fail (`POST /inbox/delete` returning 502 was captured live). An undeleted init envelope
+is therefore redelivered on any reconnect — and *successfully re-processing* it replaced the
+receiver's CURRENT healthy session with a resurrected old one that the sender no longer
+holds. Captured live 2026-07-17: redelivered init envelopes up to 60 days old, replayed on
+every hard refresh, each silently killing the fresh session (receiver console completely
+silent afterward, because frames to the now-unknown inboxes never reach the app). This is
+why conversations kept dying minutes after every manual session reset: each reset planted
+the next mine. After the guard: hard refreshes no longer kill sessions, verified live.
+
+Note the security framing: the guard does not weaken session establishment — a genuine
+re-init always carries a timestamp newer than the rows it replaces, so legitimate resets are
+unaffected. It removes a replay hazard (old envelopes being honored) that the unconditional
+install created.
+
 ## Minor divergence — the `!found` branch now logs
 
 Frames addressed to an inbox with no encryption state were deleted unread with no log of any
@@ -135,17 +167,27 @@ its decrypt is an awaited native call between state read and write, and its deli
 receipts also ride the DM ratchet. MMKV's synchronous storage narrows the race window but
 does not remove it. Concrete proposal:
 
-1. Extract `KeyedMutex` to `quorum-shared` (additive-only) and serialize mobile's ratchet
-   operations the same way — tasks exist:
-   `quorum-desktop/.agents/tasks/2026-07-17-quorum-shared-add-keyedmutex.md` and
-   `quorum-mobile/.agents/tasks/2026-07-17-serialize-dm-ratchet-state-keyedmutex.md`.
+1. `KeyedMutex` is DONE in shared (#59, 2.1.0-35); mobile serializes its ratchet operations
+   per its task: `quorum-mobile/.agents/tasks/2026-07-17-serialize-dm-ratchet-state-keyedmutex.md`.
    The mobile task includes a recon item a JS mutex cannot cover: Android's
    `BackgroundMessageService` runs in a separate JS context; if it can decrypt the same
    inbox as the foreground app, that cross-context race needs a lead-dev-level decision.
-2. Optional hardening, desktop and mobile: dedupe-before-decrypt cache (redelivered frames
+2. **Divergence 3 on mobile (verified in mobile code 2026-07-17): partially protected by
+   design.** Mobile's init handling checks an ephemeral-key cache and tries the existing
+   session before falling through to fresh X3DH, so redelivery of the CURRENT session's
+   envelope cannot nuke it. An OLDER distinct envelope (from a previous reset epoch) that
+   fails existing-session decrypt and falls through to X3DH may still install a stale
+   session over a newer one — recon item in the mobile task. If confirmed,
+   `isStaleInitEnvelope` is pure and extractable to quorum-shared so both platforms share
+   the identical staleness rule.
+3. Optional hardening, desktop and mobile: dedupe-before-decrypt cache (redelivered frames
    currently fail AEAD harmlessly but noisily — deferred, see
-   `.agents/tasks/2026-07-17-dm-dedupe-before-decrypt.md`), and folding session reset
-   (`deleteEncryptionStates`) under the same lock.
+   `.agents/tasks/2026-07-17-dm-dedupe-before-decrypt.md`), folding session reset
+   (`deleteEncryptionStates`) under the same lock, and automatic resend on missing delivery
+   receipts (`.agents/tasks/2026-07-17-dm-dead-session-autoheal.md` — the highest-value
+   follow-up; converts residual single-frame wire losses into invisible recoveries).
+4. **Server-side:** `POST /inbox/delete` intermittently returns 502 Bad Gateway. Failed
+   deletes are the enabler of the whole redelivery class; worth a server-side look.
 
 ---
 *Created: 2026-07-17 — Last updated: 2026-07-17*

--- a/src/components/context/MessageDB.tsx
+++ b/src/components/context/MessageDB.tsx
@@ -327,7 +327,21 @@ const MessageDBProvider: FC<MessageDBContextProps> = ({ children }) => {
         'base64'
       ).toString('hex'),
     } as secureChannel.DeleteMessages;
-    await apiClient.deleteInbox(del);
+    try {
+      await apiClient.deleteInbox(del);
+    } catch (err) {
+      // A failed delete leaves the frame on the server, where it will be
+      // REDELIVERED on the next re-listen. For init envelopes this is how a
+      // stale envelope can come back and silently replace a healthy session
+      // (502s on /inbox/delete observed live 2026-07-17). Make every failure
+      // loud, then rethrow so caller behavior is unchanged.
+      logger.warn('[MessageDB] ⚠️ inbox delete FAILED — frame stays on server and will be redelivered', {
+        inbox: inboxKeyset.inbox_address?.slice(0, 12),
+        timestamps,
+        err: (err as Error)?.message,
+      });
+      throw err;
+    }
   };
 
   const addOrUpdateConversation = async (

--- a/src/dev/tests/utils/initEnvelopeGuard.unit.test.ts
+++ b/src/dev/tests/utils/initEnvelopeGuard.unit.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isStaleInitEnvelope,
+  INIT_ENVELOPE_STALENESS_TOLERANCE_MS,
+} from '../../../utils/initEnvelopeGuard';
+
+const NOW = 1_784_290_000_000;
+const HOUR = 3_600_000;
+
+describe('isStaleInitEnvelope', () => {
+  it('accepts the first init for a tag (no existing rows)', () => {
+    expect(isStaleInitEnvelope(NOW, [])).toBe(false);
+  });
+
+  it('accepts a fresh envelope newer than every existing row (normal reset)', () => {
+    expect(isStaleInitEnvelope(NOW, [NOW - 5 * HOUR, NOW - HOUR])).toBe(false);
+  });
+
+  it('rejects an exact redelivery of the envelope that created a current row', () => {
+    // Init-created rows are saved with the envelope timestamp itself.
+    expect(isStaleInitEnvelope(NOW - HOUR, [NOW - HOUR])).toBe(true);
+  });
+
+  it('rejects an envelope hours older than the current session (zombie)', () => {
+    expect(isStaleInitEnvelope(NOW - 5 * HOUR, [NOW - HOUR])).toBe(true);
+  });
+
+  it('rejects a 60-day-old envelope (observed live)', () => {
+    expect(isStaleInitEnvelope(NOW - 60 * 24 * HOUR, [NOW - HOUR])).toBe(true);
+  });
+
+  it('tolerates small clock skew (envelope slightly older than newest row)', () => {
+    // Rows updated by sends carry local Date.now(); a fresh server-stamped
+    // envelope may trail a skewed local clock by a few seconds.
+    expect(isStaleInitEnvelope(NOW - 30_000, [NOW])).toBe(false);
+  });
+
+  it('rejects just past the tolerance boundary and accepts just inside it', () => {
+    const newest = NOW;
+    const inside = newest - INIT_ENVELOPE_STALENESS_TOLERANCE_MS + 1_000;
+    const outside = newest - INIT_ENVELOPE_STALENESS_TOLERANCE_MS - 1_000;
+    expect(isStaleInitEnvelope(inside, [newest])).toBe(false);
+    expect(isStaleInitEnvelope(outside, [newest])).toBe(true);
+  });
+
+  it('compares against the NEWEST row when several exist', () => {
+    const rows = [NOW - 10 * HOUR, NOW - HOUR];
+    expect(isStaleInitEnvelope(NOW - 2 * HOUR, rows)).toBe(true);
+    expect(isStaleInitEnvelope(NOW, rows)).toBe(false);
+  });
+});

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -63,6 +63,7 @@ import type { ReceiptService, ReceiptEnvelopeFields } from '@quilibrium/quorum-s
 import { TypingService, type TypingMessage } from '@quilibrium/quorum-shared';
 import { ENABLE_DM_ACTION_QUEUE } from '../config/features';
 import { dmRatchetMutex } from '../utils/keyedMutex';
+import { isStaleInitEnvelope } from '../utils/initEnvelopeGuard';
 import { ThreadService } from './ThreadService';
 import type { Ref } from '../types/ref';
 import type { SpaceInfoMap, SyncInfoMap } from '../types/spaceRefs';
@@ -2944,6 +2945,26 @@ export class MessageService {
             decryptedContent?.channelId + '/' + decryptedContent?.channelId;
           session.user_address = decryptedContent!.channelId;
         }
+        // Malformed envelope (no resolvable counterparty address): would
+        // create a garbage 'undefined/undefined' conversation row — observed
+        // live from ancient redelivered envelopes. Drop and defuse.
+        if (!session.user_address || session.user_address === 'undefined') {
+          logger.warn(
+            '[MessageService] ⚠️ MALFORMED init envelope (no user address) — dropping and deleting from server',
+            {
+              envelopeTimestamp: envelope.timestamp,
+              envelopeAgeSeconds: Math.round(
+                (Date.now() - envelope.timestamp) / 1000
+              ),
+            }
+          );
+          await this.deleteInboxMessages(
+            keyset.deviceKeyset.inbox_keyset,
+            [envelope.timestamp],
+            this.apiClient
+          );
+          return;
+        }
         if (decryptedContent?.content?.type === 'delete-conversation') {
           // Reset/delete signals are obeyed unconditionally and used to be
           // processed in COMPLETE silence — a stale one arriving late (e.g.
@@ -2996,20 +3017,39 @@ export class MessageService {
         // Ratchet critical section: replacing the session rows for this tag
         // and persisting the new session must be atomic vs concurrent sends
         // on the same conversation (see dmRatchetMutex).
-        await dmRatchetMutex.runExclusive(conversationId, async () => {
+        const installed = await dmRatchetMutex.runExclusive(conversationId, async () => {
           const encryptionStates = await this.messageDB.getEncryptionStates({
             conversationId,
           });
           const existing = encryptionStates.filter(
             (e) => JSON.parse(e.state).tag == session.tag
           );
-          // An init envelope REPLACES the session for this tag, silently and
-          // unconditionally. A STALE envelope redelivered by the server (its
-          // ack-by-delete can fail — 502s observed live) therefore replaces a
-          // HEALTHY session with a zombie the sender no longer has: the
-          // leading suspect for "fresh session dies minutes after reset".
-          // Log every replacement with the envelope's age and the age of the
-          // session rows it kills so a zombie install is visible.
+          // An init envelope REPLACES the session for this tag. The server
+          // redelivers any frame whose ack-by-delete failed (502s observed
+          // live), so a STALE envelope replayed on reconnect would replace a
+          // HEALTHY session with a zombie the sender no longer holds —
+          // confirmed live 2026-07-17 with envelopes up to 60 days old
+          // killing fresh sessions on every hard refresh. Refuse anything
+          // not strictly newer than the rows it would replace.
+          if (
+            isStaleInitEnvelope(
+              envelope.timestamp,
+              existing.map((e) => e.timestamp)
+            )
+          ) {
+            logger.warn(
+              '[MessageService] ⚠️ STALE init envelope IGNORED — zombie defused, keeping current session',
+              {
+                conversationId: conversationId?.slice(0, 16),
+                envelopeTimestamp: envelope.timestamp,
+                envelopeAgeSeconds: Math.round(
+                  (Date.now() - envelope.timestamp) / 1000
+                ),
+                newestRowTimestamp: Math.max(...existing.map((e) => e.timestamp)),
+              }
+            );
+            return false;
+          }
           logger.warn(
             '[MessageService] ⚠️ SESSION REPLACED by init envelope',
             {
@@ -3049,7 +3089,18 @@ export class MessageService {
             },
             true
           );
+          return true;
         });
+        if (!installed) {
+          // Stale envelope refused: delete it from the server so it cannot
+          // be redelivered again (defuse the mine), keep the current session.
+          await this.deleteInboxMessages(
+            keyset.deviceKeyset.inbox_keyset,
+            [envelope.timestamp],
+            this.apiClient
+          );
+          return;
+        }
         if (envelope.user_address != self_address) {
           updatedUserProfile = {
             user_address: envelope.user_address,

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -2945,6 +2945,19 @@ export class MessageService {
           session.user_address = decryptedContent!.channelId;
         }
         if (decryptedContent?.content?.type === 'delete-conversation') {
+          // Reset/delete signals are obeyed unconditionally and used to be
+          // processed in COMPLETE silence — a stale one arriving late (e.g.
+          // queued server-side across a reconnect) silently wipes a healthy
+          // session. Log loudly with the frame's age so late kills are
+          // visible in any debug session.
+          logger.warn(
+            '[MessageService] ⚠️ RESET SIGNAL received (delete-conversation, init-envelope path) — wiping encryption states',
+            {
+              conversationId: conversationId?.slice(0, 16),
+              frameTimestamp: envelope.timestamp,
+              frameAgeSeconds: Math.round((Date.now() - envelope.timestamp) / 1000),
+            }
+          );
           await this.deleteEncryptionStates({ conversationId });
           await this.deleteInboxMessages(
             keyset.deviceKeyset.inbox_keyset,
@@ -2962,6 +2975,14 @@ export class MessageService {
           decryptedContent.content.senderId === self_address
         ) {
           const target = decryptedContent.content.conversationAddress;
+          logger.warn(
+            '[MessageService] ⚠️ RESET SIGNAL received (delete-conversation-self from own device) — deleting conversation locally',
+            {
+              conversation: target?.slice(0, 16),
+              frameTimestamp: envelope.timestamp,
+              frameAgeSeconds: Math.round((Date.now() - envelope.timestamp) / 1000),
+            }
+          );
           await this.deleteConversationLocally(target + '/' + target, queryClient);
           await this.deleteInboxMessages(
             keyset.deviceKeyset.inbox_keyset,
@@ -3169,6 +3190,14 @@ export class MessageService {
               );
             const content = JSON.parse(result.message);
             if (content?.content?.type === 'delete-conversation') {
+              logger.warn(
+                '[MessageService] ⚠️ RESET SIGNAL received (delete-conversation, Confirm branch) — wiping encryption states',
+                {
+                  conversationId: conversationId?.slice(0, 16),
+                  frameTimestamp: message.timestamp,
+                  frameAgeSeconds: Math.round((Date.now() - message.timestamp) / 1000),
+                }
+              );
               await this.deleteEncryptionStates({ conversationId });
               await this.deleteInboxMessages(
                 freshKeys.receiving_inbox,
@@ -3250,6 +3279,14 @@ export class MessageService {
             }
             const content = JSON.parse(result.message);
             if (content?.content?.type === 'delete-conversation') {
+              logger.warn(
+                '[MessageService] ⚠️ RESET SIGNAL received (delete-conversation, InboxDecrypt branch) — wiping encryption states',
+                {
+                  conversationId: conversationId?.slice(0, 16),
+                  frameTimestamp: message.timestamp,
+                  frameAgeSeconds: Math.round((Date.now() - message.timestamp) / 1000),
+                }
+              );
               await this.deleteEncryptionStates({ conversationId });
               await this.deleteInboxMessages(
                 freshKeys.receiving_inbox,
@@ -5905,6 +5942,13 @@ export class MessageService {
           if (currentPasskeyInfo?.address) {
             const self = await this.apiClient.getUser(
               currentPasskeyInfo?.address!
+            );
+            // Timestamped send-side log so any RESET SIGNAL received later
+            // (see the receive-side warns) can be correlated with the reset
+            // that emitted it — or exposed as stale if none matches.
+            logger.warn(
+              '[MessageService] ⚠️ RESET SIGNAL sending (delete-conversation + delete-conversation-self)',
+              { conversation: spaceId?.slice(0, 16), at: Date.now() }
             );
             // 1. Notify the counterparty: resets their encryption session.
             await submitMessage(

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -3003,6 +3003,28 @@ export class MessageService {
           const existing = encryptionStates.filter(
             (e) => JSON.parse(e.state).tag == session.tag
           );
+          // An init envelope REPLACES the session for this tag, silently and
+          // unconditionally. A STALE envelope redelivered by the server (its
+          // ack-by-delete can fail — 502s observed live) therefore replaces a
+          // HEALTHY session with a zombie the sender no longer has: the
+          // leading suspect for "fresh session dies minutes after reset".
+          // Log every replacement with the envelope's age and the age of the
+          // session rows it kills so a zombie install is visible.
+          logger.warn(
+            '[MessageService] ⚠️ SESSION REPLACED by init envelope',
+            {
+              conversationId: conversationId?.slice(0, 16),
+              envelopeTimestamp: envelope.timestamp,
+              envelopeAgeSeconds: Math.round(
+                (Date.now() - envelope.timestamp) / 1000
+              ),
+              replacedRows: existing.map((e) => ({
+                inboxId: e.inboxId?.slice(0, 12),
+                stateTimestamp: e.timestamp,
+                stateAgeSeconds: Math.round((Date.now() - e.timestamp) / 1000),
+              })),
+            }
+          );
           for (const e of existing) {
             await this.messageDB.deleteEncryptionState(e);
           }

--- a/src/utils/initEnvelopeGuard.ts
+++ b/src/utils/initEnvelopeGuard.ts
@@ -1,0 +1,37 @@
+/**
+ * Staleness guard for Double Ratchet init envelopes.
+ *
+ * An init envelope replaces the receiver's session for its device tag,
+ * unconditionally. The server redelivers any frame whose ack-by-delete
+ * failed (502s observed live), so stale init envelopes act as mines: on a
+ * reconnect they are replayed and each one silently replaces the CURRENT
+ * healthy session with a resurrected zombie the sender no longer holds —
+ * confirmed live 2026-07-17 with redelivered envelopes up to 60 days old.
+ *
+ * Rules (pure, unit-tested, extractable to quorum-shared):
+ * 1. No existing session rows for the tag → not stale (first init).
+ * 2. Envelope timestamp EXACTLY equals an existing row's timestamp → stale.
+ *    Init-created rows are saved with the envelope's own timestamp, so an
+ *    exact match means this very envelope was already processed and is now
+ *    being redelivered; re-installing it would rewind the ratchet.
+ * 3. Envelope older than the newest existing row by more than the
+ *    tolerance → stale. The tolerance absorbs clock-domain skew (rows
+ *    updated by sends carry local Date.now(); envelope timestamps are
+ *    server-assigned) without weakening the guard — observed zombies are
+ *    hours to weeks older, far beyond any plausible skew.
+ *
+ * A genuine session reset always produces an envelope NEWER than every
+ * row it replaces, so legitimate re-inits pass rules 2 and 3 untouched.
+ */
+export const INIT_ENVELOPE_STALENESS_TOLERANCE_MS = 120_000;
+
+export function isStaleInitEnvelope(
+  envelopeTimestamp: number,
+  existingRowTimestamps: number[],
+  toleranceMs: number = INIT_ENVELOPE_STALENESS_TOLERANCE_MS
+): boolean {
+  if (existingRowTimestamps.length === 0) return false;
+  if (existingRowTimestamps.includes(envelopeTimestamp)) return true;
+  const newest = Math.max(...existingRowTimestamps);
+  return envelopeTimestamp < newest - toleranceMs;
+}


### PR DESCRIPTION
## Problem

The dominant cause of the 6-month DM delivery bug (third mechanism, found after #235/#236): an initialization envelope unconditionally and silently replaces the receiver's session for its device tag. The server redelivers any frame whose ack-by-delete failed (`POST /inbox/delete` intermittently returns 502), so stale init envelopes act as mines on the device inbox: on any reconnect or hard refresh they are replayed and each replaces the CURRENT healthy session with a resurrected zombie the sender no longer holds. Captured live: redelivered envelopes up to 60 days old, replayed on every hard refresh, each killing the fresh session — which is why conversations kept dying minutes after every manual session reset (each reset planted the next mine). Nothing about this ever failed — old frames were processed successfully — which is why it survived every failure-focused investigation.

## Changes

- `isStaleInitEnvelope` (`src/utils/initEnvelopeGuard.ts`, pure, 8 unit tests): refuse an init envelope whose timestamp exactly matches an existing session row (redelivery of an already-processed envelope) or that is older than the newest row beyond a 2-minute clock-skew tolerance. First-init and genuine resets (strictly newer) pass unchanged.
- Refused envelopes are deleted from the server so they cannot be redelivered (mine defused); if the delete 502s, the envelope is simply refused again next time.
- Malformed envelopes with no resolvable sender address are dropped (previously created garbage `undefined/undefined` conversation rows).
- Warn-level visibility on every session-replacing event: init-envelope session replacement (with envelope age and replaced-row ages), stale-envelope refusal, reset-signal send/receive (all four receive sites), and failed inbox deletes.
- Docs: master bug report rewritten with the three-mechanism resolution and corrected attribution; upstream-divergence doc gains Divergence 3; mobile task gains the init-envelope recon item (mobile is partially protected by design via its ephemeral-key cache + try-existing-session-first order).

## Verification

- 8 new unit tests for the guard; 26/26 MessageService tests pass; typecheck clean.
- Live: before the guard, every hard refresh killed the session (wall of `SESSION REPLACED` with 60-day-old envelopes, messages dead). After: multiple hard refreshes on both clients, session survives, messages keep landing.

## Follow-ups (tasked, not in this PR)

- Automatic resend on missing delivery receipts (`.agents/tasks/2026-07-17-dm-dead-session-autoheal.md`) — converts residual single-frame wire losses into invisible recoveries.
- Server-side: investigate the intermittent 502s on `POST /inbox/delete` (the enabler of the redelivery class).