### PR TITLE
chore: remove temporary receipt debug logs and per-task keyset log

### DIFF
--- a/src/components/direct/DirectMessage.tsx
+++ b/src/components/direct/DirectMessage.tsx
@@ -175,7 +175,6 @@ const DirectMessage: React.FC<{}> = () => {
           : false;
         setDeliveryReceipts(effectiveDeliveryReceipts);
         setReadReceipts(effectiveReadReceipts);
-        logger.log('[ReadReceipt:Config]', { deliveryReceipts: effectiveDeliveryReceipts, readReceipts: effectiveReadReceipts, convOverride: { delivery: conversation?.conversation?.deliveryReceipts, read: conversation?.conversation?.readReceipts } });
         if (typeof convIsRepudiable !== 'undefined') {
           const convNonRepudiable = !convIsRepudiable;
           setNonRepudiable(convNonRepudiable);
@@ -389,7 +388,6 @@ const DirectMessage: React.FC<{}> = () => {
 
   const reportRead = useCallback((messageId: string, timestamp: number) => {
     if (!readReceipts || !receiptService) return;
-    logger.log('[ReadReceipt] reportRead', { messageId: messageId.slice(0, 8), timestamp });
     receiptService.onMessageRead(address!, messageId, timestamp);
   }, [readReceipts, receiptService, address]);
 

--- a/src/services/ActionQueueHandlers.ts
+++ b/src/services/ActionQueueHandlers.ts
@@ -942,15 +942,8 @@ export class ActionQueueHandlers {
       const selfUserAddress = context.selfUserAddress as string;
 
       if (!messageIds || messageIds.length === 0) {
-        logger.log('[ActionQueue:sendDeliveryAck] Empty messageIds, skipping');
         return;
       }
-
-      logger.log('[ActionQueue:sendDeliveryAck] Sending standalone ack', {
-        address: address?.slice(0, 16),
-        messageIds,
-        selfUserAddress: selfUserAddress?.slice(0, 16),
-      });
 
       const ackMessage = {
         senderId: selfUserAddress,
@@ -960,7 +953,6 @@ export class ActionQueueHandlers {
 
       try {
         await this.deps.messageService.encryptAndSendDm(address, ackMessage, selfUserAddress, keyset);
-        logger.log('[ActionQueue:sendDeliveryAck] Ack sent successfully');
       } catch (err: any) {
         logger.error('[ActionQueue:sendDeliveryAck] Failed to send ack', err.message);
         throw err;
@@ -999,15 +991,8 @@ export class ActionQueueHandlers {
       const selfUserAddress = context.selfUserAddress as string;
 
       if (!upToMessageId) {
-        logger.log('[ActionQueue:sendReadAck] No upToMessageId, skipping');
         return;
       }
-
-      logger.log('[ActionQueue:sendReadAck] Sending standalone read ack', {
-        address: address?.slice(0, 16),
-        upToMessageId,
-        upToTimestamp,
-      });
 
       const ackMessage = {
         senderId: selfUserAddress,
@@ -1018,7 +1003,6 @@ export class ActionQueueHandlers {
 
       try {
         await this.deps.messageService.encryptAndSendDm(address, ackMessage, selfUserAddress, keyset);
-        logger.log('[ActionQueue:sendReadAck] Read ack sent successfully');
       } catch (err: any) {
         logger.error('[ActionQueue:sendReadAck] Failed to send read ack', err.message);
         throw err;

--- a/src/services/ActionQueueService.ts
+++ b/src/services/ActionQueueService.ts
@@ -93,7 +93,6 @@ export class ActionQueueService {
     deviceKeyset: secureChannel.DeviceKeyset;
     userKeyset: secureChannel.UserKeyset;
   } | null {
-    logger.log('[ActionQueue] getUserKeyset called, hasKeyset:', !!this.userKeyset);
     return this.userKeyset;
   }
 

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -448,7 +448,6 @@ export class MessageService {
     if (raw.type === 'delivery-ack') {
       if (this.receiptService && deliveryReceiptsEnabled) {
         const ackIds = raw.messageIds ?? [];
-        logger.log('[DeliveryReceipt] Processing incoming ack', { ackIds, from: senderAddress });
         this.receiptService.onAckReceived(ackIds);
       }
       return true; // Signal: intercept this message
@@ -463,7 +462,6 @@ export class MessageService {
         const upToMessageId = raw.upToMessageId;
         const upToTimestamp = raw.upToTimestamp;
         if (upToMessageId && upToTimestamp) {
-          logger.log('[ReadReceipt] Processing incoming read ack', { upToMessageId, upToTimestamp, from: senderAddress });
           this.receiptService.onReadAckReceived(upToMessageId, upToTimestamp, senderAddress);
         }
       }
@@ -504,7 +502,6 @@ export class MessageService {
     // 2. Extract piggybacked ackMessageIds, process, then strip
     const ackMessageIds = raw.ackMessageIds;
     if (ackMessageIds && this.receiptService && deliveryReceiptsEnabled) {
-      logger.log('[DeliveryReceipt] Processing piggybacked acks', { ackMessageIds, from: senderAddress });
       this.receiptService.onAckReceived(ackMessageIds);
     }
     delete raw.ackMessageIds;
@@ -512,7 +509,6 @@ export class MessageService {
     // 2b. Extract piggybacked readAckUpTo, process, then strip
     const readAckUpTo = raw.readAckUpTo;
     if (readAckUpTo && this.receiptService && readReceiptsEnabled) {
-      logger.log('[ReadReceipt] Processing piggybacked read ack', { readAckUpTo, from: senderAddress });
       this.receiptService.onReadAckReceived(readAckUpTo.messageId, readAckUpTo.timestamp, senderAddress);
     }
     delete raw.readAckUpTo;
@@ -525,7 +521,6 @@ export class MessageService {
       decryptedContent.content?.type === 'post' &&
       decryptedContent.content?.senderId !== selfAddress
     ) {
-      logger.log('[DeliveryReceipt] Buffering messageId for ack', { messageId: decryptedContent.messageId, sender: senderAddress });
       this.receiptService.onMessageReceived(senderAddress, decryptedContent.messageId);
     }
 


### PR DESCRIPTION
Removes the info-level delivery/read receipt debug logs (marked temporary during receipt feature testing, now verified working) and the per-task `getUserKeyset called` line — together the bulk of per-hour console noise. Error-level logs for real ack failures remain, as do all the warn-level session-lifecycle logs from #238.

Remaining noise sources, deliberately untouched: `[SyncService] initiateSync` chatter (space sync, possibly still useful) and the very verbose `[UnsealHubEnvelope]` logs which live in the quilibrium-js-sdk-channels dist — an upstream/lead-dev item, not fixable from this repo.