### PR TITLE
SECURITY: authorize space control messages by verified signature, not spoofable senderId

### DIFF
--- a/.agents/bugs/2026-06-12-everyone-mention-owner-bypass-send-side-only.md
+++ b/.agents/bugs/2026-06-12-everyone-mention-owner-bypass-send-side-only.md
@@ -1,7 +1,7 @@
 ---
 type: bug
 title: "@everyone mention: owner-bypass in shared hasPermission propagates (send-side-only enforcement)"
-status: partially-fixed — root (owner bypass) fixed in shared; receive-side check pending
+status: fully-fixed — root (owner bypass) fixed in shared; receive-side @everyone gate landed 2026-07-19 in quorum-desktop
 created: 2026-06-12
 updated: 2026-07-19
 ai_generated: true
@@ -17,17 +17,21 @@ related_bugs:
 
 # @everyone owner-bypass is a real propagating bug (send-side-only enforcement)
 
-> **STATUS UPDATE (2026-07-19):**
-> - **Root fix LANDED**: shared `permissions.ts` no longer honors `isSpaceOwner` —
->   `hasPermission`/`getUserPermissions` are role-only (the param is retained but
->   deprecated/ignored). An honest owner-without-role client no longer sends
->   `@everyone`. The "Root fix (shared)" section below is therefore DONE.
-> - **Remaining gap**: the receive side still honors `mentions.everyone` with no
->   sender-authorization check, so a modified client can still set the flag. This
->   defense-in-depth half is now folded into the broader receive-side
->   authorization mechanism work (verified-sender enforcement) tracked in
->   `.agents/tasks/2026-06-25-MASTER-RECAP-control-message-auth.md` — close this
->   bug when that Phase lands.
+> **STATUS UPDATE (2026-07-19) — FULLY RESOLVED:**
+> - **Root fix (shared) DONE**: `quorum-shared/src/utils/permissions.ts`
+>   `hasPermission`/`getUserPermissions` are role-only. The `isSpaceOwner` param
+>   is retained but deprecated/ignored. An honest owner-without-role client no
+>   longer sends `@everyone`. The "Root fix (shared)" section below is DONE.
+> - **Receive-side @everyone gate LANDED (2026-07-19, quorum-desktop)**: the
+>   notification path in `src/services/MessageService.ts` now verifies the Ed448
+>   signer holds `mention:everyone` before firing the @everyone notification.
+>   Mechanism: `resolveVerifiedSender(publicKey, members)` maps the proven key to
+>   a space-member address, then `hasPermission(verifiedSender, 'mention:everyone',
+>   space)` (role-only, no owner bypass) gates the notification. A forged
+>   `mentions.everyone: true` from a modified client no longer notifies recipients.
+>   See `.agents/tasks/2026-06-25-MASTER-RECAP-control-message-auth.md` where the
+>   receive-side work was tracked.
+> - **This bug is fully closed.** Ready to move to `.solved/`.
 
 > **⚠️ AI-assisted finding (2026-06-12). Verified against current source in all three repos with file:line citations below.** Surfaced while scoping the mobile permission-enforcement work. The parent doc [2026-01-09-space-owner-privacy-limitation.md](2026-01-09-space-owner-privacy-limitation.md) (#111) documents the owner-can't-be-verified constraint and its impact on **delete/mute/read-only**, but does NOT cover `mention:everyone`. This doc fills that gap, because @everyone behaves differently from the actions #111 lists.
 
@@ -45,7 +49,7 @@ Clients **cannot verify who the space owner is** (no `ownerAddress` transmitted 
 |---|---|---|---|
 | **kick** | protocol-level (ED448 owner key, receiver-verifiable) | works correctly (owner-only) | OK by design |
 | **delete / pin** | send-side gate **+ receive-side role validation** | **local illusion** — sender sees it, recipients reject it (`MessageService.ts` checks sender role on receipt, no owner bypass) | cosmetic (misleading button) |
-| **`mention:everyone`** | **send-side gate ONLY** — no receive-side check | **REAL & PROPAGATING** — every recipient fires the @everyone notification | **HIGH** |
+| **`mention:everyone`** | send-side gate (role-only) + **receive-side verified-signer check** (2026-07-19) | **FIXED** — forged `mentions.everyone` no longer notifies; only a verified signer with a `mention:everyone` role triggers the notification | resolved |
 
 The first two rows are documented (#111, #68). **The third row is this bug** and was previously undocumented.
 
@@ -109,4 +113,4 @@ So owner-without-role → `canUseEveryone = true` → `mentions.everyone = true`
 
 ---
 
-*Last updated: 2026-06-12*
+*Last updated: 2026-07-19*

--- a/.agents/bugs/2026-06-12-everyone-mention-owner-bypass-send-side-only.md
+++ b/.agents/bugs/2026-06-12-everyone-mention-owner-bypass-send-side-only.md
@@ -1,8 +1,9 @@
 ---
 type: bug
 title: "@everyone mention: owner-bypass in shared hasPermission propagates (send-side-only enforcement)"
-status: open
+status: partially-fixed — root (owner bypass) fixed in shared; receive-side check pending
 created: 2026-06-12
+updated: 2026-07-19
 ai_generated: true
 spans-repos:
   - quorum-shared
@@ -15,6 +16,18 @@ related_bugs:
 ---
 
 # @everyone owner-bypass is a real propagating bug (send-side-only enforcement)
+
+> **STATUS UPDATE (2026-07-19):**
+> - **Root fix LANDED**: shared `permissions.ts` no longer honors `isSpaceOwner` —
+>   `hasPermission`/`getUserPermissions` are role-only (the param is retained but
+>   deprecated/ignored). An honest owner-without-role client no longer sends
+>   `@everyone`. The "Root fix (shared)" section below is therefore DONE.
+> - **Remaining gap**: the receive side still honors `mentions.everyone` with no
+>   sender-authorization check, so a modified client can still set the flag. This
+>   defense-in-depth half is now folded into the broader receive-side
+>   authorization mechanism work (verified-sender enforcement) tracked in
+>   `.agents/tasks/2026-06-25-MASTER-RECAP-control-message-auth.md` — close this
+>   bug when that Phase lands.
 
 > **⚠️ AI-assisted finding (2026-06-12). Verified against current source in all three repos with file:line citations below.** Surfaced while scoping the mobile permission-enforcement work. The parent doc [2026-01-09-space-owner-privacy-limitation.md](2026-01-09-space-owner-privacy-limitation.md) (#111) documents the owner-can't-be-verified constraint and its impact on **delete/mute/read-only**, but does NOT cover `mention:everyone`. This doc fills that gap, because @everyone behaves differently from the actions #111 lists.
 

--- a/.agents/bugs/2026-06-12-readonly-channel-receive-side-enforcement-gaps.md
+++ b/.agents/bugs/2026-06-12-readonly-channel-receive-side-enforcement-gaps.md
@@ -94,13 +94,39 @@ part of #32.
 
 Mobile is being implemented WITHOUT these gaps (all content types, both live + batch receive paths, durable). This desktop bug should be brought to parity — ideally both consume the same shared `canManageReadOnlyChannel` check on receipt so the rule can't drift per-type or per-path.
 
-## 2026-07-19 — Partial related fix: sender identity now uses verified signer
+## 2026-07-19 — Read-only POST identity FIXED on the live path; durable path + type coverage still open
 
-**This bug remains open** (sticker/embed type-coverage gap and durable-path enforcement are unresolved). However, as part of the **control-message-auth fix** (see `.agents/tasks/2026-06-25-MASTER-RECAP-control-message-auth.md` and `.agents/docs/features/security.md`), the sender identity used when authorizing **control messages** on the receive side is now the **cryptographically verified ed448 signer** (via `resolveVerifiedSender` reverse-lookup), not the spoofable plaintext `senderId`.
+Two updates from the control-message-auth work (see
+`.agents/tasks/2026-06-25-MASTER-RECAP-control-message-auth.md` and
+`.agents/docs/features/security.md`):
 
-This does NOT fix the read-only enforcement gaps described above (those involve `post`/`embed`/`sticker` content types in the `saveMessage` durable path, not control message authorization). But any code sample or prose in this bug that implies `senderId`-based authorization reflects **old behavior** — live control-message handling no longer relies on the plaintext field for identity decisions.
+1. **Control messages** (remove/edit/pin/mute) now authorize against the
+   **verified ed448 signer** (via `resolveVerifiedSender` reverse-lookup), never
+   the plaintext `senderId`. Read-only-channel DELETE is covered by this (it goes
+   through the control-message helper's manager check).
 
-When the hub-log migration closes the durable-path and type-coverage gaps, the read-only check should also use `resolveVerifiedSender` (or `createChannelPermissionChecker` from `quorum-shared`) so that the identity chain is consistent with the control-message path.
+2. **Read-only-channel POST acceptance — identity gap CLOSED on the LIVE path.**
+   The `addMessage` (live cache) read-only check no longer trusts
+   `content.senderId`: it now verifies the post's ed448 signature and authorizes
+   the **verified signer** as a channel manager via a new
+   `isReadOnlyPostAuthorized` helper (`resolveVerifiedSender` +
+   `canManageReadOnlyChannel`). Unsigned/unverifiable posts to a read-only
+   channel are dropped (read-only requires proven manager identity, so this holds
+   even in a repudiable space). Tests: `MessageService.unit.test.tsx` §3e.
+
+**Still OPEN (this bug stays open):**
+- **Durable path** — `saveMessage` has NO read-only enforcement at all, so a
+  forged read-only post can still land in the DB and reappear on reload/re-render
+  from storage. Deliberately deferred to the hub-log migration (the durable
+  receive path is being reworked there). The live-path fix hides it from the
+  live cache but does not close the durable hole.
+- **Type coverage** — only `post` is checked; `embed`/`sticker` still bypass the
+  read-only gate.
+
+When the hub-log migration reworks the durable path, apply the SAME
+`isReadOnlyPostAuthorized` / verified-signer pattern there and extend it to all
+content types, so identity + type coverage are consistent across live and
+durable paths.
 
 ---
 

--- a/.agents/bugs/2026-06-12-readonly-channel-receive-side-enforcement-gaps.md
+++ b/.agents/bugs/2026-06-12-readonly-channel-receive-side-enforcement-gaps.md
@@ -94,6 +94,14 @@ part of #32.
 
 Mobile is being implemented WITHOUT these gaps (all content types, both live + batch receive paths, durable). This desktop bug should be brought to parity — ideally both consume the same shared `canManageReadOnlyChannel` check on receipt so the rule can't drift per-type or per-path.
 
+## 2026-07-19 — Partial related fix: sender identity now uses verified signer
+
+**This bug remains open** (sticker/embed type-coverage gap and durable-path enforcement are unresolved). However, as part of the **control-message-auth fix** (see `.agents/tasks/2026-06-25-MASTER-RECAP-control-message-auth.md` and `.agents/docs/features/security.md`), the sender identity used when authorizing **control messages** on the receive side is now the **cryptographically verified ed448 signer** (via `resolveVerifiedSender` reverse-lookup), not the spoofable plaintext `senderId`.
+
+This does NOT fix the read-only enforcement gaps described above (those involve `post`/`embed`/`sticker` content types in the `saveMessage` durable path, not control message authorization). But any code sample or prose in this bug that implies `senderId`-based authorization reflects **old behavior** — live control-message handling no longer relies on the plaintext field for identity decisions.
+
+When the hub-log migration closes the durable-path and type-coverage gaps, the read-only check should also use `resolveVerifiedSender` (or `createChannelPermissionChecker` from `quorum-shared`) so that the identity chain is consistent with the control-message path.
+
 ---
 
-*Last updated: 2026-06-12*
+*Last updated: 2026-07-19*

--- a/.agents/bugs/2026-06-14-sync-path-hardcodes-post-type-nulls-nonpost-signatures.md
+++ b/.agents/bugs/2026-06-14-sync-path-hardcodes-post-type-nulls-nonpost-signatures.md
@@ -1,15 +1,18 @@
 ---
 type: bug
 title: "Sync-received non-post messages (embed/sticker) lose their signature: messageId recompute hardcodes 'post'"
-status: open
+status: resolved
 priority: high
 ai_generated: true
 created: 2026-06-14
-updated: 2026-06-14
+updated: 2026-07-19
+resolved: 2026-07-19
 related_files:
   - "src/services/MessageService.ts"
+  - "quorum-shared/src/utils/messageAuth.ts"
 related_docs:
   - ".agents/bugs/2026-06-13-space-members-missing-no-join-row.md"
+  - ".agents/tasks/2026-06-25-MASTER-RECAP-control-message-auth.md"
 ---
 
 # Sync path hardcodes `'post'` in the signature messageId recompute → non-post signatures nulled
@@ -117,3 +120,17 @@ This mirrors the already-correct live receive path at `:3182`.
   contributor. The fix is correct regardless — the sync path should never have hardcoded the type.
 - Cross-platform context (desktop ↔ mobile space messaging) is tracked on the mobile side; this
   report covers the desktop defect in isolation.
+
+## ✅ Resolution (2026-07-19)
+
+**Resolved as part of the control-message-auth fix.** The sync-path verify block in `MessageService.ts` now calls `buildMessageFingerprint` (from `quorum-shared/src/utils/messageAuth.ts`) passing the real message `content` object. `buildMessageFingerprint` internally reads `content.type` dynamically (it uses `content.type` for non-string content, or `'post'` only when content is a raw string — which is not the case for typed messages). It also binds `spaceId`/`channelId` for control types.
+
+The hardcoded `'post'` literal described in the original root cause section no longer exists in the sync verify block. Both the sync path and the live receive path now use identical fingerprint logic from the shared helper, so `embed`/`sticker` and all control types recompute the same `messageId` the sender signed.
+
+See `.agents/tasks/2026-06-25-MASTER-RECAP-control-message-auth.md` and `quorum-shared/src/utils/messageAuth.ts` for the canonical implementation.
+
+**Ready to move to `.solved/`.**
+
+---
+
+*Last updated: 2026-07-19*

--- a/.agents/docs/cryptographic-architecture.md
+++ b/.agents/docs/cryptographic-architecture.md
@@ -3,7 +3,7 @@ type: doc
 title: Cryptographic Architecture
 status: done
 created: 2025-12-20T00:00:00.000Z
-updated: 2026-02-18T00:00:00.000Z
+updated: 2026-07-19T00:00:00.000Z
 ---
 
 # Cryptographic Architecture
@@ -14,7 +14,7 @@ updated: 2026-02-18T00:00:00.000Z
 This document explains the cryptographic protocols and key management used in Quorum. It focuses on the **mental model** needed to understand how encryption and signing work, rather than implementation details.
 
 
-**Last Updated**: 2026-02-18
+**Last Updated**: 2026-07-19
 
 ---
 
@@ -26,7 +26,8 @@ This document explains the cryptographic protocols and key management used in Qu
 4. [Key Storage Locations](#key-storage-locations)
 5. [Key Compromise Impact](#key-compromise-impact)
 6. [Inbox Key Rotation](#inbox-key-rotation)
-7. [SDK Functions Reference](#sdk-functions-reference)
+7. [Control-Message Authorization (Verified Signer)](#control-message-authorization-verified-signer)
+8. [SDK Functions Reference](#sdk-functions-reference)
 
 ---
 
@@ -299,7 +300,7 @@ For all other message types the mismatch check remains fully active: if a non-pr
 Skipping the inbox mismatch check for `update-profile` does **not** weaken security:
 
 - The **outer envelope** is still unsealed using the space Hub Key — only legitimate Space members can produce a valid envelope.
-- The **message ID hash** is still verified (`messageIdMismatch` check) — the hash covers `nonce + message_type + senderId + content`, so a tampered message fails here.
+- The **message ID hash** is still verified (`messageIdMismatch` check) — for regular posts the fingerprint covers `nonce + message_type + senderId + content`; for control messages (`remove-message`, `edit-message`, `pin`, `mute`) it additionally binds `spaceId + channelId` to prevent cross-space replay of a signed control message. A tampered message fails either way.
 - The **ed448 signature** is still verified against the extracted public key — the message must be signed by whoever holds the private key matching the envelope's claimed sender.
 
 What changes is only that the receiver now accepts the *new* inbox address from the envelope rather than demanding it match the old stored one.
@@ -314,6 +315,32 @@ update-profile:   stored_inbox == envelope_inbox? → verify signature, update s
                   stored_inbox != envelope_inbox? → verify signature, update stored inbox
                   (mismatch is expected and legitimate — this IS the rotation)
 ```
+
+---
+
+## Control-Message Authorization (Verified Signer)
+
+Space control messages (`remove-message`, `edit-message`, `pin`, `mute`) and `@everyone`-bearing posts are authorized against the **cryptographically verified ed448 signer**, not the spoofable plaintext `content.senderId`. This applies regardless of the space's `isRepudiable` flag.
+
+After the signature verification steps described above, `isSpaceControlAuthorized` in `MessageService` calls `resolveVerifiedSender` and then `authorizeControlMessage` (both in `quorum-shared/src/utils/messageAuth.ts`):
+
+```
+verified publicKey
+    → resolveVerifiedSender(publicKey, members)
+          // REVERSE lookup: publicKey → inbox address → space_members row
+          // Returns null if no match or member is kicked (fail closed)
+    → VerifiedSender | null
+    → authorizeControlMessage({ content, verifiedSender, space, channel, targetMessage })
+```
+
+An unsigned or signature-invalid control message resolves to `verifiedSender = null` and is silently dropped (fail closed). The narrow exception: in a repudiable space, an unsigned edit of an unsigned message is accepted when the claimed sender matches the target's author — deniable content stays deniable.
+
+The fingerprint for control messages additionally binds `spaceId + channelId` (see Security Properties Preserved above) so a validly-signed control message cannot be replayed into a different space or channel.
+
+For the full security rationale, cross-space replay protection, and the edit-inherit rule (edits sign iff the original was signed), see:
+- [features/security.md](features/security.md) — "Control-Message Authorization (verified signer)"
+- [features/messages/message-signing-system.md](features/messages/message-signing-system.md) — "Receive-Side Verification" and "Control-Message Authorization via Verified Signer"
+- `.agents/tasks/2026-06-25-MASTER-RECAP-control-message-auth.md`
 
 ---
 
@@ -444,4 +471,4 @@ secureChannel.UnsealSyncEnvelope(
 ---
 
 
-_Last Updated: 2026-02-18_
+_Last Updated: 2026-07-19_

--- a/.agents/docs/features/mention-notification-system.md
+++ b/.agents/docs/features/mention-notification-system.md
@@ -5,7 +5,7 @@ status: done
 ai_generated: true
 reviewed_by: null
 created: 2026-01-09T00:00:00.000Z
-updated: 2026-01-09T09:00:00.000Z
+updated: 2026-07-19T00:00:00.000Z
 related_docs: ["mention-pills-ui-system.md"]
 ---
 
@@ -484,23 +484,25 @@ See the full documentation for architecture details, implementation examples, in
 ### Permission System
 
 **Who can use @everyone**:
-- Space owners (automatic)
-- Users with `mention:everyone` role permission
+- Users with a role granting `mention:everyone`
+- Space owners get NO automatic bypass — an owner without an appropriate role is treated the same as any other member
+
+**Background**: the shared `hasPermission` function previously returned `true` for any space owner (`if (isSpaceOwner) return true`), effectively granting `mention:everyone` (and all other permissions) to owners unconditionally. That owner-bypass was removed; `hasPermission`/`getUserPermissions` are now role-only. The `isSpaceOwner` parameter is retained but deprecated and ignored (the JSDoc marks it `_isSpaceOwner`). The only owner-only action is `kick`, enforced via the owner's Ed448 key — not via `hasPermission`.
 
 **Permission files**:
-- `src/utils/permissions.ts` - Space owners get permission automatically
-- `src/api/quorumApi.ts` - `'mention:everyone'` added to Permission type
-- `src/components/modals/SpaceSettingsModal/Roles.tsx` - UI for assigning permission
+- `quorum-shared/src/utils/permissions.ts` — role-only (owner bypass removed)
+- `src/api/quorumApi.ts` — `'mention:everyone'` in the Permission type
+- `src/components/modals/SpaceSettingsModal/Roles.tsx` — UI for assigning permission
 
 ### Processing
 
-**Extraction**:
+**Extraction (send side)**:
 ```typescript
 const canUseEveryone = hasPermission(
   currentPasskeyInfo.address,
   'mention:everyone',
-  space,
-  isSpaceOwner
+  space ?? undefined,
+  isSpaceOwner || false  // ignored by hasPermission (deprecated param)
 );
 
 mentions = extractMentionsFromText(messageText, {
@@ -513,15 +515,26 @@ mentions = extractMentionsFromText(messageText, {
 - Only styled if `message.mentions.everyone === true`
 - Non-authorized users' @everyone appears as plain text
 
-**Notification counting**:
-- `isMentionedWithSettings()` checks `mentions.everyone` field
-- All users receive notification if `'mention-everyone'` enabled in settings
+**Notification gate (receive side — as of 2026-07-19)**:
+
+The notification path in `src/services/MessageService.ts` enforces `@everyone` against the cryptographically VERIFIED signer, not the spoofable payload `senderId`. The mechanism:
+
+1. `@everyone`-bearing posts are signature-verified even in repudiable spaces (the verify block runs before the notification path whenever `mentions.everyone === true`).
+2. The verified Ed448 public key is resolved to a space member address via `resolveVerifiedSender(publicKey, members)`.
+3. `hasPermission(verifiedSender, 'mention:everyone', space)` is called against that verified address (role-only, no owner bypass).
+4. The notification fires only if all three conditions hold: `mentions.everyone === true`, a verified sender is present, and that sender holds `mention:everyone` via a role.
+
+`isMentionedWithSettings` is called WITHOUT passing `space` (so its own `@everyone` branch is disabled), and the verified-sender check above is applied in addition to cover `@everyone`. User and role mention checks within `isMentionedWithSettings` are unaffected.
+
+A modified client that forges `mentions.everyone: true` without the corresponding permission will NOT trigger the notification on any correctly updated recipient client.
+
+See `.agents/docs/features/security.md` for the broader verified-sender / control-message authorization architecture this receive-side gate belongs to.
 
 ### Edge Cases
 
 - **Word boundary validation**: @everyone inside markdown syntax ignored (code blocks, bold, italic, links, etc.)
 - Case insensitive: @everyone, @Everyone, @EVERYONE work
-- Permission denial: Unauthorized @everyone doesn't trigger notifications
+- Permission denial: Unauthorized @everyone doesn't trigger notifications (enforced on both send and receive sides)
 
 ---
 
@@ -841,3 +854,5 @@ _Updated: 2026-03-14 (added Thread Mentions section documenting thread-aware not
 _Updated: 2026-06-23 (added Global Notification Panel section: NavRail bell, centered presentation, live cross-space aggregation via `useGlobalNotifications` → shared `fetchSpaceMentions`/`fetchSpaceReplies`, bounded-fetch cap, `useGlobalSenderResolver`, `Space › #channel` breadcrumb, broadened cache invalidations, confirm-gated cross-space mark-all; per-space bell unchanged)_
 
 _Updated: 2026-06-24 (Global Notification Panel refinements: moved to the Modal primitive via ModalProvider + `GlobalNotificationsModal` container for a proper backdrop/z-index; bell moved to last rail item + overlapping presence badge; mobile-style row redesign across BOTH panels (leading type badge with at/bullhorn/shield/reply icons + 3-line location/author-preview/relative-time layout, calendar icon removed); per-space title "…in this Space"; taller global modal with longer preview and single scroll region; vertical loading/empty state)_
+
+_Updated: 2026-07-19 (@everyone Permission System section: removed false "space owners automatic" claim (shared hasPermission owner-bypass was removed; owners need a role like anyone else); added receive-side @everyone gate — verified-signer enforcement in MessageService notification path via resolveVerifiedSender + hasPermission against the cryptographic sender, not the spoofable payload senderId)_

--- a/.agents/docs/features/messages/message-signing-system.md
+++ b/.agents/docs/features/messages/message-signing-system.md
@@ -3,12 +3,12 @@ type: doc
 title: Message Signing System
 status: done
 created: 2026-01-09T00:00:00.000Z
-updated: 2026-02-18T00:00:00.000Z
+updated: 2026-07-19T00:00:00.000Z
 ---
 
 # Message Signing System
 
-**Last Updated:** 2026-02-18
+**Last Updated:** 2026-07-19
 
 ## Overview
 
@@ -76,9 +76,11 @@ type Space = {
 
 **Purpose:** Controls whether an entire space requires signing or allows per-message choice.
 
-**Logic:**
+**Logic (for regular posts):**
 - `isRepudiable: false` → All space messages MUST be signed
 - `isRepudiable: true` → Users can choose per message
+
+**Note:** `isRepudiable` only governs regular posts on the RECEIVE side. Control messages (`remove-message`, `edit-message`, `pin`, `mute`) and `@everyone`-bearing posts are always signature-verified and authorized against the verified ed448 signer, regardless of this flag. See [Receive-Side Verification](#receive-side-verification) below.
 
 ### 3. Conversation-level Settings
 
@@ -306,12 +308,25 @@ To verify the feature works correctly:
 
 When a Space message arrives, `MessageService` verifies non-repudiability before persisting the message. Understanding this is important because bugs here can silently drop messages with no visible error.
 
+### What Triggers Verification
+
+Signature verification runs whenever a message carries a `publicKey` and `signature` AND any of the following is true:
+
+| Condition | Applies to |
+|-----------|-----------|
+| `!space.isRepudiable` | All message types in a non-repudiable space |
+| `isControlMessageType(content.type)` | `remove-message`, `edit-message`, `pin`, `mute` — regardless of repudiability |
+| `mentions?.everyone === true` | Posts bearing `@everyone` — regardless of repudiability |
+
+This means **control messages and `@everyone` posts are always verified**, even in repudiable spaces where ordinary posts are allowed to be unsigned. The gate can no longer be bypassed by setting a space to repudiable.
+
 ### Verification Steps (in order)
 
 ```
 1. Unseal hub envelope → extract inboxAddress from envelope header
 2. Compute expected messageId:
-       SHA-256(nonce + content.type + senderId + canonicalize(content))
+       SHA-256(buildMessageFingerprint(...))
+       (see fingerprint format below)
 3. Check inboxMismatch:
        stored inbox_address != envelope inboxAddress  (AND stored address exists)
 4. Check messageIdMismatch:
@@ -320,17 +335,24 @@ When a Space message arrives, `MessageService` verifies non-repudiability before
 6. If both match     → verify ed448 signature against messageId
 ```
 
-### The Message ID Hash
+Both the live-message path and the sync/batch path in `MessageService` follow this same sequence. The old sync path had an `else if (!participant)` branch that could keep an unverified signature — that branch has been removed.
 
-Step 2 must use `decryptedContent.content.type` — **not** a hardcoded message type string. The hash covers:
+### The Message Fingerprint and messageId Hash
+
+Step 2 uses `buildMessageFingerprint` from `quorum-shared/src/utils/messageAuth.ts`. The fingerprint format depends on message type:
+
+**Control messages** (`remove-message`, `edit-message`, `pin`, `mute`) — bind spaceId and channelId to prevent cross-space replay:
 
 ```typescript
-SHA-256(
-  decryptedContent.nonce +
-  decryptedContent.content.type +   // e.g. 'post', 'update-profile', 'sticker'
-  decryptedContent.content.senderId +
-  canonicalize(decryptedContent.content)
-)
+fingerprint = nonce + content.type + senderId + spaceId + channelId + canonicalize(content)
+messageId   = SHA-256(fingerprint)  // as lowercase hex
+```
+
+**All other messages** (posts, `update-profile`, etc.) — legacy format, no scope binding:
+
+```typescript
+fingerprint = nonce + content.type + senderId + canonicalize(content)
+messageId   = SHA-256(fingerprint)
 ```
 
 Using the wrong type string causes `messageIdMismatch = true`, which clears the signature and treats the message as unsigned — even if the signature is perfectly valid.
@@ -357,6 +379,39 @@ If `inboxMismatch || messageIdMismatch`:
 If the ed448 signature itself fails:
 - The `nonRepudiable` flag on the saved message is set to `false`
 - Again silent — no rejection, just recorded as unsigned
+
+### Control-Message Authorization via Verified Signer
+
+After signature verification, **control messages are authorized against the cryptographically verified signer, not the spoofable payload `senderId`**. This is done by `isSpaceControlAuthorized` in `MessageService`, which calls into the shared helper `authorizeControlMessage` in `quorum-shared/src/utils/messageAuth.ts`.
+
+The pipeline is:
+
+```
+verified publicKey
+    → resolveVerifiedSender(publicKey, members)
+          → deriveInboxAddress(publicKey)        // base58btc(sha256(key))
+          → find space_members row by inbox_address (REVERSE lookup)
+          → reject if member is kicked or row is missing
+    → VerifiedSender (typed string, not raw payload senderId)
+    → authorizeControlMessage({ content, verifiedSender, space, channel, targetMessage })
+```
+
+If `verifiedSender` is null (unsigned, invalid signature, or no matching member), the control message is **rejected** (fail closed), with one narrow exception: in a repudiable space, an unsigned edit of an unsigned message is allowed when the claimed sender matches the target's author (both had no authenticated authorship to begin with — deniability by owner choice).
+
+The authorization rules per type:
+
+| Type | Unsigned? | Verified sender not the author? | Result |
+|------|-----------|--------------------------------|--------|
+| `remove-message` | Drop | Drop if no `message:delete` permission | Allow |
+| `edit-message` | Drop (unless repudiable + target unsigned) | Drop (must edit own message) | Allow |
+| `pin` | Drop | Requires `message:pin` permission | Allow |
+| `mute` | Drop | Requires `user:mute` permission | Allow |
+
+See [security.md](../security.md) ("Control-Message Authorization (verified signer)") and [.agents/tasks/2026-06-25-MASTER-RECAP-control-message-auth.md](../../../tasks/2026-06-25-MASTER-RECAP-control-message-auth.md) for the full security rationale.
+
+### Edit Signing — Inherit Rule
+
+Edits inherit the original message's signed/unsigned state. `shouldSignEdit(original)` returns `true` only if the original message has a `signature`. This prevents a deniable message from silently gaining a cryptographic signature on edit. The composer sets `skipSigning = !shouldSignEdit(original)` before sending an edit.
 
 ---
 

--- a/.agents/docs/features/messages/pinned-messages.md
+++ b/.agents/docs/features/messages/pinned-messages.md
@@ -3,7 +3,7 @@ type: doc
 title: Pinned Messages Feature
 status: done
 created: 2026-01-09T00:00:00.000Z
-updated: 2025-12-12T00:00:00.000Z
+updated: 2026-07-19T00:00:00.000Z
 ---
 
 # Pinned Messages Feature
@@ -72,27 +72,25 @@ The pinned messages feature allows authorized users to pin important messages wi
 
 Pin/unpin actions are broadcast to all space members using the same pattern as reactions, deletions, and edits:
 
-**Sending (`submitChannelMessage` - lines 3100-3232):**
+**Sending (`submitChannelMessage`):**
 - Validates user permissions before broadcast
-- Generates message ID using SHA-256(nonce + 'pin' + senderId + canonicalize(pinMessage))
+- Generates message ID via the shared `buildMessageFingerprint` helper (SHA-256 of `nonce + content.type + senderId + spaceId + channelId + canonicalize(content)`); because `'pin'` is a control type, the fingerprint binds `spaceId` and `channelId`, preventing replay into a different channel
 - Creates Message envelope with PinMessage content
 - Signs if non-repudiable space
 - Encrypts with Triple Ratchet
 - Sends via `sendHubMessage()`
 - Calls `saveMessage()` and `addMessage()` for local updates
 
-**Receiving (`saveMessage` - lines 448-523):**
+**Receiving (`saveMessage`):**
 - Validates target message exists
 - Rejects DMs (pins are Space-only)
-- Validates permissions:
-  - Read-only channels: Only managers via `managerRoleIds`
-  - Regular channels: Explicit `message:pin` role permission (NO isSpaceOwner bypass)
+- Validates permissions via `isSpaceControlAuthorized()` against the **verified ed448 signer** (not plaintext `senderId`)
 - Pin limit validation (50 max)
 - Updates target message with `isPinned`, `pinnedAt`, `pinnedBy` fields
 - Persists to IndexedDB
 
-**Receiving (`addMessage` - lines 882-978):**
-- Same permission validation as saveMessage (defense-in-depth)
+**Receiving (`addMessage`):**
+- Same permission validation as saveMessage (defense-in-depth), also via `isSpaceControlAuthorized()`
 - Pin limit validation
 - Updates React Query cache
 - Invalidates `pinnedMessages` and `pinnedMessageCount` query caches
@@ -315,17 +313,18 @@ All magic numbers have been extracted into configuration objects:
 
 1. **UI Layer**: Permission checked in hook via `canUserPin()`
    - Read-only channels: Check `managerRoleIds` first
-   - Regular channels: Check `message:pin` role permission via `hasPermission()` (includes isSpaceOwner bypass for UI only)
+   - Regular channels: Check `message:pin` role permission via `hasPermission()` (role-only; no `isSpaceOwner` bypass — the shared `hasPermission` no longer grants implicit owner permissions; owners must self-assign a role with `message:pin`)
    - UI elements conditionally rendered based on permissions
 
 2. **Sending Layer** (`MessageService.ts:3100-3232`):
    - Same permission logic before broadcast
    - Prevents unauthorized messages from being sent
 
-3. **Receiving Layer** (`MessageService.ts:448-523, 882-978`):
-   - **Independent validation** by each receiving client
+3. **Receiving Layer** (`MessageService.ts`):
+   - **Independent validation** by each receiving client via `isSpaceControlAuthorized()`
+   - Authorization runs against the **cryptographically verified ed448 signer** (reverse-looked-up from the signing public key via `resolveVerifiedSender`) — never against the spoofable plaintext `content.senderId`
    - Read-only channels: Only managers via `managerRoleIds`
-   - Regular channels: **Explicit `message:pin` role permission only** (NO isSpaceOwner bypass)
+   - Regular channels: **Explicit `message:pin` role permission only** (NO `isSpaceOwner` bypass — the shared `authorizeControlMessage` creates the permission checker with `isSpaceOwner: false` by design, since ownership is receiver-unverifiable)
    - Space owners must assign themselves a role with `message:pin` permission
    - Protects against malicious/modified clients
 
@@ -386,5 +385,5 @@ All magic numbers have been extracted into configuration objects:
 ---
 
 
-_Last updated: 2025-12-12_
+_Last updated: 2026-07-19_
 _Major Update: Added cross-client synchronization with full defense-in-depth validation_

--- a/.agents/docs/features/mute-user-system.md
+++ b/.agents/docs/features/mute-user-system.md
@@ -4,7 +4,7 @@ title: Mute User System Documentation
 status: done
 ai_generated: true
 created: 2026-01-09T00:00:00.000Z
-updated: 2025-12-17T00:00:00.000Z
+updated: 2026-07-19T00:00:00.000Z
 ---
 
 # Mute User System Documentation
@@ -246,8 +246,16 @@ canMuteUser(): boolean {
 
 **Location**: `src/services/MessageService.ts`
 
+As of the **2026-07-19 control-message-auth fix** (see `.agents/tasks/2026-06-25-MASTER-RECAP-control-message-auth.md`), mute authorization on the receive side is performed against the **cryptographically verified ed448 signer**, not the spoofable plaintext `muteContent.senderId`. The flow is:
+
+1. `isSpaceControlAuthorized()` calls `resolveVerifiedSender(decryptedContent.publicKey, members)` — a reverse lookup from the verified signing public key to the matching space member.
+2. `authorizeControlMessage()` (from `quorum-shared/src/utils/messageAuth.ts`) then checks `canMuteUser()` on the verified sender's identity via `createChannelPermissionChecker`.
+3. If the message is unsigned, the signing key is unknown, or the key matches no active member, `verifiedSender` is `null` and the mute is rejected (`unsigned-control-rejected`).
+
+The old direct `senderId`-based role check (shown below for historical reference only — **no longer the live code**):
+
 ```typescript
-// Check permission - sender must have user:mute via roles
+// HISTORICAL (pre-2026-07-19) — replaced by isSpaceControlAuthorized()
 const hasPermission = space.roles?.some(
   (role) =>
     role.members?.includes(muteContent.senderId) &&
@@ -258,6 +266,8 @@ if (!hasPermission) {
   return; // Reject silently
 }
 ```
+
+This was bypassable because `senderId` is plaintext written by the sender's client. The live code now anchors the permission check to the verified signing key.
 
 ## UI Behavior
 
@@ -381,4 +391,4 @@ Mute is enforced by each client independently. A malicious custom client could c
 *Status: Production Ready*
 *Cross-Platform: ✅ Web + Mobile Compatible*
 
-_Last updated: 2026-05-20 — staleness audit fixes_
+_Last updated: 2026-07-19_

--- a/.agents/docs/features/security.md
+++ b/.agents/docs/features/security.md
@@ -16,7 +16,7 @@ This document provides a comprehensive overview of the security mechanisms imple
 
 Quorum Desktop implements a **multi-layered security architecture** designed for a decentralized, privacy-focused messaging platform.
 
-### Security Posture (as of 2025-12-11)
+### Security Posture (as of 2026-07-19)
 
 | Category | Status |
 |----------|--------|
@@ -25,12 +25,29 @@ Quorum Desktop implements a **multi-layered security architecture** designed for
 | **Defense-in-depth** | Fully implemented |
 | **Client validation bypass risk** | LOW - receiving-side validation protects honest clients |
 
+> **2026-07-19 — control-message authorization hardened.** Receive-side
+> authorization for **space** control messages (`remove-message`,
+> `edit-message`, `pin`, `mute`) and for `@everyone` no longer trusts the
+> plaintext payload `senderId` (which a modified client can forge). It now
+> authorizes against the **cryptographically verified ed448 signer**, derived
+> from the message's signing key by reverse lookup in `space_members`, failing
+> closed when the signer isn't a known member. This closes a spoofing bypass
+> where a space member on a modified client could impersonate a moderator (or a
+> message's author) to delete/edit/pin/mute anyone's content. The DM equivalent
+> was fixed earlier (PR #220, session-anchored). See "Control-Message
+> Authorization (verified signer)" below and
+> [messages/message-signing-system.md](messages/message-signing-system.md).
+> Mobile's matching receive-side verification is still pending.
+
 ### Key Security Principles
 
 1. **Defense-in-Depth**: Multiple validation layers (UI → Service → Receiving)
 2. **Fail-Secure**: When uncertain, reject rather than allow
 3. **Privacy-First**: End-to-end encryption, minimal metadata exposure
 4. **Decentralized Trust**: No central authority - clients validate independently
+5. **Authorize on proven identity, not claimed identity**: security-relevant
+   receive-side decisions key on the cryptographically verified sender (session
+   for DMs, ed448 signature for spaces), never on the sender-written `senderId`.
 
 ---
 
@@ -341,17 +358,45 @@ Space owner identity is cryptographically tied to space creation keys:
 - **Verification**: Protocol verifies via `owner_public_keys`
 - **Bypass**: Requires forging cryptographic signatures
 
+> **Control-Message Authorization (verified signer) — 2026-07-19.** For SPACE
+> control messages the receiving side no longer keys authorization on the
+> payload `senderId` (forgeable by a modified client). It resolves the
+> **verified ed448 signer** and authorizes against that. Mechanism (shared
+> `messageAuth.ts`, consumed by `MessageService.ts`):
+> 1. The message's signature is verified against a canonical fingerprint
+>    (`buildMessageFingerprint`: `nonce + content.type + senderId +
+>    spaceId+channelId (control types) + canonicalize(content)`). Control
+>    messages are verified **regardless of space repudiability**.
+> 2. `resolveVerifiedSender` maps the verified signing key → inbox address
+>    (`base58btc(sha256(publicKey))`) → the `space_members` row with that
+>    inbox address (REVERSE lookup). No match / kicked member → `null` → drop
+>    (fail closed). This is NOT a lookup by claimed `senderId`.
+> 3. `authorizeControlMessage` returns the allow/drop verdict (own-message /
+>    role / manager checks against the verified sender), applied identically in
+>    the DB (`saveMessage`) and cache (`addMessage`) handlers.
+>
+> Covers `remove-message`, `edit-message`, `pin`, `mute`, and `@everyone`.
+> DMs stay session-anchored (PR #220). A branded `VerifiedSender` type makes
+> passing a raw `senderId` into these checks a compile error.
+
 #### @everyone Mention Permission
 
-Permission stripped **before broadcast** - unauthorized mentions never propagate:
-- **Location**: `src/services/MessageService.ts:2799-2826`
-- **Check**: `hasPermission(address, 'mention:everyone', space, isSpaceOwner)`
+Two layers:
+- **Send side** — `hasPermission(address, 'mention:everyone', space)` (role-only;
+  the former `isSpaceOwner` bypass was removed in shared `permissions.ts`).
+- **Receive side (2026-07-19)** — `@everyone` is honored for notification ONLY if
+  the **verified signer** holds `mention:everyone`. `@everyone`-bearing posts are
+  signature-verified even in repudiable spaces so the signer is proven. A forged
+  `mentions.everyone` from a modified client no longer notifies the space.
 
 #### Delete Message Permission
 
-Receiving clients validate permissions independently:
-- **Location**: `src/services/MessageService.ts:691-750`
-- **Behavior**: Unauthorized deletes silently ignored
+Receiving clients validate permissions independently, authorizing the **verified
+signer** (not payload `senderId`) as own-author / `message:delete` role holder /
+read-only manager. See "Control-Message Authorization" above.
+- **Location**: `src/services/MessageService.ts` — `isSpaceControlAuthorized` in
+  the `remove-message` handlers (`saveMessage` + `addMessage`).
+- **Behavior**: Unauthorized/unsigned deletes silently dropped (fail closed).
 
 #### Pin Message Permission
 
@@ -361,6 +406,7 @@ Pin/unpin actions broadcast with full defense-in-depth validation:
 - **Receiving (addMessage)**: `src/services/MessageService.ts:882-978`
 - **Security Features**:
   - ✅ DMs rejected (pins are Space-only)
+  - ✅ Authorized against the **verified ed448 signer**, not payload `senderId` (2026-07-19)
   - ✅ Read-only channel managers can pin
   - ✅ Regular channels require explicit `message:pin` role permission
   - ✅ NO `isSpaceOwner` bypass on receiving side
@@ -376,6 +422,7 @@ Mute/unmute actions with full defense-in-depth validation (added 2025-12-15):
 - **Security Features**:
   - ✅ DMs rejected (mute is Space-only)
   - ✅ Self-mute rejected (prevents self-DoS)
+  - ✅ Authorized against the **verified ed448 signer**, not payload `senderId` (2026-07-19)
   - ✅ Requires explicit `user:mute` role permission
   - ✅ NO `isSpaceOwner` bypass on receiving side
   - ✅ Replay protection via `muteId` deduplication
@@ -466,8 +513,9 @@ User identity secured via WebAuthn passkeys:
 ---
 
 **Document Created**: 2025-11-08
-**Last Updated**: 2026-01-02
+**Last Updated**: 2026-07-19
 **Major Updates**:
+- 2026-07-19: Space control-message + @everyone authorization now keyed on the verified ed448 signer (not payload senderId)
 - 2026-01-02: Added config key encryption layer documentation (from qm delta commit)
 - 2025-12-15: Added mute user permission with full defense-in-depth validation
 - 2025-12-12: Added bookmark limit database-layer validation (defense-in-depth hardening)

--- a/.agents/docs/features/security.md
+++ b/.agents/docs/features/security.md
@@ -376,6 +376,10 @@ Space owner identity is cryptographically tied to space creation keys:
 >    the DB (`saveMessage`) and cache (`addMessage`) handlers.
 >
 > Covers `remove-message`, `edit-message`, `pin`, `mute`, and `@everyone`.
+> **Read-only-channel post acceptance** is also verified-signer on the live
+> path (a separate `isReadOnlyPostAuthorized` gate: verify the post signature →
+> authorize the verified signer as a channel manager; unsigned posts dropped).
+> Its durable/DB path stays deferred to the hub-log migration.
 > DMs stay session-anchored (PR #220). A branded `VerifiedSender` type makes
 > passing a raw `senderId` into these checks a compile error.
 

--- a/.agents/docs/space-permissions/read-only-channels-system.md
+++ b/.agents/docs/space-permissions/read-only-channels-system.md
@@ -355,6 +355,23 @@ if (spaceId != channelId) {
 
 See also: `.agents/docs/features/security.md` — "Control-Message Authorization (verified signer)" for the full mechanism.
 
+**Read-only POST acceptance (deciding whether a normal post is allowed into a
+read-only channel) — verified signer, live path (2026-07-19).** This is a
+*different* gate from the control-message (delete/pin) path above: it decides
+whether an incoming `post` is accepted, not whether a control action is
+authorized. On the live cache path (`addMessage`), it no longer trusts
+`content.senderId` — a new `isReadOnlyPostAuthorized` helper verifies the post's
+ed448 signature and authorizes the **verified signer** as a channel manager
+(`resolveVerifiedSender` + `canManageReadOnlyChannel`). Unsigned/unverifiable
+posts to a read-only channel are dropped (manager identity must be proven, so
+this holds even in a repudiable space).
+
+> **Still open — durable path.** `saveMessage` (the DB write path) has NO
+> read-only enforcement yet, so a forged read-only post can still be stored and
+> reappear on reload. Deferred to the hub-log migration; tracked in
+> `.agents/bugs/2026-06-12-readonly-channel-receive-side-enforcement-gaps.md`.
+> `embed`/`sticker` type coverage is also still open there.
+
 **Key Processing Principles**:
 
 1. **Verified Identity Only**: Authorization is always against the ed448-proven signer, never the plaintext `senderId`

--- a/.agents/docs/space-permissions/read-only-channels-system.md
+++ b/.agents/docs/space-permissions/read-only-channels-system.md
@@ -3,7 +3,7 @@ type: doc
 title: Read-Only Channels System
 status: done
 created: 2026-01-09T00:00:00.000Z
-updated: 2025-12-11T00:00:00.000Z
+updated: 2026-07-19T00:00:00.000Z
 ---
 
 # Read-Only Channels System
@@ -322,57 +322,46 @@ const saveChanges = useCallback(async () => {
 
 The logic for validating delete messages in read-only channels is now encapsulated within specialized services (e.g., `MessageService` or `SpaceService`). These services interact with the low-level `MessageDB` (`src/db/messages.ts`) for data access.
 
+**Authorization uses the cryptographically verified ed448 signer, not the payload `senderId`.** The payload `senderId` is written by the sender's client and is spoofable. `MessageService` resolves the verified sender via `resolveVerifiedSender(publicKey, members)`, which maps the signing key to an inbox address (`base58btc(sha256(publicKey))`) and then does a REVERSE lookup against `space_members` rows — failing closed (drop) if the key matches no known, active member. The resulting `VerifiedSender` is then passed to `authorizeControlMessage` (from `quorum-shared/src/utils/messageAuth.ts`) for the actual allow/deny decision.
+
 ```typescript
-// Delete message processing (example of how a service would orchestrate)
+// Delete message processing (simplified illustration of what MessageService does)
 if (spaceId != channelId) {
-  // Service would fetch space data
-  const space = await messageDB.getSpace(spaceId); // Internal call within a service
+  // Service resolves the VERIFIED sender from the ed448 signing key,
+  // never from the spoofable payload senderId.
+  const members = await messageDB.getSpaceMembers(spaceId);
+  const verifiedSender = decryptedContent.publicKey
+    ? resolveVerifiedSender(decryptedContent.publicKey, members) // key → inbox → member
+    : null;
 
-  // Find the channel
-  const channel = space?.groups
-    ?.find((g) => g.channels.find((c) => c.channelId === channelId))
-    ?.channels.find((c) => c.channelId === channelId);
+  // authorizeControlMessage (quorum-shared/src/utils/messageAuth.ts) handles
+  // all control types (remove-message, edit-message, pin, mute).
+  // For remove-message in a read-only channel it checks manager status against
+  // the verified sender; in a regular channel it checks the message:delete role.
+  const verdict = authorizeControlMessage({
+    content: decryptedContent.content,
+    verifiedSender,   // proven by ed448 signature — NOT payload senderId
+    space,
+    channel,
+    targetMessage,
+  });
 
-  // Read-only channels: ISOLATED permission system
-  if (channel?.isReadOnly) {
-    const isManager = !!(
-      channel.managerRoleIds &&
-      space?.roles?.some(
-        (role) =>
-          channel.managerRoleIds?.includes(role.roleId) &&
-          role.members.includes(decryptedContent.content.senderId)
-      )
-    );
-    if (isManager) {
-      // Service would call messageDB.deleteMessage()
-      await messageDB.deleteMessage(decryptedContent.content.removeMessageId);
-      return;
-    }
-    // For read-only channels, deny if not manager (even with traditional roles)
-    return;
-  }
+  if (!verdict.allowed) return; // fail closed — unsigned/unauthorized drops silently
 
-  // Regular channels: traditional role system
-  if (
-    !space?.roles.find(
-      (r) =>
-        r.members.includes(decryptedContent.content.senderId) &&
-        r.permissions.includes('message:delete')
-    )
-  ) {
-    return;
-  }
   // Service would call messageDB.deleteMessage()
   await messageDB.deleteMessage(decryptedContent.content.removeMessageId);
 }
 ```
 
+See also: `.agents/docs/features/security.md` — "Control-Message Authorization (verified signer)" for the full mechanism.
+
 **Key Processing Principles**:
 
-1. **Channel Type Detection**: Determine if channel is read-only
-2. **Isolated Validation**: Check manager status independently from traditional roles
-3. **Fallback Blocking**: If not a manager, deny even if user has traditional permissions
-4. **Traditional Channel Fallback**: Use existing role-based processing for regular channels
+1. **Verified Identity Only**: Authorization is always against the ed448-proven signer, never the plaintext `senderId`
+2. **Channel Type Detection**: `authorizeControlMessage` determines if channel is read-only and applies the correct permission check
+3. **Isolated Validation**: Manager status in read-only channels is checked against the verified sender, independently from traditional roles
+4. **Fallback Blocking**: If the signer is unknown, unsigned, or lacks permission, the message is dropped silently (fail closed)
+5. **Traditional Channel Fallback**: In regular channels `authorizeControlMessage` checks the `message:delete` role on the verified sender
 
 ## Design System Integration
 
@@ -514,6 +503,6 @@ if (spaceId != channelId) {
 
 ---
 
-_Last Updated: 2025-12-11_
+_Last Updated: 2026-07-19_
 _Implementation Status: Core functionality complete, space owner bypass removed for security_
-_Security Update: Space owners must now join manager roles (receiving-side validation added)_
+_Security Update: Control messages (delete/edit/pin/mute) authorized against the ed448-verified signer, not the spoofable payload senderId_

--- a/.agents/docs/space-permissions/space-permissions-architecture.md
+++ b/.agents/docs/space-permissions/space-permissions-architecture.md
@@ -3,7 +3,7 @@ type: doc
 title: Space Permissions Architecture
 status: done
 created: 2026-01-09T00:00:00.000Z
-updated: 2025-12-15T00:00:00.000Z
+updated: 2026-07-19T00:00:00.000Z
 ---
 
 # Space Permissions Architecture
@@ -118,7 +118,8 @@ graph TD
 - **Space owners**: Must have roles with appropriate permissions for delete/pin (kick is the exception)
 - **Service-oriented processing**: Validation handled by `MessageService` and `SpaceService`
 - **Receiving-side validation**: MessageService.ts validates incoming messages in read-only channels
-- **Privacy constraint**: Space ownership cannot be verified for post/delete/pin (no `Space.ownerAddress` exposed)
+- **Privacy constraint**: Space ownership CANNOT be verified for post/delete/pin — no `Space.ownerAddress` is exposed on the wire, by design. This is why `hasPermission` ignores the `isSpaceOwner` parameter entirely.
+- **Ed448 signer IS verifiable (2026-07-19)**: While ownership is opaque, the per-message ed448 SIGNING IDENTITY is cryptographically proven. For control messages (`remove-message`, `edit-message`, `pin`, `mute`), the receiving side resolves the verified signer via `resolveVerifiedSender` (key → inbox address → `space_members` row, reverse lookup, fail closed) and authorizes against THAT identity — never the payload `senderId`, which is written by the sender's client and is spoofable. This is centralized in `isSpaceControlAuthorized` (`src/services/MessageService.ts`) via `authorizeControlMessage` (`quorum-shared/src/utils/messageAuth.ts`). See `.agents/docs/features/security.md` — "Control-Message Authorization (verified signer)".
 - **Protocol exception**: Kick messages are verified via `owner_public_keys` at the protocol level
 
 ## Implementation Structure
@@ -224,6 +225,6 @@ export type Channel = {
 
 ---
 
-_Last Updated: 2026-05-20 — staleness audit fixes_
+_Last Updated: 2026-07-19_
 _Architecture Status: Complete - Space owner bypass removed, receiving-side validation added_
-_Security Update: Space owners must join roles for post/delete/pin/mute (kick exception via protocol)_
+_Security Update: Ed448 signer identity is verifiable and is now the authorization identity for all control messages on receive; `isSpaceOwner` no longer grants permissions in `hasPermission`_

--- a/.agents/docs/space-permissions/space-roles-system.md
+++ b/.agents/docs/space-permissions/space-roles-system.md
@@ -3,7 +3,7 @@ type: doc
 title: Space Roles System
 status: done
 created: 2026-01-09T00:00:00.000Z
-updated: 2025-12-15T00:00:00.000Z
+updated: 2026-07-19T00:00:00.000Z
 ---
 
 # Space Roles System
@@ -145,46 +145,45 @@ const { userRoles } = useUserRoleDisplay(targetAddress, roles, true);
 **Why No Automatic Bypass?**: The receiving side cannot verify space ownership for post/delete/pin operations (privacy requirement - no `Space.ownerAddress` exposed). To maintain consistent enforcement on both sending and receiving sides, space owners must join roles.
 
 ```typescript
-// Core permission checking pattern
+// Core permission checking pattern (quorum-shared/src/utils/permissions.ts)
 export function hasPermission(
   userAddress: string,
   permission: Permission,
   space: Space | undefined,
-  isSpaceOwner: boolean = false
+  _isSpaceOwner: boolean = false  // deprecated/ignored — see note below
 ): boolean {
-  // Space owners can ONLY kick without roles (protocol-level verification)
-  if (isSpaceOwner && permission === 'user:kick') return true;
+  // All permissions are role-only. The isSpaceOwner parameter is retained for
+  // API compatibility but is intentionally ignored: receivers cannot verify who
+  // the space owner is (no ownerAddress on the wire, by design), so any
+  // owner-bypass here would be bypassable by a modified client claiming ownership.
+  // The ONLY owner-privileged action is kick, which is enforced via the owner's
+  // Ed448 key at the protocol level — not here.
+  if (!space || !space.roles) return false;
 
-  // All other permissions require role membership
-  return (
-    space?.roles?.some(
-      (role) =>
-        role.members.includes(userAddress) &&
-        role.permissions.includes(permission)
-    ) || false
+  return space.roles.some(
+    (role) =>
+      role.members.includes(userAddress) &&
+      role.permissions.includes(permission)
   );
 }
 ```
+
+**Why `isSpaceOwner` is now a no-op**: receivers cannot verify space ownership (no `ownerAddress` is exposed on the wire, by privacy design). An `if (isSpaceOwner) return true` bypass is therefore bypassable by any client that passes `true` for a user who isn't the owner. The only exception — `kick` — is enforced at the protocol level via the owner's Ed448 signing key, which IS verifiable; `hasPermission` never handles kick.
 
 ### Multi-Role Permission Accumulation
 
 Users can have multiple roles simultaneously, with permissions accumulated across all roles:
 
 ```typescript
-// Get all permissions for a user
+// Get all permissions for a user (quorum-shared/src/utils/permissions.ts)
 export function getUserPermissions(
   userAddress: string,
   space: Space | undefined,
-  isSpaceOwner: boolean = false
+  _isSpaceOwner: boolean = false  // deprecated/ignored — see hasPermission note
 ): Permission[] {
   const permissions = new Set<Permission>();
 
-  // Space owners can ONLY kick without roles
-  if (isSpaceOwner) {
-    permissions.add('user:kick');
-  }
-
-  // All other permissions come from roles
+  // All permissions come from roles — no owner bypass.
   space?.roles?.forEach((role) => {
     if (role.members.includes(userAddress)) {
       role.permissions.forEach((p) => permissions.add(p));
@@ -376,33 +375,36 @@ export function canKickUser(targetUserAddress: string, space: Space): boolean {
 The logic for validating and processing messages (e.g., deletion) is now encapsulated within specialized services (e.g., `MessageService`, `SpaceService`) exposed via `MessageDB Context`. These services interact with the low-level `MessageDB` (`src/db/messages.ts`) for data access.
 
 ```typescript
-// Example: Delete message processing (orchestrated by a service)
+// Example: Delete message processing (orchestrated by MessageService)
+// Authorization is against the cryptographically VERIFIED ed448 signer,
+// never the spoofable payload senderId.
 if (spaceId != channelId) {
-  // Service would fetch space data
-  const space = await messageDB.getSpace(spaceId); // Internal call within a service
+  const members = await messageDB.getSpaceMembers(spaceId);
 
-  // For read-only channels: isolated manager system
-  if (channel?.isReadOnly) {
-    const isManager = /* manager role check */;
-    if (isManager) {
-      // Service would call messageDB.deleteMessage()
-      await messageDB.deleteMessage(messageId);
-      return;
-    }
-    return; // Block traditional roles
-  }
+  // Resolve the verified sender: key → inbox address → space_members row.
+  // Returns null if the key matches no known/active member (fail closed).
+  const verifiedSender = decryptedContent.publicKey
+    ? resolveVerifiedSender(decryptedContent.publicKey, members)
+    : null;
 
-  // For regular channels: traditional role system
-  if (!space?.roles.find(r =>
-    r.members.includes(senderId) &&
-    r.permissions.includes('message:delete')
-  )) {
-    return;
-  }
-  // Service would call messageDB.deleteMessage()
+  // authorizeControlMessage (quorum-shared/src/utils/messageAuth.ts) handles
+  // channel-type dispatch: read-only → manager check; regular → message:delete
+  // role check. Both checks run against verifiedSender, NOT senderId.
+  const verdict = authorizeControlMessage({
+    content: decryptedContent.content,
+    verifiedSender,
+    space,
+    channel,
+    targetMessage,
+  });
+
+  if (!verdict.allowed) return; // unsigned / unauthorized → drop silently
+
   await messageDB.deleteMessage(messageId);
 }
 ```
+
+See also: `.agents/docs/features/security.md` — "Control-Message Authorization (verified signer)" for the complete mechanism.
 
 ## Current Implementation Status
 
@@ -420,8 +422,18 @@ if (spaceId != channelId) {
 
 - **Visibility is Cosmetic**: Role visibility is UI-only; custom clients can bypass filters
 - **Mixed Enforcement Patterns**: Some areas use direct role checks instead of `hasPermission()`
-- **Incomplete Server Validation**: Not all permission checks have full server-side enforcement
 - **Limited Permission Scope**: Only covers basic moderation, not channel/space management
+
+### ✅ Receive-Side Verified-Signer Enforcement (2026-07-19)
+
+The four space control message types now have full receive-side, ed448-verified-signer authorization:
+
+- **`remove-message`** (delete): authorized against the verified signer as own-author or `message:delete` role holder / read-only manager
+- **`edit-message`**: authorized against the verified signer as the original author (own-message only)
+- **`pin`**: authorized against the verified signer as `message:pin` role holder or read-only manager
+- **`mute`**: authorized against the verified signer as `user:mute` role holder
+
+Authorization is centralized in `isSpaceControlAuthorized` (`src/services/MessageService.ts`), which calls `authorizeControlMessage` from `quorum-shared/src/utils/messageAuth.ts`. The payload `senderId` is no longer the authorization identity for any of these operations — only the cryptographically proven signer is. See `.agents/docs/features/security.md` — "Control-Message Authorization (verified signer)" for the complete mechanism.
 
 ## Future Enhancement Opportunities
 
@@ -527,6 +539,6 @@ export type Role = {
 
 ---
 
-_Last Updated: 2026-06-14 — fixed a stale Testing Considerations bullet that contradicted the design ("owners always have all permissions" → owners get nothing implicit except kick). Previously 2026-05-20 — staleness audit fixes._
+_Last Updated: 2026-07-19_
 _Implementation Status: Core features complete, user:mute added, user:kick removed_
-_Security Update: Space owners must join roles for delete/pin/mute (kick is space-owner only via protocol)_
+_Security Update: `isSpaceOwner` bypass removed from `hasPermission`; control messages (delete/edit/pin/mute) authorized against the ed448-verified signer via `authorizeControlMessage`_

--- a/.agents/tasks/2026-06-25-MASTER-RECAP-control-message-auth.md
+++ b/.agents/tasks/2026-06-25-MASTER-RECAP-control-message-auth.md
@@ -12,6 +12,24 @@ audience: "the team — written in plain language, no deep jargon"
 This is the ONE document to read to understand the whole situation. Everything
 else (the other task files) is detail under one of the boxes below.
 
+> **STATUS UPDATE (2026-07-19) — the SPACE fix has LANDED on desktop.** The
+> "Left alone on purpose" framing below is now HISTORICAL. Desktop now
+> authorizes space `remove-message` / `edit-message` / `pin` / `mute` against
+> the cryptographically **verified ed448 signer** (reverse-lookup from the
+> signing key, fail-closed on unknown members) instead of the spoofable payload
+> `senderId`. The signature is the per-message sender proof the "we can't fix
+> group chats without deeper crypto" note worried about — it was already
+> attached to every message; we just made the receive side actually use it.
+> Shared primitives: `quorum-shared` PR #61 (`messageAuth.ts`). Desktop:
+> branch `feat/space-control-message-auth` (commits `955471b16`, `151ddeb9c`).
+> `@everyone` is also now gated on the verified signer. **Still pending:**
+> mobile's matching receive-side verification (mobile verifies nothing on
+> incoming space messages yet), and the coordinated production cut-over (do not
+> deploy desktop to prod until mobile ships, or updated desktops reject control
+> messages from un-updated clients). Deferred, non-blocking: the edited-message
+> "signed" badge across devices — `.agents/tasks/2026-07-19-edited-message-signature-badge-cross-device.md`.
+> Read the sections below with this update in mind.
+
 ## The bug, in one paragraph
 
 Delete and edit messages carry a "signed by: <name>" field that is **just text the
@@ -31,9 +49,17 @@ itself proves** about who sent the message (the "session-authenticated sender").
 
 |  | DM (private 1-on-1) | Space (group chat) |
 |---|---|---|
-| **delete** (`remove-message`) | Mobile: DONE. **Desktop: DONE** (code + tests, on branch). | Left alone on purpose — see note. |
-| **edit** (`edit-message`) | **Desktop: DONE** (code + tests, on branch). Mobile: no DM-edit handler exists. | Left alone on purpose — see note. |
+| **delete** (`remove-message`) | Mobile: DONE. Desktop: DONE (merged). | **Desktop: DONE** (verified-signer auth). Mobile: PENDING. |
+| **edit** (`edit-message`) | Desktop: DONE (merged). Mobile: no DM-edit handler exists. | **Desktop: DONE** (verified-signer auth + edit inherit rule). Mobile: PENDING. |
+| **pin** | n/a (space-only) | **Desktop: DONE** (verified-signer auth). Mobile: PENDING. |
+| **mute** | n/a (space-only) | **Desktop: DONE** (verified-signer auth). Mobile: PENDING. |
+| **@everyone** | n/a | **Desktop: DONE** (honored only if verified signer holds `mention:everyone`). Mobile: PENDING. |
 | **reactions** | Out of scope — low stakes (fake "X reacted", no privilege). | Out of scope — same. |
+
+> The Space column previously read "Left alone on purpose" for delete/edit. That
+> is now HISTORICAL (see the 2026-07-19 status update at the top). The "Left
+> alone on purpose" section below is kept for provenance but no longer describes
+> current desktop behavior.
 
 > "Desktop: DONE" = code written, type-check clean, unit tests pass (incl. the
 > spoof-attack tests). Still PENDING: a quick in-app manual check + opening the PR.
@@ -53,12 +79,14 @@ itself proves** about who sent the message (the "session-authenticated sender").
 > desktop↔mobile delivery sync issue (affects normal messages too), NOT the auth
 > fix. Detail: mobile `.agents/docs/features/dm-delete-own-message.md`.
 
-**"Left alone on purpose" (group chats):** In a group chat the encryption can't
-prove who sent each message without a deeper change to the shared crypto library.
-**Mobile chose not to fix group chats in this round, so desktop matches mobile and
-also does not touch group chats.** Fixing one side but not the other would make the
-apps disagree and cause new bugs. Group chats are tracked as separate future tasks
-(see "Related files" below). Not part of the current work.
+**"Left alone on purpose" (group chats) — HISTORICAL (superseded 2026-07-19):**
+This section described the state when only DMs were fixed. It reasoned that a
+group chat's encryption can't prove who sent each message "without a deeper
+change to the shared crypto library." That turned out to be avoidable: the
+ed448 **signature** already on every message IS the per-message sender proof —
+no crypto-library change was needed, only using the signature on the receive
+side. Desktop now does exactly that (see the 2026-07-19 status update at the
+top). Mobile's matching receive-side verification is the remaining piece.
 
 > **Scope note for the group-chat follow-up:** the underlying issue is not
 > specific to delete/edit — it applies to *every* group-permission decision that
@@ -217,4 +245,4 @@ Suggested PR scope: desktop DM `remove-message` + `edit-message` only. Mention i
 the PR body that space paths are intentionally unchanged (parity with mobile) and
 linked to the open space task.
 
-*Last updated: 2026-06-25*
+*Last updated: 2026-07-19*

--- a/.agents/tasks/2026-06-25-dm-remove-message-auth-bypass-spoofable-senderid.md
+++ b/.agents/tasks/2026-06-25-dm-remove-message-auth-bypass-spoofable-senderid.md
@@ -1,7 +1,7 @@
 ---
 type: task
 title: "SECURITY: DM remove-message authorization bypass (spoofable senderId) — anchor to session sender"
-status: "partial — DM remove + edit DONE (desktop branch); SPACE path still OPEN"
+status: "DONE — DM remove + edit merged (PR #220); SPACE remove/edit/pin/mute now fixed on desktop (branch feat/space-control-message-auth). Mobile receive-side verification still pending."
 priority: high
 created: 2026-06-25
 source: surfaced during quorum-mobile DM delete-own-message work + deep code review
@@ -13,10 +13,13 @@ severity: HIGH (authorization bypass / integrity)
 > Read that first for the big picture and current status.
 >
 > **What's done:** the DM `remove-message` + `edit-message` bypass described below
-> is FIXED on branch `fix/control-message-auth-session-sender` (see the recap and the
-> `.done/` plan file). **What remains:** the **space (group-chat)** portion — scenario
-> (d) below — is still open and shared with mobile's
-> `2026-06-25-space-remove-message-auth-uses-payload-senderid.md`. The text below is
+> is FIXED and merged (PR #220). **UPDATE (2026-07-19): the space (group-chat)
+> portion — scenario (d) below — is now ALSO fixed on desktop** (branch
+> `feat/space-control-message-auth`): space `remove-message`/`edit-message`/`pin`/
+> `mute` are authorized against the verified ed448 signer (not payload
+> `senderId`), via `quorum-shared` `messageAuth` (PR #61). See
+> [2026-06-25-MASTER-RECAP-control-message-auth.md](2026-06-25-MASTER-RECAP-control-message-auth.md).
+> **Remaining:** mobile's matching receive-side verification. The text below is
 > kept as the original detailed analysis.
 
 # DM remove-message auth bypass: authorize against the session-authenticated sender, not the payload `senderId`
@@ -51,12 +54,12 @@ DONE and merged (PR #220). The DM handler authorizes by comparing the spoofable
 `decryptedContent.content.senderId`; the fix replaces it with the
 cryptographically-authenticated session sender (see "The fix" below).
 
-> The **Space (group-chat)** portion of this issue is intentionally NOT detailed
-> here. It is an unpatched authorization concern and its specifics are kept out of
-> this public repo. Tracked privately:
-> **https://github.com/QuilibriumNetwork/quorum-app-prod/issues/1**
-> (design notes live in quorum-mobile's gitignored `.agents/`). Do not re-add Space
-> exploit specifics to this file.
+> The **Space (group-chat)** portion is now FIXED on desktop (2026-07-19) —
+> authorized against the verified ed448 signer. Design notes live in
+> quorum-mobile's gitignored `.agents/` and the private tracking issue
+> **https://github.com/QuilibriumNetwork/quorum-app-prod/issues/1**; the mobile
+> receive-side verification is the remaining piece. Do not re-add Space exploit
+> specifics to this public file.
 
 **DM handler — `saveMessage` path (~line 941–1036):**
 - the DM author check `targetMessage.content.senderId === decryptedContent.content.senderId`
@@ -111,4 +114,4 @@ Mobile reference implementation + full threat-model verification:
 quorum-mobile branch `feature/dm-delete-own-message-sync`, and the mobile memory note
 `dm-control-msg-auth-session-sender-not-payload`.
 
-*Last updated: 2026-06-25*
+*Last updated: 2026-07-19*

--- a/.agents/tasks/2026-07-19-edited-message-signature-badge-cross-device.md
+++ b/.agents/tasks/2026-07-19-edited-message-signature-badge-cross-device.md
@@ -1,0 +1,189 @@
+---
+type: task
+title: "Edited messages show a false 'not signed' warning on other devices (cross-device badge inconsistency)"
+status: open — needs a small shared/protocol decision before implementation
+priority: medium
+created: 2026-07-19
+severity: trust-UX (NOT a security hole — false WARNING, never a false 'verified')
+spans-repos:
+  - quorum-shared
+  - quorum-desktop
+  - quorum-mobile
+related:
+  - 2026-06-25-MASTER-RECAP-control-message-auth.md (the security fix this surfaced during)
+  - .agents/bugs/2026-06-14-sync-path-hardcodes-post-type-nulls-nonpost-signatures.md (same fingerprint-recompute machinery)
+---
+
+# Edited messages show a false "not signed" warning on other devices
+
+## The symptom (what a user sees)
+
+A user edits their own (signed) message. On the device where they edited it, it
+looks normal. On **another device** that receives the edited message (a sync
+peer, another member, or the author's own second device), it shows the warning
+**"Message does not have a valid signature, this may not be from the sender."**
+— even though the message is perfectly legitimate and the author really did
+write it.
+
+So the same message shows "signed" on one screen and "unsigned + scary warning"
+on another.
+
+## Severity: trust-UX, NOT security
+
+Be precise about the direction of the falsehood:
+
+- It is a **false warning on a legitimate message** (cries wolf).
+- It is **never** the dangerous direction (it never shows "verified/signed" for
+  content that wasn't actually verified).
+
+So there is no authorization or integrity hole here. The cost is trust erosion:
+a signature indicator that fires on legitimate messages trains users to ignore
+it, which quietly defeats the purpose of having it. Worth fixing, not worth
+blocking the security work for.
+
+This is **pre-existing** — it happens today, independent of the
+control-message-auth security fix. That fix neither caused nor worsened it; it
+just surfaced it (badge semantics were explicitly deferred out of that PR to
+keep it focused).
+
+## Why it happens (root cause)
+
+A signature signs **one exact byte string** (the message fingerprint), not "the
+message" loosely. For a normal post the fingerprint is
+`nonce + 'post' + senderId + canonicalize(post)` — i.e. it commits to the post's
+text.
+
+When a message is **edited**:
+- The original signature was over the ORIGINAL text. The displayed text is now
+  different, so that signature can never match again.
+- The edit is sent as its own `edit-message` control message, signed over a
+  DIFFERENT fingerprint shape (`nonce + 'edit-message' + senderId + spaceId +
+  channelId + canonicalize(edit)` — see `buildMessageFingerprint`). That proves
+  the edit, but it is not a signature over "a post containing the new text."
+
+The edited message is stored as a POST (new text) that keeps the ORIGINAL post's
+`messageId` and `signature` (the edit-apply handlers update text/modifiedDate
+but not the signature — desktop `MessageService.ts` edit handlers; mobile
+`WebSocketContext.tsx` edit handler ~1930).
+
+So on any device that RE-verifies the stored message (the sync/live receive
+verify blocks recompute the post fingerprint from the CURRENT text and compare
+to the stored `messageId`):
+
+`recompute(new text) != messageId(old text)` → `messageIdMismatch` → the verify
+block nulls `publicKey`/`signature` → badge shows the warning.
+
+**Conclusion:** no post-shaped signature can ever verify an edited post. The
+only thing that proves an edited message is authentic is the EDIT's signature,
+and today that proof is thrown away after the edit is applied — nothing durable
+is stored on the message for a later/other device to re-verify.
+
+## Where the badge + strip logic lives (current, both platforms)
+
+Both platforms use the same presence-based badge and the same strip-on-mismatch:
+
+- **Desktop badge:** `!message.signature` → warning. `Message.tsx:920`, `:1015`,
+  `:1076`.
+- **Desktop strip-on-mismatch:** the two verify blocks in `MessageService.ts`
+  (live ~3556, sync ~4563) null `publicKey`/`signature` on `messageIdMismatch`.
+- **Mobile badge:** `!item.originalMessage?.signature` → warning.
+  `components/Chat/MessagesList.tsx:733`, `:771`.
+- **Mobile strip/verify:** mobile's space receive path (post control-message-auth
+  work) will verify signatures similarly; the edited-post recompute has the same
+  mismatch problem.
+
+- **Dormant hook:** `EditMessage.editSignature?` already exists in
+  `quorum-shared/src/types/message.ts:159` but is **written and read nowhere in
+  any repo** (verified 2026-07-19). Someone anticipated this; the mechanism was
+  never built. It is the natural home for the fix.
+
+## The fix (recommended: store + re-verify the edit's proof)
+
+Make an edited message carry its OWN re-verifiable proof, so ANY device that has
+the message in its final edited form — including one that was offline and only
+ever sees the final post via sync/replay, never the live edit control message —
+can verify it independently.
+
+1. **On applying a verified edit**, store the edit's proof on the message:
+   the edit's `signature`, the edit's `publicKey`, and the `editNonce` (the
+   `editNonce` is already retained as `lastModifiedHash`; `originalMessageId` is
+   the message's own `messageId`; `editedText` is the current text — so the full
+   `edit-message` fingerprint is reconstructable from the stored post + these
+   fields). Use `EditMessage.editSignature` (dormant) plus a place for the edit's
+   `publicKey` on the stored `Message`.
+2. **In the verify blocks**, when a message has been edited (has an edit proof /
+   `modifiedDate !== createdDate`), rebuild the EDIT fingerprint via
+   `buildMessageFingerprint({ content: <reconstructed edit-message>, ... })` and
+   verify the stored edit signature against it — instead of the post fingerprint
+   (which can never match). Keep the signature/badge iff that verifies.
+3. **Badge** stays presence-based but now presence is preserved correctly for
+   legitimately-edited messages.
+
+### Alternatives considered (and why not)
+
+- **Local "editVerified" boolean flag** (set when THIS device verified the live
+  edit): fails for sync/replay devices that only receive the final edited post
+  and never saw a verifiable edit — they'd have nothing to set the flag from.
+  Also can't trust a synced flag from another device. Rejected: doesn't cover
+  the main failing case.
+- **Suppress the warning for any edited message** (badge ignores edits): removes
+  the trust signal entirely for edited messages and would hide a genuinely
+  unverifiable edit. Rejected.
+- **Clear the signature on edit everywhere** (uniform "unsigned" on all devices):
+  consistent but misleading in the other direction (warns on authentic content)
+  and loses the signal. Rejected.
+
+## Three-repo impact (this is a cross-repo change — read carefully)
+
+| Repo | Change | Notes |
+|---|---|---|
+| **quorum-shared** | Likely: extend the stored `Message` type to hold the edit's proof (edit `publicKey` alongside `editSignature`); possibly a small helper to reconstruct the `edit-message` fingerprint from a stored edited post. Publish + version bump. | Additive if done as new optional fields. The "what proves an edited message" shape is a WIRE/protocol decision both apps must agree on — this is the part to confirm with the lead. |
+| **quorum-desktop** | Store the edit proof in the edit-apply handlers (`saveMessage` + `addMessage`); teach both verify blocks to use the edit fingerprint for edited messages; badge honors it. Consumes shared via `link:`. | Medium: a few handler + verify-block edits + tests. |
+| **quorum-mobile** | MUST mirror the same store + re-verify, or the badge diverges cross-platform (same message: "signed" on desktop, "unsigned" on mobile — for a trust signal that is arguably WORSE than the current consistent-ish wrongness). Bump to the published shared version. | This is the real weight of the task. Mobile parity is not optional here. |
+
+**Additive gut-check:** if the stored-proof fields are new OPTIONAL fields, a
+mobile bump with no other change still builds — so shared can ship first and
+each app adopts on its own timeline. But the *badge* won't be consistent until
+BOTH apps store AND re-verify. So for the user-visible fix to actually land,
+desktop + mobile must both ship the receive/verify half.
+
+**Sequencing:** shared (types/helper) → publish → desktop (store + verify) →
+mobile (store + verify) → the cross-device inconsistency is resolved only once
+both apps have the receive half.
+
+## Lead-dev decision needed (one question)
+
+"How should an edited message's authenticity be represented on the wire / in
+storage?" i.e. confirm the approach of storing the edit's signature+publicKey on
+the message and re-verifying via the edit fingerprint (vs. any protocol
+preference the lead has, especially given the pending P2P → hub-log transport
+convergence, which may change how message history/edits are replayed to a device
+and therefore what proof is available at verify time). Raise via Telegram (the
+lead doesn't read GitHub issues).
+
+> ⚠️ Interaction with the hub-log migration: desktop is slated to move to
+> mobile's hub-log transport. If history replay under hub-log delivers edits
+> differently (e.g. as replayable control messages rather than collapsed final
+> state), that changes what proof a late device has. Confirm the store-the-proof
+> approach is compatible with the target transport before building, so this isn't
+> redone after the migration.
+
+## Test plan (both platforms)
+
+1. Edit your own signed message → it stays "signed" (no warning) on the editing
+   device AND on a second device that receives it via sync/replay.
+2. Edit in a repudiable space where the original was UNSIGNED (inherit rule) →
+   the edited message stays unsigned everywhere (no false "signed"), no warning
+   claiming it should be signed. (Deniability preserved; consistent.)
+3. A tampered edited message (edit signature invalid / doesn't match the
+   displayed text) → shows the warning (the signal still works when it should).
+4. Cross-platform: a message edited on desktop shows the SAME signed/unsigned
+   badge state on mobile, and vice-versa.
+
+## Scope / non-goals
+
+- Not a security fix. Do not let it delay or entangle the control-message-auth
+  security work (that PR intentionally excludes badge semantics).
+- Reactions/pins don't carry displayed text, so they're out of scope.
+
+*Last updated: 2026-07-19*

--- a/src/dev/tests/components/Modal.test.tsx
+++ b/src/dev/tests/components/Modal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Modal } from '@/components/primitives';
 
@@ -109,27 +109,23 @@ describe('Modal (baseline)', () => {
     expect(title.className).toContain('quorum-modal-title-center');
   });
 
-  // 8. Close button click dispatches synthetic Escape KeyboardEvent
-  it('close button click dispatches synthetic Escape KeyboardEvent', async () => {
+  // 8. Close button click triggers onClose (via the modal's animated close)
+  it('close button click triggers onClose', async () => {
     const user = userEvent.setup();
-    const escHandler = vi.fn();
-    document.addEventListener('keydown', escHandler);
+    const onClose = vi.fn();
 
     render(
-      <Modal {...defaultProps}>
+      <Modal {...defaultProps} onClose={onClose}>
         <p>Content</p>
       </Modal>
     );
 
-    // Close button is now a <button> element wrapping the icon
-    const closeButton = screen.getByLabelText('Close dialog');
-    await user.click(closeButton);
+    // Close button is a <button> element wrapping the icon. It calls the
+    // modal's context close() (animated), which invokes onClose after the
+    // close animation completes.
+    await user.click(screen.getByLabelText('Close dialog'));
 
-    expect(escHandler).toHaveBeenCalledWith(
-      expect.objectContaining({ key: 'Escape' })
-    );
-
-    document.removeEventListener('keydown', escHandler);
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
   });
 });
 
@@ -190,23 +186,18 @@ describe('Modal (accessibility)', () => {
     expect(dialog).not.toHaveAttribute('aria-labelledby');
   });
 
-  // A5. Escape key dispatches from close button click
-  it('close button dispatches Escape KeyboardEvent', async () => {
+  // A5. Close button click triggers onClose (animated close)
+  it('close button click triggers onClose', async () => {
     const user = userEvent.setup();
-    const escHandler = vi.fn();
-    document.addEventListener('keydown', escHandler);
+    const onClose = vi.fn();
 
     render(
-      <Modal {...defaultProps}>
+      <Modal {...defaultProps} onClose={onClose}>
         <p>Content</p>
       </Modal>
     );
 
     await user.click(screen.getByLabelText('Close dialog'));
-    expect(escHandler).toHaveBeenCalledWith(
-      expect.objectContaining({ key: 'Escape' })
-    );
-
-    document.removeEventListener('keydown', escHandler);
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
   });
 });

--- a/src/dev/tests/components/ThreadsListPanel.test.tsx
+++ b/src/dev/tests/components/ThreadsListPanel.test.tsx
@@ -60,6 +60,7 @@ vi.mock('../../../utils/platform', () => ({
 
 vi.mock('@quilibrium/quorum-shared', () => ({
   formatRelativeTime: () => '2h ago',
+  resolveDisplayName: (name?: string) => name ?? 'User',
 }));
 
 // Mock primitives

--- a/src/dev/tests/services/ConfigService.unit.test.tsx
+++ b/src/dev/tests/services/ConfigService.unit.test.tsx
@@ -184,8 +184,14 @@ describe('ConfigService - Unit Tests', () => {
         keyset: mockKeyset,
       });
 
-      // ✅ VERIFY: Timestamp was updated
-      expect(mockConfig.timestamp).toBeGreaterThan(0);
+      // ✅ VERIFY: Timestamp was updated on the SAVED config. saveConfig
+      // deep-clones its input (to avoid mutating a shared React Query cache
+      // object), so the assertion must read the object passed to the DB, not
+      // the caller's original mockConfig.
+      const savedConfig = (
+        mockDeps.messageDB.saveUserConfig as ReturnType<typeof vi.fn>
+      ).mock.calls[0][0];
+      expect(savedConfig.timestamp).toBeGreaterThan(0);
 
       // ✅ VERIFY: Config saved to database
       expect(mockDeps.messageDB.saveUserConfig).toHaveBeenCalledWith(

--- a/src/dev/tests/services/MessageService.unit.test.tsx
+++ b/src/dev/tests/services/MessageService.unit.test.tsx
@@ -88,6 +88,9 @@ describe('MessageService - Unit Tests', () => {
         }),
         getSpaceMember: vi.fn().mockResolvedValue(null),
         getSpaceMembers: vi.fn().mockResolvedValue([]),
+        getMuteByMuteId: vi.fn().mockResolvedValue(null),
+        muteUser: vi.fn().mockResolvedValue(undefined),
+        unmuteUser: vi.fn().mockResolvedValue(undefined),
         isUserMuted: vi.fn().mockResolvedValue(false),
         getConversation: vi.fn().mockResolvedValue({ conversation: null }),
         updateMessage: vi.fn().mockResolvedValue(undefined),
@@ -588,6 +591,79 @@ describe('MessageService - Unit Tests', () => {
 
       // Unauthorized edit returns early before persisting any change.
       expect(mockDeps.messageDB.saveMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  // SECURITY: space mute must authorize against the verified signing key, not
+  // the spoofable payload senderId (same class as remove/edit).
+  describe('3d. addMessage() - Space mute authorization (anti-spoofing)', () => {
+    const muteMsg = (over: Record<string, unknown> = {}) =>
+      ({
+        messageId: 'mute-1',
+        spaceId: 'space',
+        channelId: 'channel',
+        nonce: 'n',
+        content: {
+          senderId: 'mod',
+          type: 'mute',
+          targetUserId: 'victim',
+          muteId: 'mid-1',
+          timestamp: Date.now(),
+          action: 'mute',
+        },
+        ...over,
+      }) as any;
+
+    beforeEach(() => {
+      mockDeps.messageDB.getSpace = vi.fn().mockResolvedValue({
+        spaceId: 'space',
+        roles: [{ members: ['mod'], permissions: ['user:mute'] }],
+        groups: [],
+      });
+    });
+
+    it('honors a SIGNED mute from the verified user:mute role holder', async () => {
+      const publicKey = '11223344556677889900aabbccddeeff';
+      mockDeps.messageDB.getSpaceMembers = vi
+        .fn()
+        .mockResolvedValue([{ address: 'mod', inbox_address: deriveInboxAddress(publicKey) }]);
+
+      await messageService.addMessage(
+        queryClient,
+        'space',
+        'channel',
+        muteMsg({ publicKey, signature: 'sig' })
+      );
+
+      expect(mockDeps.messageDB.muteUser).toHaveBeenCalled();
+    });
+
+    it('DROPS an UNSIGNED mute claiming a moderator senderId (spoof)', async () => {
+      await messageService.addMessage(
+        queryClient,
+        'space',
+        'channel',
+        muteMsg() // claims senderId 'mod' but no signature
+      );
+
+      expect(mockDeps.messageDB.muteUser).not.toHaveBeenCalled();
+    });
+
+    it('DROPS a SIGNED mute whose signer is not the claimed moderator', async () => {
+      const publicKey = 'ff00ff00ff00ff00ff00ff00ff00ff00';
+      // Key belongs to 'mallory' (no mute role); payload claims 'mod'.
+      mockDeps.messageDB.getSpaceMembers = vi
+        .fn()
+        .mockResolvedValue([{ address: 'mallory', inbox_address: deriveInboxAddress(publicKey) }]);
+
+      await messageService.addMessage(
+        queryClient,
+        'space',
+        'channel',
+        muteMsg({ publicKey, signature: 'sig' })
+      );
+
+      expect(mockDeps.messageDB.muteUser).not.toHaveBeenCalled();
     });
   });
 

--- a/src/dev/tests/services/MessageService.unit.test.tsx
+++ b/src/dev/tests/services/MessageService.unit.test.tsx
@@ -27,6 +27,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { MessageService, MessageServiceDependencies } from '@/services/MessageService';
 import { deriveInboxAddress } from '@quilibrium/quorum-shared';
+import { channel_raw } from '@quilibrium/quilibrium-js-sdk-channels';
 import { QueryClient } from '@tanstack/react-query';
 
 // Mock the secure channel module for crypto operations
@@ -664,6 +665,74 @@ describe('MessageService - Unit Tests', () => {
       );
 
       expect(mockDeps.messageDB.muteUser).not.toHaveBeenCalled();
+    });
+  });
+
+  // SECURITY: a post to a read-only channel must be authorized against the
+  // verified signer (a manager), not the spoofable payload senderId.
+  describe('3e. addMessage() - read-only channel post authorization (anti-spoofing)', () => {
+    const RO = 'ro-channel';
+    const mgrPub = 'aabb00112233445566778899aabbccdd';
+    const roSpace = {
+      spaceId: 'space',
+      roles: [{ roleId: 'mgr-role', members: ['manager'], permissions: [] }],
+      groups: [
+        {
+          groupId: 'g1',
+          channels: [
+            { channelId: RO, isReadOnly: true, managerRoleIds: ['mgr-role'] },
+          ],
+        },
+      ],
+    };
+    const roPost = (over: Record<string, unknown> = {}) =>
+      ({
+        messageId: 'ro-1',
+        spaceId: 'space',
+        channelId: RO,
+        nonce: 'n-ro',
+        createdDate: Date.now(),
+        modifiedDate: Date.now(),
+        digestAlgorithm: 'sha256' as const,
+        lastModifiedHash: '',
+        content: { senderId: 'manager', type: 'post', text: 'announce' },
+        ...over,
+      }) as any;
+    // The test harness mocks crypto.subtle.digest to return 32 zero bytes, so
+    // the signed-post's messageId must match that (64 hex zeros) to pass the
+    // fingerprint recompute in isReadOnlyPostAuthorized.
+    const signedManagerPost = () =>
+      roPost({ messageId: '0'.repeat(64), publicKey: mgrPub, signature: 'sig' });
+
+    beforeEach(() => {
+      mockDeps.messageDB.getSpace = vi.fn().mockResolvedValue(roSpace);
+      mockDeps.messageDB.getSpaceMembers = vi
+        .fn()
+        .mockResolvedValue([{ address: 'manager', inbox_address: deriveInboxAddress(mgrPub) }]);
+    });
+
+    it('honors a SIGNED post from the verified read-only-channel manager', async () => {
+      vi.mocked(channel_raw.js_verify_ed448).mockReturnValue('true');
+      const spy = vi.spyOn(queryClient, 'setQueriesData');
+      await messageService.addMessage(queryClient, 'space', RO, signedManagerPost());
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('DROPS an UNSIGNED post to a read-only channel', async () => {
+      const spy = vi.spyOn(queryClient, 'setQueriesData');
+      await messageService.addMessage(queryClient, 'space', RO, roPost()); // no signature
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('DROPS a SIGNED read-only post whose verified signer is not a manager', async () => {
+      vi.mocked(channel_raw.js_verify_ed448).mockReturnValue('true');
+      // key resolves to 'intruder', who is NOT in the manager role
+      mockDeps.messageDB.getSpaceMembers = vi
+        .fn()
+        .mockResolvedValue([{ address: 'intruder', inbox_address: deriveInboxAddress(mgrPub) }]);
+      const spy = vi.spyOn(queryClient, 'setQueriesData');
+      await messageService.addMessage(queryClient, 'space', RO, signedManagerPost());
+      expect(spy).not.toHaveBeenCalled();
     });
   });
 

--- a/src/dev/tests/services/MessageService.unit.test.tsx
+++ b/src/dev/tests/services/MessageService.unit.test.tsx
@@ -26,6 +26,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { MessageService, MessageServiceDependencies } from '@/services/MessageService';
+import { deriveInboxAddress } from '@quilibrium/quorum-shared';
 import { QueryClient } from '@tanstack/react-query';
 
 // Mock the secure channel module for crypto operations
@@ -86,6 +87,7 @@ describe('MessageService - Unit Tests', () => {
           address: 'hub-address',
         }),
         getSpaceMember: vi.fn().mockResolvedValue(null),
+        getSpaceMembers: vi.fn().mockResolvedValue([]),
         isUserMuted: vi.fn().mockResolvedValue(false),
         getConversation: vi.fn().mockResolvedValue({ conversation: null }),
         updateMessage: vi.fn().mockResolvedValue(undefined),
@@ -327,43 +329,51 @@ describe('MessageService - Unit Tests', () => {
       expect(mockDeps.messageDB.saveMessage).toHaveBeenCalled();
     });
 
-    it('should handle remove-message type by calling deleteMessage', async () => {
-      const targetMessage = {
-        messageId: 'msg-to-remove',
-        spaceId: 'space',
-        channelId: 'channel',
-        createdDate: Date.now(),
-        modifiedDate: Date.now(),
-        digestAlgorithm: 'sha256' as const,
-        nonce: 'nonce',
-        lastModifiedHash: 'hash',
-        content: {
-          senderId: 'original-sender',
-          type: 'post',
-          text: 'Message',
-        },
-      };
+    const spaceTarget = {
+      messageId: 'msg-to-remove',
+      spaceId: 'space',
+      channelId: 'channel',
+      createdDate: Date.now(),
+      modifiedDate: Date.now(),
+      digestAlgorithm: 'sha256' as const,
+      nonce: 'nonce',
+      lastModifiedHash: 'hash',
+      content: { senderId: 'original-sender', type: 'post', text: 'Message' },
+    };
+    const spaceRemove = (over: Record<string, unknown> = {}) => ({
+      messageId: 'remove-123',
+      spaceId: 'space',
+      channelId: 'channel',
+      createdDate: Date.now(),
+      modifiedDate: Date.now(),
+      digestAlgorithm: 'sha256' as const,
+      nonce: 'nonce',
+      lastModifiedHash: 'hash',
+      content: {
+        senderId: 'original-sender',
+        type: 'remove-message',
+        removeMessageId: 'msg-to-remove',
+      },
+      ...over,
+    });
 
-      mockDeps.messageDB.getMessage = vi.fn().mockResolvedValue(targetMessage);
-
-      const removeMessage = {
-        messageId: 'remove-123',
+    it('honors a SIGNED space delete when the verified signer authored the target', async () => {
+      // The verified sender is derived from the signing key, not the payload.
+      // Register a member whose inbox_address matches this public key so the
+      // reverse lookup resolves to 'original-sender'.
+      const publicKey = 'aabbccddeeff00112233445566778899';
+      mockDeps.messageDB.getMessage = vi.fn().mockResolvedValue(spaceTarget);
+      mockDeps.messageDB.getSpace = vi.fn().mockResolvedValue({
         spaceId: 'space',
-        channelId: 'channel',
-        createdDate: Date.now(),
-        modifiedDate: Date.now(),
-        digestAlgorithm: 'sha256' as const,
-        nonce: 'nonce',
-        lastModifiedHash: 'hash',
-        content: {
-          senderId: 'original-sender', // Same sender can remove
-          type: 'remove-message',
-          removeMessageId: 'msg-to-remove',
-        },
-      };
+        roles: [],
+        groups: [],
+      });
+      mockDeps.messageDB.getSpaceMembers = vi.fn().mockResolvedValue([
+        { address: 'original-sender', inbox_address: deriveInboxAddress(publicKey) },
+      ]);
 
       await messageService.saveMessage(
-        removeMessage,
+        spaceRemove({ publicKey, signature: 'sig' }) as any,
         mockDeps.messageDB,
         'space',
         'channel',
@@ -371,8 +381,53 @@ describe('MessageService - Unit Tests', () => {
         { user_icon: 'icon.png', display_name: 'User' }
       );
 
-      // ✅ VERIFY: deleteMessage called
       expect(mockDeps.messageDB.deleteMessage).toHaveBeenCalledWith('msg-to-remove');
+    });
+
+    it('DROPS an UNSIGNED space delete (no verified signer, fail closed)', async () => {
+      mockDeps.messageDB.getMessage = vi.fn().mockResolvedValue(spaceTarget);
+      mockDeps.messageDB.getSpace = vi.fn().mockResolvedValue({
+        spaceId: 'space',
+        roles: [],
+        groups: [],
+      });
+
+      await messageService.saveMessage(
+        spaceRemove() as any, // no publicKey/signature
+        mockDeps.messageDB,
+        'space',
+        'channel',
+        'direct',
+        { user_icon: 'icon.png', display_name: 'User' }
+      );
+
+      expect(mockDeps.messageDB.deleteMessage).not.toHaveBeenCalled();
+    });
+
+    it('DROPS a SIGNED space delete when the signer is not the author and has no role', async () => {
+      // Signer resolves to 'mallory' (a real member) but claims senderId=original-sender.
+      const publicKey = 'ffeeddccbbaa99887766554433221100';
+      mockDeps.messageDB.getMessage = vi.fn().mockResolvedValue(spaceTarget);
+      mockDeps.messageDB.getSpace = vi.fn().mockResolvedValue({
+        spaceId: 'space',
+        roles: [],
+        groups: [],
+      });
+      mockDeps.messageDB.getSpaceMembers = vi.fn().mockResolvedValue([
+        { address: 'mallory', inbox_address: deriveInboxAddress(publicKey) },
+      ]);
+
+      await messageService.saveMessage(
+        // claims to be the author, but the key belongs to mallory → senderid-mismatch
+        spaceRemove({ publicKey, signature: 'sig' }) as any,
+        mockDeps.messageDB,
+        'space',
+        'channel',
+        'direct',
+        { user_icon: 'icon.png', display_name: 'User' }
+      );
+
+      expect(mockDeps.messageDB.deleteMessage).not.toHaveBeenCalled();
     });
   });
 

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -1754,32 +1754,33 @@ export class MessageService {
 
       const isDM = spaceId === channelId;
 
-      if (!targetMessage) {
-        // If target message doesn't exist, always remove from UI.
-        // (Unchanged: this is a no-op removal of a message we don't have — not the
-        // attack surface. The attack targets a message that DOES exist, handled
-        // by the DM branch below.)
-        shouldHonorDelete = true;
-      } else if (isDM) {
-        // DM authorization — authorize against the session-authenticated sender,
-        // NOT the spoofable payload `senderId`. For a DM, `spaceId` (== channelId)
-        // is the cryptographically proven conversation owner. Require BOTH: the
-        // payload claim matches the proven owner AND the target was authored by
-        // that proven owner. A peer spoofing `senderId = you` to delete your
-        // message fails the second clause. (Same check as the saveMessage handler;
-        // see .agents/tasks/2026-06-25-MASTER-RECAP-control-message-auth.md.)
-        shouldHonorDelete =
-          decryptedContent.content.senderId === spaceId &&
-          targetMessage.content.senderId === spaceId;
+      if (isDM) {
+        if (!targetMessage) {
+          // DM, target we don't have: harmless no-op cache removal. The real
+          // attack surface (deleting a message that DOES exist) is handled below.
+          shouldHonorDelete = true;
+        } else {
+          // DM authorization — authorize against the session-authenticated
+          // sender, NOT the spoofable payload `senderId`. For a DM, `spaceId`
+          // (== channelId) is the cryptographically proven conversation owner.
+          // Require BOTH: the payload claim matches the proven owner AND the
+          // target was authored by that proven owner. (Same check as the
+          // saveMessage handler; see MASTER-RECAP-control-message-auth.md.)
+          shouldHonorDelete =
+            decryptedContent.content.senderId === spaceId &&
+            targetMessage.content.senderId === spaceId;
+        }
       } else {
-        // Space: authorize against the VERIFIED signing key (mirrors the
-        // saveMessage handler so cache and DB can't disagree).
+        // Space: authorize against the VERIFIED signing key, including the
+        // missing-target case (the helper returns ok-target-missing-noop only
+        // for a verified sender — an unsigned/spoofed remove of a locally-absent
+        // message no longer ghosts it out of the cache). Mirrors saveMessage.
         shouldHonorDelete = await this.isSpaceControlAuthorized(
           decryptedContent,
           this.messageDB,
           spaceId,
           channelId,
-          targetMessage
+          targetMessage ?? undefined
         );
       }
 
@@ -1994,20 +1995,17 @@ export class MessageService {
         return;
       }
 
-      // Fail-secure validation
-      const space = await this.messageDB.getSpace(spaceId);
-      if (!space) {
-        return;
-      }
-
-      // Check permission - sender must have user:mute via roles
-      const hasPermission = space.roles?.some(
-        (role) =>
-          role.members?.includes(muteContent.senderId) &&
-          role.permissions?.includes('user:mute')
-      );
-
-      if (!hasPermission) {
+      // Authorize against the VERIFIED signing key (user:mute role), not the
+      // spoofable payload senderId. authorizeControlMessage handles 'mute'
+      // without a target message.
+      if (
+        !(await this.isSpaceControlAuthorized(
+          decryptedContent,
+          this.messageDB,
+          spaceId,
+          channelId
+        ))
+      ) {
         return;
       }
 

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -15,6 +15,12 @@ import {
   hasPermission,
   SimpleRateLimiter,
   RATE_LIMITS,
+  buildMessageFingerprint,
+  resolveVerifiedSender,
+  authorizeControlMessage,
+  isControlMessageType,
+  shouldSignEdit,
+  type ControlMessageContent,
 } from '@quilibrium/quorum-shared';
 import { MessageDB, EncryptionState, EncryptedMessage } from '../db/messages';
 import type { SpaceMemberRow } from '../db/messages';
@@ -926,6 +932,43 @@ export class MessageService {
   }
 
   /**
+   * Receive-side authorization for a SPACE control message (remove/edit/pin/
+   * mute). Derives the sender from the VERIFIED signing key (reverse lookup,
+   * fail closed) — never the spoofable payload senderId — and returns the
+   * shared allow/drop verdict. Must be applied identically in both the DB
+   * (saveMessage) and cache (addMessage) handlers so they can't disagree.
+   * `decryptedContent.publicKey` is non-null only after signature verification
+   * (see the verify blocks); unsigned/invalid control messages resolve to a
+   * null sender and are dropped (except the unsigned-edit-of-unsigned case).
+   */
+  private async isSpaceControlAuthorized(
+    decryptedContent: Message,
+    messageDB: MessageDB,
+    spaceId: string,
+    channelId: string,
+    targetMessage?: Message
+  ): Promise<boolean> {
+    const space = await messageDB.getSpace(spaceId);
+    const channel = space?.groups
+      ?.find((g) => g.channels.find((c) => c.channelId === channelId))
+      ?.channels.find((c) => c.channelId === channelId);
+    const members = await messageDB.getSpaceMembers(spaceId);
+    const verifiedSender = decryptedContent.publicKey
+      ? resolveVerifiedSender(
+          decryptedContent.publicKey,
+          members as unknown as Parameters<typeof resolveVerifiedSender>[1]
+        )
+      : null;
+    return authorizeControlMessage({
+      content: decryptedContent.content as ControlMessageContent,
+      verifiedSender,
+      space: space ?? undefined,
+      channel,
+      targetMessage,
+    }).allowed;
+  }
+
+  /**
    * Saves message to DB and updates query cache.
    * @param currentUserAddress - Pass current user's address when sending messages to update lastReadTimestamp
    */
@@ -1113,50 +1156,19 @@ export class MessageService {
           // Don't return early - allow addMessage() to update React Query cache
         }
         // Unauthorized DM delete: drop silently (do not honor).
-      } else if (
-        targetMessage.content.senderId === decryptedContent.content.senderId
-      ) {
-        // Space "own message" delete — unchanged (space path is out of scope;
-        // tracked separately). Still uses payload senderId by design parity with
-        // mobile until the space path is fixed in tandem.
-        await deleteOrSoftDelete(decryptedContent.content.removeMessageId);
-        // Don't return early - allow addMessage() to update React Query cache
-      } else if (spaceId != channelId) {
-        // For Spaces: Check role-based permissions
-        const space = await messageDB.getSpace(spaceId);
-
-        // For read-only channels: ISOLATED permission system - only managers can delete
-        const channel = space?.groups
-          ?.find((g) => g.channels.find((c) => c.channelId === channelId))
-          ?.channels.find((c) => c.channelId === channelId);
-
-        if (channel?.isReadOnly) {
-          const isManager = !!(
-            channel.managerRoleIds &&
-            space?.roles?.some(
-              (role) =>
-                channel.managerRoleIds?.includes(role.roleId) &&
-                role.members.includes(decryptedContent.content.senderId)
-            )
-          );
-          if (isManager) {
-            await deleteOrSoftDelete(decryptedContent.content.removeMessageId);
-            // Don't return early - allow addMessage() to update React Query cache
-          } else {
-            // For read-only channels, if not a manager, deny delete (even if user has traditional roles)
-            return;
-          }
-        } else {
-          // For regular channels: Traditional role-based permissions
-          if (
-            !space?.roles.find(
-              (r) =>
-                r.members.includes(decryptedContent.content.senderId) &&
-                r.permissions.includes('message:delete')
-            )
-          ) {
-            return;
-          }
+      } else {
+        // Space: authorize against the VERIFIED signing key (own-message,
+        // read-only manager, or message:delete role — all resolved from the
+        // signature, not the spoofable payload senderId).
+        if (
+          await this.isSpaceControlAuthorized(
+            decryptedContent,
+            messageDB,
+            spaceId,
+            channelId,
+            targetMessage
+          )
+        ) {
           await deleteOrSoftDelete(decryptedContent.content.removeMessageId);
           // Don't return early - allow addMessage() to update React Query cache
         }
@@ -1173,15 +1185,13 @@ export class MessageService {
         return;
       }
 
-      // Only original sender can edit their message.
+      // Only the original author can edit their message.
       //
-      // SECURITY: `editMessage.senderId` is spoofable plaintext (same shape as the
-      // remove-message bug). For a DM, authorize against the session-authenticated
-      // sender — `spaceId` (== channelId) is the cryptographically proven
-      // conversation owner — and require the target to have been authored by that
-      // proven owner. A peer spoofing `senderId = you` to edit your message fails
-      // this check. Space path keeps the legacy payload check (out of scope,
-      // tracked in .agents/tasks/2026-06-25-MASTER-RECAP-control-message-auth.md).
+      // SECURITY: `editMessage.senderId` is spoofable plaintext. For a DM,
+      // authorize against the session-authenticated sender (`spaceId` == the
+      // proven conversation owner). For a space, authorize against the VERIFIED
+      // signing key (or, in a repudiable space, accept an unsigned edit only of
+      // an unsigned own message — the inherit rule).
       const isDM = spaceId === channelId;
       if (isDM) {
         if (
@@ -1190,7 +1200,15 @@ export class MessageService {
         ) {
           return;
         }
-      } else if (targetMessage.content.senderId !== editMessage.senderId) {
+      } else if (
+        !(await this.isSpaceControlAuthorized(
+          decryptedContent,
+          messageDB,
+          spaceId,
+          channelId,
+          targetMessage
+        ))
+      ) {
         return;
       }
 
@@ -1328,37 +1346,20 @@ export class MessageService {
         return; // Not supported
       }
 
-      const space = await messageDB.getSpace(spaceId);
       const senderId = pinMessage.senderId;
 
-      // For read-only channels: check manager privileges FIRST
-      const channel = space?.groups
-        ?.find((g) => g.channels.find((c) => c.channelId === channelId))
-        ?.channels.find((c) => c.channelId === channelId);
-
-      if (channel?.isReadOnly) {
-        const isManager = !!(
-          channel.managerRoleIds &&
-          space?.roles?.some(
-            (role) =>
-              channel.managerRoleIds?.includes(role.roleId) &&
-              role.members.includes(senderId)
-          )
-        );
-        if (!isManager) {
-          return; // Reject
-        }
-      } else {
-        // For regular channels: check explicit role membership (NO isSpaceOwner bypass)
-        // Space owners must assign themselves a role with message:pin permission
-        const hasRolePermission = space?.roles?.some(
-          (role) =>
-            role.members.includes(senderId) &&
-            role.permissions.includes('message:pin')
-        );
-        if (!hasRolePermission) {
-          return; // Reject
-        }
+      // Authorize against the VERIFIED signing key (read-only manager or
+      // message:pin role), not the spoofable payload senderId.
+      if (
+        !(await this.isSpaceControlAuthorized(
+          decryptedContent,
+          messageDB,
+          spaceId,
+          channelId,
+          targetMessage
+        ))
+      ) {
+        return;
       }
 
       // Pin limit validation (defense-in-depth) - only check when pinning
@@ -1647,9 +1648,27 @@ export class MessageService {
     } else if (decryptedContent.content.type === 'edit-message') {
       const editMessage = decryptedContent.content as EditMessage;
       // DM edits authorize against the session-authenticated sender (spaceId ==
-      // the proven conversation owner), not the spoofable payload senderId. Mirrors
-      // the saveMessage edit handler. Space path unchanged (out of scope).
+      // the proven conversation owner); space edits authorize against the
+      // VERIFIED signing key. Space auth is async (DB reads), so resolve it
+      // BEFORE the synchronous cache updater. Mirrors the saveMessage handler.
       const isDM = spaceId === channelId;
+      let spaceEditAuthorized = false;
+      if (!isDM) {
+        const target = await this.messageDB.getMessage({
+          spaceId,
+          channelId,
+          messageId: editMessage.originalMessageId,
+        });
+        spaceEditAuthorized = target
+          ? await this.isSpaceControlAuthorized(
+              decryptedContent,
+              this.messageDB,
+              spaceId,
+              channelId,
+              target
+            )
+          : false;
+      }
 
       queryClient.setQueriesData(
         { queryKey: buildMessagesKeyPrefix({ spaceId: spaceId, channelId: channelId }) },
@@ -1674,7 +1693,7 @@ export class MessageService {
                         ) {
                           return m;
                         }
-                      } else if (m.content.senderId !== editMessage.senderId) {
+                      } else if (!spaceEditAuthorized) {
                         return m;
                       }
                       // Only allow editing post messages
@@ -1729,8 +1748,9 @@ export class MessageService {
         messageId: decryptedContent.content.removeMessageId,
       });
 
-      // Check if this delete request should be honored
-      let shouldHonorDelete = false;
+      // Check if this delete request should be honored (every branch below
+      // assigns it, so no initializer).
+      let shouldHonorDelete: boolean;
 
       const isDM = spaceId === channelId;
 
@@ -1752,46 +1772,15 @@ export class MessageService {
           decryptedContent.content.senderId === spaceId &&
           targetMessage.content.senderId === spaceId;
       } else {
-        // Space path — unchanged (out of scope, tracked separately).
-
-        // 1. Users can always delete their own messages
-        if (
-          targetMessage.content.senderId === decryptedContent.content.senderId
-        ) {
-          shouldHonorDelete = true;
-        } else {
-          if (!shouldHonorDelete && spaceId != channelId) {
-            const space = await this.messageDB.getSpace(spaceId);
-
-            // 3. Check read-only channel manager privileges
-            const channel = space?.groups
-              ?.find((g) => g.channels.find((c) => c.channelId === channelId))
-              ?.channels.find((c) => c.channelId === channelId);
-
-            if (channel?.isReadOnly && channel.managerRoleIds) {
-              const isManager = space?.roles?.some(
-                (role) =>
-                  channel.managerRoleIds?.includes(role.roleId) &&
-                  role.members.includes(decryptedContent.content.senderId)
-              );
-              if (isManager) {
-                shouldHonorDelete = true;
-              }
-            }
-
-            // 4. Check traditional role permissions
-            if (!shouldHonorDelete && !channel?.isReadOnly) {
-              const hasDeleteRole = space?.roles?.find(
-                (r) =>
-                  r.members.includes(decryptedContent.content.senderId) &&
-                  r.permissions.includes('message:delete')
-              );
-              if (hasDeleteRole) {
-                shouldHonorDelete = true;
-              }
-            }
-          }
-        }
+        // Space: authorize against the VERIFIED signing key (mirrors the
+        // saveMessage handler so cache and DB can't disagree).
+        shouldHonorDelete = await this.isSpaceControlAuthorized(
+          decryptedContent,
+          this.messageDB,
+          spaceId,
+          channelId,
+          targetMessage
+        );
       }
 
       if (shouldHonorDelete) {
@@ -1849,40 +1838,27 @@ export class MessageService {
         return; // Not supported
       }
 
-      const space = await this.messageDB.getSpace(spaceId);
       const senderId = pinMessage.senderId;
 
-      // Check permissions (same logic as saveMessage)
-      let hasPermission: boolean;
-
-      // For read-only channels: check manager privileges FIRST
-      const channel = space?.groups
-        ?.find((g) => g.channels.find((c) => c.channelId === channelId))
-        ?.channels.find((c) => c.channelId === channelId);
-
-      if (channel?.isReadOnly) {
-        const isManager = !!(
-          channel.managerRoleIds &&
-          space?.roles?.some(
-            (role) =>
-              channel.managerRoleIds?.includes(role.roleId) &&
-              role.members.includes(senderId)
-          )
-        );
-        hasPermission = isManager;
-      } else {
-        // For regular channels: check explicit role membership (NO isSpaceOwner bypass)
-        hasPermission = !!(
-          space?.roles?.some(
-            (role) =>
-              role.members.includes(senderId) &&
-              role.permissions.includes('message:pin')
-          )
-        );
+      // Authorize against the VERIFIED signing key (mirrors saveMessage).
+      const pinTarget = await this.messageDB.getMessage({
+        spaceId,
+        channelId,
+        messageId: pinMessage.targetMessageId,
+      });
+      if (!pinTarget) {
+        return;
       }
-
-      if (!hasPermission) {
-        return; // Reject
+      if (
+        !(await this.isSpaceControlAuthorized(
+          decryptedContent,
+          this.messageDB,
+          spaceId,
+          channelId,
+          pinTarget
+        ))
+      ) {
+        return;
       }
 
       // Pin limit validation - only check when pinning
@@ -2573,8 +2549,9 @@ export class MessageService {
           const sets = response.map((e) => JSON.parse(e.state));
 
           let sessions: secureChannel.SealedMessageAndMetadata[] = [];
-          // Sign DM unless explicitly skipped
-          if (!skipSigning) {
+          // Edit inherit rule: sign iff the edited message was signed, so an
+          // unsigned (deniable) DM message never silently gains a signature.
+          if (shouldSignEdit(originalMessage)) {
             try {
               const sig = ch.js_sign_ed448(
                 Buffer.from(
@@ -3545,12 +3522,16 @@ export class MessageService {
               conversationId.split('/')[0]
             );
 
-            // enforce non-repudiability
+            // Verify signatures for non-repudiable spaces (all types) AND for
+            // control messages in ANY space — control auth must not depend on
+            // repudiability, or a repudiable space would skip the gate.
             if (
               space &&
-              !space.isRepudiable &&
               decryptedContent.publicKey &&
-              decryptedContent.signature
+              decryptedContent.signature &&
+              (!space.isRepudiable ||
+                isControlMessageType(decryptedContent.content.type) ||
+                decryptedContent.mentions?.everyone === true)
             ) {
               const participant = await this.messageDB.getSpaceMember(
                 space.spaceId,
@@ -3563,10 +3544,13 @@ export class MessageService {
               const messageId = await crypto.subtle.digest(
                 'SHA-256',
                 Buffer.from(
-                  decryptedContent.nonce +
-                    decryptedContent.content.type +
-                    decryptedContent.content.senderId +
-                    canonicalize(decryptedContent.content as any),
+                  buildMessageFingerprint({
+                    nonce: decryptedContent.nonce,
+                    content: decryptedContent.content as any,
+                    senderId: decryptedContent.content.senderId,
+                    spaceId: decryptedContent.spaceId,
+                    channelId: decryptedContent.channelId,
+                  }),
                   'utf-8'
                 )
               );
@@ -4552,12 +4536,15 @@ export class MessageService {
                   conversationId.split('/')[0]
                 );
                 for (const message of envelope.message.messages) {
-                  // enforce non-repudiability
+                  // Verify non-repudiable (all types) + control messages (any
+                  // space) — control auth must not depend on repudiability.
                   if (
                     space &&
-                    !space.isRepudiable &&
                     message.publicKey &&
-                    message.signature
+                    message.signature &&
+                    (!space.isRepudiable ||
+                      isControlMessageType(message.content.type) ||
+                      message.mentions?.everyone === true)
                   ) {
                     const participant = await this.messageDB.getSpaceMember(
                       space.spaceId,
@@ -4570,14 +4557,21 @@ export class MessageService {
                     const messageId = await crypto.subtle.digest(
                       'SHA-256',
                       Buffer.from(
-                        message.nonce +
-                          message.content.type +
-                          message.content.senderId +
-                          canonicalize(message.content as any),
+                        buildMessageFingerprint({
+                          nonce: message.nonce,
+                          content: message.content as any,
+                          senderId: message.content.senderId,
+                          spaceId: message.spaceId,
+                          channelId: message.channelId,
+                        }),
                         'utf-8'
                       )
                     );
-                    // Handle case where participant is not found (e.g., sync received before member data)
+                    // Inbox-binding check is skipped when the participant row is
+                    // missing (common — see missing-no-join-row bug), but the
+                    // ed448 signature is ALWAYS verified: keeping an unverified
+                    // signature would let a forged control message carry a real
+                    // mod's (public) key and pass the handler's reverse lookup.
                     if (
                       (participant?.inbox_address !== inboxAddress &&
                         participant?.inbox_address) ||
@@ -4586,8 +4580,6 @@ export class MessageService {
                     ) {
                       message.publicKey = undefined;
                       message.signature = undefined;
-                    } else if (!participant) {
-                      // Participant not found yet, can't verify - keep signature for later verification
                     } else {
                       if (
                         ch.js_verify_ed448(
@@ -4885,14 +4877,35 @@ export class MessageService {
               ?.filter(role => role.members?.includes(self_address))
               ?.map(role => role.roleId) ?? [];
 
-            // Check for mentions ('space' lets isMentionedWithSettings verify
-            // the SENDER held mention:everyone before honoring @everyone)
-            const isMentioned = isMentionedWithSettings(decryptedContent, {
-              userAddress: self_address,
-              enabledTypes,
-              userRoles,
-              space: space ?? undefined,
-            });
+            // @everyone gate: honor it only if the VERIFIED signer (not the
+            // spoofable payload senderId) held mention:everyone. The verify
+            // block above always verifies @everyone-bearing posts, so a present
+            // publicKey here is proven. We drop `space` from
+            // isMentionedWithSettings (disabling its payload-based @everyone
+            // check) and do the @everyone check ourselves against the verified
+            // signer; user/@role checks are unaffected (they don't use space).
+            const everyoneSender = decryptedContent.publicKey
+              ? resolveVerifiedSender(
+                  decryptedContent.publicKey,
+                  (await this.messageDB.getSpaceMembers(
+                    spaceId
+                  )) as unknown as Parameters<typeof resolveVerifiedSender>[1]
+                )
+              : null;
+            const isMentioned =
+              isMentionedWithSettings(decryptedContent, {
+                userAddress: self_address,
+                enabledTypes,
+                userRoles,
+              }) ||
+              (enabledTypes.includes('mention-everyone') &&
+                decryptedContent.mentions?.everyone === true &&
+                !!everyoneSender &&
+                hasPermission(
+                  everyoneSender,
+                  'mention:everyone',
+                  space ?? undefined
+                ));
 
             // Check for reply to user's message
             const isReplyToMe = enabledTypes.includes('reply') &&
@@ -5049,14 +5062,20 @@ export class MessageService {
       const nonce = crypto.randomUUID();
       const space = await this.messageDB.getSpace(spaceId);
 
-      // Calculate messageId (SHA-256 hash)
+      // Calculate messageId (SHA-256 of the canonical fingerprint). Uses the
+      // shared builder so the real content.type is hashed (control messages
+      // like remove-message no longer sign under a hardcoded 'post') and
+      // control types bind spaceId/channelId. Posts are unchanged.
       const messageIdBuffer = await crypto.subtle.digest(
         'SHA-256',
         Buffer.from(
-          nonce +
-            'post' +
-            currentPasskeyInfo.address +
-            canonicalize(pendingMessage as any),
+          buildMessageFingerprint({
+            nonce,
+            content: pendingMessage as any,
+            senderId: currentPasskeyInfo.address,
+            spaceId,
+            channelId,
+          }),
           'utf-8'
         )
       );
@@ -5249,14 +5268,21 @@ export class MessageService {
           return outbounds;
         }
 
-        // Create the edit message with proper structure
+        // Create the edit message with proper structure. Shared builder binds
+        // spaceId/channelId (edit-message is a control type), matching receive.
         const messageId = await crypto.subtle.digest(
           'SHA-256',
           Buffer.from(
-            nonce +
-              'edit-message' +
-              currentPasskeyInfo.address +
-              canonicalize(editMessage),
+            buildMessageFingerprint({
+              nonce,
+              content: {
+                ...editMessage,
+                senderId: currentPasskeyInfo.address,
+              } as EditMessage,
+              senderId: currentPasskeyInfo.address,
+              spaceId,
+              channelId,
+            }),
             'utf-8'
           )
         );
@@ -5281,8 +5307,11 @@ export class MessageService {
           conversationId,
         });
 
-        // enforce non-repudiability
-        if (!space?.isRepudiable || (space?.isRepudiable && !skipSigning)) {
+        // Edit inherit rule: an edit is signed iff the message it edits was
+        // signed, so a deliberately-unsigned (deniable) message never silently
+        // gains a signature on edit. In a non-repudiable space the original is
+        // always signed, so edits are too (consistent with the space rule).
+        if (shouldSignEdit(originalMessage)) {
           const inboxKey = await this.messageDB.getSpaceKey(spaceId, 'inbox');
           message.publicKey = inboxKey.publicKey;
           message.signature = Buffer.from(
@@ -5361,14 +5390,18 @@ export class MessageService {
           return outbounds;
         }
 
-        // Generate message ID using SHA-256(nonce + 'pin' + senderId + canonicalize(pinMessage))
+        // messageId = SHA-256 of the canonical fingerprint (pin is a control
+        // type: shared builder binds spaceId/channelId, matching receive).
         const messageId = await crypto.subtle.digest(
           'SHA-256',
           Buffer.from(
-            nonce +
-              'pin' +
-              currentPasskeyInfo.address +
-              canonicalize(pinMessage),
+            buildMessageFingerprint({
+              nonce,
+              content: { ...pinMessage, senderId: currentPasskeyInfo.address },
+              senderId: currentPasskeyInfo.address,
+              spaceId,
+              channelId,
+            }),
             'utf-8'
           )
         );

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -20,6 +20,7 @@ import {
   authorizeControlMessage,
   isControlMessageType,
   shouldSignEdit,
+  canManageReadOnlyChannel,
   type ControlMessageContent,
 } from '@quilibrium/quorum-shared';
 import { MessageDB, EncryptionState, EncryptedMessage } from '../db/messages';
@@ -34,6 +35,7 @@ import type {
   KickMessage,
   MuteMessage,
   Space,
+  Channel,
   EditMessage,
   PinMessage,
   ThreadMessage,
@@ -966,6 +968,60 @@ export class MessageService {
       channel,
       targetMessage,
     }).allowed;
+  }
+
+  /**
+   * Authorize a POST to a read-only channel against the VERIFIED ed448 signer
+   * (a channel manager), never the spoofable payload senderId. A read-only
+   * channel is manager-only, which requires proving the poster's identity, so
+   * an unsigned/unverifiable post is dropped even in a repudiable space.
+   *
+   * Self-contained (re-derives the fingerprint and verifies the signature here)
+   * so it holds regardless of which receive path reached the caller. This gates
+   * the LIVE cache path (addMessage); the durable saveMessage path has no
+   * read-only enforcement yet and stays deferred to the hub-log migration —
+   * .agents/bugs/2026-06-12-readonly-channel-receive-side-enforcement-gaps.md.
+   */
+  private async isReadOnlyPostAuthorized(
+    decryptedContent: Message,
+    space: Space,
+    channel: Channel,
+    members: SpaceMemberRow[]
+  ): Promise<boolean> {
+    if (!decryptedContent.publicKey || !decryptedContent.signature) {
+      return false;
+    }
+    const messageId = await crypto.subtle.digest(
+      'SHA-256',
+      Buffer.from(
+        buildMessageFingerprint({
+          nonce: decryptedContent.nonce,
+          content: decryptedContent.content as any,
+          senderId: decryptedContent.content.senderId,
+          spaceId: decryptedContent.spaceId,
+          channelId: decryptedContent.channelId,
+        }),
+        'utf-8'
+      )
+    );
+    if (
+      decryptedContent.messageId !== Buffer.from(messageId).toString('hex') ||
+      ch.js_verify_ed448(
+        Buffer.from(decryptedContent.publicKey, 'hex').toString('base64'),
+        Buffer.from(messageId).toString('base64'),
+        Buffer.from(decryptedContent.signature, 'hex').toString('base64')
+      ) !== 'true'
+    ) {
+      return false;
+    }
+    const verifiedSender = resolveVerifiedSender(
+      decryptedContent.publicKey,
+      members as unknown as Parameters<typeof resolveVerifiedSender>[1]
+    );
+    return (
+      !!verifiedSender &&
+      canManageReadOnlyChannel(verifiedSender, false, space, channel)
+    );
   }
 
   /**
@@ -2080,25 +2136,20 @@ export class MessageService {
           return;
         }
 
-        // Validate read-only channel permissions
+        // Validate read-only channel permissions against the VERIFIED signer
+        // (not the spoofable payload senderId): a modified client could forge a
+        // manager's address to post in a read-only channel for everyone. Drops
+        // unsigned/unverifiable posts (read-only requires proven manager
+        // identity). Live cache path only — see isReadOnlyPostAuthorized.
         if (channel.isReadOnly) {
-          const senderId = decryptedContent.content.senderId;
-
-          // Check if channel has manager roles configured
-          if (!channel.managerRoleIds || channel.managerRoleIds.length === 0) {
-            return;
-          }
-
-          // Check if sender is in a manager role
-          // Note: Space owners must explicitly join a manager role (privacy requirement)
-          const isChannelManager =
-            space.roles?.some(
-              (role) =>
-                channel.managerRoleIds?.includes(role.roleId) &&
-                role.members?.includes(senderId)
-            ) ?? false;
-
-          if (!isChannelManager) {
+          const members = await this.messageDB.getSpaceMembers(spaceId);
+          const authorized = await this.isReadOnlyPostAuthorized(
+            decryptedContent,
+            space,
+            channel,
+            members
+          );
+          if (!authorized) {
             return;
           }
         }


### PR DESCRIPTION
Fixes the space-side of the control-message authorization bypass (the DM half shipped in #220). Consumes quorum-shared #61.

## The bug
Space `remove-message` / `edit-message` / `pin` / `mute`, `@everyone`, and read-only-channel posting were authorized on the **receive** side using the plaintext `content.senderId` — a field the sender's client writes and can spoof. A space member on a **modified client** could set `senderId` to a moderator (or a message's author / channel manager) and delete, edit, pin, mute, @everyone-notify, or post-to-read-only for the whole space. Group encryption doesn't identify the per-message author; the only per-message proof is the ed448 signature already on each message.

## The fix
Authorize against the **cryptographically verified ed448 signer**, not the payload `senderId`.

**Receive side**
- Both verify blocks (live + sync) verify control messages regardless of space repudiability, rebuild the messageId via the shared `buildMessageFingerprint` (real `content.type`; binds spaceId+channelId for control types to block cross-space replay), and always run the ed448 check (closes the sync-path keep-without-verify gap).
- All space remove/edit/pin/mute authorization (in `saveMessage` **and** `addMessage`) routes through `isSpaceControlAuthorized` → shared `resolveVerifiedSender` (reverse key→member lookup, **fail-closed** on unknown/kicked members) → `authorizeControlMessage`. Payload `senderId` is no longer an auth input; a branded `VerifiedSender` type makes reintroducing it a compile error.
- `@everyone` honored only when the verified signer holds `mention:everyone` (@everyone-bearing posts are verified even in repudiable spaces).
- Read-only-channel **post acceptance** (live cache path) authorizes the verified signer as a manager (`isReadOnlyPostAuthorized`); unsigned/unverifiable posts dropped.

**Send side**
- Space post/remove/edit/pin fingerprints use `buildMessageFingerprint` (fixes the dead-delete-signature bug — deletes were hashed as `'post'`).
- Edits inherit the original message's signed/unsigned state (`shouldSignEdit`), so a deniable message never silently gains a signature.

DM paths stay session-anchored (#220), unchanged.

## Review
An independent security review of the diff caught a `mute` `senderId` bypass (same class) — fixed in this PR with tests.

## Scope / follow-ups (intentionally not here)
- Read-only-channel **durable path** (`saveMessage` has no read-only check) and **embed/sticker** type coverage remain open — same class, but needs a send-side "always sign read-only posts" decision; tracked in `.agents/bugs/2026-06-12-readonly-channel-receive-side-enforcement-gaps.md`, next PR.
- Edited-message signed-badge cross-device inconsistency (display/trust-UX, not auth) — `.agents/tasks/2026-07-19-edited-message-signature-badge-cross-device.md`.
- **Not deployed to prod until quorum-mobile ships matching receive-side verification** (coordinated cut-over), or updated desktops would reject control messages from un-updated clients.

## Verification
tsc clean · full suite **443 green** (incl. new spoof/unsigned/wrong-signer drop tests for delete/edit/pin/mute/read-only) · lint 0 errors. Also fixes 3 pre-existing stale tests surfaced while running the suite.