### PR TITLE
Enforce read-only channels for embed/sticker + durable path, force-sign posts

### DIFF
--- a/.agents/bugs/2026-06-12-readonly-channel-receive-side-enforcement-gaps.md
+++ b/.agents/bugs/2026-06-12-readonly-channel-receive-side-enforcement-gaps.md
@@ -114,19 +114,23 @@ Two updates from the control-message-auth work (see
    channel are dropped (read-only requires proven manager identity, so this holds
    even in a repudiable space). Tests: `MessageService.unit.test.tsx` §3e.
 
-**Still OPEN (this bug stays open):**
+**Still OPEN (this bug stays open) — tracked in a completion task:**
+`.agents/tasks/2026-07-19-readonly-channel-completion-durable-embed-sticker.md`
+(desktop + mobile; the plan below is its summary).
 - **Durable path** — `saveMessage` has NO read-only enforcement at all, so a
   forged read-only post can still land in the DB and reappear on reload/re-render
-  from storage. Deliberately deferred to the hub-log migration (the durable
-  receive path is being reworked there). The live-path fix hides it from the
-  live cache but does not close the durable hole.
+  from storage. The live-path fix hides it from the live cache but does not close
+  the durable hole. (Note: no longer strictly gated on the hub-log migration —
+  the manager-check logic is transport-agnostic and can be added to `saveMessage`
+  now; see the completion task.)
 - **Type coverage** — only `post` is checked; `embed`/`sticker` still bypass the
   read-only gate.
 
-When the hub-log migration reworks the durable path, apply the SAME
-`isReadOnlyPostAuthorized` / verified-signer pattern there and extend it to all
-content types, so identity + type coverage are consistent across live and
-durable paths.
+The completion task applies the SAME `isReadOnlyPostAuthorized` / verified-signer
+pattern to the durable path and all postable content types, plus a send-side
+"always sign read-only posts" change (so legit managers' own posts aren't
+dropped) and a composer toggle-disable for read-only channels. Closing it on both
+platforms resolves this bug.
 
 ---
 

--- a/.agents/tasks/2026-07-19-readonly-channel-completion-durable-embed-sticker.md
+++ b/.agents/tasks/2026-07-19-readonly-channel-completion-durable-embed-sticker.md
@@ -1,0 +1,121 @@
+---
+type: task
+title: "Complete read-only-channel enforcement: durable path + embed/sticker + always-sign read-only posts"
+status: open — ready to implement (new session)
+priority: medium-high
+created: 2026-07-19
+severity: HIGH (authorization bypass — same class as the merged control-message-auth fix)
+spans-repos:
+  - quorum-desktop
+  - quorum-mobile
+  - (quorum-shared: NO change needed — reuses existing exports)
+closes-bug: .agents/bugs/2026-06-12-readonly-channel-receive-side-enforcement-gaps.md
+builds-on: quorum-desktop#241, quorum-shared#61
+---
+
+# Complete read-only-channel enforcement
+
+## Where we are (what's already done)
+
+quorum-desktop#241 made read-only-channel **post acceptance** authorize the
+**verified ed448 signer** as a channel manager — but only on the **live cache
+path** (`addMessage` → `isReadOnlyPostAuthorized`), and only for `type: 'post'`.
+Two gaps remain (they ARE the two gaps in the closes-bug doc):
+
+1. **Durable path unguarded.** `saveMessage` (the IndexedDB write) has NO
+   read-only check at all, so a forged read-only post still lands on disk and
+   **reappears on the next refetch from storage** (remount / invalidate /
+   navigate away and back). The live-path fix only hides it until reload.
+2. **`embed` / `sticker` bypass.** The gate keys on `type === 'post'`, so a
+   non-manager can put an **image or sticker** into a read-only channel and it's
+   accepted (on both paths — it never even reaches the post-only live gate).
+
+Net: a determined or non-text sender can still get content into a read-only
+channel that recipients see. This is the same authorization-bypass class as the
+control-message fix; finishing it fully closes the closes-bug.
+
+## The design decision (confirmed with lead-dev intent 2026-07-19)
+
+**Posts to a read-only channel must be SIGNED.** A read-only channel is
+manager-only, and the only way to prove "this really came from a manager" is the
+ed448 signature. So an unsigned post to a read-only channel is dropped —
+including in a repudiable space (this is the one place where a repudiable space
+does not get to be unsigned, because the channel's whole purpose is
+manager-attributed content).
+
+### Why this forces a 3-part change (the own-message gotcha)
+
+A receive-side guard that drops *unsigned* read-only posts would also drop a
+**legitimate manager's own post** if that post is unsigned — which can happen in
+a repudiable space via the composer's "send unsigned" toggle. We cannot skip
+"own messages" on the receive side, because every field we'd key on
+(`senderId`, `sendStatus`) lives in the payload and is spoofable. So the fix
+must ALSO guarantee legit read-only posts are always signed on send:
+
+1. **Receive guard** (security) — drop unsigned/unverified/non-manager
+   `post`/`embed`/`sticker` to a read-only channel, on BOTH the live and durable
+   paths.
+2. **Send-side force-sign** (so legit clients comply) — always sign a post to a
+   read-only channel, overriding the unsigned toggle, so a manager's own post is
+   never unsigned and never dropped.
+3. **Composer UX** (honesty) — disable / hide the "send unsigned" toggle when the
+   active channel is read-only, so a user isn't surprised their toggle had no
+   effect. Recommended (cheap, good UX); the real enforcement is (1)+(2). Not a
+   security control on its own — a modified client ignores the UI.
+
+## Implementation — quorum-desktop
+
+- **Receive guard, both paths.** Generalize the existing
+  `isReadOnlyPostAuthorized` into a single guard used by BOTH `addMessage` (live)
+  and `saveMessage` (durable), applied to `post` + `embed` + `sticker` for space
+  channels. Simplest shape: an early guard at the top of each handler —
+  `if (spaceId !== channelId && isReadOnlyGatedContent(type) && channelIsReadOnly
+  && !authorized) return;` — so the intricate downstream branches don't need
+  touching. `isReadOnlyPostAuthorized` already re-derives the fingerprint via
+  `buildMessageFingerprint` and verifies ed448 self-containedly, and
+  `canonicalize` already covers embed/sticker, so it works for those types as-is.
+  - Replace the current post-only inline read-only block in `addMessage` with the
+    generalized guard; add the guard to `saveMessage`'s catch-all `else` (where
+    post/embed/sticker are persisted, `MessageService.ts` ~1508).
+  - **Care:** `saveMessage` is shared by live + sync + offline replay. The guard
+    is self-verifying so it holds on any path, but trace each caller to confirm a
+    fail-closed drop can't lose a *legitimate* (signed) message. Legit signed
+    manager posts pass on every path; only unsigned/forged ones drop.
+- **Send-side force-sign.** In `submitChannelMessage`, when the target channel is
+  read-only, force `skipSigning = false` (sign regardless of the repudiable
+  toggle). The channel is already looked up on send.
+- **Composer UX.** In `Channel.tsx` (composer wiring), disable/hide the signing
+  lock when `channel.isReadOnly` (a manager posting there is always signed).
+
+## Implementation — quorum-mobile (SAME change, mirror desktop)
+
+- Bump `@quilibrium/quorum-shared` to **2.1.0-35** (published, includes the
+  messageAuth primitives + `canManageReadOnlyChannel`). No shared change needed.
+- Receive guard: `WebSocketContext.tsx` read-only post checks (live ~2280 and
+  batch ~3816 use `canManageReadOnlyChannel(senderId, …)` on the payload
+  senderId today) → switch to the verified signer (verify the post's ed448
+  signature, resolve the signer, then `canManageReadOnlyChannel`), covering
+  post/embed/sticker on both the live and durable/batch paths.
+- Send-side force-sign for read-only channels (mobile send path in
+  `services/space/spaceMessageService.ts` / `useSendSpaceMessage`).
+- Composer UX: disable the signing lock in `MessageInput.tsx` when the channel is
+  read-only (`signingOptional` already gates the lock on `isRepudiable`; add
+  `&& !channel.isReadOnly`).
+- iOS review pass (no runtime iOS testing available) + Android device test.
+
+## Tests
+
+Both platforms: signed manager post/embed/sticker to a read-only channel →
+accepted; unsigned → dropped; signed non-manager → dropped; forged
+`senderId`/`sendStatus` → dropped; and — crucially — a legit manager's OWN post
+to a read-only channel is NEVER dropped (because it's force-signed). Durable:
+confirm a forged read-only post does not survive a reload/refetch.
+
+## Done = closes the bug
+
+When both platforms enforce read-only for post/embed/sticker on live + durable
+paths with force-signed sends, mark
+`.agents/bugs/2026-06-12-readonly-channel-receive-side-enforcement-gaps.md`
+resolved.
+
+*Last updated: 2026-07-19*

--- a/.agents/tasks/2026-07-19-readonly-channel-completion-durable-embed-sticker.md
+++ b/.agents/tasks/2026-07-19-readonly-channel-completion-durable-embed-sticker.md
@@ -118,4 +118,13 @@ paths with force-signed sends, mark
 `.agents/bugs/2026-06-12-readonly-channel-receive-side-enforcement-gaps.md`
 resolved.
 
+## References (for a cold review / full code check)
+
+- **The bug this completes:** `.agents/bugs/2026-06-12-readonly-channel-receive-side-enforcement-gaps.md` (the two gaps = durable + embed/sticker).
+- **The merged base this builds on:** quorum-desktop#241 (https://github.com/QuilibriumNetwork/quorum-desktop/pull/241). Desktop `src/services/MessageService.ts` — the existing `isReadOnlyPostAuthorized` (generalize it) and its use in `addMessage`; `saveMessage`'s catch-all `else` (~1508) is where durable enforcement goes. Tests: `src/dev/tests/services/MessageService.unit.test.tsx` §3e.
+- **Shared primitives (published, consume as-is):** `@quilibrium/quorum-shared@2.1.0-35` — `buildMessageFingerprint`, `resolveVerifiedSender` (`D:/GitHub/Quilibrium/quorum-shared/src/utils/messageAuth.ts`), `canManageReadOnlyChannel` (`D:/GitHub/Quilibrium/quorum-shared/src/utils/channelPermissions.ts`).
+- **Private tracking issue (the whole effort):** https://github.com/QuilibriumNetwork/quorum-app-prod/issues/1.
+- **Mobile side:** the full mobile audit + reference list is in `D:/GitHub/Quilibrium/quorum-mobile/.agents/tasks/2026-06-25-space-control-msg-auth-signature-design.md` (gitignored/local) — mirror it for the mobile half of this task.
+- **Cross-repo rules:** `D:/GitHub/Quilibrium/quorum-atlas.md` (esp. iOS-review-only, ship/PR conventions).
+
 *Last updated: 2026-07-19*

--- a/.agents/tasks/2026-07-19-readonly-channel-completion-durable-embed-sticker.md
+++ b/.agents/tasks/2026-07-19-readonly-channel-completion-durable-embed-sticker.md
@@ -1,7 +1,7 @@
 ---
 type: task
 title: "Complete read-only-channel enforcement: durable path + embed/sticker + always-sign read-only posts"
-status: open — ready to implement (new session)
+status: desktop DONE (shipping via PR) — mobile half still open (tracked in quorum-mobile 2026-06-25-space-control-msg-auth-signature-design.md). Bug stays open until both platforms land.
 priority: medium-high
 created: 2026-07-19
 severity: HIGH (authorization bypass — same class as the merged control-message-auth fix)
@@ -14,6 +14,39 @@ builds-on: quorum-desktop#241, quorum-shared#61
 ---
 
 # Complete read-only-channel enforcement
+
+## ✅ Desktop — DONE (2026-07-19)
+
+All three desktop parts shipped on branch `readonly-channel-durable-embed-sticker`
+(`src/services/MessageService.ts`, `src/components/space/Channel.tsx`):
+
+1. **Receive guard** — generalized `isReadOnlyPostAuthorized` (already
+   content-type agnostic) is now applied to `post` + `embed` + `sticker` on BOTH
+   the live (`addMessage`) and durable (`saveMessage`) paths via a shared
+   `isReadOnlyGatedType` set + `findChannelInSpace` helper. The live path
+   fail-secures on missing space/channel; the **durable path fail-OPENs** (drops
+   only when the channel is confirmed read-only AND the verified signer is not a
+   manager) so a legit signed manager message arriving before its space row
+   during replay is never permanently lost — the exact failure that reverted the
+   first attempt. Durable guard exempts thread replies to match the live path.
+2. **Send-side force-sign** — `submitChannelMessage` forces
+   `effectiveSkipSigning = false` when the target channel is read-only, so a
+   manager's own post is always signed (never dropped by the receive guard).
+3. **Composer UX** — `showSigningToggle={space?.isRepudiable && !channel?.isReadOnly}`.
+
+**Verification:** `MessageService.unit.test.tsx` extended (§3e live embed/sticker,
+new §3f durable path incl. fail-open + thread-reply exemption) — 44/44 pass;
+`tsc --noEmit` clean; manual smoke confirmed (manager can post text/embed/sticker
+in a read-only channel and they persist across reload; signing toggle hidden in
+read-only channels).
+
+**Still open:** the **mobile** half (send-side force-sign + composer toggle-disable,
+plus the read-only receive coverage) is being handled alongside the mobile
+control-message-auth work. Coordination note: the receive-side "drop unsigned
+read-only post" and the send-side force-sign MUST land together on mobile, or a
+manager's own unsigned post (repudiable space) gets dropped. Bug
+`2026-06-12-readonly-channel-receive-side-enforcement-gaps.md` stays OPEN until
+mobile lands.
 
 ## Where we are (what's already done)
 

--- a/src/components/space/Channel.tsx
+++ b/src/components/space/Channel.tsx
@@ -1738,7 +1738,7 @@ const Channel: React.FC<ChannelProps> = ({
                 isProcessingImage={composer.isProcessingImage}
                 mapSenderToUser={mapSenderToUser}
                 setInReplyTo={composer.setInReplyTo}
-                showSigningToggle={space?.isRepudiable}
+                showSigningToggle={space?.isRepudiable && !channel?.isReadOnly}
                 skipSigning={skipSigning}
                 onSigningToggle={() => setSkipSigning(!skipSigning)}
                 disabled={!canPost}

--- a/src/dev/tests/services/MessageService.unit.test.tsx
+++ b/src/dev/tests/services/MessageService.unit.test.tsx
@@ -734,6 +734,160 @@ describe('MessageService - Unit Tests', () => {
       await messageService.addMessage(queryClient, 'space', RO, signedManagerPost());
       expect(spy).not.toHaveBeenCalled();
     });
+
+    // The read-only gate must cover ALL visible content types, not just 'post'.
+    // Before the fix, embed/sticker skipped the gate entirely (isPostMessage
+    // === false) and were accepted from anyone.
+    it('DROPS an UNSIGNED embed to a read-only channel', async () => {
+      const spy = vi.spyOn(queryClient, 'setQueriesData');
+      await messageService.addMessage(
+        queryClient,
+        'space',
+        RO,
+        roPost({
+          messageId: 'ro-embed',
+          content: { senderId: 'manager', type: 'embed', imageUrl: 'x' },
+        })
+      );
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('DROPS an UNSIGNED sticker to a read-only channel', async () => {
+      const spy = vi.spyOn(queryClient, 'setQueriesData');
+      await messageService.addMessage(
+        queryClient,
+        'space',
+        RO,
+        roPost({
+          messageId: 'ro-sticker',
+          content: { senderId: 'manager', type: 'sticker', stickerId: 's1' },
+        })
+      );
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('honors a SIGNED manager embed to a read-only channel', async () => {
+      vi.mocked(channel_raw.js_verify_ed448).mockReturnValue('true');
+      const spy = vi.spyOn(queryClient, 'setQueriesData');
+      await messageService.addMessage(
+        queryClient,
+        'space',
+        RO,
+        roPost({
+          messageId: '0'.repeat(64),
+          publicKey: mgrPub,
+          signature: 'sig',
+          content: { senderId: 'manager', type: 'embed', imageUrl: 'x' },
+        })
+      );
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+
+  // SECURITY (durable path): the disk write (saveMessage) must enforce read-only
+  // the same way the live cache path does — otherwise a forged post/embed/sticker
+  // is persisted and reappears on the next refetch from storage. FAIL-OPEN on
+  // missing space/channel data: a fail-secure drop here would permanently lose a
+  // legit (signed) manager message that arrives before its space row during
+  // replay (see bug 2026-06-12, reverted first attempt).
+  describe('3f. saveMessage() - read-only channel durable enforcement (anti-spoofing)', () => {
+    const RO = 'ro-channel';
+    const mgrPub = 'aabb00112233445566778899aabbccdd';
+    const roSpace = {
+      spaceId: 'space',
+      roles: [{ roleId: 'mgr-role', members: ['manager'], permissions: [] }],
+      groups: [
+        {
+          groupId: 'g1',
+          channels: [
+            { channelId: RO, isReadOnly: true, managerRoleIds: ['mgr-role'] },
+          ],
+        },
+      ],
+    };
+    const roPost = (over: Record<string, unknown> = {}) =>
+      ({
+        messageId: 'ro-d1',
+        spaceId: 'space',
+        channelId: RO,
+        nonce: 'n-ro',
+        createdDate: Date.now(),
+        modifiedDate: Date.now(),
+        digestAlgorithm: 'sha256' as const,
+        lastModifiedHash: '',
+        content: { senderId: 'manager', type: 'post', text: 'announce' },
+        ...over,
+      }) as any;
+    const signedManagerPost = (over: Record<string, unknown> = {}) =>
+      roPost({ messageId: '0'.repeat(64), publicKey: mgrPub, signature: 'sig', ...over });
+
+    const save = (msg: any) =>
+      messageService.saveMessage(
+        msg,
+        mockDeps.messageDB,
+        'space',
+        RO,
+        'group',
+        { user_icon: 'i.png', display_name: 'U' }
+      );
+
+    beforeEach(() => {
+      mockDeps.messageDB.getSpace = vi.fn().mockResolvedValue(roSpace);
+      mockDeps.messageDB.getSpaceMembers = vi
+        .fn()
+        .mockResolvedValue([{ address: 'manager', inbox_address: deriveInboxAddress(mgrPub) }]);
+    });
+
+    it('PERSISTS a SIGNED manager post to a read-only channel', async () => {
+      vi.mocked(channel_raw.js_verify_ed448).mockReturnValue('true');
+      await save(signedManagerPost());
+      expect(mockDeps.messageDB.saveMessage).toHaveBeenCalled();
+    });
+
+    it('does NOT persist an UNSIGNED post to a read-only channel', async () => {
+      await save(roPost()); // no signature
+      expect(mockDeps.messageDB.saveMessage).not.toHaveBeenCalled();
+    });
+
+    it('does NOT persist an UNSIGNED embed to a read-only channel', async () => {
+      await save(
+        roPost({ messageId: 'ro-de', content: { senderId: 'manager', type: 'embed', imageUrl: 'x' } })
+      );
+      expect(mockDeps.messageDB.saveMessage).not.toHaveBeenCalled();
+    });
+
+    it('does NOT persist an UNSIGNED sticker to a read-only channel', async () => {
+      await save(
+        roPost({ messageId: 'ro-ds', content: { senderId: 'manager', type: 'sticker', stickerId: 's1' } })
+      );
+      expect(mockDeps.messageDB.saveMessage).not.toHaveBeenCalled();
+    });
+
+    it('does NOT persist a SIGNED post whose verified signer is not a manager', async () => {
+      vi.mocked(channel_raw.js_verify_ed448).mockReturnValue('true');
+      mockDeps.messageDB.getSpaceMembers = vi
+        .fn()
+        .mockResolvedValue([{ address: 'intruder', inbox_address: deriveInboxAddress(mgrPub) }]);
+      await save(signedManagerPost());
+      expect(mockDeps.messageDB.saveMessage).not.toHaveBeenCalled();
+    });
+
+    // FAIL-OPEN: with no space row loaded we cannot prove the channel is
+    // read-only, so we must NOT drop — otherwise a legit signed manager message
+    // arriving before its space during replay is lost from disk forever.
+    it('PERSISTS when space data is unavailable (fail-open, no legit-message loss)', async () => {
+      mockDeps.messageDB.getSpace = vi.fn().mockResolvedValue(null);
+      await save(roPost()); // unsigned, but space unknown → cannot confirm read-only
+      expect(mockDeps.messageDB.saveMessage).toHaveBeenCalled();
+    });
+
+    // Thread replies are exempt to match the live path (addMessage short-circuits
+    // them before its read-only gate); the durable path must not be stricter.
+    it('does NOT gate a thread reply (matches live path)', async () => {
+      mockDeps.messageDB.getChannelThreads = vi.fn().mockResolvedValue([]);
+      await save(roPost({ messageId: 'ro-tr', isThreadReply: true, threadId: 't1' }));
+      expect(mockDeps.messageDB.saveMessage).toHaveBeenCalled();
+    });
   });
 
   describe('4. encryptAndSendToSpace() - Hub Message Helper', () => {

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -76,6 +76,12 @@ import { ThreadService } from './ThreadService';
 import type { Ref } from '../types/ref';
 import type { SpaceInfoMap, SyncInfoMap } from '../types/spaceRefs';
 
+// Visible-content types gated by read-only-channel enforcement. Control
+// messages (reaction/pin/edit/remove/…) carry their own authorization.
+const READ_ONLY_GATED_TYPES = new Set(['post', 'embed', 'sticker']);
+const isReadOnlyGatedType = (type: string): boolean =>
+  READ_ONLY_GATED_TYPES.has(type);
+
 // Type definitions for the service
 export interface MessageServiceDependencies {
   messageDB: MessageDB;
@@ -970,17 +976,24 @@ export class MessageService {
     }).allowed;
   }
 
+  /** Locate a channel by id within a space's groups. */
+  private findChannelInSpace(
+    space: Space,
+    channelId: string
+  ): Channel | undefined {
+    return space.groups
+      ?.find((g) => g.channels.find((c) => c.channelId === channelId))
+      ?.channels.find((c) => c.channelId === channelId);
+  }
+
   /**
-   * Authorize a POST to a read-only channel against the VERIFIED ed448 signer
-   * (a channel manager), never the spoofable payload senderId. A read-only
-   * channel is manager-only, which requires proving the poster's identity, so
-   * an unsigned/unverifiable post is dropped even in a repudiable space.
+   * Authorize a read-only-channel post/embed/sticker against the VERIFIED ed448
+   * signer (a channel manager), never the spoofable payload senderId. An
+   * unsigned/unverifiable post is dropped even in a repudiable space.
    *
-   * Self-contained (re-derives the fingerprint and verifies the signature here)
-   * so it holds regardless of which receive path reached the caller. This gates
-   * the LIVE cache path (addMessage); the durable saveMessage path has no
-   * read-only enforcement yet and stays deferred to the hub-log migration —
-   * .agents/bugs/2026-06-12-readonly-channel-receive-side-enforcement-gaps.md.
+   * Self-contained (re-derives the fingerprint and verifies the signature here),
+   * so it holds on any receive path and for any content type. Used by both the
+   * live (addMessage) and durable (saveMessage) paths.
    */
   private async isReadOnlyPostAuthorized(
     decryptedContent: Message,
@@ -1506,6 +1519,38 @@ export class MessageService {
           : undefined;
       await messageDB.saveSpaceMember(spaceId, participant);
     } else {
+      // Read-only enforcement on the durable path, mirroring the live gate so a
+      // forged post can't survive on disk and resurface on refetch. Fail-OPEN on
+      // missing space/channel: this path also runs during sync/replay where a
+      // message can arrive before its space row, and a fail-secure drop would
+      // lose a legit (signed) manager message permanently. So we drop only when
+      // the channel is confirmed read-only AND the verified signer isn't a
+      // manager. Thread replies are exempt to match the live path.
+      const isDM = spaceId === channelId;
+      if (
+        !isDM &&
+        !decryptedContent.isThreadReply &&
+        isReadOnlyGatedType(decryptedContent.content.type)
+      ) {
+        const space = await messageDB.getSpace(spaceId);
+        const channel = space
+          ? this.findChannelInSpace(space, channelId)
+          : undefined;
+        if (space && channel?.isReadOnly) {
+          const members = await messageDB.getSpaceMembers(spaceId);
+          if (
+            !(await this.isReadOnlyPostAuthorized(
+              decryptedContent,
+              space,
+              channel,
+              members
+            ))
+          ) {
+            return; // forged/unsigned read-only post: do not persist
+          }
+        }
+      }
+
       // Check tombstone before saving - prevents deleted messages from being re-added during sync
       if (await messageDB.isMessageDeleted(decryptedContent.messageId)) {
         return;
@@ -2112,7 +2157,10 @@ export class MessageService {
       const isDM = spaceId === channelId;
       const isPostMessage = decryptedContent.content.type === 'post';
 
-      if (!isDM && isPostMessage) {
+      // Read-only enforcement covers all visible content (post/embed/sticker),
+      // not just text. Live path fail-secures on missing space/channel (the
+      // durable path fail-opens instead).
+      if (!isDM && isReadOnlyGatedType(decryptedContent.content.type)) {
         const space = await this.messageDB.getSpace(spaceId);
 
         // FAIL-SECURE: Reject if space data unavailable
@@ -2124,9 +2172,7 @@ export class MessageService {
         }
 
         // Find the target channel in space groups
-        const channel = space.groups
-          ?.find((g) => g.channels.find((c) => c.channelId === channelId))
-          ?.channels.find((c) => c.channelId === channelId);
+        const channel = this.findChannelInSpace(space, channelId);
 
         // FAIL-SECURE: Reject if channel not found
         if (!channel) {
@@ -2140,7 +2186,7 @@ export class MessageService {
         // (not the spoofable payload senderId): a modified client could forge a
         // manager's address to post in a read-only channel for everyone. Drops
         // unsigned/unverifiable posts (read-only requires proven manager
-        // identity). Live cache path only — see isReadOnlyPostAuthorized.
+        // identity). See isReadOnlyPostAuthorized.
         if (channel.isReadOnly) {
           const members = await this.messageDB.getSpaceMembers(spaceId);
           const authorized = await this.isReadOnlyPostAuthorized(
@@ -5111,6 +5157,16 @@ export class MessageService {
       const nonce = crypto.randomUUID();
       const space = await this.messageDB.getSpace(spaceId);
 
+      // Read-only posts must always be signed (receive-side drops unsigned ones,
+      // including a manager's own), so force-sign regardless of the repudiable
+      // "send unsigned" toggle.
+      const targetChannel = space
+        ? this.findChannelInSpace(space, channelId)
+        : undefined;
+      const effectiveSkipSigning = targetChannel?.isReadOnly
+        ? false
+        : skipSigning;
+
       // Calculate messageId (SHA-256 of the canonical fingerprint). Uses the
       // shared builder so the real content.type is hashed (control messages
       // like remove-message no longer sign under a hardcoded 'post') and
@@ -5217,7 +5273,10 @@ export class MessageService {
       } as Message;
 
       // Sign message BEFORE optimistic display (non-repudiability requirement)
-      if (!space?.isRepudiable || (space?.isRepudiable && !skipSigning)) {
+      if (
+        !space?.isRepudiable ||
+        (space?.isRepudiable && !effectiveSkipSigning)
+      ) {
         const inboxKey = await this.messageDB.getSpaceKey(spaceId, 'inbox');
         message.publicKey = inboxKey.publicKey;
         message.signature = Buffer.from(


### PR DESCRIPTION
## What

Completes the desktop half of read-only-channel receive-side enforcement (closes-bug: `.agents/bugs/2026-06-12-readonly-channel-receive-side-enforcement-gaps.md`, builds on #241). Three changes:

1. **Receive guard generalized to all visible content, on both paths.** The read-only gate previously keyed on `type === 'post'` and lived only in the live cache path (`addMessage`). It now covers `post` + `embed` + `sticker` on **both** the live path and the durable IndexedDB path (`saveMessage`), reusing the existing self-verifying `isReadOnlyPostAuthorized` (re-derives the fingerprint, verifies ed448, authorizes the verified signer as a channel manager). This closes two gaps: a non-manager could put an image/sticker into a read-only channel (never hit the post-only gate), and even a blocked post was still written to disk and reappeared on the next refetch.

2. **Durable path fail-opens on missing data.** `saveMessage` also runs during sync/offline replay, where a message can arrive before its space row loads. So the durable guard drops **only** when it can positively confirm the channel is read-only **and** the verified signer is not a manager; if space/channel data is unavailable it does not drop. This avoids permanently losing a legitimate signed manager message (the failure mode that reverted the first attempt). Thread replies are exempt, matching the live path.

3. **Send-side force-sign + composer UX.** A read-only channel is manager-only and manager-attributed, so posts there must be signed — an unsigned read-only post is dropped on receipt, which would otherwise drop a manager's **own** post in a repudiable space with the "send unsigned" toggle on. `submitChannelMessage` now forces signing for read-only channels regardless of the toggle, and the composer hides the toggle for read-only channels.

## Tests

`MessageService.unit.test.tsx`: extended §3e (live embed/sticker: unsigned dropped, signed manager honored) and added §3f (durable path — unsigned post/embed/sticker not persisted, signed non-manager not persisted, signed manager persisted, **fail-open when space unavailable**, **thread reply not gated**). 44/44 pass; `tsc --noEmit` clean; manual smoke confirmed (manager can post text/embed/sticker in a read-only channel and they persist across reload; signing toggle hidden in read-only channels).

## Scope

Desktop only. The **mobile** mirror (receive coverage + send-side force-sign + composer toggle-disable) is being handled alongside the mobile control-message-auth work; the receive-side drop-unsigned and send-side force-sign must land together on mobile. The tracking bug therefore stays **open** until mobile lands — this PR does not close it.