### PR TITLE
SECURITY: authorize update-profile by verified signer (fix inbox_address poisoning → control-message impersonation)

### DIFF
--- a/.agents/bugs/2026-07-19-update-profile-inbox-poisoning-control-msg-impersonation.md
+++ b/.agents/bugs/2026-07-19-update-profile-inbox-poisoning-control-msg-impersonation.md
@@ -1,0 +1,107 @@
+---
+type: bug
+title: "update-profile repoints a victim's inbox_address (poisons verified-signer reverse-lookup → control-message impersonation)"
+status: fixed (pending merge) — desktop; mobile never had it
+created: 2026-07-19
+severity: HIGH (authorization bypass — escalates a display spoof into control-message impersonation)
+related:
+  - 2026-06-25 control-message-auth (verified-signer reverse lookup this poisons)
+  - .solved/2026-06-07-space-profile-save-missing-inbox.md
+  - 2026-06-13-space-members-missing-no-join-row.md
+---
+
+# update-profile inbox_address poisoning → control-message impersonation
+
+> Surfaced during the cross-repo control-message-auth review (2026-07-19). The
+> mobile implementation deliberately does NOT mirror the desktop shape; this is
+> the desktop-side finding + fix.
+
+## The bug
+
+The space `update-profile` receive handler selected the member row to update by
+the **claimed, spoofable** `content.senderId`, then overwrote that row's
+`inbox_address` with the address derived from the **message's signing key**. The
+upstream signature check for `update-profile` only proves the message was signed
+by *some* key over a fingerprint that itself contains the claimed `senderId` —
+it does **not** bind the key to the claimed sender (the inbox-mismatch guard is
+explicitly skipped for `update-profile`, `MessageService.ts:3652-3667`,
+"inbox address changes are legitimate (key rotation)").
+
+Control-message authorization (`#241`) resolves the acting member by the REVERSE
+lookup `signing key → inbox_address → member` (`resolveVerifiedSender`). Writing
+an attacker's key onto a victim's row **poisons exactly that table**.
+
+### Attack chain
+
+1. Attacker (any space member, or even a non-member with a fresh key) sends
+   `update-profile` with `content.senderId = victimAddress`, signed with the
+   attacker's OWN key. It passes the upstream check (messageId matches the
+   fingerprint the attacker computed with the victim's senderId; the ed448
+   signature is valid for the attacker's key; the inbox-mismatch guard is
+   skipped for `update-profile`).
+2. The handler looked up the victim's row by `senderId` and set
+   `participant.inbox_address = base58(sha256(attackerPublicKey))`.
+3. Now `resolveVerifiedSender(attackerKey)` resolves to the **victim's**
+   address.
+4. The attacker sends a `remove-message` / `edit-message` / `pin` / `mute`
+   signed with their own key → it is authorized as the victim. If the victim
+   holds a manager/owner role, the attacker now deletes/edits/pins/mutes as the
+   victim. It also DoSes the victim: their real key no longer matches any row,
+   so their own legitimate control messages stop resolving.
+
+Net: a self-asserted profile message escalates into full control-message
+impersonation — defeating the `#241` verified-signer fix.
+
+## Evidence (pre-fix)
+
+- `MessageService.ts` two handlers (durable `saveMessage` ~1475 and live
+  `addMessage` ~2027): `const existing = getSpaceMember(spaceId, senderId)`
+  (lookup by claimed senderId), create fallback `inbox_address: inboxAddress`,
+  then `participant.inbox_address = inboxAddress` (the poisoning write).
+- `MessageService.ts:3652-3667`: `inboxMismatch = !isUpdateProfile && …` — the
+  key↔member binding check is disabled for `update-profile`.
+- `quorum-shared` `messageAuth.ts` `resolveVerifiedSender`: the reverse lookup
+  keyed on `inbox_address` that the write poisons.
+
+## Fix (desktop — mirrors mobile's shape)
+
+New helper `isUpdateProfileAuthorized(message, messageDB, spaceId)`:
+
+- Drops unsigned/invalid.
+- `resolveVerifiedSender(publicKey, members)`: a key **already registered to a
+  member** may only speak for THAT member (`verified === senderId`); a key
+  matching **no** member returns `null` and is accepted as a rotation/bootstrap
+  announcement (so a member whose join row never arrived can still surface a
+  display name).
+
+And, critically, the handler **never writes the announced key onto the row**:
+
+- Upsert-create uses `inbox_address: ''` (display-only), never the announced
+  key.
+- Existing rows keep their `inbox_address` untouched.
+
+The authoritative `inbox_address` comes only from the VERIFIED join control
+(`js_verify_point` + ed448, `MessageService.ts:3705-3741`), never from a
+self-asserted `update-profile`.
+
+Applied to BOTH handlers (`saveMessage` + `addMessage`). Tests:
+`MessageService.unit.test.tsx` §3g (unsigned dropped; known key claiming another
+member dropped; existing inbox preserved under an unknown key; bootstrap creates
+with empty inbox; own update accepted).
+
+## Accepted residual (parity with mobile)
+
+An unregistered key can still set the **display name / avatar** on a claimed
+`senderId` (needed for the missing-join-row bootstrap). This is a cosmetic spoof
+only — it cannot poison `inbox_address`, so it grants no control-message
+authority. Two-slot LWW + the public-profile fallback bound its impact. Mobile
+makes the same trade-off.
+
+## Mobile
+
+Mobile never shipped this bug: `services/space/spaceMessageAuth.ts`
+`isUpdateProfileAuthorized` implements the known-key binding and the handler
+(`WebSocketContext.tsx` ~2148) creates with `inbox_address: ''` and never writes
+the announced key back.
+
+*Last updated: 2026-07-19*

--- a/src/dev/tests/services/MessageService.unit.test.tsx
+++ b/src/dev/tests/services/MessageService.unit.test.tsx
@@ -890,6 +890,115 @@ describe('MessageService - Unit Tests', () => {
     });
   });
 
+  // SECURITY: update-profile must authorize against the VERIFIED signer, never
+  // the spoofable payload senderId, and must NEVER write the announced key onto
+  // a member row. Otherwise a forged senderId + attacker key repoints a victim's
+  // inbox_address and poisons the resolveVerifiedSender reverse-lookup that
+  // control-message auth (delete/edit/pin/mute) relies on.
+  describe('3g. saveMessage() - update-profile authorization (anti-poisoning)', () => {
+    const attackerPub = '1111111111111111111111111111111111111111111111111111111111111111';
+    const victimPub = '2222222222222222222222222222222222222222222222222222222222222222';
+    const freshPub = '3333333333333333333333333333333333333333333333333333333333333333';
+    const attackerInbox = deriveInboxAddress(attackerPub);
+    const victimInbox = deriveInboxAddress(victimPub);
+
+    const upMsg = (over: Record<string, unknown> = {}) =>
+      ({
+        messageId: 'up-1',
+        spaceId: 'space',
+        channelId: 'space',
+        nonce: 'n-up',
+        createdDate: Date.now(),
+        modifiedDate: Date.now(),
+        digestAlgorithm: 'sha256' as const,
+        lastModifiedHash: '',
+        content: { senderId: 'victim', type: 'update-profile', displayName: 'Hacked' },
+        publicKey: attackerPub,
+        signature: 'sig',
+        ...over,
+      }) as any;
+
+    const save = (msg: any) =>
+      messageService.saveMessage(
+        msg,
+        mockDeps.messageDB,
+        'space',
+        'space',
+        'group',
+        { user_icon: 'i.png', display_name: 'U' }
+      );
+
+    beforeEach(() => {
+      mockDeps.messageDB.saveSpaceMember = vi.fn().mockResolvedValue(undefined);
+      mockDeps.messageDB.getSpaceMember = vi.fn().mockResolvedValue(null);
+      mockDeps.messageDB.getSpaceMembers = vi.fn().mockResolvedValue([]);
+    });
+
+    it('DROPS an unsigned update-profile', async () => {
+      await save(upMsg({ publicKey: undefined, signature: undefined }));
+      expect(mockDeps.messageDB.saveSpaceMember).not.toHaveBeenCalled();
+    });
+
+    it('DROPS when a KNOWN key claims another member as senderId', async () => {
+      // attacker's key is registered to 'attacker'; it may not speak for 'victim'
+      mockDeps.messageDB.getSpaceMembers = vi.fn().mockResolvedValue([
+        { user_address: 'attacker', address: 'attacker', inbox_address: attackerInbox },
+        { user_address: 'victim', address: 'victim', inbox_address: victimInbox },
+      ]);
+      await save(upMsg()); // senderId 'victim', signed with attacker's key
+      expect(mockDeps.messageDB.saveSpaceMember).not.toHaveBeenCalled();
+    });
+
+    it('does NOT overwrite an existing member inbox_address (unknown key claiming victim)', async () => {
+      // fresh key resolves to no member → accepted as a bootstrap announcement,
+      // but the victim's existing inbox_address must be preserved (no poisoning).
+      mockDeps.messageDB.getSpaceMembers = vi.fn().mockResolvedValue([
+        { user_address: 'victim', address: 'victim', inbox_address: victimInbox },
+      ]);
+      mockDeps.messageDB.getSpaceMember = vi.fn().mockResolvedValue({
+        user_address: 'victim',
+        address: 'victim',
+        inbox_address: victimInbox,
+      });
+      await save(upMsg({ publicKey: freshPub }));
+      expect(mockDeps.messageDB.saveSpaceMember).toHaveBeenCalledWith(
+        'space',
+        expect.objectContaining({ inbox_address: victimInbox })
+      );
+    });
+
+    it('bootstraps an unknown sender with an EMPTY inbox_address (never the announced key)', async () => {
+      // no existing row; unknown key → create display-only row, inbox stays ''
+      await save(
+        upMsg({
+          content: { senderId: 'newuser', type: 'update-profile', displayName: 'Ada' },
+          publicKey: freshPub,
+        })
+      );
+      expect(mockDeps.messageDB.saveSpaceMember).toHaveBeenCalledWith(
+        'space',
+        expect.objectContaining({ user_address: 'newuser', inbox_address: '' })
+      );
+    });
+
+    it('accepts a member updating their OWN profile (verified signer === senderId)', async () => {
+      mockDeps.messageDB.getSpaceMembers = vi.fn().mockResolvedValue([
+        { user_address: 'victim', address: 'victim', inbox_address: victimInbox },
+      ]);
+      mockDeps.messageDB.getSpaceMember = vi.fn().mockResolvedValue({
+        user_address: 'victim',
+        address: 'victim',
+        inbox_address: victimInbox,
+      });
+      // signed with victim's own key
+      await save(upMsg({ publicKey: victimPub }));
+      expect(mockDeps.messageDB.saveSpaceMember).toHaveBeenCalledWith(
+        'space',
+        expect.objectContaining({ inbox_address: victimInbox })
+      );
+    });
+  });
+
   describe('4. encryptAndSendToSpace() - Hub Message Helper', () => {
     const createTestMessage = () =>
       ({

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -987,6 +987,37 @@ export class MessageService {
   }
 
   /**
+   * Authorize an update-profile against the VERIFIED signer, never the
+   * spoofable payload senderId. A signing key already registered to a member
+   * may only update THAT member's profile; a key matching no member is accepted
+   * as a rotation/bootstrap announcement. Drops unsigned/invalid messages.
+   *
+   * Weaker than control-message auth by design (an unregistered key is accepted
+   * so a member whose join row never arrived can still surface a display name),
+   * but it closes the escalation: without it, a forged senderId + attacker key
+   * repoints a victim's inbox_address and poisons the resolveVerifiedSender
+   * reverse-lookup that control-message auth relies on.
+   */
+  private async isUpdateProfileAuthorized(
+    decryptedContent: Message,
+    messageDB: MessageDB,
+    spaceId: string
+  ): Promise<boolean> {
+    if (!decryptedContent.publicKey || !decryptedContent.signature) {
+      return false;
+    }
+    const members = await messageDB.getSpaceMembers(spaceId);
+    const verifiedSender = resolveVerifiedSender(
+      decryptedContent.publicKey,
+      members as unknown as Parameters<typeof resolveVerifiedSender>[1]
+    );
+    return (
+      verifiedSender === null ||
+      verifiedSender === decryptedContent.content.senderId
+    );
+  }
+
+  /**
    * Authorize a read-only-channel post/embed/sticker against the VERIFIED ed448
    * signer (a channel manager), never the spoofable payload senderId. An
    * unsigned/unverifiable post is dropped even in a repudiable space.
@@ -1473,42 +1504,40 @@ export class MessageService {
         },
       });
     } else if (decryptedContent.content.type === 'update-profile') {
-      // Drop unsigned messages — we can't validate authenticity or derive
-      // the inbox address without the signing key material.
-      if (!decryptedContent.publicKey || !decryptedContent.signature) {
+      // SECURITY: authorize against the VERIFIED signer (reverse key→member
+      // lookup), never the spoofable payload senderId. Drops unsigned/invalid;
+      // a key already registered to a member may only update THAT member; an
+      // unregistered key is accepted as a rotation/bootstrap announcement.
+      if (
+        !(await this.isUpdateProfileAuthorized(
+          decryptedContent,
+          messageDB,
+          spaceId
+        ))
+      ) {
         return;
       }
 
-      const sh = await sha256.digest(
-        Buffer.from(decryptedContent.publicKey, 'hex')
-      );
-      const inboxAddress = base58btc.baseEncode(sh.bytes);
-
       // UPSERT: if we don't have a member record yet (joined the space after
-      // the sender sent their update, or join control was missed), create one
-      // from the profile data itself. Mirrors mobile WebSocketContext.tsx:1841-1854.
-      // Without this, every update-profile from an unknown sender was silently
-      // dropped, leaving messages with no displayable name or avatar.
+      // the sender sent their update, or join control was missed), create a
+      // display-only row so their name/avatar still render. inbox_address stays
+      // '' — the authoritative value comes from the VERIFIED join control, never
+      // from this self-asserted message (writing the announced key here would
+      // let a forged senderId poison the resolveVerifiedSender reverse-lookup).
       const existing = await messageDB.getSpaceMember(
         spaceId,
         decryptedContent.content.senderId
       );
       const participant: SpaceMemberRow = existing ?? {
         user_address: decryptedContent.content.senderId,
-        inbox_address: inboxAddress,
+        inbox_address: '',
       };
 
-      // update-profile is itself a key rotation announcement — accept inbox address changes.
-      // Signature was already verified upstream; rejecting on mismatch would permanently
-      // block profile updates after any key rotation.
-      //
       // Two-slot, per-slot-LWW merge (see applyProfileUpdate). Presence
       // semantics: omitted = no change, '' = deliberate clear (falls back to
-      // initials for an emptied icon). The public-profile backfill
-      // (useMembersWithPublicProfileFallback) also honors '' as a deliberate
-      // clear, so it won't resurrect the sender's global avatar.
+      // initials for an emptied icon). inbox_address is deliberately NOT touched
+      // here — see the security note above.
       applyProfileUpdate(participant, decryptedContent.content, decryptedContent.createdDate);
-      participant.inbox_address = inboxAddress;
       // Validate inbound spaceTag — reject SVG data URIs (XSS) and oversized payloads
       const inboundTag = decryptedContent.content.spaceTag;
       participant.spaceTag =
@@ -2025,43 +2054,39 @@ export class MessageService {
         queryClient,
       });
     } else if (decryptedContent.content.type === 'update-profile') {
-      // Drop unsigned messages — we can't validate authenticity or derive
-      // the inbox address without the signing key material.
-      if (!decryptedContent.publicKey || !decryptedContent.signature) {
+      // SECURITY: authorize against the VERIFIED signer (reverse key→member
+      // lookup), never the spoofable payload senderId. Drops unsigned/invalid;
+      // a key already registered to a member may only update THAT member; an
+      // unregistered key is accepted as a rotation/bootstrap announcement.
+      if (
+        !(await this.isUpdateProfileAuthorized(
+          decryptedContent,
+          this.messageDB,
+          spaceId
+        ))
+      ) {
         return;
       }
 
-      const sh = await sha256.digest(
-        Buffer.from(decryptedContent.publicKey, 'hex')
-      );
-      const inboxAddress = base58btc.baseEncode(sh.bytes);
-
       // UPSERT: if we don't have a member record yet (joined the space after
-      // the sender sent their update, or join control was missed), create one
-      // from the profile data itself. Mirrors the new-session path above
-      // (saveMessage) and mobile WebSocketContext.tsx:1925-1985. Without this,
-      // an update-profile from a sender whose join broadcast never arrived was
-      // silently dropped, leaving every one of their messages on a truncated
-      // address with no path to recovery. See
-      // .agents/bugs/2026-06-13-space-members-missing-no-join-row.md.
+      // the sender sent their update, or join control was missed), create a
+      // display-only row so their name/avatar still render. inbox_address stays
+      // '' — the authoritative value comes from the VERIFIED join control, never
+      // from this self-asserted message (writing the announced key here would
+      // let a forged senderId poison the resolveVerifiedSender reverse-lookup).
       const existing = await this.messageDB.getSpaceMember(
         spaceId,
         decryptedContent.content.senderId
       );
       const participant: SpaceMemberRow = existing ?? {
         user_address: decryptedContent.content.senderId,
-        inbox_address: inboxAddress,
+        inbox_address: '',
       };
 
-      // update-profile is itself a key rotation announcement — accept inbox address changes.
-      // Signature was already verified upstream; rejecting on mismatch would permanently
-      // block profile updates after any key rotation.
-      //
-      // Two-slot, per-slot-LWW merge (see applyProfileUpdate + the saveMessage
-      // block above for the full rationale). Presence semantics: omitted =
-      // no change, '' = deliberate clear.
+      // Two-slot, per-slot-LWW merge (see applyProfileUpdate). Presence
+      // semantics: omitted = no change, '' = deliberate clear. inbox_address is
+      // deliberately NOT touched here — see the security note above.
       applyProfileUpdate(participant, decryptedContent.content, decryptedContent.createdDate);
-      participant.inbox_address = inboxAddress;
       // Validate inbound spaceTag — reject SVG data URIs (XSS) and oversized payloads
       const inboundTag = decryptedContent.content.spaceTag;
       participant.spaceTag =


### PR DESCRIPTION
## The bug (HIGH — authorization bypass)

The space `update-profile` receive handler selected the member row to update by the **spoofable** payload `content.senderId`, then overwrote that row's `inbox_address` with the address derived from the message's **signing key**. The upstream signature check for `update-profile` deliberately skips the key↔member binding (`inboxMismatch = !isUpdateProfile && …`, [MessageService.ts:3652-3667](src/services/MessageService.ts#L3652-L3667)), so it only proves the message was signed by *some* key — not that the key belongs to the claimed sender.

Control-message auth (#241) resolves the acting member via the reverse lookup `signing key → inbox_address → member` (`resolveVerifiedSender`). Writing an attacker's key onto a victim's row poisons exactly that table:

1. Attacker sends `update-profile` with `senderId = victim`, signed with the attacker's own key (passes upstream: messageId matches the fingerprint they computed with the victim's senderId; valid ed448 sig; inbox-mismatch skipped for update-profile).
2. Handler set `victim.inbox_address = base58(sha256(attackerKey))`.
3. `resolveVerifiedSender(attackerKey)` now resolves to the **victim**.
4. Attacker sends `remove-message`/`edit-message`/`pin`/`mute` signed with their key → authorized as the victim (and the victim's own key stops resolving → DoS).

A self-asserted profile message escalates into full control-message impersonation, defeating the #241 verified-signer fix.

## The fix (mirrors mobile, which never had this gap)

New `isUpdateProfileAuthorized` gate: drops unsigned/invalid; a key **already registered to a member** may only update THAT member; a key matching **no** member is accepted as a rotation/bootstrap announcement (so a member whose join row never arrived can still surface a display name). And the handler **never writes the announced key onto the row** — upsert-create uses `inbox_address: ''`, existing rows keep their `inbox_address`. The authoritative `inbox_address` comes only from the verified join control.

Applied to **both** the durable (`saveMessage`) and live (`addMessage`) handlers.

## Accepted residual (parity with mobile)

An unregistered key can still set the **display name/avatar** on a claimed senderId (needed for the missing-join-row bootstrap) — a cosmetic spoof only, no `inbox_address` poisoning, so no control-message authority. Bounded by two-slot LWW + the public-profile fallback.

## Tests

`MessageService.unit.test.tsx` §3g: unsigned dropped; known key claiming another member dropped; existing inbox preserved under an unknown key claiming the victim; bootstrap creates with empty inbox (never the announced key); own update accepted. 49/49 pass; `tsc --noEmit` clean.

Full writeup: `.agents/bugs/2026-07-19-update-profile-inbox-poisoning-control-msg-impersonation.md`.