### PR TITLE
Fix multi-device: sign space messages with a per-user signing key

### DIFF
--- a/.agents/bugs/2025-12-09-encryption-state-evals-bloat.md
+++ b/.agents/bugs/2025-12-09-encryption-state-evals-bloat.md
@@ -55,4 +55,105 @@ This would allow:
 
 Note: Consumed evals are already removed from state when private invites are sent (`InvitationService.ts:95-102`). The issue is the initial 10K allocation.
 
+## Update 2026-07-19 — desktop-vs-mobile: same bloat, different failure surface
+
+Investigated on the security multi-device signing-key work's critical path.
+The prompting question was "mobile creates spaces flawlessly even after
+several, desktop 400s after a few created ones — is mobile a different invite
+architecture we should port?" Answer: **no, the invite architecture is the
+same; what differs is how each platform handles a FAILED config upload.**
+
+### The bloat is identical on both platforms
+
+- Both store/upload a ~10K-eval pool (~2MB) per *created* space. Desktop
+  `SpaceService.ts:350` calls the SDK with no `total` (defaults ~10K); mobile
+  `quorum-mobile/services/space/spaceService.ts:352` passes `10000` explicitly.
+  Both upload the full untrimmed state in the config blob
+  (desktop `ConfigService.ts:433-448`, mobile `configService.ts:448-455`).
+- The public-invite rework (`MAX_PUBLIC_EVALS = 1`) is already on desktop
+  (`InvitationService.ts:25`, "Matches mobile") and does NOT shrink the blob.
+- So a space *created* on mobile bloats mobile's own upload too. Mobile is not
+  immune to the bloat.
+
+### Why mobile FEELS flawless (the real answer)
+
+Different failure surface, not different data:
+- **Mobile** treats config save as non-fatal during create
+  (`quorum-mobile/services/space/spaceService.ts:398-411`, comment
+  "Non-fatal - space is created") and its `saveConfig` swallows an upload 400
+  as a logged warning, then still saves locally
+  (`configService.ts:566-579`). The user always sees space creation succeed —
+  even when the sync silently failed. Cost: silent cross-device sync breakage
+  (matches the tracker test-log D: a mobile-created space never reached desktop).
+- **Desktop** awaits `saveConfig` on the create path and wraps the config POST
+  in a blocking 30s save modal (mutate 22s timeout ×retries, `baseTypes.ts`),
+  so the same 400/timeout surfaces as a loud error that blocks creation.
+
+So mobile isn't immune to the bloat — it is immune to *showing* the failure,
+which is arguably worse (the sync is broken but nobody is told). Desktop just
+tells the truth loudly.
+
+### Actionable
+
+- The desktop SDK already accepts a `total?` arg
+  (`quilibrium-js-sdk-channels/dist/index.d.ts:796`); desktop's create call
+  omits it → pool size is tunable with a one-line change, no SDK bump.
+- Real fix is a blob-contract change on BOTH platforms: shrink the pool at
+  creation (small `total`), or trim evals from the config upload only (keep
+  full pool local). Must match across platforms. Deferred to lead-dev decision
+  (raise via Telegram).
+
+---
+
+## Compounding bug 2026-07-19 — space deletion LEAKS the bloated state (garbage accumulation)
+
+Found while cleaning a real test account. The diagnostic
+(`window.__messageDB.analyzeEncryptionStates()`) showed **10 bloated ~2MB
+created-space states = 19.4MB local**, while the UI showed only **2 created
+spaces**. So ~8 created-space encryption states (~16MB) were orphaned debris
+from spaces "deleted" earlier — the space vanished from the UI but its ~2MB
+encryption state (plus keys/members/messages) was never removed.
+
+Root cause — `SpaceService.deleteSpace()` (`src/services/SpaceService.ts:563`)
+runs all LOCAL cleanup LAST, gated behind a network call and an early throw:
+
+- `:569-576` throws immediately if the hub key is missing ("incomplete
+  configuration") → no cleanup (the tracker's D7 corrupted-space case).
+- `:619` `postHubDelete()` is a network call; if it fails/times out the
+  function throws here, BEFORE the local cleanup at `:654-685`.
+- `:654-685` (delete encryption state, messages, members, keys, space row)
+  only runs if the network delete succeeded.
+
+There is also NO garbage collector: nothing ever removes encryption
+states/keys/members for a spaceId no longer in `getSpaces()`. Spaces removed
+via config-sync from another device (which drops the space row but not the
+encryption state) leak the same way.
+
+Impact: local IndexedDB accumulates ~2MB per abandoned created space. NOTE the
+config upload filters spaceKeys to `config.spaceIds` (`ConfigService.ts:476-479`),
+so ghosts are NOT uploaded — the 400/timeout is caused by the REAL created
+spaces still in the config (each ~2MB; 2 created ≈ 4MB ≈ the server limit).
+So garbage cleanup fixes local storage but does NOT fix the 400 on its own —
+the real created spaces still need the #108 shrink (trim pool / smaller total).
+Confirmed on a live account 2026-07-19: config.spaceIds = 4 (2 created + 2
+joined), getSpaces() = 13 → 9 ghost space rows (8 carrying ~2MB states = ~16MB
+local garbage; 1 is the empty `QmVBXRsHg…` missing-state row). Server-side data
+for orphaned created spaces (manifest/hub/evals) is also never cleaned.
+
+Proposed fix (lead's call):
+1. Make local cleanup network-independent — run the `deleteEncryptionState /
+   deleteMessage / deleteSpaceMember / deleteSpaceKey / deleteSpace` block
+   regardless of whether `postHubDelete` succeeds (best-effort network leave,
+   guaranteed local purge). Wrap in try/finally.
+2. Add a force-delete path for corrupted spaces (missing hub key) that skips
+   the network leave and purges local rows (D7).
+3. Add an orphan sweep: on startup or on demand, delete encryption
+   states/keys/members/messages whose spaceId is absent from `getSpaces()`
+   (guard the space-self conversation pattern `id/id` so DM states are never
+   touched).
+
+Manual unblock used meanwhile: console script — purge orphan space states
+fully (state+keys+members+messages), trim live created spaces' eval pool to
+~256. Both operate only on `id/id` space conversations, never DMs.
+
 ---

--- a/.agents/bugs/2026-07-20-join-binding-hijack-unauthenticated-member-rebind.md
+++ b/.agents/bugs/2026-07-20-join-binding-hijack-unauthenticated-member-rebind.md
@@ -1,0 +1,166 @@
+---
+type: bug
+title: "Space member-binding can be rebound/blanked by a spoofable join/leave/sync-members payload (verified-signer bypass via the join path)"
+status: OPEN — statically confirmed in source, NOT runtime-tested; needs lead-dev awareness
+created: 2026-07-20
+severity: HIGH (authorization-integrity — same class as #243, reached through the join/leave path instead of update-profile)
+platforms: quorum-desktop + quorum-mobile
+related:
+  - .agents/bugs/2026-07-19-update-profile-inbox-poisoning-control-msg-impersonation.md (#243 — the update-profile form of this, fixed)
+  - .agents/tasks/2026-07-19-per-device-signing-keys-registration-anchored.md (durable design whose master-signature machinery this hardening reuses)
+  - .agents/bugs/2026-01-09-space-owner-privacy-limitation.md (#111)
+  - .agents/docs/features/security.md ("Control-Message Authorization")
+---
+
+# Join-binding hijack: unauthenticated member rebind/blank
+
+> Surfaced 2026-07-20 during the per-device-signing-keys deep-dive, while
+> tracing how a member's `inbox_address` binding (the anchor
+> `resolveVerifiedSender` uses) gets written. #243 closed the `update-profile`
+> route to poisoning that binding; the **join / leave / sync-members** routes to
+> the same table were never given the same treatment. Every code claim below is
+> re-verified in source; **exploitability is reasoned, not runtime-confirmed** —
+> see "Confidence & what still needs testing".
+
+## The invariant being broken
+
+Control-message auth (#241) resolves the acting member by REVERSE lookup:
+verified signing key → `deriveInboxAddress` → the `space_members` row whose
+`inbox_address` matches (shared `utils/messageAuth.ts:110`
+`resolveVerifiedSender`). The whole security of delete/edit/pin/mute/read-only/
+@everyone therefore rests on **who is allowed to write a member row's
+`inbox_address`**. #243 established the rule: only the cryptographically
+**verified join control** may set it; a self-asserted message must not.
+
+The join/leave/sync-members handlers violate that rule.
+
+## Route 1 — forged `join` re-binds a victim's row (desktop)
+
+`MessageService.ts:3747-3783`. On a `join` control envelope the handler:
+
+1. `js_verify_point(ratchet_state, point=participant.pubKey, index=participant.id)`
+   — checks ratchet-slot possession against the receiver's own ratchet state.
+2. `js_verify_ed448(participant.inboxPubKey, blob, participant.signature)` where
+   `blob` = `address + id + inboxAddress + pubKey + inboxKey + … + displayName`.
+3. On pass: `saveSpaceMember({ user_address: participant.address, inbox_address:
+   participant.inboxAddress, … })` — an unconditional IndexedDB `put`
+   (`db/messages.ts:1146`), overwriting any existing row for that address.
+
+The ed448 check proves only that **whoever holds the private key for the
+announced `inboxPubKey` signed the blob** — the attacker supplies BOTH
+`inboxPubKey` and `address`, so it is a self-signature over an attacker-chosen
+(address, key) pair. It does **not** bind the key to the claimed address.
+Nothing else in the handler ties `participant.address` to a verified identity.
+So the only thing standing between a member and rebinding another member's row
+to an attacker-held key is `js_verify_point`.
+
+If `js_verify_point` can be satisfied for a re-broadcast (see confidence note),
+the consequence is identical to #243: `resolveVerifiedSender(attackerKey)`
+resolves to the victim → the attacker's signed `remove-message` / `edit` /
+`pin` / `mute` is authorized **as the victim** (role escalation if the victim
+holds manager/owner powers), and the victim's own control messages stop
+resolving (self-DoS).
+
+## Route 2 — unauthenticated `leave` blanks a victim's binding (mobile)
+
+`WebSocketContext.tsx:928-960`. The `leave` handler reads
+`participant.address || address` **straight from the payload**, loads that
+member, and writes `inbox_address: ''` with **no signature or point check at
+all**. A single forged `leave` naming any member blanks their binding →
+`resolveVerifiedSender` can no longer resolve their key → all their control
+ops drop fleet-wide on every receiver that processed the forged leave
+(unauthenticated control-message DoS against an arbitrary member). Desktop's
+`leave` path should be checked for the same shape.
+
+## Route 3 — mobile `join` verifies nothing
+
+`WebSocketContext.tsx:708-860`. The mobile `join` control case updates the
+ratchet peer maps and calls `adapter.saveSpaceMember({ address:
+participant.address, inbox_address: participant.inboxAddress, … })` with **no
+`js_verify_point` and no ed448 check** — strictly weaker than desktop Route 1.
+On mobile the rebind needs only a hub-sealed `join` envelope with an arbitrary
+(address, inboxAddress) pair.
+
+## Route 4 — `sync-members` bulk-overwrites rows (desktop, weaker gate)
+
+`MessageService.ts:4533-4605`. `sync-members` overwrites member rows from a
+sync peer, gated on `reg.owner_public_keys.includes(owner_public_key) ||
+this.syncInfo.current[spaceId]`. The `syncInfo` branch trusts **any peer during
+an active sync handshake**, so a peer mid-sync can assert member rows
+(including `inbox_address`) that were never owner-signed. Lower confidence /
+narrower window than routes 1–3, but the same table, the same missing
+"only verified data may write bindings" rule.
+
+## Threat model (who can do this)
+
+All routes require sealing a valid **hub control envelope**, which needs the
+space **hub key** — i.e. the attacker is a **space member** (or a
+former/compromised member's client). This is a **member-against-member**
+integrity break, not an anonymous-internet attack. That is exactly the threat
+model #241/#243 were built for: within a space, one member must not be able to
+act as another. Kick's ratchet re-key does not help — these writes happen
+before/independently of kick, and #243 proved the binding table is the sharp
+edge.
+
+## Why #243's fix does not already cover this
+
+#243 hardened only the `update-profile` handler (`isUpdateProfileAuthorized`,
+never writes the announced key to a row). The join/leave/sync-members handlers
+predate that rule and still write `inbox_address` from payload-supplied values.
+Same poisoning target, different doors.
+
+## Fix direction (reuses the per-device-signing-keys machinery)
+
+The durable design in
+`.agents/tasks/2026-07-19-per-device-signing-keys-registration-anchored.md`
+gives every device a **master-identity-signed statement** binding
+`(userAddress → signing key)`, verifiable against the `user_address` already in
+the member row, with zero trust in payload `senderId`. The hardening rides that
+machinery:
+
+1. **Bind join to the master identity.** Carry (optionally, additively) a
+   master-key signature inside the join `participant` blob that attests
+   `address ↔ inboxAddress`; verify it when present; a member row already
+   written from master-verified data may only be overwritten by master-verified
+   data. Absent-signature joins stay display-only (bootstrap), never authoritative
+   for `inbox_address` — same posture #243 took for `update-profile`.
+2. **Authenticate `leave`.** Require a signature by the leaving member's bound
+   key (or master key) before blanking a binding; drop unauthenticated leaves
+   (they can remain cache-only "inactive" hints, never a binding write).
+3. **Tighten `sync-members`.** Only adopt rows carried as self-certifying
+   master-signed statements (the same statements the durable design already
+   re-verifies on sync); drop the `syncInfo`-only trust branch for
+   binding-bearing fields.
+4. **Mobile join parity.** Add the same verification mobile currently skips.
+
+Sequence this **with or immediately after** the per-device-signing-keys task —
+they share the statement type, the domain-separated bytes, and the
+`deriveInboxAddress` check, so doing them together avoids building the same
+verification twice.
+
+## Confidence & what still needs testing
+
+- **High confidence (static):** the ed448 self-signature in Route 1 does not
+  bind address→key; the leave (Route 2) and mobile join (Route 3) handlers do
+  no verification; sync-members (Route 4) has a peer-trust branch. All read
+  directly from source at the lines cited.
+- **Not yet confirmed:** whether `js_verify_point` (WASM, unaudited here) can be
+  satisfied by an existing member re-broadcasting a forged join for an arbitrary
+  `(address, id, point)` — this is the gate that decides whether Route 1 is a
+  live exploit on desktop or merely a defense-in-depth gap. Routes 2 and 3 have
+  no such gate and look exploitable as written, but neither has been
+  runtime-reproduced. **Do not mark solved on reasoning alone** — needs a
+  crafted-envelope test (or user-driven repro) per platform before claiming
+  either the exploit or a fix.
+
+## Suggested next steps
+
+1. Lead-dev heads-up (Telegram, short) — this touches mobile and the shared
+   auth boundary; it's their call whether to fold the hardening into the
+   per-device-signing-keys work or track it separately.
+2. Runtime-confirm Routes 2 & 3 (cheapest, no WASM question): forge a
+   hub-sealed `leave` / `join` in a test space, observe a victim's binding
+   blank/rebind.
+3. Probe `js_verify_point` re-broadcast resistance to settle Route 1 severity.
+
+*Last updated: 2026-07-20*

--- a/.agents/docs/cryptographic-architecture.md
+++ b/.agents/docs/cryptographic-architecture.md
@@ -281,37 +281,10 @@ After rotation the old `inbox_address` stored in the receiver's `space_members` 
 > display update isn't dropped after a rotation), but the handler no longer acts
 > on the new key.
 >
-> **⚠️ MULTI-DEVICE — exposed 2026-07-19; sender-side fix implemented.**
-> This is more than a rare rotation edge case. Each device generates its OWN
-> space signing keypair (`spaceSyncService.ts` `generateEd448()`), so one user
-> signs space messages with a different key per device. The verified-signer
-> reverse-lookup binds a member to a SINGLE `inbox_address`, and the removed
-> `update-profile` rebinding was — accidentally — the only thing that let a
-> second device's key get into other members' tables. With it gone, a control
-> message (e.g. a delete) sent from a user's second device fails the reverse
-> lookup on other clients and is dropped (posts still land, because unverifiable
-> post signatures are nulled and processed anyway; control messages fail closed).
-> The vulnerable line was genuinely load-bearing for multi-device.
->
-> **Fix — signing/mailbox key split (implemented, sender-side).** The per-space
-> `inbox` key played two roles with opposite lifetimes: the MAILBOX (per-device
-> transport address, correctly regenerated per device) and the SIGNING identity
-> (per-user — the join key receivers bound). Space CREATE/JOIN now also store the
-> join key under a `signing` slot, the config-sync path preserves it instead of
-> letting the fresh per-device keypair overwrite it, and all space-message
-> signing uses `getSigningKey(spaceId)` = `signing` ?? `inbox` (the fallback
-> covers the join device and pre-migration state). No wire, receive-side, or
-> member-table change; the signing key already crossed devices inside the
-> E2E-encrypted config payload (and was discarded) — trust is unchanged from DMs
-> (all of a user's devices act as the user). Existing pre-fix second devices stay
-> broken until they re-add the space (acceptable for beta).
->
-> **Durable follow-up (separate task):** a member holds MULTIPLE verified inbox
-> keys, new keys admitted only with a proof chained to the **authenticated device
-> registration** the DM stack already trusts. That also repairs the lost-join-key
-> case and enables true per-device keys. Cross-platform (shared + both apps).
-> Full analysis: quorum-mobile bug
-> `2026-07-19-multidevice-inbox-key-breaks-verified-signer-auth.md`.
+> **Multi-device note.** The per-space inbox key turned out to play two roles
+> with opposite lifetimes (per-device mailbox vs per-user signing identity),
+> which broke verified-signer auth for second devices. That is now a first-class
+> concern — see **"Multi-Device Signing (mailbox key vs signing key)"** below.
 
 ### How Rotation Is Announced: `update-profile` (HISTORICAL — see note above)
 
@@ -370,6 +343,82 @@ update-profile:   (current — #243) verify signature, authorize the VERIFIED
                   stored inbox_address from the announcement — the authoritative
                   value comes only from the verified join control.
 ```
+
+---
+
+## Multi-Device Signing (mailbox key vs signing key)
+
+Verified-signer authorization (below) maps a message's signing key back to a
+member via a single bound `inbox_address` (set by the join broadcast). That
+assumed one key per member — which multi-device breaks.
+
+### The two roles of the per-space inbox key
+
+The per-space `inbox` key was doing two jobs that need **opposite lifetimes**:
+
+| Role | Must be | Why |
+|------|---------|-----|
+| **Mailbox** (hub transport address: `postHubAdd`, `listen`, inbox cleanup) | **per-DEVICE** | each device receives its own copy of space messages |
+| **Signing identity** (what verified-signer auth resolves to a member) | **per-USER** | receivers bound ONE key (the join key) for the member; every device must sign with it to be recognized |
+
+When a space syncs to a second device, that device generates a **fresh** inbox
+keypair (correct for the mailbox role). Before the fix it also signed with that
+fresh key — which no receiver's member table has seen — so `resolveVerifiedSender`
+failed closed and **every control message from a second device was dropped**
+(delete/edit/pin/mute, read-only posts, @everyone). Ordinary posts still landed
+(an unverifiable post signature is nulled and the post processed anyway); only
+signature-gated actions failed.
+
+> Historically, desktop's `update-profile` handler rewrote a member's stored
+> `inbox_address` from the signing key, which accidentally re-bound a second
+> device's key. That line was removed as a poisoning vulnerability (#243), which
+> is what exposed this gap — the rebinding was load-bearing for multi-device.
+
+### The fix: split the two roles (interim, sender-side)
+
+A per-user `signing` key slot holds the join key; the `inbox` slot stays the
+per-device mailbox key. Space messages are signed with
+`getSigningKey(spaceId)` = `signing` ?? `inbox` (the fallback covers the join
+device and pre-migration state, where the two are identical). No wire,
+receive-side, or member-table change — receivers already verify against whatever
+key signed the message; only *which key the sender uses* changed. The signing
+private key crossing devices is not new exposure: it already travelled inside the
+E2E-encrypted config payload (and was discarded). Trust is unchanged from DMs —
+all of a user's devices act as the user.
+
+### Desktop vs mobile (they diverge — intentional, for now)
+
+Both platforms ship the same core (sign with the per-user signing key), but the
+migration/heal behavior differs:
+
+| Aspect | Desktop | Mobile |
+|--------|---------|--------|
+| Store `signing` on create/join | yes | yes |
+| Sign via `signing ?? inbox` | yes (6 send sites) | yes |
+| Preserve `signing` on **new-space** sync | yes (`ConfigService`, `!existingSpace`) | yes |
+| Heal **already-synced** spaces (ongoing, every config receive) | **no** | **yes** |
+| Key provenance tag (`origin` / `promoted` / `adopted`) | no | yes — `origin` (own join key) never overwritten; others yield to the synced blob |
+| Promote join key → `signing` at config save | no | yes |
+| Re-anchor self member row to the signing address | no | yes |
+
+Consequence: an **existing** second device that was broken *before* the fix
+**auto-heals on mobile** (its primary device promotes and publishes the join key;
+the second device adopts it on the next sync) but **stays degraded on desktop**
+(desktop only wires the new-space path + the `signing ?? inbox` fallback). On
+desktop that user can still do admin actions from their primary device; the
+durable follow-up (below) heals the rest. This divergence is tolerable because
+receivers only ever needed the join binding, but any future migration must not
+assume the two platforms hold identical `signing` state.
+
+### Known limitation + durable follow-up
+
+The interim fix makes all of a user's devices share **one** signing key: no
+per-device attribution or revocation, and a lost join key breaks control ops
+until re-join. The durable design gives each device its **own** key, admitted by
+receivers only via a statement signed by the user's **master identity key** (the
+same root the device registration and every config upload already use) — which
+also auto-heals existing devices on cut-over and repairs the lost-join-key case.
+Spec: [`.agents/tasks/2026-07-19-per-device-signing-keys-registration-anchored.md`](../tasks/2026-07-19-per-device-signing-keys-registration-anchored.md).
 
 ---
 

--- a/.agents/docs/cryptographic-architecture.md
+++ b/.agents/docs/cryptographic-architecture.md
@@ -281,7 +281,7 @@ After rotation the old `inbox_address` stored in the receiver's `space_members` 
 > display update isn't dropped after a rotation), but the handler no longer acts
 > on the new key.
 >
-> **⚠️ KNOWN REGRESSION — multi-device (exposed 2026-07-19, fix in flight).**
+> **⚠️ MULTI-DEVICE — exposed 2026-07-19; sender-side fix implemented.**
 > This is more than a rare rotation edge case. Each device generates its OWN
 > space signing keypair (`spaceSyncService.ts` `generateEd448()`), so one user
 > signs space messages with a different key per device. The verified-signer
@@ -293,12 +293,25 @@ After rotation the old `inbox_address` stored in the receiver's `space_members` 
 > post signatures are nulled and processed anyway; control messages fail closed).
 > The vulnerable line was genuinely load-bearing for multi-device.
 >
-> The proper fix is neither keeping the spoofable rebinding nor just deleting it:
-> a member needs MULTIPLE verified inbox keys (one per device), bound through the
-> **authenticated device registration** the DM stack already trusts — not a
-> spoofable in-band announcement. That is a cross-platform shared/desktop design
-> change, above the scope of the #243 fix. An agent is working on it; this
-> section will be rewritten when it lands.
+> **Fix — signing/mailbox key split (implemented, sender-side).** The per-space
+> `inbox` key played two roles with opposite lifetimes: the MAILBOX (per-device
+> transport address, correctly regenerated per device) and the SIGNING identity
+> (per-user — the join key receivers bound). Space CREATE/JOIN now also store the
+> join key under a `signing` slot, the config-sync path preserves it instead of
+> letting the fresh per-device keypair overwrite it, and all space-message
+> signing uses `getSigningKey(spaceId)` = `signing` ?? `inbox` (the fallback
+> covers the join device and pre-migration state). No wire, receive-side, or
+> member-table change; the signing key already crossed devices inside the
+> E2E-encrypted config payload (and was discarded) — trust is unchanged from DMs
+> (all of a user's devices act as the user). Existing pre-fix second devices stay
+> broken until they re-add the space (acceptable for beta).
+>
+> **Durable follow-up (separate task):** a member holds MULTIPLE verified inbox
+> keys, new keys admitted only with a proof chained to the **authenticated device
+> registration** the DM stack already trusts. That also repairs the lost-join-key
+> case and enables true per-device keys. Cross-platform (shared + both apps).
+> Full analysis: quorum-mobile bug
+> `2026-07-19-multidevice-inbox-key-breaks-verified-signer-auth.md`.
 
 ### How Rotation Is Announced: `update-profile` (HISTORICAL — see note above)
 

--- a/.agents/docs/features/messages/message-signing-system.md
+++ b/.agents/docs/features/messages/message-signing-system.md
@@ -372,9 +372,18 @@ messageId   = SHA-256(fingerprint)
 
 Using the wrong type string causes `messageIdMismatch = true`, which clears the signature and treats the message as unsigned — even if the signature is perfectly valid.
 
+### Which key signs a space message (mailbox vs signing)
+
+Space messages are signed with a per-user **signing** key
+(`getSigningKey(spaceId)` = `signing` ?? `inbox`), NOT the per-device `inbox`
+(mailbox) key. A synced second device regenerates its `inbox` key, so signing
+with it would fail the receiver's verified-signer lookup and its control messages
+would be dropped. See [Multi-Device Signing](../../cryptographic-architecture.md#multi-device-signing-mailbox-key-vs-signing-key)
+for the full split, the desktop/mobile divergence, and the durable follow-up.
+
 ### Inbox Mismatch and Key Rotation
 
-The inbox mismatch check compares the sender's stored inbox address against the one in the envelope. This check must be **skipped for `update-profile`** messages because that message type is itself the key rotation announcement — the whole point is to update the stored address to the new one. See [Inbox Key Rotation](../../cryptographic-architecture.md#inbox-key-rotation) for full details.
+The inbox mismatch check compares the sender's stored inbox address against the one in the envelope. This check is **skipped for `update-profile`** messages so a display update isn't dropped after a key rotation. (Note: as of #243 the handler no longer updates the stored address from `update-profile` — it is display-only and authorized by the verified signer; the authoritative address comes from the verified join control. See [Inbox Key Rotation](../../cryptographic-architecture.md#inbox-key-rotation).)
 
 ```typescript
 const isUpdateProfile = decryptedContent.content.type === 'update-profile';

--- a/.agents/docs/features/security.md
+++ b/.agents/docs/features/security.md
@@ -388,6 +388,15 @@ Space owner identity is cryptographically tied to space creation keys:
 > composer hides the toggle for read-only channels (#242).
 > DMs stay session-anchored (PR #220). A branded `VerifiedSender` type makes
 > passing a raw `senderId` into these checks a compile error.
+>
+> **Multi-device:** verified-signer auth resolves a member from a single bound
+> key (the join key), so a second device — which generates its own per-space key
+> — would have all its control messages dropped. Space messages are therefore
+> signed with a per-user **signing** key shared across a user's devices
+> (`getSigningKey` = `signing` ?? `inbox`), while the per-device `inbox` key
+> stays the mailbox. Details + the desktop/mobile divergence + the durable
+> per-device-key follow-up: `cryptographic-architecture.md` → "Multi-Device
+> Signing".
 
 #### @everyone Mention Permission
 
@@ -550,6 +559,7 @@ User identity secured via WebAuthn passkeys:
 **Document Created**: 2025-11-08
 **Last Updated**: 2026-07-19
 **Major Updates**:
+- 2026-07-19: Multi-device — space messages signed with a per-user `signing` key (shared across a user's devices) so verified-signer auth works from second devices; `inbox` stays the per-device mailbox key. See crypto-architecture "Multi-Device Signing"
 - 2026-07-19: `update-profile` authorized by verified signer + never writes the announced key onto a member row (closes inbox_address poisoning → control-message impersonation) (#243)
 - 2026-07-19: Read-only-channel enforcement completed — verified-signer gate on the durable path and for embed/sticker, plus force-signed read-only sends and composer toggle-hide (#242)
 - 2026-07-19: Space control-message + @everyone authorization now keyed on the verified ed448 signer (not payload senderId)

--- a/.agents/docs/quorum-db-schema.md
+++ b/.agents/docs/quorum-db-schema.md
@@ -227,6 +227,13 @@ Quick reference for debugging and creating console snippets.
 }
 ```
 
+**`keyId` slots:** `owner`, `config`, `hub`, `inbox`, `signing`, plus the
+`<spaceAddress>` and `<groupAddress>` group keys. Note the split between `inbox`
+(per-DEVICE mailbox/transport key, regenerated on each device) and `signing`
+(per-USER identity key — the join key receivers bind; used to sign space
+messages via `getSigningKey` = `signing` ?? `inbox`). See
+`cryptographic-architecture.md` → "Multi-Device Signing".
+
 ---
 
 ### space_members
@@ -577,4 +584,4 @@ for (const s of stores) console.log(s, await countStore(s));
 
 ---
 
-*Last updated: 2026-05-20 — staleness audit fixes*
+*Last updated: 2026-07-19*

--- a/.agents/tasks/2026-07-19-per-device-signing-keys-registration-anchored.md
+++ b/.agents/tasks/2026-07-19-per-device-signing-keys-registration-anchored.md
@@ -1,0 +1,345 @@
+---
+type: task
+title: "Durable multi-device: per-device space signing keys, admitted via master-identity-signed device statements"
+status: DEEP-DIVE COMPLETE — spec ready; not yet implemented
+priority: high (follow-up to the interim signing-split fix)
+created: 2026-07-19
+severity: HIGH (security-critical — touches the verified-signer auth boundary)
+platforms: quorum-desktop + quorum-mobile + quorum-shared
+supersedes: the interim per-user `signing`-slot fix (branch fix-multidevice-signing-key)
+related:
+  - quorum-mobile .agents/bugs/2026-07-19-multidevice-inbox-key-breaks-verified-signer-auth.md (root analysis)
+  - .agents/bugs/2026-07-19-update-profile-inbox-poisoning-control-msg-impersonation.md (why in-band rebinding is banned)
+  - .agents/docs/cryptographic-architecture.md ("Inbox Key Rotation" section — carries the interim note)
+  - .agents/bugs/2026-01-09-space-owner-privacy-limitation.md (#111 — owner unverifiable by design)
+---
+
+# Durable multi-device: per-device signing keys via master-signed device statements
+
+> Deep-dive completed 2026-07-20 against real source on all three repos
+> (desktop branch `fix-multidevice-signing-key`, mobile branch
+> `fix/multidevice-space-signing-key`, shared `main`). Every claim below was
+> re-derived from code; file references are to those trees. The design changed
+> in one important way from the draft: the proof anchors to the **master
+> identity key directly**, not to a fetched device registration — see
+> "Key finding #2" for why that is both simpler and equally strong.
+
+## Why (context — unchanged from draft)
+
+Verified-signer auth (#241) maps a message's signing key → member via a SINGLE
+bound `inbox_address` per member (`resolveVerifiedSender`, shared
+`utils/messageAuth.ts:110`). Multi-device breaks this: each device generates
+its own per-space keypair, so a second device signs with a key no receiver's
+member table has seen, and its control messages (delete/edit/pin/mute,
+read-only posts, @everyone) are dropped.
+
+The **interim fix** (shipping first) makes all devices share one signing key
+(the join key) carried in the E2E-encrypted config payload. It unbreaks
+multi-device but: no per-device attribution or revocation, the shared private
+key crosses devices, and a lost join key breaks control ops until re-join.
+
+## Key findings from the deep-dive (verified in source)
+
+1. **What the device registration attests.** `UserRegistration = {
+   user_address, user_public_key, peer_public_key, device_registrations[],
+   signature }` where `user_address = base58btc(multihash(sha256(user_public_key)))`
+   and `signature` is ed448 by the **master user key** over the full device
+   list (SDK `ConstructUserRegistration`, sdk-channels `dist/index.js:1550`).
+   Each `DeviceRegistration` carries the device's X448 keys and its DM
+   `inbox_registration.inbox_address`, which is
+   `base58btc(multihash(sha256(device ed448 inbox pubkey)))` — the **same
+   derivation as shared `deriveInboxAddress`** (SDK `NewInboxKeyset`,
+   `dist/index.js:1539`). There is **no timestamp** in the registration
+   (freshness comes from the hub fetch), and **no client verifies the
+   registration signature today** (DM fan-out trusts the HTTPS response).
+
+2. **Every device holds the master ed448 private key.** Desktop: UserKeyset in
+   KeyDB id=2, used to sign every config upload (`ConfigService.saveConfig`).
+   Mobile: SecureStore `quorum.privateKey`, same use
+   (`services/config/configService.ts` `signConfigData`,
+   `services/onboarding/secureStorage.ts:59`). This is the pivotal fact: a
+   device can sign a statement **directly with the master key**, whose hash is
+   the `user_address` already present in every receiver's member row (from the
+   join broadcast). Chaining through the fetched registration adds a network
+   round-trip and an unverified-today signature check, but no security: the
+   registration's own root of trust IS the master key. So the proof anchors to
+   the master key; the registration stays involved only for the device list UI,
+   the revocation trigger, and the per-device tag (below).
+
+3. **Spaces already know the user's master address.** `participant.address` in
+   the join broadcast is the user address; member rows key on it; desktop's
+   kick flow calls `getUser(member.user_address)` (SpaceService.ts:870). No new
+   privacy exposure from binding statements to it (and the per-address device
+   list is already publicly fetchable from the hub).
+
+4. **Join binding mechanics (and a discovered pre-existing hole).** Desktop
+   verifies a join via `js_verify_point` (ratchet-slot possession) + an ed448
+   self-signature by the **announced inbox key itself** (MessageService.ts:3747),
+   then `saveSpaceMember` = unconditional IndexedDB `put` (db/messages.ts:1146).
+   Nothing binds `participant.address` to the master key → **any space member
+   holding a valid ratchet slot can re-broadcast a forged join claiming another
+   member's address with their own inbox key, overwriting the victim's binding**
+   (same class as #243, via join). Mobile is weaker still: its join handler
+   verifies **nothing** (WebSocketContext.tsx:708 saves the row as-is), and its
+   unauthenticated `leave` handler blanks a claimed member's `inbox_address`.
+   Desktop's `sync-members` also bulk-overwrites rows from a sync peer.
+   → Needs its own bug report + lead-dev ping (statically confirmed, not
+   runtime-tested). This task's design mitigates for announced keys (statements
+   are forgery-proof) but does NOT close the base join-binding hole; the
+   hardening (optional master signature inside the join participant blob,
+   verified when present, master-verified rows only overwritable by
+   master-signed data) reuses this task's machinery and should ride along or
+   immediately after.
+
+5. **Interim-fix state actually shipped.** Mobile evolved past the bug doc:
+   `signing` keys carry local provenance `origin | promoted | adopted`; `origin`
+   is never replaced, everything else yields to the blob on every config
+   receive; self member row re-anchored to the signing address idempotently
+   (spaceSyncService.ts:87-141). Desktop only handles the new-space path
+   (ConfigService.ts:110-145 runs under `!existingSpace`): no ongoing heal, no
+   promotion-at-save for pre-fix spaces, no self-row re-anchor. Divergence is
+   tolerable because receivers only ever needed the join binding, but the
+   durable migration must not assume the platforms hold identical `signing`
+   state.
+
+6. **Transport facts.** New hub **control** envelope types are wire-additive:
+   desktop's control chain (MessageService.ts:3747-4791) and mobile's switch
+   (WebSocketContext.tsx:707) silently ignore unknown types — old clients are
+   unaffected. Mobile's hub-log transport durably replays hub messages from a
+   seq cursor (offline catch-up covers control envelopes); desktop's P2P path
+   has no control-message replay, so late/offline desktop receivers need the
+   statements carried via member sync + on-connect re-broadcast. Desktop will
+   later migrate to hub-log (lead-confirmed), which makes replay uniform —
+   keep all statement logic transport-agnostic in shared.
+
+7. **Ratchet sharing.** A second device reuses the SAME triple-ratchet slot
+   (config sync copies `encryptionState`; only `inboxId` changes). Announcing
+   per-device signing keys does not touch the ratchet.
+
+## Goal (durable end state)
+
+A member's identity admits **multiple verified signing keys, one per device**.
+Each device signs space messages with its own per-space key (its existing
+per-device `inbox` mailbox key — no third keypair), admitted by receivers ONLY
+via a **device-key statement signed by the user's master identity key** and
+verified against the `user_address` already bound in the member table.
+Private signing keys never leave their device (strict improvement over the
+interim shared-key model). Revocation is first-class via the device-deletion
+flow. The interim `signing` slot is retired.
+
+## The design
+
+### Wire: two new hub CONTROL envelope types (sealed like join/leave)
+
+```jsonc
+// admit: "device D of user U signs space S with key K"
+{
+  "type": "announce-keys",
+  "userAddress": "...",         // must match an existing member row key
+  "userPublicKey": "hex",       // master ed448 pubkey; multihash must equal userAddress
+  "spaceId": "...",             // scope binding (no cross-space replay)
+  "deviceInboxAddress": "...",  // the device's DM inbox_address from UserRegistration
+                                 // (attribution + revocation handle; not verified against
+                                 // the registration at receive — self-scoped, see edges)
+  "spaceKeyPublicKey": "hex",   // K: this device's per-space ed448 signing pubkey
+  "timestamp": 1234567890,
+  "signature": "hex"            // ed448 by master key over the statement bytes
+}
+
+// revoke: "device D of user U is no longer trusted in space S"
+{
+  "type": "revoke-device",
+  "userAddress": "...", "userPublicKey": "hex", "spaceId": "...",
+  "deviceInboxAddress": "...", "timestamp": 123, "signature": "hex"
+}
+```
+
+Statement bytes = `utf8(DOMAIN_PREFIX + canonicalize({userAddress, spaceId,
+deviceInboxAddress, spaceKeyPublicKey?, timestamp}))` with distinct domain
+prefixes (`quorum:announce-keys:v1` / `quorum:revoke-device:v1`) so these
+signatures can never collide with config-upload or registration signatures
+made by the same key. Control envelopes (not content messages): no feed
+pollution, no ratchet advance, idempotent re-broadcast, ignored by old clients.
+
+### Receive-side verification (fail closed at every step)
+
+1. `deriveInboxAddress(userPublicKey) === userAddress` (self-certifying id;
+   same multihash derivation as user_address — verified identical in SDK).
+2. ed448 verify `signature` over statement bytes (ed448 stays in each app,
+   bytes-building in shared — the `messageAuth.ts` pattern).
+3. `timestamp <= now + 30s` skew guard (see edges: future-dated ADD would
+   otherwise be revocation-proof) and LWW against the stored row/tombstone.
+4. Member gate: a row for `userAddress` must exist and not be kicked.
+5. Upsert admission `{spaceId, userAddress, deviceInboxAddress,
+   inboxAddress: deriveInboxAddress(spaceKeyPublicKey), spaceKeyPublicKey,
+   timestamp, statement}` — store the **verbatim statement** so admissions can
+   be re-gossiped (member sync) and re-verified by anyone. `revoke-device`
+   writes a tombstone that beats any admission with an older timestamp and is
+   never deleted (a re-added device gets fresh DM keys → new tag; same-tag
+   re-admit needs a newer-ts announce, which only the master key can mint).
+6. **Never write member rows from statements.** The member row's
+   `inbox_address` (join binding) is untouched — poisoning-proof by
+   construction (#243 lesson).
+
+### Resolver: key-set reverse lookup (quorum-shared)
+
+`resolveVerifiedSender(publicKeyHex, members, deviceKeys?)` — third param
+OPTIONAL (additive; mobile pinned to an older shared build keeps compiling):
+
+1. Current path: member whose `inbox_address` matches, not kicked → address.
+2. Else: non-revoked admission whose `inboxAddress` matches → its member row
+   (must exist, not kicked) → address.
+
+`authorizeControlMessage` unchanged downstream. Covers remove/edit/pin/mute,
+read-only posts, @everyone gates, and `isUpdateProfileAuthorized` on both
+platforms automatically (all funnel through the resolver).
+
+### Send-side
+
+On space connect (same cadence slot as the existing on-connect
+`update-profile` broadcast), each device broadcasts its `announce-keys` for
+that space — idempotent, cheap, self-healing for receivers that missed it —
+then signs everything with its **own** per-device key (`inbox`). The interim
+`getSigningKey` fallback (`signing ?? inbox`) stays during rollout and is
+removed at cleanup. The join device's per-device key IS the join key, so its
+announce also tags the join binding with a `deviceInboxAddress` for revocation.
+
+### Revocation trigger
+
+Desktop Security modal already: `removeDevice` → `ConstructUserRegistration(
+userKeyset, remainingDevices, [])` → re-upload (useUserSettings.ts:522). Hook
+in there: for each of the user's spaces, broadcast `revoke-device` with the
+removed device's `inbox_registration.inbox_address` (the UI already has it).
+Mobile's device-management flow mirrors this when it lands there. Offline
+receivers catch up via mobile hub-log replay / desktop member-sync statements
+/ the next time any of the user's devices re-announces (receivers can also
+lazily drop admissions whose device disappears from a registration fetch —
+optional TTL hardening, not required for correctness).
+
+### Storage
+
+- **Desktop:** new IndexedDB store `space_member_devices`, keyPath
+  `[spaceId, inboxAddress]` (reverse lookup is the native shape), index on
+  `[spaceId, userAddress]`; DB version bump. Verify blocks + control handlers
+  in `MessageService.ts` load admissions alongside members.
+- **Mobile:** MMKV adapter mirror (`getSpaceMemberDevices` /
+  `saveSpaceMemberDevice` / tombstones), receive in `WebSocketContext.tsx`
+  control switch, verify via `spaceMessageAuth.ts`.
+- **Shared:** types + pure logic only (no storage — storage adapters are
+  per-app, matching today's split).
+
+## What lives in quorum-shared (the drift-proof core)
+
+- `SpaceMemberDevice` type + statement types; control-type name constants +
+  domain prefixes.
+- `buildDeviceKeyStatementBytes(...)` (canonical bytes both platforms sign and
+  verify — byte-identical or auth splits, exactly like `buildMessageFingerprint`).
+- `verifyDeviceKeyStatement(...)`: address-derivation check, timestamp/skew +
+  LWW/tombstone verdict; ed448 verification injected/adjacent per app.
+- `resolveVerifiedSender` extended with the optional `deviceKeys` param.
+- Tests for all of it (statement forgery, cross-space/user replay, future-ts,
+  tombstone ordering, kicked member, revoked key).
+
+All **additive** → ship shared alone; mobile catches up on its next pinned
+bump (per the additive-vs-breaking gut-check).
+
+## Edge cases (resolved)
+
+- **Revocation lifecycle** — see above. Residuals stated honestly: (a) a
+  device that still physically holds the master key is not cryptographically
+  stripped by revocation (it can sign new statements; registration deletion
+  doesn't remove master-key possession either) — device revocation protects
+  retired/lost devices, not an actively-malicious master-key holder; that
+  boundary is identical to today's trust model (master key = account).
+  (b) The 30s future-ts guard prevents a compromised device pre-minting a
+  revocation-proof ADD.
+- **Lost join key** — solved structurally: post-flip no device needs the join
+  key; each announces its own. Also unbricks the mobile bug's documented
+  "third device locked on a wrongly-promoted signing key" race.
+- **Ordering** — control-before-content within a session (announce sent on
+  connect, before any signed sends); unknown-key control messages still drop
+  fail-closed; re-announce every connect + hub-log replay (mobile) + statement
+  carriage in member sync (desktop) close the gaps. No receive-side buffering.
+- **Late joiners** — extend desktop `sync-members` additively with the stored
+  statements; receivers RE-VERIFY each statement before adopting (statements
+  are self-certifying, so peer-asserted sync data can carry them safely —
+  unlike the raw member rows sync-members asserts today).
+- **Kicked members** — resolver's member gate keeps `isKicked` fail-closed for
+  both paths; kick's ratchet re-key already cuts decryption.
+- **Per-space vs per-user** — statements are per-(user, device, space); one
+  announce per space per device, broadcast on connect. No global fan-out.
+- **Owner (#111)** — untouched: `authorizeControlMessage` still sets
+  `isSpaceOwner: false`; owner authority remains role-based. Owner's devices
+  announce like anyone's.
+- **Repudiability** — untouched: this changes which keys are ADMITTED, not
+  whether signing is required; unsigned-edit-of-unsigned exception intact.
+- **Config payload** — statements do NOT ride the config blob (no size/churn
+  growth, no LWW-merge problem: each device announces itself; nobody needs a
+  global key inventory). The blob eventually stops carrying `signing`.
+- **Migration from interim `signing`** — zero-gap: receive-side (resolver +
+  handlers) ships first on both platforms while everyone still signs with the
+  join-bound key (join binding keeps resolving); send-side flips per device
+  only after it broadcasts its announce; `signing` fallback read retained one
+  release, then slot dropped from create/join/sync (per-platform divergence in
+  interim heal logic — finding #5 — becomes irrelevant once the flip lands).
+  Beta = clean cut-over per prior decisions.
+
+## Answers to the draft's open questions
+
+1. **What does registration attest / can receivers fetch it?** Attests the
+   master-signed device list incl. each device's DM `inbox_address` (= hash of
+   its DM ed448 key). Fetchable by `user_address` (member rows have it). But
+   the durable design doesn't need the fetch in the verify path — the master
+   key itself (held by every device) signs the statement, and the member table
+   already anchors its hash. Registration remains the device-list UI +
+   revocation trigger + `deviceInboxAddress` tag source.
+2. **Announcement shape** — see Wire section: master-signed, domain-separated,
+   space-scoped statement; verifiable offline with zero trust in payload
+   senderId or transport.
+3. **Revocation transport + authority** — master-signed `revoke-device` per
+   space, triggered by the existing device-deletion flow; tombstoned LWW;
+   catch-up via hub-log replay (mobile), member-sync statements (desktop),
+   re-announce cadence; optional registration TTL cross-check as hardening.
+4. **Schema/wire bump?** — No wire version bump: new control types are ignored
+   by old clients (verified both platforms); shared change is additive;
+   desktop needs an IndexedDB store (version bump of the local DB only);
+   mobile a new MMKV keyspace. Clean cut-over acceptable for beta.
+
+## Cross-repo scope + sequencing (vertical slices)
+
+1. **quorum-shared** — types, statement bytes/verify, resolver extension,
+   tests. Additive publish. (Observable: shared tests green; both apps build.)
+2. **Receive-side, desktop + mobile** — control handlers, admission storage,
+   resolver wired with admissions, member-sync statement carriage (desktop).
+   Observable: everything works exactly as before (interim model untouched);
+   new tests prove forged/replayed/revoked statements are rejected.
+3. **Send-side flip, both platforms** — on-connect announce + per-device
+   signing + Security-modal revocation broadcast. Observable (the real test):
+   fresh second device (no shared `signing`) deletes/edits/pins from day one;
+   deleting that device from Security settings makes its subsequent control
+   ops drop on other clients.
+4. **Cleanup** — retire `signing` slot writes + fallback, rewrite
+   `cryptographic-architecture.md` multi-device section, resolve the mobile
+   bug report, file the join-binding hardening follow-up.
+
+## Discovered issues to handle OUTSIDE this task
+
+- **Join-binding hijack** (finding #4): forged join / unauthenticated leave /
+  sync-members assertion can rewrite bindings. Filed:
+  `.agents/bugs/2026-07-20-join-binding-hijack-unauthenticated-member-rebind.md`.
+  Needs a lead-dev ping (Telegram, short). Hardening rider reuses this task's
+  master-signature machinery.
+- Desktop interim branch lacks mobile's heal/promotion parity (finding #5) —
+  acceptable if this durable task lands promptly; revisit only if the durable
+  work slips.
+
+## Implementation-time verifications (small, listed so they aren't lost)
+
+- Mobile hub-log seq ordering: confirm control envelopes replay in-order
+  relative to content messages after offline catch-up.
+- Exact on-connect broadcast hook sites on each platform (desktop: the
+  update-profile-on-connect site; mobile: its profile broadcast on socket up).
+- `revoke-device` fan-out cost for users in many spaces (batch per connect).
+- Desktop DB migration bump mechanics for the new store.
+
+*Last updated: 2026-07-20*

--- a/.agents/tasks/2026-07-19-space-deletion-ghost-cleanup.md
+++ b/.agents/tasks/2026-07-19-space-deletion-ghost-cleanup.md
@@ -1,0 +1,158 @@
+---
+type: task
+title: "Space deletion: instant/offline UX via action queue + tombstone-driven multi-device cleanup (kills ghost spaces)"
+status: open — design agreed, implement on a SEPARATE branch (not fix-multidevice-signing-key)
+priority: high
+created: 2026-07-19
+severity: data-integrity + UX (blocking-leave, no offline; garbage accumulation compounds #108)
+spans-repos:
+  - quorum-desktop
+  - quorum-mobile (mirror — same add-only sync bug, tracked as mobile M2)
+related:
+  - .agents/bugs/2025-12-09-encryption-state-evals-bloat.md (#108 — 2MB/created-space bloat this compounds)
+  - .agents/docs/features/action-queue.md (delete-space is "not yet integrated"; recommended pattern lines 731-753)
+  - ../../quorum-mobile/.agents/reports/2026-07-19-signing-key-multidevice-hunt-tracker.md (M2 add-only sync; D7 corrupted-space delete)
+---
+
+# Space deletion: instant + offline UX, and stop leaking ghost spaces
+
+## Evidence (live desktop account, 2026-07-19)
+
+- `config.spaceIds` = 4 (UI truth: 2 created + 2 joined); `getSpaces()` = 13 →
+  **9 ghost space rows**; `analyzeEncryptionStates()` = 10 bloated ~2MB states
+  (8 are ghosts ≈ 16MB local garbage) + 1 `undefined/undefined` corrupt row +
+  history-duplicate rows. All invisible in the UI until inspected.
+
+## Three root problems (confirmed in code)
+
+1. **Leave is synchronous/blocking, no offline.** `useSpaceLeaving.leaveSpace`
+   does `await deleteSpace()` THEN closes the modal
+   (`useSpaceLeaving.ts:50`). `SpaceService.deleteSpace` (`:563`) calls the
+   network `postHubDelete` (`:619`) and only cleans local rows afterward
+   (`:654-685`). Offline / network failure → throws → modal stays open, nothing
+   happens. `delete-space` is NOT integrated with the action queue
+   (action-queue.md:126, listed under "Potential Future Actions").
+2. **Config-apply is add-only → ghosts.** `ConfigService.getConfig` loops the
+   synced config's spaces and only ADDS missing ones (`ConfigService.ts:110`,
+   `if (!existingSpace)`). Nothing removes a local space that dropped out of the
+   config. So a space deleted on device B is never cleaned off device A (mirrors
+   mobile M2). This is the ghost factory.
+3. **Ambiguity: "DB space not in config" is overloaded.** The existing "Restore
+   Spaces" button (`useSpaceRecovery.ts:47`) treats that exact set as
+   "lost → re-add to config"; naive reconciliation would treat it as
+   "deleted → purge." They contradict. Resolve with explicit tombstones.
+
+Secondary: D7 corrupted space (missing hub key) hard-throws before cleanup →
+untrappable debris. Unbounded `encryption_states` history (`messages.ts:1395`
+always appends) → per-conversation row growth.
+
+## Design constraint (from lead) and how it is honored
+
+> "Delete locally only if the deletion actually propagated — otherwise other
+> users still see the space and you've lost it locally."
+
+Honored via **pre-seal + durable queue**, not blocking:
+- At click, WHILE the space keys exist, build and SEAL the leave: the hub 'leave'
+  control envelope + the signed `postHubDelete` payload. These are ciphertext +
+  signatures only (no private keys) — safe to store in the queue per its
+  security rule.
+- Then optimistically wipe local + close modal. Local wipe can no longer strand
+  the leave, because the sealed payload is already captured and durable.
+- The queue guarantees eventual propagation (retry up to 3 days, offline-safe).
+  So propagation is guaranteed-eventual rather than blocked-on. Residual: if the
+  queued leave permanently fails, best-effort semantics (left locally, server
+  membership may linger) — same contract the doc already accepts, surfaced via
+  the offline banner / failed-action state.
+
+This SUPERSEDES the earlier "gate local wipe on network success" idea: the
+action-queue integration is the correct mechanism and gives instant + offline
+UX without the strand risk.
+
+## Fix — vertical slices (each ends in an observable outcome)
+
+### Slice 1 — Instant, offline-capable leave (action-queue integration)
+Outcome: clicking Delete/Leave closes the modal and removes the space from the
+sidebar IMMEDIATELY, works offline, and the leave still reaches the hub when
+back online.
+
+- Refactor `SpaceService.deleteSpace` into: (a) `buildLeavePayload(spaceId)` —
+  seals the leave envelope + `postHubDelete` payload from local keys (returns
+  plain data, no private keys); (b) `purgeSpaceLocal(spaceId)` — the local
+  cleanup block from `:654-685` (states/keys/members/messages/row), network-free.
+- New flow in `leaveSpace`:
+  1. `buildLeavePayload` (needs keys — do first).
+  2. Optimistic: tombstone id in config `deletedSpaceIds` + remove from
+     `spaceIds`/`items` → enqueue `save-user-config`; remove from React Query
+     cache (sidebar updates); `purgeSpaceLocal`; navigate away + close modal.
+  3. Enqueue `delete-space-notify` with the sealed payload → handler POSTs
+     hub-delete + sends the leave envelope, retrying/offline per the queue.
+- Follow the `kick-user` handler shape (already queued, similar crypto).
+
+### Slice 2 — Tombstone-driven multi-device reconciliation (kills ghosts safely)
+Outcome: a space deleted on one device disappears (with its storage) on the
+other device after sync; `getSpaces()` stops diverging from `config.spaceIds`.
+
+- Add `deletedSpaceIds` to the synced config (mirror the existing
+  `deletedBookmarkIds` / `deletedUserNoteAddresses` tombstone pattern, including
+  the reset-after-successful-sync lifecycle with enough retention for all
+  devices to catch up).
+- On config apply, after the add-loop, `purgeSpaceLocal` for any local space
+  whose id is in `config.deletedSpaceIds`. **Only tombstoned ids — never "absent
+  from config."** This defuses the transient/partial-config wipe risk AND the
+  Restore-button conflict.
+- One-time heal for already-affected users: since existing ghosts predate
+  tombstones, provide a guarded manual sweep (or a bounded migration) that uses
+  `config.spaceIds` as oracle — but gate hard (valid, non-empty config; the
+  `keep.size===0` abort). Keep this conservative; prefer tombstones going forward.
+
+### Slice 3 — Delete always works, even for corrupted spaces (D7)
+Outcome: the "Bb"-style corrupted space (missing hub key) can be removed; Delete
+never dead-ends with "incomplete configuration."
+
+- When `buildLeavePayload` can't seal (missing hub key), skip the network notify
+  and still run the optimistic local purge + tombstone. Surface a quiet note
+  ("couldn't notify the server; removed locally"). NOT a separate settings
+  button — the same Delete button, graceful fallback.
+
+### Slice 4 — Reconcile the "Restore Spaces" button with tombstones
+Outcome: the recovery tool can no longer resurrect a space you deleted.
+
+- `restoreMissingSpaces` must exclude tombstoned ids (`config.deletedSpaceIds`)
+  from the "restore" set. Today it re-adds any DB-not-in-config space (it already
+  skips >500KB states, so not the 2MB ghosts, but it WOULD resurrect small
+  deleted ones). Decide with lead: keep as a narrow sync-loss recovery tool, or
+  retire once reconciliation makes sync-loss rare.
+
+### Slice 5 (optional, lower priority) — Bound encryption-state history
+Outcome: storage stops growing per conversation. Cap/prune `encryption_states`
+history (keep latest N per conversationId). Independent of the above.
+
+## Cross-platform
+Mobile has the identical add-only bug (M2) and no delete-space queueing. Mirror
+the tombstone + reconciliation contract so behaviour matches; `deletedSpaceIds`
+is a config/wire addition both apps must agree on — additive, but confirm with
+the lead alongside #108. Do NOT change the encryption-state blob shape here.
+
+## Test plan
+1. Online leave: modal closes + sidebar updates instantly; hub-delete fires;
+   local rows fully purged.
+2. Offline leave: modal closes + space vanishes instantly; `delete-space-notify`
+   sits in the queue; on reconnect it POSTs; other device then reconciles.
+3. Multi-device: delete on A → B purges local rows + state after sync;
+   `getSpaces()` on B matches `config.spaceIds`.
+4. Reconciliation safety: a failed/empty/partial config fetch removes NOTHING
+   (only tombstoned ids are ever purged).
+5. Corrupted space (missing hub key): Delete removes it locally without throwing;
+   does not reappear.
+6. Restore button: a tombstoned (deleted) space is NOT offered for restore; a
+   genuinely sync-lost, non-tombstoned space still is.
+7. Regression: DM states never touched by reconciliation.
+
+## Non-goals / relation to #108
+Does NOT fix the 2MB-per-created-space creation bloat (#108 — separate
+blob-contract decision). Even ghost-free, 2+ created spaces approach the ~4MB
+upload limit until #108 lands. This task stops accumulation + fixes the leave UX;
+#108 fixes per-space size. Implement on a SEPARATE branch, not
+`fix-multidevice-signing-key`.
+
+*Last updated: 2026-07-19*

--- a/src/dev/tests/services/MessageService.unit.test.tsx
+++ b/src/dev/tests/services/MessageService.unit.test.tsx
@@ -999,6 +999,37 @@ describe('MessageService - Unit Tests', () => {
     });
   });
 
+  // Multi-device: a synced second device regenerates the per-device `inbox`
+  // (mailbox) key, but must SIGN with the per-user `signing` key (the join key
+  // receivers bound), else verified-signer auth drops its control messages. The
+  // join device / pre-migration state has no `signing` key → fall back to `inbox`.
+  describe('3h. getSigningKey() - per-user signing key selection (multi-device)', () => {
+    const signingKey = { spaceId: 'space', keyId: 'signing', address: 'a', publicKey: 'signpub', privateKey: 'signpriv' };
+    const inboxKey = { spaceId: 'space', keyId: 'inbox', address: 'b', publicKey: 'inboxpub', privateKey: 'inboxpriv' };
+
+    it('signs with the per-user signing key when present', async () => {
+      mockDeps.messageDB.getSpaceKey = vi
+        .fn()
+        .mockImplementation((_s: string, keyId: string) =>
+          Promise.resolve(
+            keyId === 'signing' ? signingKey : keyId === 'inbox' ? inboxKey : undefined
+          )
+        );
+      const key = await (messageService as any).getSigningKey('space');
+      expect(key.publicKey).toBe('signpub');
+    });
+
+    it('falls back to the inbox (mailbox) key when no signing key exists', async () => {
+      mockDeps.messageDB.getSpaceKey = vi
+        .fn()
+        .mockImplementation((_s: string, keyId: string) =>
+          Promise.resolve(keyId === 'inbox' ? inboxKey : undefined)
+        );
+      const key = await (messageService as any).getSigningKey('space');
+      expect(key.publicKey).toBe('inboxpub');
+    });
+  });
+
   describe('4. encryptAndSendToSpace() - Hub Message Helper', () => {
     const createTestMessage = () =>
       ({

--- a/src/services/ConfigService.ts
+++ b/src/services/ConfigService.ts
@@ -127,6 +127,23 @@ export class ConfigService {
             await this.messageDB.saveSpaceKey(key);
           }
 
+          // Preserve the join-bound key as the per-USER SIGNING identity before
+          // the `inbox` (mailbox) slot is overwritten below with a fresh
+          // per-DEVICE keypair. Receivers verify control messages against the
+          // join key, so a second device must keep signing with it. A
+          // post-migration uploader carries an explicit `signing` slot (already
+          // saved by the loop above); older uploads only carry `inbox`, so
+          // derive `signing` from it.
+          if (!space.keys.find((k) => k.keyId === 'signing')) {
+            const syncedInbox = space.keys.find((k) => k.keyId === 'inbox');
+            if (syncedInbox) {
+              await this.messageDB.saveSpaceKey({
+                ...syncedInbox,
+                keyId: 'signing',
+              });
+            }
+          }
+
           const reg = (await this.apiClient.getSpace(space.spaceId)).data;
           this.spaceInfo.current[space.spaceId] = reg;
 

--- a/src/services/InvitationService.ts
+++ b/src/services/InvitationService.ts
@@ -747,6 +747,21 @@ export class InvitationService {
           new Uint8Array(inboxPair.private_key)
         ).toString('hex'),
       });
+      // The join key is also the per-USER SIGNING identity that receivers bind
+      // in their member table (the join broadcast). Store it under `signing` so
+      // it survives a second device regenerating the per-device `inbox`
+      // (mailbox) key on config sync.
+      await this.messageDB.saveSpaceKey({
+        spaceId: space.spaceId,
+        keyId: 'signing',
+        address: inboxAddress,
+        publicKey: Buffer.from(new Uint8Array(inboxPair.public_key)).toString(
+          'hex'
+        ),
+        privateKey: Buffer.from(
+          new Uint8Array(inboxPair.private_key)
+        ).toString('hex'),
+      });
       // Clear any tombstones from a previous join to allow messages to sync
       await this.messageDB.clearTombstonesForSpace(space.spaceId);
       await this.messageDB.saveSpace(space);

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -716,7 +716,7 @@ export class MessageService {
           } as Message;
 
           // Sign (non-repudiable — required for profile updates)
-          const inboxKey = await this.messageDB.getSpaceKey(s.spaceId, 'inbox');
+          const inboxKey = await this.getSigningKey(s.spaceId);
           message.publicKey = inboxKey.publicKey;
           message.signature = Buffer.from(
             JSON.parse(
@@ -984,6 +984,23 @@ export class MessageService {
     return space.groups
       ?.find((g) => g.channels.find((c) => c.channelId === channelId))
       ?.channels.find((c) => c.channelId === channelId);
+  }
+
+  /**
+   * The key to SIGN space messages with. The per-space `inbox` key plays two
+   * roles with opposite lifetimes: the MAILBOX (per-device transport address,
+   * regenerated on each device) and the SIGNING identity (per-user, the join
+   * key that receivers bound in their member table). A synced second device has
+   * a fresh `inbox` key no receiver has seen, so signing with it fails the
+   * verified-signer reverse-lookup and the message is dropped. The `signing`
+   * slot holds the join key across devices; fall back to `inbox` for the join
+   * device and pre-migration state (where the two keys are identical).
+   */
+  private async getSigningKey(spaceId: string) {
+    return (
+      (await this.messageDB.getSpaceKey(spaceId, 'signing')) ??
+      (await this.messageDB.getSpaceKey(spaceId, 'inbox'))
+    );
   }
 
   /**
@@ -5302,7 +5319,7 @@ export class MessageService {
         !space?.isRepudiable ||
         (space?.isRepudiable && !effectiveSkipSigning)
       ) {
-        const inboxKey = await this.messageDB.getSpaceKey(spaceId, 'inbox');
+        const inboxKey = await this.getSigningKey(spaceId);
         message.publicKey = inboxKey.publicKey;
         message.signature = Buffer.from(
           JSON.parse(
@@ -5445,7 +5462,7 @@ export class MessageService {
         // gains a signature on edit. In a non-repudiable space the original is
         // always signed, so edits are too (consistent with the space rule).
         if (shouldSignEdit(originalMessage)) {
-          const inboxKey = await this.messageDB.getSpaceKey(spaceId, 'inbox');
+          const inboxKey = await this.getSigningKey(spaceId);
           message.publicKey = inboxKey.publicKey;
           message.signature = Buffer.from(
             JSON.parse(
@@ -5561,7 +5578,7 @@ export class MessageService {
 
         // Enforce non-repudiability
         if (!space?.isRepudiable || (space?.isRepudiable && !skipSigning)) {
-          const inboxKey = await this.messageDB.getSpaceKey(spaceId, 'inbox');
+          const inboxKey = await this.getSigningKey(spaceId);
           message.publicKey = inboxKey.publicKey;
           message.signature = Buffer.from(
             JSON.parse(
@@ -5641,7 +5658,7 @@ export class MessageService {
 
         // Sign (same pattern as pin messages)
         if (!space?.isRepudiable || (space?.isRepudiable && !skipSigning)) {
-          const inboxKey = await this.messageDB.getSpaceKey(spaceId, 'inbox');
+          const inboxKey = await this.getSigningKey(spaceId);
           message.publicKey = inboxKey.publicKey;
           message.signature = Buffer.from(
             JSON.parse(
@@ -5714,7 +5731,7 @@ export class MessageService {
         } as Message;
 
         // Enforce non-repudiability (required for profile updates to verify sender)
-        const inboxKey = await this.messageDB.getSpaceKey(spaceId, 'inbox');
+        const inboxKey = await this.getSigningKey(spaceId);
         message.publicKey = inboxKey.publicKey;
         message.signature = Buffer.from(
           JSON.parse(

--- a/src/services/SpaceService.ts
+++ b/src/services/SpaceService.ts
@@ -395,6 +395,20 @@ export class SpaceService {
         'hex'
       ),
     });
+    // The join key is also the per-USER SIGNING identity that receivers bind in
+    // their member table. Store it under `signing` so it survives a second
+    // device regenerating the per-device `inbox` (mailbox) key on config sync.
+    await this.messageDB.saveSpaceKey({
+      spaceId: spaceAddress,
+      keyId: 'signing',
+      address: inboxAddress,
+      publicKey: Buffer.from(new Uint8Array(inboxPair.public_key)).toString(
+        'hex'
+      ),
+      privateKey: Buffer.from(new Uint8Array(inboxPair.private_key)).toString(
+        'hex'
+      ),
+    });
     await this.messageDB.saveSpaceKey({
       spaceId: spaceAddress,
       keyId: groupAddress,


### PR DESCRIPTION
## The bug

Each device generates its own per-space `inbox` keypair on sync, so one user signs space messages with a **different key per device**. Verified-signer authorization (#241) maps a signing key back to a member via a single bound `inbox_address` (the join key), so control messages (delete/edit/pin/mute, read-only posts, @everyone) sent from a **second device** fail the reverse lookup and are dropped everywhere. Ordinary posts still land (an unverifiable post signature is nulled and processed anyway); only signature-gated actions fail. The `update-profile` inbox rewrite that used to paper over this was removed as a poisoning vector (#243), leaving no rebinding path.

## The fix (interim, sender-side)

The per-space `inbox` key was doing two jobs with opposite lifetimes: the **mailbox** (per-device transport address) and the **signing identity** (per-user — the join key receivers bound). Split them:

- A per-user **`signing`** slot holds the join key. Space CREATE (`SpaceService`) and JOIN (`InvitationService`) store it; config-sync (`ConfigService`) preserves it instead of letting the fresh per-device keypair overwrite it.
- All six space-message signing sites use `getSigningKey(spaceId)` = `signing` ?? `inbox` (the fallback covers the join device and pre-migration state). The two mailbox sites (hub delete, inbox cleanup) stay on the per-device `inbox` key.

No wire, receive-side, or member-table change — receivers already verify against whatever key signed the message; only *which key the sender uses* changed. The signing private key crossing devices is not new exposure: it already travelled inside the E2E-encrypted config payload. Trust is unchanged from DMs (all of a user's devices act as the user).

## Scope / staging (deliberate)

- **New** multi-device setups are fixed by this change on both platforms.
- **Desktop is intentionally minimal** (no heal for already-broken pre-fix second devices); **mobile ships a fuller interim heal** (provenance tags + heal-on-sync + promotion + self-row re-anchor). The divergence is cosmetic recovery-UX, fully interoperable — documented in `cryptographic-architecture.md` → "Multi-Device Signing".
- The **durable** design (each device its own key, admitted via a master-identity-signed device statement) is the near-term next task; it heals everyone on cut-over and converges both platforms. Spec: `.agents/tasks/2026-07-19-per-device-signing-keys-registration-anchored.md`. It should also close the separate join-binding hole (`.agents/bugs/2026-07-20-join-binding-hijack-unauthenticated-member-rebind.md`).

## Tests

`MessageService.unit.test.tsx` §3h: `getSigningKey` selects the per-user signing key when present and falls back to `inbox` otherwise. Full suite: 296/296 service tests pass; `tsc --noEmit` clean.

## Docs

Documents the mailbox/signing split as a first-class crypto-architecture section (with the desktop/mobile divergence table), cross-referenced from the security and message-signing docs, plus the `space_keys` `signing` slot in the schema doc. Also carries related security-workstream tracking (durable spec, join-binding bug, and a config-bloat note).