### PR TITLE
feat: per-device signing keys (desktop receive-side)

### DIFF
--- a/.agents/bugs/2026-07-20-announce-keys-flooding-unbounded-admissions.md
+++ b/.agents/bugs/2026-07-20-announce-keys-flooding-unbounded-admissions.md
@@ -1,0 +1,102 @@
+---
+type: bug
+title: "announce-keys flooding: a malicious member can grow the per-device admission store without bound (needs a non-destructive cap)"
+status: OPEN — known limitation, deliberately shipped without a cap; needs a solid, non-evicting fix (likely a lead-dev call)
+created: 2026-07-20
+severity: LOW (member-only DoS: storage/perf degradation, no impersonation, no data loss)
+platforms: quorum-desktop + quorum-mobile (+ shared owns MAX_DEVICES_PER_MEMBER)
+related:
+  - .agents/tasks/2026-07-19-per-device-signing-keys-registration-anchored.md (the feature; lists the cap as a pre-send-side prerequisite)
+  - quorum-shared src/utils/deviceKeys.ts (MAX_DEVICES_PER_MEMBER constant, currently unused)
+---
+
+# announce-keys flooding → unbounded per-device admission store
+
+> Surfaced 2026-07-20 during code review of the desktop receive-side slice.
+> A first attempt at an evict-oldest cap was written and then REJECTED because
+> it silently deleted legitimate in-use devices (see "Why the naive fix is
+> wrong"). Filing this so the real fix is designed deliberately, not rushed.
+
+## The issue
+
+Per-device signing keys are admitted by a receiver whenever a valid
+`announce-keys` statement arrives (master-signed, self-certifying identity,
+30s skew, LWW — see `verifyDeviceKeyStatement` in shared). Each admission is
+stored one row per device tag in `space_member_devices`, and
+`resolveVerifiedSender` scans a space's rows on every gated receive
+(control message / read-only post / @everyone / update-profile).
+
+Nothing bounds how many admissions a single member can create. A member can
+sign an unlimited number of valid `announce-keys`, each with a fresh
+`deviceInboxAddress` + `spaceKeyPublicKey`, and flood them. Every receiver
+stores every one, so:
+
+- the local `space_member_devices` store grows without bound, and
+- the resolver's per-message scan degrades toward O(flood size).
+
+## Reachability + severity
+
+- **Reachable as soon as the receive-side ships.** A member does NOT need our
+  official send-side UI: the statement format is open-source, they hold their
+  own master key, and they hold the space hub key (they are a member). So they
+  can hand-craft and seal valid `announce-keys` at will.
+- **Low severity.** The flood is self-attributed (every admission carries the
+  attacker's OWN master `userAddress` — it can never resolve to a victim, so no
+  impersonation). Impact is limited to storage bloat + slower control-message
+  auth on other clients. No data loss. Requires a space member. Acceptable for
+  beta as a known limitation.
+
+## Why the naive fix (evict-oldest cap) is WRONG — do not reintroduce it
+
+The tempting fix — "cap live admissions per member at N, evict the oldest" —
+was written and reverted because it breaks the feature it supports:
+
+- **It deletes legitimate, in-use devices.** A user at the cap who adds one
+  more device would have their oldest device's key deleted. If that device is
+  still in use, its deletes/edits/pins silently stop being honored everywhere.
+- **Thrashing.** Devices re-announce on every reconnect, so an evicted-but-active
+  device re-adds itself and bumps off a different one — with many active devices
+  they knock each other out indefinitely.
+- **Punishes honest users for an attacker's behavior.** The whole point of
+  per-device keys is durable multi-device; a mechanism that can silently drop a
+  working device contradicts the feature.
+- The `MAX_DEVICES_PER_MEMBER = 10` value floated for it is also arbitrary and
+  far too low for a real per-user device count over time.
+
+## Constraints a good fix MUST satisfy
+
+1. **Never delete or break a device that is still in use.** The failure mode for
+   hitting any limit must fall on the *attacker's excess* or a *brand-new*
+   admission, never on an already-working device.
+2. **Bound storage + resolver scan** against a malicious member.
+3. **Distinguish honest growth from a flood** (or make the honest ceiling so
+   high no real user ever hits it).
+
+## Candidate directions (design deliberately; likely a lead-dev call)
+
+- **Reject-new above a very high sanity bound** (e.g. 32–64 live admissions per
+  member). Existing devices are never touched; only implausibly-many NEW
+  admissions are refused. Simple; the only cost is a device-rich attacker (or an
+  extremely unusual real user) can't add beyond the bound.
+- **Rate-limit `announce-keys` per member** (e.g. N new device tags per time
+  window) instead of a hard total — bounds flood velocity without a hard ceiling.
+- **Anchor admissions to the authenticated device registration** and lazily drop
+  admissions whose `deviceInboxAddress` is not in the member's current
+  registration (TTL / registration cross-check). This is the strongest option:
+  it ties the admission set to the user's real device list, so a flood of
+  fabricated device tags is dropped on the next registration fetch. It also
+  dovetails with the join-binding hardening
+  (`2026-07-20-join-binding-hijack-unauthenticated-member-rebind.md`) and the
+  durable design's revocation story.
+- Whatever is chosen must live in shared (or be identically enforced on both
+  platforms) so desktop and mobile agree.
+
+## Current state (what shipped)
+
+The desktop receive-side slice ships **without any cap** — deliberately, to
+avoid baking in the destructive eviction. The store grows only under active
+attack by a member; honest clients add one row per real device. Tracked here
+until a non-destructive bound is designed. `MAX_DEVICES_PER_MEMBER` remains
+defined in shared but unused pending that design.
+
+*Last updated: 2026-07-20*

--- a/.agents/bugs/2026-07-20-join-binding-hijack-unauthenticated-member-rebind.md
+++ b/.agents/bugs/2026-07-20-join-binding-hijack-unauthenticated-member-rebind.md
@@ -69,8 +69,15 @@ member, and writes `inbox_address: ''` with **no signature or point check at
 all**. A single forged `leave` naming any member blanks their binding →
 `resolveVerifiedSender` can no longer resolve their key → all their control
 ops drop fleet-wide on every receiver that processed the forged leave
-(unauthenticated control-message DoS against an arbitrary member). Desktop's
-`leave` path should be checked for the same shape.
+(unauthenticated control-message DoS against an arbitrary member).
+
+> **Mobile-only (corrected 2026-07-20 after independent review).** Desktop's
+> `leave` handler (`MessageService.ts:4069-4090`) is NOT vulnerable: it verifies
+> `ed448(inboxPublicKey, 'delete' + hubKey.publicKey, inboxSignature)` and only
+> blanks the binding of the member whose inbox key the sender actually holds —
+> i.e. self-targeting only. Route 2 is therefore a **mobile-only** unauthenticated
+> victim-targeting attack; the earlier "check desktop for the same shape" was an
+> overstatement — desktop has a real cryptographic gate here.
 
 ## Route 3 — mobile `join` verifies nothing
 
@@ -87,9 +94,16 @@ On mobile the rebind needs only a hub-sealed `join` envelope with an arbitrary
 sync peer, gated on `reg.owner_public_keys.includes(owner_public_key) ||
 this.syncInfo.current[spaceId]`. The `syncInfo` branch trusts **any peer during
 an active sync handshake**, so a peer mid-sync can assert member rows
-(including `inbox_address`) that were never owner-signed. Lower confidence /
-narrower window than routes 1–3, but the same table, the same missing
-"only verified data may write bindings" rule.
+(including `inbox_address`) that were never owner-signed.
+
+> **Worse than first written (independent review, 2026-07-20).** The branch does
+> run an `ed448` verify (`:4548`), but against `exteriorEnvelope.owner_public_key`
+> — a field the attacker supplies. They pass their OWN key as `owner_public_key`
+> and self-sign the envelope; the verify passes and proves nothing. So under an
+> active sync window this is the **same severity** as routes 2/3 (arbitrary
+> member-row overwrite incl. the owner's), not a lesser one. The only limiter is
+> the sync window, and sync is peer-triggerable (`sync-info`, `:4499`), so an
+> attacker can open the window themselves.
 
 ## Threat model (who can do this)
 
@@ -140,10 +154,13 @@ verification twice.
 
 ## Confidence & what still needs testing
 
-- **High confidence (static):** the ed448 self-signature in Route 1 does not
-  bind address→key; the leave (Route 2) and mobile join (Route 3) handlers do
-  no verification; sync-members (Route 4) has a peer-trust branch. All read
-  directly from source at the lines cited.
+- **High confidence (static, independently reviewed 2026-07-20):** the ed448
+  self-signature in Route 1 does not bind address→key; the mobile leave (Route 2)
+  and mobile join (Route 3) handlers do no verification; sync-members (Route 4)
+  verifies only an attacker-supplied `owner_public_key` (self-signature → proves
+  nothing) under an active, peer-triggerable sync window. Desktop's `leave` is
+  NOT vulnerable (real key-possession gate — Route 2 is mobile-only). All read
+  directly from source at the lines cited and confirmed by a second reviewer.
 - **Not yet confirmed:** whether `js_verify_point` (WASM, unaudited here) can be
   satisfied by an existing member re-broadcasting a forged join for an arbitrary
   `(address, id, point)` — this is the gate that decides whether Route 1 is a

--- a/.agents/docs/cryptographic-architecture.md
+++ b/.agents/docs/cryptographic-architecture.md
@@ -3,7 +3,7 @@ type: doc
 title: Cryptographic Architecture
 status: done
 created: 2025-12-20T00:00:00.000Z
-updated: 2026-07-19T00:00:00.000Z
+updated: 2026-07-20T00:00:00.000Z
 ---
 
 # Cryptographic Architecture
@@ -14,7 +14,7 @@ updated: 2026-07-19T00:00:00.000Z
 This document explains the cryptographic protocols and key management used in Quorum. It focuses on the **mental model** needed to understand how encryption and signing work, rather than implementation details.
 
 
-**Last Updated**: 2026-07-19
+**Last Updated**: 2026-07-20
 
 ---
 
@@ -420,6 +420,19 @@ same root the device registration and every config upload already use) — which
 also auto-heals existing devices on cut-over and repairs the lost-join-key case.
 Spec: [`.agents/tasks/2026-07-19-per-device-signing-keys-registration-anchored.md`](../tasks/2026-07-19-per-device-signing-keys-registration-anchored.md).
 
+**Progress (2026-07-20):** the drift-proof core shipped in `quorum-shared`
+(`utils/deviceKeys.ts`: `announce-keys`/`revoke-device` statements, canonical
+byte builder, `verifyDeviceKeyStatement`, and a `deviceKeys`-aware
+`resolveVerifiedSender`), and desktop's **receive-side** landed (the
+`space_member_devices` store + the two control-message handlers, resolver wired
+into all four auth paths). This is **additive and behavior-neutral**: until the
+**send-side flip** ships on both platforms, every device still signs with the
+interim join-bound key, so nothing user-visible changes yet. Remaining:
+send-side (per-device signing + on-connect announce + Security-modal revocation)
+on desktop + mobile, mobile receive-side, then retire the interim `signing`
+slot. A non-destructive bound on `announce-keys` flooding is tracked in
+[`.agents/bugs/2026-07-20-announce-keys-flooding-unbounded-admissions.md`](../bugs/2026-07-20-announce-keys-flooding-unbounded-admissions.md).
+
 ---
 
 ## Control-Message Authorization (Verified Signer)
@@ -575,4 +588,4 @@ secureChannel.UnsealSyncEnvelope(
 ---
 
 
-_Last Updated: 2026-07-19_
+_Last Updated: 2026-07-20_

--- a/.agents/docs/quorum-db-schema.md
+++ b/.agents/docs/quorum-db-schema.md
@@ -3,7 +3,7 @@ type: doc
 title: 'IndexedDB Schema Reference: `quorum_db`'
 status: done
 created: 2026-01-09T00:00:00.000Z
-updated: 2025-12-23T00:00:00.000Z
+updated: 2026-07-20T00:00:00.000Z
 ---
 
 # IndexedDB Schema Reference: `quorum_db`
@@ -15,8 +15,19 @@ Quick reference for debugging and creating console snippets.
 | Property | Value |
 |----------|-------|
 | **Database Name** | `quorum_db` |
-| **Current Version** | 12 |
+| **Current Version** | 14 |
 | **Schema Location** | `src/db/messages.ts` |
+
+> **Dev gotcha (not a real-user issue):** IndexedDB only runs upgrades on a
+> version CHANGE. If two branches use the same `DB_VERSION` with different store
+> sets, switching between them against the same `localhost` origin leaves the DB
+> stamped at that version with a mismatched store set — reads then throw
+> `NotFoundError: ... object store ... not found`. Fix while developing: reset
+> the DB (Settings → Danger Zone → Reset App Data, or delete `quorum_db` in
+> DevTools → Application). Production users only ever run one monotonically
+> versioned build, so they can't hit this. The app closes its own connection on
+> `versionchange` (so a delete/upgrade isn't blocked by its own tab); a second
+> open tab can still block it.
 
 ---
 
@@ -42,6 +53,8 @@ Quick reference for debugging and creating console snippets.
 | **channel_threads** | `threadId` | `by_channel` |
 | **thread_read_times** | `threadId` | `by_channel` |
 | **user_notes** | `targetAddress` | — |
+| **search_indices** | `indexKey` | `by_lastUpdated` |
+| **space_member_devices** | `[spaceId, deviceInboxAddress]` | `by_member` |
 
 ---
 
@@ -446,13 +459,64 @@ Private annotations one user writes about another. Never synced — local only.
 
 ---
 
+### search_indices
+
+**Key:** `indexKey` (string) — `space:<spaceId>` or `dm:<conversationId>`
+
+**Indexes:**
+- `by_lastUpdated` → `lastUpdated`
+
+Serialized MiniSearch indices, persisted so full-text search survives restarts.
+
+```typescript
+{
+  indexKey: string          // "space:<id>" | "dm:<conversationId>"
+  serializedIndex: string   // JSON-serialized MiniSearch index
+  messageCount: number
+  lastUpdated: number
+}
+```
+
+---
+
+### space_member_devices
+
+**Key:** `[spaceId, deviceInboxAddress]` (compound)
+
+**Indexes:**
+- `by_member` → `[spaceId, userAddress]`
+
+Per-device space signing keys admitted via master-signed statements (durable
+multi-device). One row per device tag; the verified-signer resolver scans a
+space's rows and matches a message's signing key against `inboxAddress`. Never
+derived from the member row (poisoning-proof); revoked rows are kept as
+tombstones. Reads degrade gracefully if the store is absent (see
+`getSpaceMemberDevices`). See `cryptographic-architecture.md` → "Multi-Device
+Signing" and the shared `utils/deviceKeys.ts`.
+
+```typescript
+{
+  spaceId: string
+  userAddress: string          // the member (master user address)
+  deviceInboxAddress: string   // the device's DM inbox tag (attribution + revocation handle)
+  inboxAddress: string         // deriveInboxAddress(spaceKeyPublicKey) — the reverse-lookup key
+  spaceKeyPublicKey: string    // the device's per-space ed448 signing pubkey (hex)
+  timestamp: number            // statement timestamp (LWW ordering)
+  revoked?: boolean            // true once a revoke-device tombstone at >= timestamp arrived
+}
+```
+
+**MessageDB methods:** `getSpaceMemberDevices(spaceId)`, `getSpaceMemberDevice(spaceId, deviceInboxAddress)`, `saveSpaceMemberDevice(device)`
+
+---
+
 ## Console Snippets
 
 ### Open Database
 
 ```javascript
 const db = await new Promise((resolve, reject) => {
-  const req = indexedDB.open('quorum_db', 12);
+  const req = indexedDB.open('quorum_db'); // omit version = open at current, no upgrade
   req.onsuccess = () => resolve(req.result);
   req.onerror = () => reject(req.error);
 });
@@ -581,7 +645,9 @@ for (const s of stores) console.log(s, await countStore(s));
 | 10 | Added: channel_threads store |
 | 11 | Added: thread_read_times store |
 | 12 | Added: user_notes store (private per-user annotations, local-only) |
+| 13 | Added: search_indices store (persisted MiniSearch full-text indices) |
+| 14 | Added: space_member_devices store (per-device space signing keys — durable multi-device) |
 
 ---
 
-*Last updated: 2026-07-19*
+*Last updated: 2026-07-20*

--- a/.agents/tasks/2026-07-19-per-device-signing-keys-registration-anchored.md
+++ b/.agents/tasks/2026-07-19-per-device-signing-keys-registration-anchored.md
@@ -253,11 +253,16 @@ bump (per the additive-vs-breaking gut-check).
    verification silently across platforms. This project already carries
    `buildMessageFingerprint`/`canonicalize` precisely because of this class of
    bug — treat byte-identity as a hard gate, not an implementation detail.
-2. **Cap admissions per `(spaceId, userAddress)`** (e.g. ≤10, evict oldest
-   non-revoked). Each valid `announce-keys` is master-signed but a compromised/
-   malicious account could mint many with different `spaceKeyPublicKey`s,
-   bloating storage and turning the resolver's second-path scan into an O(n)
-   DoS. Enforce the cap at upsert and early-exit the resolver scan.
+2. **Bound `announce-keys` flooding per member** — but NOT with an evict-oldest
+   cap (that silently deletes in-use devices; rejected 2026-07-20). A valid
+   `announce-keys` is master-signed, but a member could mint many with distinct
+   `spaceKeyPublicKey`s, bloating storage and the resolver scan. The fix must
+   never break a working device (reject-new above a very high bound / rate-limit
+   / registration-anchored TTL). Tracked, with the rejected approach and
+   candidate directions, in
+   `.agents/bugs/2026-07-20-announce-keys-flooding-unbounded-admissions.md`.
+   Low severity (member-only, storage/perf, no impersonation) — receive-side
+   ships without a cap deliberately.
 3. **Document that `deviceInboxAddress` is a self-asserted tag**, not verified
    against the hub registration at receive (attribution + revocation handle
    only). Consequence: revocation is only as reliable as the master-key holder's

--- a/.agents/tasks/2026-07-19-per-device-signing-keys-registration-anchored.md
+++ b/.agents/tasks/2026-07-19-per-device-signing-keys-registration-anchored.md
@@ -1,7 +1,7 @@
 ---
 type: task
 title: "Durable multi-device: per-device space signing keys, admitted via master-identity-signed device statements"
-status: DEEP-DIVE COMPLETE — spec ready; not yet implemented
+status: IN PROGRESS — shared core (#62) + desktop receive-side done; mobile receive + both-platform send-side pending (staged, see release order)
 priority: high (follow-up to the interim signing-split fix)
 created: 2026-07-19
 severity: HIGH (security-critical — touches the verified-signer auth boundary)
@@ -334,66 +334,66 @@ bump (per the additive-vs-breaking gut-check).
 ## Cross-repo scope + sequencing (vertical slices)
 
 1. **quorum-shared** — types, statement bytes/verify, resolver extension,
-   tests. Additive publish. (Observable: shared tests green; both apps build.)
-2. **Receive-side, desktop + mobile** — control handlers, admission storage,
-   resolver wired with admissions, member-sync statement carriage (desktop).
-   Observable: everything works exactly as before (interim model untouched);
-   new tests prove forged/replayed/revoked statements are rejected.
+   tests. ✅ DONE — merged as #62 (`utils/deviceKeys.ts`, `SpaceMemberDevice`,
+   `resolveVerifiedSender` deviceKeys param; 20 tests).
+2. **Receive-side, DESKTOP** — ✅ DONE this session (branch
+   `feat/per-device-signing-keys`, PR pending): `space_member_devices` store
+   (DB v14), `announce-keys`/`revoke-device` control handlers, `resolveSpaceSender`
+   wired into all four auth paths; missing-store read guards + `onversionchange`
+   DB hygiene; 63 desktop tests green. Verified by regression testing (delete
+   own/other, mute, @everyone, update-profile) — no behavior change, as designed.
+   Member-sync statement carriage NOT included (deferred with send-side).
+2b. **Receive-side, MOBILE** — pending (mobile effort).
 3. **Send-side flip, both platforms** — on-connect announce + per-device
-   signing + Security-modal revocation broadcast. Observable (the real test):
-   fresh second device (no shared `signing`) deletes/edits/pins from day one;
-   deleting that device from Security settings makes its subsequent control
-   ops drop on other clients.
-4. **Cleanup** — retire `signing` slot writes + fallback, rewrite
+   signing + Security-modal revocation broadcast. Gated on mobile-full per the
+   release order below. Observable (the real test): fresh second device (no
+   shared `signing`) deletes/edits/pins from day one; deleting that device from
+   Security settings makes its subsequent control ops drop on other clients.
+4. **Cleanup** — retire `signing` slot fallback, rewrite
    `cryptographic-architecture.md` multi-device section, resolve the mobile
    bug report, file the join-binding hardening follow-up.
 
-## Production release order (decided 2026-07-20)
+## Production release order (revised 2026-07-20 — STAGED, supersedes the earlier "ship together" decision)
 
-**Decision: ship the full fix (receive + send) on both apps, then deploy desktop
-to prod immediately AFTER the lead ships mobile to prod.** Not the fully
-decoupled "receive-side everywhere, soak, then flip" order — deliberately, for
-beta, because the blast radius is tiny (below).
+**Decision: ship the desktop RECEIVE-side on its own now; gate the desktop
+SEND-side flip until mobile is FULLY implemented (receive + send) and live.**
+This replaces the earlier "ship receive+send together on both, deploy desktop
+right after mobile" plan — the staged order is safer and costs nothing extra
+because the receive-side is inert.
 
-- **The receive-side is inherently tolerant regardless of order.** During any
-  transition a space contains both old shared-key signers and new per-device
-  signers, so `resolveVerifiedSender` must accept BOTH paths at once. That is
-  not extra work; it is required for correctness. It also means the "decoupled"
-  structure exists at the code level anyway — the only real choice is the
-  DEPLOY timing of the send-side flip.
+Concrete order:
+1. **quorum-shared** — additive core. ✅ merged (#62).
+2. **Desktop receive-side** — this PR. Ships alone NOW. It's **inert and
+   additive**: understands the new `announce-keys`/`revoke-device` statements
+   and can resolve per-device keys, but nothing broadcasts statements yet, so
+   there is **zero behavior change** (every device still signs with the interim
+   join-bound key; single-device and existing multi-device behavior unchanged).
+   Real users just get the normal additive v14 DB migration.
+3. **Mobile receive-side + send-side** — implemented and shipped by the mobile
+   effort (lead's territory / mobile task).
+4. **Desktop send-side flip** — ONLY after step 3 is live: on-connect announce +
+   per-device signing + Security-modal revocation. Waiting for mobile to be
+   *fully* done is more conservative than strictly required (the flip only needs
+   mobile's RECEIVE-side live), so it cannot strand mobile users.
+5. **Cleanup** — retire the `signing ?? inbox` fallback once both apps are
+   broadly updated; rewrite the crypto-architecture multi-device section.
 
-- **Why the aggressive timing is acceptable for beta.** The flip only changes
-  behavior for a **secondary** device. A user's PRIMARY (join) device signs
-  with the join-bound key receivers already hold, so it verifies on old clients
-  with no announcement. Therefore:
-  - Single-device users: zero regression, ever.
-  - Primary device of a multi-device user: unaffected.
-  - Only affected case: a control action (delete/edit/pin/mute) sent from a
-    SECONDARY device, received by a client still on an OLD build → that one
-    action silently doesn't apply on that one stale receiver until it updates
-    (no crash, no data loss). Multi-device users are rare, and during beta they
-    are mostly the devs/testers, who understand the transition.
-  - **Honest framing (independent review 2026-07-20):** the flip is a
-    regression *relative to the interim fix's current behavior*, not just
-    relative to the ideal. Today a secondary device signs with the shared join
-    key, which every receiver already has → its control ops work everywhere.
-    Post-flip it signs with its own key, which OLD receivers can't resolve →
-    those ops break for stale receivers until they update. We are knowingly
-    re-breaking secondary-device control ops on not-yet-updated clients for the
-    rollout window, in exchange for the durable end state. Acceptable at beta
-    scale; not "neutral."
-
-- **The one thing that makes it safe rather than fragile:** "prod" is a spread
-  of build versions, not a switch, so the flip's regression persists per-stale-
-  receiver until they update — it is NOT closed by deploying desktop right after
-  mobile. We accept that tail for beta given the blast radius. If real-user
-  multi-device usage grows or we leave beta, revert to the decoupled order
-  (soak receive-side to saturation before flipping).
-
-Concrete order: (1) shared additive publish → (2) desktop + mobile receive-side
-+ send-side both merged → (3) lead ships mobile to prod → (4) we ship desktop to
-prod right after. Keep the `signing ?? inbox` fallback through this whole window;
-remove it only at cleanup once both apps are broadly updated.
+**Why staged is safe (and why the flip is the only sensitive step):** the
+receive-side is inherently tolerant — a space in transition holds both
+old-shared-key and new-per-device signers, and `resolveVerifiedSender` accepts
+both paths, so shipping receive early breaks nothing. The **send-side flip** is
+the only step with a blast radius, and it is bounded:
+- Single-device users: zero regression, ever.
+- Primary (join) device of a multi-device user: unaffected (it signs with the
+  join-bound key receivers already hold).
+- Only affected case: a control action from a **secondary** device, received by
+  a client still on an OLD build → that one action silently doesn't apply on
+  that stale receiver until it updates (no crash, no data loss).
+- Honest framing: relative to the interim fix, the flip *re-breaks*
+  secondary-device control ops on not-yet-updated receivers for the rollout
+  window, in exchange for the durable end state. Staging the flip behind
+  mobile-full minimises that window. Keep the `signing ?? inbox` fallback
+  through the whole window.
 
 ## Discovered issues to handle OUTSIDE this task
 

--- a/.agents/tasks/2026-07-19-per-device-signing-keys-registration-anchored.md
+++ b/.agents/tasks/2026-07-19-per-device-signing-keys-registration-anchored.md
@@ -243,6 +243,27 @@ optional TTL hardening, not required for correctness).
 All **additive** → ship shared alone; mobile catches up on its next pinned
 bump (per the additive-vs-breaking gut-check).
 
+### Hard prerequisites before the send-side flip (from independent review 2026-07-20)
+
+1. **`buildDeviceKeyStatementBytes` MUST live in shared and be the ONLY code
+   both platforms use to build statement bytes, for BOTH sign and verify.** Not
+   the existing `canonicalize` (it throws on non-message objects); a new,
+   dedicated function. If desktop and mobile serialize statements independently,
+   any field-order/encoding/whitespace difference makes signatures fail
+   verification silently across platforms. This project already carries
+   `buildMessageFingerprint`/`canonicalize` precisely because of this class of
+   bug — treat byte-identity as a hard gate, not an implementation detail.
+2. **Cap admissions per `(spaceId, userAddress)`** (e.g. ≤10, evict oldest
+   non-revoked). Each valid `announce-keys` is master-signed but a compromised/
+   malicious account could mint many with different `spaceKeyPublicKey`s,
+   bloating storage and turning the resolver's second-path scan into an O(n)
+   DoS. Enforce the cap at upsert and early-exit the resolver scan.
+3. **Document that `deviceInboxAddress` is a self-asserted tag**, not verified
+   against the hub registration at receive (attribution + revocation handle
+   only). Consequence: revocation is only as reliable as the master-key holder's
+   self-report of which tag to tombstone — fine in the normal UI flow (the tag
+   comes from the real registration), but must be stated as a design assumption.
+
 ## Edge cases (resolved)
 
 - **Revocation lifecycle** — see above. Residuals stated honestly: (a) a
@@ -322,6 +343,53 @@ bump (per the additive-vs-breaking gut-check).
    `cryptographic-architecture.md` multi-device section, resolve the mobile
    bug report, file the join-binding hardening follow-up.
 
+## Production release order (decided 2026-07-20)
+
+**Decision: ship the full fix (receive + send) on both apps, then deploy desktop
+to prod immediately AFTER the lead ships mobile to prod.** Not the fully
+decoupled "receive-side everywhere, soak, then flip" order — deliberately, for
+beta, because the blast radius is tiny (below).
+
+- **The receive-side is inherently tolerant regardless of order.** During any
+  transition a space contains both old shared-key signers and new per-device
+  signers, so `resolveVerifiedSender` must accept BOTH paths at once. That is
+  not extra work; it is required for correctness. It also means the "decoupled"
+  structure exists at the code level anyway — the only real choice is the
+  DEPLOY timing of the send-side flip.
+
+- **Why the aggressive timing is acceptable for beta.** The flip only changes
+  behavior for a **secondary** device. A user's PRIMARY (join) device signs
+  with the join-bound key receivers already hold, so it verifies on old clients
+  with no announcement. Therefore:
+  - Single-device users: zero regression, ever.
+  - Primary device of a multi-device user: unaffected.
+  - Only affected case: a control action (delete/edit/pin/mute) sent from a
+    SECONDARY device, received by a client still on an OLD build → that one
+    action silently doesn't apply on that one stale receiver until it updates
+    (no crash, no data loss). Multi-device users are rare, and during beta they
+    are mostly the devs/testers, who understand the transition.
+  - **Honest framing (independent review 2026-07-20):** the flip is a
+    regression *relative to the interim fix's current behavior*, not just
+    relative to the ideal. Today a secondary device signs with the shared join
+    key, which every receiver already has → its control ops work everywhere.
+    Post-flip it signs with its own key, which OLD receivers can't resolve →
+    those ops break for stale receivers until they update. We are knowingly
+    re-breaking secondary-device control ops on not-yet-updated clients for the
+    rollout window, in exchange for the durable end state. Acceptable at beta
+    scale; not "neutral."
+
+- **The one thing that makes it safe rather than fragile:** "prod" is a spread
+  of build versions, not a switch, so the flip's regression persists per-stale-
+  receiver until they update — it is NOT closed by deploying desktop right after
+  mobile. We accept that tail for beta given the blast radius. If real-user
+  multi-device usage grows or we leave beta, revert to the decoupled order
+  (soak receive-side to saturation before flipping).
+
+Concrete order: (1) shared additive publish → (2) desktop + mobile receive-side
++ send-side both merged → (3) lead ships mobile to prod → (4) we ship desktop to
+prod right after. Keep the `signing ?? inbox` fallback through this whole window;
+remove it only at cleanup once both apps are broadly updated.
+
 ## Discovered issues to handle OUTSIDE this task
 
 - **Join-binding hijack** (finding #4): forged join / unauthenticated leave /
@@ -331,7 +399,27 @@ bump (per the additive-vs-breaking gut-check).
   master-signature machinery.
 - Desktop interim branch lacks mobile's heal/promotion parity (finding #5) —
   acceptable if this durable task lands promptly; revisit only if the durable
-  work slips.
+  work slips. **Sharpened by independent review (2026-07-20):** the concrete gap
+  is that desktop's `signing`-key preservation sits inside `if (!existingSpace)`
+  (`ConfigService.ts:112`), so a PRE-fix desktop second device that ALREADY has
+  the space never adopts the blob's `signing` key on a later config sync — it
+  stays broken until the space is re-added. Mobile heals existing spaces
+  (`spaceSyncService.ts:86-141`); desktop does not. Once the durable per-device
+  work lands this is moot (no device needs the shared key); until then it's a
+  desktop-only "re-add to fix," which the release notes should state plainly.
+
+- **Desktop P2P revocation replay gap.** Until desktop migrates to the hub-log
+  transport, an offline desktop receiver has no replay path for a `revoke-device`
+  (or `announce-keys`) it missed; it catches up only on the announcing device's
+  next re-announce. Mobile's hub-log replay covers this. Not a design flaw
+  (inherent to the P2P transport, converges on hub-log migration), but note it
+  in the implementation plan: revocation propagation is asymmetric until then.
+
+- **`isSpaceControlAuthorized` durable path is not self-contained** (defense-in-
+  depth, not an active exploit): the `saveMessage` path resolves the verified
+  sender but relies on the streaming handler having already nulled a bad
+  `publicKey` rather than re-verifying the ed448 signature itself. Worth a
+  belt-and-braces re-verify when this code is next touched.
 
 ## Implementation-time verifications (small, listed so they aren't lost)
 

--- a/src/components/modals/UserSettingsModal/DangerZone.tsx
+++ b/src/components/modals/UserSettingsModal/DangerZone.tsx
@@ -16,12 +16,15 @@ const DangerZone: React.FunctionComponent = () => {
       // Clear React Query cache
       queryClient.clear();
 
-      // Delete IndexedDB database
+      // Delete IndexedDB database. A blocked delete means another tab still
+      // holds the DB open — treating it as success (the old behavior) silently
+      // reloaded on the SAME data, so the reset appeared to do nothing. Reject
+      // so the user is told to close other tabs instead.
       await new Promise<void>((resolve, reject) => {
         const req = indexedDB.deleteDatabase('quorum_db');
         req.onsuccess = () => resolve();
         req.onerror = () => reject(req.error);
-        req.onblocked = () => resolve();
+        req.onblocked = () => reject(new Error('blocked'));
       });
 
       // Clear all localStorage
@@ -34,7 +37,7 @@ const DangerZone: React.FunctionComponent = () => {
       window.location.reload();
     } catch (error) {
       console.error('Failed to reset app data:', error);
-      setResetError('unknown');
+      setResetError((error as Error)?.message === 'blocked' ? 'blocked' : 'unknown');
     }
   };
 
@@ -57,7 +60,11 @@ const DangerZone: React.FunctionComponent = () => {
                 dismissible
                 onClose={() => setResetError(null)}
               >
-                <Trans>An error occurred while resetting app data. Please try again.</Trans>
+                {resetError === 'blocked' ? (
+                  <Trans>Couldn't reset: Quorum is open in another tab. Close all other Quorum tabs, then try again.</Trans>
+                ) : (
+                  <Trans>An error occurred while resetting app data. Please try again.</Trans>
+                )}
               </Callout>
             </div>
           )}

--- a/src/db/messages.ts
+++ b/src/db/messages.ts
@@ -1,6 +1,6 @@
 import { logger, isValidIPFSCID } from '@quilibrium/quorum-shared';
 import { channel } from '@quilibrium/quilibrium-js-sdk-channels';
-import type { Conversation, Message, Space, Bookmark, BroadcastSpaceTag, ChannelThread, UserNote, FarcasterLink } from '@quilibrium/quorum-shared';
+import type { Conversation, Message, Space, Bookmark, BroadcastSpaceTag, ChannelThread, UserNote, FarcasterLink, SpaceMemberDevice } from '@quilibrium/quorum-shared';
 import { BOOKMARKS_CONFIG } from '@quilibrium/quorum-shared';
 import type { SpaceNotificationSettings } from '../types/notifications';
 import type { IconColor } from '../components/space/IconPicker/types';
@@ -196,7 +196,7 @@ interface StoredSearchIndex {
 export class MessageDB {
   private db: IDBDatabase | null = null;
   private readonly DB_NAME = 'quorum_db';
-  private readonly DB_VERSION = 13;
+  private readonly DB_VERSION = 14;
   private searchIndices: Map<string, MiniSearch<SearchableMessage>> = new Map();
   private indexLoadPromises: Map<string, Promise<void>> = new Map();
   private dirtyIndices: Set<string> = new Set();
@@ -369,6 +369,17 @@ export class MessageDB {
             keyPath: 'indexKey',
           });
           indexStore.createIndex('by_lastUpdated', 'lastUpdated');
+        }
+
+        if (event.oldVersion < 14) {
+          // Per-device space signing keys admitted via master-signed statements.
+          // Keyed by the device's DM inbox tag so announce/revoke upsert one row
+          // per device; the resolver scans a space's rows and matches on the
+          // signing-key `inboxAddress` field (see utils/deviceKeys in shared).
+          const memberDevices = db.createObjectStore('space_member_devices', {
+            keyPath: ['spaceId', 'deviceInboxAddress'],
+          });
+          memberDevices.createIndex('by_member', ['spaceId', 'userAddress']);
         }
       };
     });
@@ -1202,6 +1213,57 @@ export class MessageDB {
       request.onsuccess = () => {
         resolve();
       };
+      request.onerror = () => reject(request.error);
+    });
+  }
+
+  /**
+   * Per-device signing-key admissions (and revocation tombstones), one row per
+   * device tag. Never derived from the member row — admitted only via a
+   * master-signed statement (see MessageService announce-keys/revoke-device
+   * handlers). Passed to resolveVerifiedSender as its optional 3rd arg.
+   */
+  async saveSpaceMemberDevice(device: SpaceMemberDevice): Promise<void> {
+    await this.init();
+    return new Promise((resolve, reject) => {
+      const transaction = this.db!.transaction(
+        'space_member_devices',
+        'readwrite'
+      );
+      transaction.objectStore('space_member_devices').put(device);
+      transaction.oncomplete = () => resolve();
+      transaction.onerror = () => reject(transaction.error);
+    });
+  }
+
+  /** The stored admission/tombstone for a device tag, if any (for LWW). */
+  async getSpaceMemberDevice(
+    spaceId: string,
+    deviceInboxAddress: string
+  ): Promise<SpaceMemberDevice | undefined> {
+    await this.init();
+    return new Promise((resolve, reject) => {
+      const transaction = this.db!.transaction('space_member_devices', 'readonly');
+      const request = transaction
+        .objectStore('space_member_devices')
+        .get([spaceId, deviceInboxAddress]);
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+  }
+
+  /** All device admissions for a space (revoked rows included; resolver skips them). */
+  async getSpaceMemberDevices(spaceId: string): Promise<SpaceMemberDevice[]> {
+    await this.init();
+    return new Promise((resolve, reject) => {
+      const transaction = this.db!.transaction('space_member_devices', 'readonly');
+      const store = transaction.objectStore('space_member_devices');
+      const range = IDBKeyRange.bound(
+        [spaceId, ' '],
+        [spaceId, '￿']
+      );
+      const request = store.getAll(range);
+      request.onsuccess = () => resolve(request.result ?? []);
       request.onerror = () => reject(request.error);
     });
   }

--- a/src/db/messages.ts
+++ b/src/db/messages.ts
@@ -215,8 +215,23 @@ export class MessageDB {
       const request = indexedDB.open(this.DB_NAME, this.DB_VERSION);
 
       request.onerror = () => reject(request.error);
+      // A version bump can't apply while another tab holds an older connection
+      // open — the upgrade blocks until that connection closes. Log it so the
+      // stuck state is diagnosable rather than a silent hang.
+      request.onblocked = () => {
+        logger.warn(
+          '[MessageDB] DB upgrade blocked by another open tab; close other tabs to finish upgrading'
+        );
+      };
       request.onsuccess = () => {
         this.db = request.result;
+        // If another tab later requests a higher version, yield: close this
+        // connection so its upgrade isn't blocked (prevents a wedged DB across
+        // version bumps). The next DB call reopens via init().
+        this.db.onversionchange = () => {
+          this.db?.close();
+          this.db = null;
+        };
         resolve();
       };
 
@@ -1225,6 +1240,9 @@ export class MessageDB {
    */
   async saveSpaceMemberDevice(device: SpaceMemberDevice): Promise<void> {
     await this.init();
+    // Degrade gracefully if the v14 store isn't present yet (e.g. an upgrade
+    // blocked by another open tab). Never let an optional write crash a caller.
+    if (!this.db!.objectStoreNames.contains('space_member_devices')) return;
     return new Promise((resolve, reject) => {
       const transaction = this.db!.transaction(
         'space_member_devices',
@@ -1242,6 +1260,7 @@ export class MessageDB {
     deviceInboxAddress: string
   ): Promise<SpaceMemberDevice | undefined> {
     await this.init();
+    if (!this.db!.objectStoreNames.contains('space_member_devices')) return undefined;
     return new Promise((resolve, reject) => {
       const transaction = this.db!.transaction('space_member_devices', 'readonly');
       const request = transaction
@@ -1255,6 +1274,9 @@ export class MessageDB {
   /** All device admissions for a space (revoked rows included; resolver skips them). */
   async getSpaceMemberDevices(spaceId: string): Promise<SpaceMemberDevice[]> {
     await this.init();
+    // Missing store (upgrade not yet applied) → no admissions; the resolver
+    // falls back to join-bound member rows. Keeps the receive path alive.
+    if (!this.db!.objectStoreNames.contains('space_member_devices')) return [];
     return new Promise((resolve, reject) => {
       const transaction = this.db!.transaction('space_member_devices', 'readonly');
       const store = transaction.objectStore('space_member_devices');

--- a/src/dev/tests/db/spaceMemberDevices.test.ts
+++ b/src/dev/tests/db/spaceMemberDevices.test.ts
@@ -1,0 +1,81 @@
+import 'fake-indexeddb/auto';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { MessageDB } from '../../../db/messages';
+import type { SpaceMemberDevice } from '@quilibrium/quorum-shared';
+
+// Validates the DB v14 migration: the space_member_devices store is created and
+// its CRUD (used by the per-device signing-key admission handlers) works against
+// a real (fake-indexeddb) database — i.e. opening the DB at the new version
+// doesn't throw and the store behaves as the resolver expects.
+describe('MessageDB - space_member_devices store (v14)', () => {
+  let db: MessageDB;
+
+  beforeEach(async () => {
+    const FDBFactory = (await import('fake-indexeddb/lib/FDBFactory')).default;
+    globalThis.indexedDB = new FDBFactory();
+    db = new MessageDB();
+    await db.init(); // opens at DB_VERSION 14 → runs the onupgradeneeded chain
+  });
+
+  const device = (over: Partial<SpaceMemberDevice> = {}): SpaceMemberDevice => ({
+    spaceId: 'space-1',
+    userAddress: 'alice',
+    deviceInboxAddress: 'dev-1',
+    inboxAddress: 'signing-addr-1',
+    spaceKeyPublicKey: 'pub-1',
+    timestamp: 1000,
+    revoked: false,
+    ...over,
+  });
+
+  it('opens at v14 and starts with an empty store', async () => {
+    expect(await db.getSpaceMemberDevices('space-1')).toEqual([]);
+    expect(await db.getSpaceMemberDevice('space-1', 'dev-1')).toBeUndefined();
+  });
+
+  it('saves and retrieves an admission by device tag', async () => {
+    await db.saveSpaceMemberDevice(device());
+    expect(await db.getSpaceMemberDevice('space-1', 'dev-1')).toMatchObject({
+      userAddress: 'alice',
+      inboxAddress: 'signing-addr-1',
+    });
+  });
+
+  it('upserts on the same (spaceId, deviceInboxAddress) key', async () => {
+    await db.saveSpaceMemberDevice(device({ timestamp: 1000 }));
+    await db.saveSpaceMemberDevice(
+      device({ timestamp: 2000, spaceKeyPublicKey: 'pub-2', inboxAddress: 'signing-addr-2' })
+    );
+    const all = await db.getSpaceMemberDevices('space-1');
+    expect(all).toHaveLength(1);
+    expect(all[0]).toMatchObject({ timestamp: 2000, inboxAddress: 'signing-addr-2' });
+  });
+
+  it('scopes getSpaceMemberDevices to the requested space', async () => {
+    await db.saveSpaceMemberDevice(device({ spaceId: 'space-1', deviceInboxAddress: 'd1' }));
+    await db.saveSpaceMemberDevice(device({ spaceId: 'space-2', deviceInboxAddress: 'd2' }));
+    const s1 = await db.getSpaceMemberDevices('space-1');
+    expect(s1).toHaveLength(1);
+    expect(s1[0].deviceInboxAddress).toBe('d1');
+  });
+
+  it('returns every device tag for a space, including base58/hex-style tags', async () => {
+    // Real device tags are base58btc; assert the key range captures a realistic set.
+    const tags = ['1abc', 'QmZzz', 'zzz9', 'AAAA'];
+    for (const t of tags) {
+      await db.saveSpaceMemberDevice(device({ deviceInboxAddress: t }));
+    }
+    const all = await db.getSpaceMemberDevices('space-1');
+    expect(all.map((d) => d.deviceInboxAddress).sort()).toEqual([...tags].sort());
+  });
+
+  it('stores a revocation tombstone (revoked row) alongside live admissions', async () => {
+    await db.saveSpaceMemberDevice(device({ deviceInboxAddress: 'live', revoked: false }));
+    await db.saveSpaceMemberDevice(
+      device({ deviceInboxAddress: 'dead', revoked: true, inboxAddress: '' })
+    );
+    const all = await db.getSpaceMemberDevices('space-1');
+    expect(all).toHaveLength(2);
+    expect(all.find((d) => d.deviceInboxAddress === 'dead')?.revoked).toBe(true);
+  });
+});

--- a/src/dev/tests/services/MessageService.unit.test.tsx
+++ b/src/dev/tests/services/MessageService.unit.test.tsx
@@ -89,6 +89,9 @@ describe('MessageService - Unit Tests', () => {
         }),
         getSpaceMember: vi.fn().mockResolvedValue(null),
         getSpaceMembers: vi.fn().mockResolvedValue([]),
+        getSpaceMemberDevices: vi.fn().mockResolvedValue([]),
+        getSpaceMemberDevice: vi.fn().mockResolvedValue(undefined),
+        saveSpaceMemberDevice: vi.fn().mockResolvedValue(undefined),
         getMuteByMuteId: vi.fn().mockResolvedValue(null),
         muteUser: vi.fn().mockResolvedValue(undefined),
         unmuteUser: vi.fn().mockResolvedValue(undefined),
@@ -1504,6 +1507,164 @@ describe('MessageService - Unit Tests', () => {
       await messageService.addMessage(queryClient, spaceId, channelId, postMessage);
 
       expect(spy).not.toHaveBeenCalled();
+    });
+  });
+
+  // Per-device signing keys: control auth resolves a second device's key via an
+  // admitted statement (stored in space_member_devices), and the receive handler
+  // persists admissions/tombstones. The statement crypto itself is covered by
+  // shared's deviceKeys.test.ts; these assert the desktop WIRING.
+  describe('9. Per-device signing keys (admission wiring)', () => {
+    const SPACE = 'space-pdk';
+    const CHANNEL = 'chan-pdk';
+    const ALICE = 'addr-alice-pdk';
+    const USER_PUB = '11'.repeat(57);
+    const DEVICE_KEY_PUB = '22'.repeat(57);
+    const JOIN_KEY_PUB = '33'.repeat(57);
+    const USER_ADDRESS = deriveInboxAddress(USER_PUB);
+    const DEVICE_INBOX = 'dev-inbox-1';
+
+    const aliceMember = {
+      address: ALICE,
+      user_address: ALICE,
+      inbox_address: deriveInboxAddress(JOIN_KEY_PUB),
+    };
+    const admission = {
+      spaceId: SPACE,
+      userAddress: ALICE,
+      deviceInboxAddress: DEVICE_INBOX,
+      inboxAddress: deriveInboxAddress(DEVICE_KEY_PUB),
+      spaceKeyPublicKey: DEVICE_KEY_PUB,
+      timestamp: 1,
+      revoked: false,
+    };
+    // remove-message of Alice's own message, signed by her SECOND device key.
+    const removeOwn = {
+      publicKey: DEVICE_KEY_PUB,
+      signature: 'sig',
+      content: { type: 'remove-message', senderId: ALICE, removeMessageId: 'm1' },
+    } as any;
+    const targetByAlice = { content: { senderId: ALICE, type: 'post' } } as any;
+
+    beforeEach(() => {
+      mockDeps.messageDB.getSpace = vi
+        .fn()
+        .mockResolvedValue({ spaceId: SPACE, groups: [], roles: [] });
+      mockDeps.messageDB.getSpaceMembers = vi.fn().mockResolvedValue([aliceMember]);
+    });
+
+    it('authorizes a control message signed by an admitted second-device key', async () => {
+      mockDeps.messageDB.getSpaceMemberDevices = vi
+        .fn()
+        .mockResolvedValue([admission]);
+      const ok = await (messageService as any).isSpaceControlAuthorized(
+        removeOwn,
+        mockDeps.messageDB,
+        SPACE,
+        CHANNEL,
+        targetByAlice
+      );
+      expect(ok).toBe(true);
+    });
+
+    it('drops the same message when no admission exists (fail closed)', async () => {
+      mockDeps.messageDB.getSpaceMemberDevices = vi.fn().mockResolvedValue([]);
+      const ok = await (messageService as any).isSpaceControlAuthorized(
+        removeOwn,
+        mockDeps.messageDB,
+        SPACE,
+        CHANNEL,
+        targetByAlice
+      );
+      expect(ok).toBe(false);
+    });
+
+    it('drops the message when the admitted device key is revoked', async () => {
+      mockDeps.messageDB.getSpaceMemberDevices = vi
+        .fn()
+        .mockResolvedValue([{ ...admission, revoked: true }]);
+      const ok = await (messageService as any).isSpaceControlAuthorized(
+        removeOwn,
+        mockDeps.messageDB,
+        SPACE,
+        CHANNEL,
+        targetByAlice
+      );
+      expect(ok).toBe(false);
+    });
+
+    it('persists an admission for a valid announce-keys statement', async () => {
+      // Force the WASM verifier to accept (real Ed448 is exercised elsewhere).
+      vi.mocked(channel_raw.js_verify_ed448).mockReturnValue('true' as any);
+      const statement = {
+        type: 'announce-keys',
+        userAddress: USER_ADDRESS,
+        userPublicKey: USER_PUB,
+        spaceId: SPACE,
+        deviceInboxAddress: DEVICE_INBOX,
+        spaceKeyPublicKey: DEVICE_KEY_PUB,
+        timestamp: 1000,
+        signature: 'ab'.repeat(114),
+      };
+      const save = vi.fn().mockResolvedValue(undefined);
+      mockDeps.messageDB.saveSpaceMemberDevice = save;
+      mockDeps.messageDB.getSpaceMemberDevice = vi.fn().mockResolvedValue(undefined);
+
+      await (messageService as any).processDeviceKeyStatement(statement, SPACE);
+
+      expect(save).toHaveBeenCalledTimes(1);
+      expect(save.mock.calls[0][0]).toMatchObject({
+        spaceId: SPACE,
+        userAddress: USER_ADDRESS,
+        deviceInboxAddress: DEVICE_INBOX,
+        inboxAddress: deriveInboxAddress(DEVICE_KEY_PUB),
+        revoked: false,
+      });
+    });
+
+    it('persists a revocation tombstone for a valid revoke-device statement', async () => {
+      vi.mocked(channel_raw.js_verify_ed448).mockReturnValue('true' as any);
+      const statement = {
+        type: 'revoke-device',
+        userAddress: USER_ADDRESS,
+        userPublicKey: USER_PUB,
+        spaceId: SPACE,
+        deviceInboxAddress: DEVICE_INBOX,
+        timestamp: 2000,
+        signature: 'ab'.repeat(114),
+      };
+      const save = vi.fn().mockResolvedValue(undefined);
+      mockDeps.messageDB.saveSpaceMemberDevice = save;
+      mockDeps.messageDB.getSpaceMemberDevice = vi
+        .fn()
+        .mockResolvedValue({ ...admission, timestamp: 1000 });
+
+      await (messageService as any).processDeviceKeyStatement(statement, SPACE);
+
+      expect(save).toHaveBeenCalledTimes(1);
+      expect(save.mock.calls[0][0]).toMatchObject({
+        deviceInboxAddress: DEVICE_INBOX,
+        revoked: true,
+        timestamp: 2000,
+      });
+    });
+
+    it('drops a statement whose signed spaceId does not match the delivering space', async () => {
+      vi.mocked(channel_raw.js_verify_ed448).mockReturnValue('true' as any);
+      const save = vi.fn().mockResolvedValue(undefined);
+      mockDeps.messageDB.saveSpaceMemberDevice = save;
+      const statement = {
+        type: 'announce-keys',
+        userAddress: USER_ADDRESS,
+        userPublicKey: USER_PUB,
+        spaceId: 'a-different-space',
+        deviceInboxAddress: DEVICE_INBOX,
+        spaceKeyPublicKey: DEVICE_KEY_PUB,
+        timestamp: 1000,
+        signature: 'ab'.repeat(114),
+      };
+      await (messageService as any).processDeviceKeyStatement(statement, SPACE);
+      expect(save).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -21,7 +21,9 @@ import {
   isControlMessageType,
   shouldSignEdit,
   canManageReadOnlyChannel,
+  verifyDeviceKeyStatement,
   type ControlMessageContent,
+  type DeviceKeyStatement,
 } from '@quilibrium/quorum-shared';
 import { MessageDB, EncryptionState, EncryptedMessage } from '../db/messages';
 import type { SpaceMemberRow } from '../db/messages';
@@ -949,6 +951,81 @@ export class MessageService {
    * (see the verify blocks); unsigned/invalid control messages resolve to a
    * null sender and are dropped (except the unsigned-edit-of-unsigned case).
    */
+  /**
+   * Ed448 verifier in the shape shared's verifyDeviceKeyStatement expects,
+   * backed by the WASM channel primitive (base64 in, 'true'/'false' out).
+   */
+  private readonly signingProvider = {
+    verifyEd448: async (publicKey: string, message: string, signature: string) =>
+      ch.js_verify_ed448(publicKey, message, signature) === 'true',
+  };
+
+  /**
+   * Resolve a verified signer against BOTH the join-bound member table and the
+   * per-device signing keys admitted via master-signed statements. Every
+   * control/read-only/update-profile auth path funnels through here so the
+   * two lookup paths stay consistent.
+   */
+  private async resolveSpaceSender(
+    publicKey: string,
+    messageDB: MessageDB,
+    spaceId: string,
+    members: SpaceMemberRow[]
+  ) {
+    const deviceKeys = await messageDB.getSpaceMemberDevices(spaceId);
+    return resolveVerifiedSender(
+      publicKey,
+      members as unknown as Parameters<typeof resolveVerifiedSender>[1],
+      deviceKeys as unknown as Parameters<typeof resolveVerifiedSender>[2]
+    );
+  }
+
+  /**
+   * Receive an announce-keys / revoke-device statement (new hub control types).
+   * Verifies it via shared (master-signed, self-certifying identity, 30s skew,
+   * last-write-wins) and persists the admission or a revocation tombstone.
+   * Fails closed silently. NEVER touches the join-bound member row — admissions
+   * live in their own store (the #243 poisoning lesson). Unknown types are
+   * ignored by the caller, so old clients are unaffected.
+   */
+  private async processDeviceKeyStatement(
+    statement: DeviceKeyStatement,
+    contextSpaceId: string
+  ): Promise<void> {
+    // The signature binds spaceId; only honor a statement meant for the space
+    // whose hub delivered it (defense in depth over the hub-key scoping).
+    if (statement.spaceId !== contextSpaceId) return;
+
+    const existing = await this.messageDB.getSpaceMemberDevice(
+      statement.spaceId,
+      statement.deviceInboxAddress
+    );
+    const verdict = await verifyDeviceKeyStatement(
+      this.signingProvider,
+      statement,
+      existing
+        ? { timestamp: existing.timestamp, revoked: !!existing.revoked }
+        : undefined
+    );
+
+    if (verdict.action === 'admit') {
+      await this.messageDB.saveSpaceMemberDevice(verdict.device);
+    } else if (verdict.action === 'revoke') {
+      // Tombstone: keep the row marked revoked so a later STALE announce is
+      // rejected by LWW; a strictly-newer announce (re-added device) re-admits.
+      await this.messageDB.saveSpaceMemberDevice({
+        spaceId: verdict.spaceId,
+        userAddress: verdict.userAddress,
+        deviceInboxAddress: verdict.deviceInboxAddress,
+        inboxAddress: existing?.inboxAddress ?? '',
+        spaceKeyPublicKey: existing?.spaceKeyPublicKey ?? '',
+        timestamp: verdict.timestamp,
+        revoked: true,
+      });
+    }
+    // reject → drop
+  }
+
   private async isSpaceControlAuthorized(
     decryptedContent: Message,
     messageDB: MessageDB,
@@ -962,9 +1039,11 @@ export class MessageService {
       ?.channels.find((c) => c.channelId === channelId);
     const members = await messageDB.getSpaceMembers(spaceId);
     const verifiedSender = decryptedContent.publicKey
-      ? resolveVerifiedSender(
+      ? await this.resolveSpaceSender(
           decryptedContent.publicKey,
-          members as unknown as Parameters<typeof resolveVerifiedSender>[1]
+          messageDB,
+          spaceId,
+          members
         )
       : null;
     return authorizeControlMessage({
@@ -1024,9 +1103,11 @@ export class MessageService {
       return false;
     }
     const members = await messageDB.getSpaceMembers(spaceId);
-    const verifiedSender = resolveVerifiedSender(
+    const verifiedSender = await this.resolveSpaceSender(
       decryptedContent.publicKey,
-      members as unknown as Parameters<typeof resolveVerifiedSender>[1]
+      messageDB,
+      spaceId,
+      members
     );
     return (
       verifiedSender === null ||
@@ -1075,9 +1156,11 @@ export class MessageService {
     ) {
       return false;
     }
-    const verifiedSender = resolveVerifiedSender(
+    const verifiedSender = await this.resolveSpaceSender(
       decryptedContent.publicKey,
-      members as unknown as Parameters<typeof resolveVerifiedSender>[1]
+      this.messageDB,
+      space.spaceId,
+      members
     );
     return (
       !!verifiedSender &&
@@ -4910,6 +4993,14 @@ export class MessageService {
                 }, true);
               }
             }
+          } else if (
+            envelope.message.type === 'announce-keys' ||
+            envelope.message.type === 'revoke-device'
+          ) {
+            await this.processDeviceKeyStatement(
+              envelope.message as unknown as DeviceKeyStatement,
+              conversationId.split('/')[0]
+            );
           }
         }
       } catch (e) { console.error('[MessageService] Error processing hub/sync message:', e); }
@@ -5022,11 +5113,11 @@ export class MessageService {
             // check) and do the @everyone check ourselves against the verified
             // signer; user/@role checks are unaffected (they don't use space).
             const everyoneSender = decryptedContent.publicKey
-              ? resolveVerifiedSender(
+              ? await this.resolveSpaceSender(
                   decryptedContent.publicKey,
-                  (await this.messageDB.getSpaceMembers(
-                    spaceId
-                  )) as unknown as Parameters<typeof resolveVerifiedSender>[1]
+                  this.messageDB,
+                  spaceId,
+                  await this.messageDB.getSpaceMembers(spaceId)
                 )
               : null;
             const isMentioned =


### PR DESCRIPTION
Additive desktop **receive-side** for durable per-device space signing keys, building on quorum-shared #62. It's **inert until the send-side flip ships** — no behavior change today: it adds the infrastructure to admit and resolve multiple per-device signing keys per member, while every device still signs with the interim join-bound key. Real users just get the normal additive v14 DB migration.

### Receive-side (additive, no behavior change)
- New `space_member_devices` IndexedDB store (DB v14) + CRUD.
- `announce-keys` / `revoke-device` hub control handlers: verify master-signed statements via shared (`verifyDeviceKeyStatement`), persist admissions / revocation tombstones; fail closed; never touch the join-bound member row (the #243 poisoning lesson).
- `resolveSpaceSender` feeds stored admissions into the extended `resolveVerifiedSender` across all four auth paths (control messages, update-profile, read-only posts, @everyone).

### Robustness / fixes
- Missing-store read guards so an absent store can never crash the inbound message path (falls back to join-bound member resolution).
- DB init hygiene: `onversionchange` / `onblocked` so a version bump can't wedge the database behind another open tab.
- "Reset App Data" no longer silently no-ops on a blocked delete — it reports an actionable "close other tabs" message.

### Docs / tracking
- `quorum-db-schema.md` brought current (v14, `search_indices` + `space_member_devices` stores, dev-only version-collision note).
- `cryptographic-architecture.md` progress note; task file updated with the staged release order (ship receive-side now; gate the send-side flip on mobile being fully implemented).
- Two tracked bug reports: `announce-keys` flooding bound, and the join-binding hijack (a pre-existing member-binding weakness surfaced during review).

Verified: 63 desktop tests + 20 shared tests green, 0 type errors, production build green, and manual regression (delete own/other, mute, @everyone, update-profile) shows no behavior change.

### Commits
- feat: per-device signing keys — desktop receive-side
- docs: track announce-keys flooding as a bug (reject evict-oldest cap)
- test: real-DB coverage for the space_member_devices v14 store
- docs: note per-device signing keys shared core + desktop receive-side landed
- fix: survive a missing space_member_devices store + DB upgrade hygiene
- fix: reliable app-data reset + db-schema doc; keep DB at v14 (additive)
- docs(task): staged release order — ship desktop receive-side alone now