### PR TITLE
refactor(edit): use shared applyEdit + MESSAGE_EDIT_WINDOW_MS

### DIFF
--- a/src/components/message/MessageEditTextarea.tsx
+++ b/src/components/message/MessageEditTextarea.tsx
@@ -15,7 +15,7 @@ import { usePasskeysContext, channel as secureChannel } from '@quilibrium/quilib
 import { DefaultImages } from '../../utils';
 import { isTouchDevice } from '../../utils/platform';
 import { ENABLE_MARKDOWN, ENABLE_DM_ACTION_QUEUE, ENABLE_MENTION_PILLS } from '../../config/features';
-import { createIPFSCIDRegex, extractMentionsFromText } from '@quilibrium/quorum-shared';
+import { createIPFSCIDRegex, extractMentionsFromText, applyEdit } from '@quilibrium/quorum-shared';
 import { useMentionInput, type MentionOption, useMentionPillEditor } from '../../hooks/business/mentions';
 import { getCaretCoordinates, type CaretCoordinates } from '../../utils/caretCoordinates';
 
@@ -426,43 +426,34 @@ export function MessageEditTextarea({
       spaceChannels: spaceChannels.map(c => ({ channelId: c.channelId, channelName: c.channelName })),
     });
 
-    // Preserve current content in edits array before updating
-    const currentText = message.content.type === 'post' ? message.content.text : '';
-    const existingEdits = message.edits || [];
-
-    // Build edits array optimistically
-    const edits = message.modifiedDate === message.createdDate
-      ? // First edit: add original content to edits array
-        [
-          {
-            text: currentText,
-            modifiedDate: message.createdDate,
-            lastModifiedHash: message.nonce,
-          },
-        ]
-      : existingEdits.length > 0
-      ? // Subsequent edits: add current version
-        [
-          ...existingEdits,
-          {
-            text: currentText,
-            modifiedDate: message.modifiedDate,
-            lastModifiedHash: message.lastModifiedHash || message.nonce,
-          },
-        ]
-      : existingEdits;
+    // Apply the edit optimistically via the shared helper (same logic as the
+    // receive path — single source of truth). The optimistic path always
+    // retains prior versions; if the conversation/space has saveEditHistory
+    // off, the authoritative receive/DB path reconciles edits[] to empty. No
+    // replay guard fires here (fresh nonce never matches the stored one).
+    const applied = applyEdit(
+      {
+        text: message.content.type === 'post' ? message.content.text : '',
+        createdDate: message.createdDate,
+        modifiedDate: message.modifiedDate,
+        nonce: message.nonce,
+        lastModifiedHash: message.lastModifiedHash,
+        edits: message.edits,
+      },
+      { editedAt, editNonce, saveEditHistory: true }
+    );
 
     // Create updated message object
     const updatedMessage: MessageType = {
       ...message,
-      modifiedDate: editedAt,
-      lastModifiedHash: editNonce,
+      modifiedDate: applied.modifiedDate,
+      lastModifiedHash: applied.lastModifiedHash,
       mentions: mentions, // Update mentions with newly extracted mentions
       content: {
         ...message.content,
         text: editedText,
       } as PostMessage,
-      edits: edits,
+      edits: applied.edits,
     };
 
     // Update React Query cache IMMEDIATELY
@@ -517,7 +508,7 @@ export function MessageEditTextarea({
         }
 
         // If saveEditHistory is disabled, clear edits array
-        if (!saveEditHistoryEnabled && edits.length > 0) {
+        if (!saveEditHistoryEnabled && applied.edits.length > 0) {
           const correctedMessage: MessageType = {
             ...updatedMessage,
             edits: [],

--- a/src/hooks/business/messages/useMessageActions.ts
+++ b/src/hooks/business/messages/useMessageActions.ts
@@ -1,4 +1,4 @@
-import { logger } from '@quilibrium/quorum-shared';
+import { logger, MESSAGE_EDIT_WINDOW_MS } from '@quilibrium/quorum-shared';
 import { useCallback, useState } from 'react';
 import React from 'react';
 import type { Message as MessageType, Role, Channel, ReactionMessage, RemoveReactionMessage, RemoveMessage, PostMessage } from '@quilibrium/quorum-shared';
@@ -99,11 +99,10 @@ export function useMessageActions(options: UseMessageActionsOptions) {
   const canUserDelete = Boolean(canDeleteMessages);
 
   // Calculate if user can edit this message
-  // Only original sender can edit, and only within 15 minutes
-  const EDIT_TIME_WINDOW = 15 * 60 * 1000; // 15 minutes in milliseconds
+  // Only original sender can edit, and only within the shared edit window
   const canUserEdit = message.content.senderId === userAddress &&
     message.content.type === 'post' &&
-    (Date.now() - message.createdDate) <= EDIT_TIME_WINDOW;
+    (Date.now() - message.createdDate) <= MESSAGE_EDIT_WINDOW_MS;
 
   // Helper to build DM context for action queue handlers
   const buildDmActionContext = useCallback((address: string) => {

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -22,6 +22,8 @@ import {
   shouldSignEdit,
   canManageReadOnlyChannel,
   verifyDeviceKeyStatement,
+  MESSAGE_EDIT_WINDOW_MS,
+  applyEdit,
   type ControlMessageContent,
   type DeviceKeyStatement,
 } from '@quilibrium/quorum-shared';
@@ -1417,10 +1419,9 @@ export class MessageService {
         return;
       }
 
-      // Check edit time window (15 minutes = 900000 ms)
-      const editTimeWindow = 15 * 60 * 1000;
+      // Check edit time window
       const timeSinceCreation = Date.now() - targetMessage.createdDate;
-      if (timeSinceCreation > editTimeWindow) {
+      if (timeSinceCreation > MESSAGE_EDIT_WINDOW_MS) {
         return;
       }
 
@@ -1458,67 +1459,45 @@ export class MessageService {
         saveEditHistoryEnabled = space?.saveEditHistory ?? false;
       }
 
-      // Check if this edit has already been applied (by comparing lastModifiedHash with editNonce)
-      // This prevents duplicate edits when processing the same edit message multiple times
-      const isAlreadyApplied =
-        targetMessage.lastModifiedHash === editMessage.editNonce;
+      // Apply the received edit via the shared helper (single source of truth
+      // with the send path and mobile). It retains prior versions in edits[]
+      // (seeding the original on the first edit); the replay guard makes a
+      // re-delivered edit a no-op so a duplicate can't clobber stored history.
+      const applied = applyEdit(
+        {
+          text:
+            targetMessage.content.type === 'post'
+              ? targetMessage.content.text
+              : '',
+          createdDate: targetMessage.createdDate,
+          modifiedDate: targetMessage.modifiedDate,
+          nonce: targetMessage.nonce,
+          lastModifiedHash: targetMessage.lastModifiedHash,
+          edits: targetMessage.edits,
+        },
+        {
+          editedAt: editMessage.editedAt,
+          editNonce: editMessage.editNonce,
+          saveEditHistory: saveEditHistoryEnabled,
+        }
+      );
 
-      // Preserve current content in edits array before updating (only if saveEditHistory is enabled)
-      const currentText =
-        targetMessage.content.type === 'post' ? targetMessage.content.text : '';
-
-      // Create edits array if it doesn't exist
-      const existingEdits = targetMessage.edits || [];
-
-      // Only add to edits if saveEditHistory is enabled AND this edit hasn't been applied yet
-      let edits: Array<{
-        text: string | string[];
-        modifiedDate: number;
-        lastModifiedHash: string;
-      }>;
-
-      if (isAlreadyApplied) {
-        // Edit already applied: use existing edits array (don't modify)
-        edits = existingEdits;
-      } else if (!saveEditHistoryEnabled) {
-        // saveEditHistory disabled: don't preserve edits
-        edits = [];
-      } else if (targetMessage.modifiedDate === targetMessage.createdDate) {
-        // First edit: add original content to edits array
-        edits = [
-          {
-            text: currentText,
-            modifiedDate: targetMessage.createdDate,
-            lastModifiedHash: targetMessage.nonce, // Use original nonce as hash
-          },
-        ];
-      } else if (existingEdits.length > 0) {
-        // Subsequent edits: add current version (which is now the previous version)
-        edits = [
-          ...existingEdits,
-          {
-            text: currentText,
-            modifiedDate: targetMessage.modifiedDate,
-            lastModifiedHash:
-              targetMessage.lastModifiedHash || targetMessage.nonce,
-          },
-        ];
-      } else {
-        // Edge case: edited before but edits array is empty (shouldn't happen, but handle gracefully)
-        edits = existingEdits;
+      // Replayed edit (already applied): make no change.
+      if (!applied.changed) {
+        return;
       }
 
       // Update the original message with edited text and mentions
       const updatedMessage: Message = {
         ...targetMessage,
-        modifiedDate: editMessage.editedAt,
-        lastModifiedHash: editMessage.editNonce,
+        modifiedDate: applied.modifiedDate,
+        lastModifiedHash: applied.lastModifiedHash,
         mentions: editMessage.mentions || targetMessage.mentions, // Update mentions if provided
         content: {
           ...targetMessage.content,
           text: editMessage.editedText,
         } as PostMessage,
-        edits: edits,
+        edits: applied.edits,
       };
 
       await messageDB.saveMessage(
@@ -1931,10 +1910,9 @@ export class MessageService {
                         return m;
                       }
 
-                      // Check edit time window (15 minutes)
-                      const editTimeWindow = 15 * 60 * 1000;
+                      // Check edit time window
                       const timeSinceCreation = Date.now() - m.createdDate;
-                      if (timeSinceCreation > editTimeWindow) {
+                      if (timeSinceCreation > MESSAGE_EDIT_WINDOW_MS) {
                         return m;
                       }
 
@@ -2707,10 +2685,9 @@ export class MessageService {
           return outbounds;
         }
 
-        // Check edit time window (15 minutes)
-        const editTimeWindow = 15 * 60 * 1000;
+        // Check edit time window
         const timeSinceCreation = Date.now() - originalMessage.createdDate;
-        if (timeSinceCreation > editTimeWindow) {
+        if (timeSinceCreation > MESSAGE_EDIT_WINDOW_MS) {
           return outbounds;
         }
 
@@ -5502,10 +5479,9 @@ export class MessageService {
           return outbounds;
         }
 
-        // Check edit time window (15 minutes)
-        const editTimeWindow = 15 * 60 * 1000;
+        // Check edit time window
         const timeSinceCreation = Date.now() - originalMessage.createdDate;
-        if (timeSinceCreation > editTimeWindow) {
+        if (timeSinceCreation > MESSAGE_EDIT_WINDOW_MS) {
           return outbounds;
         }
 


### PR DESCRIPTION
## What

Converge desktop's message-edit logic onto quorum-shared (single source of truth with mobile):
- All 5 `15 * 60 * 1000` edit-window literals → shared `MESSAGE_EDIT_WINDOW_MS` (MessageService.ts ×4, useMessageActions.ts).
- Inlined edit-apply logic → shared `applyEdit` on both the receive/DB path (`MessageService.ts`) and the send/optimistic composer (`MessageEditTextarea.tsx`).

## Why

Pairs with **quorum-shared #64** (merged), which replaced the buggy `buildLocalEdits`/`applyReceivedEdit` (they lost the original version and duplicated the current) with `applyEdit`, embodying the model desktop already used: `edits[]` retains **prior versions** (original seeded on first edit); timeline = `[...edits, current]`.

## Behavior

Pure refactor for desktop — edit-history behavior is unchanged (verified: DM + Space edit history still shows original → v1 → v2 with no loss/duplication). Two minor, intentional divergences: the replay guard now skips a redundant re-save of an already-applied edit, and empty-`editNonce` legacy edits are always applied.

## Verification

- `tsc` clean; 124/124 service unit tests green.
- Manual UI: DM and Space edit-history timelines correct.

## Notes

- Desktop resolves shared via `link:../quorum-shared` (now on master), so this is not gated on an npm publish.
- **Mobile** follow-up (needs a shared publish + pin bump): adopt `applyEdit` + fix its EditHistoryModal — tracked in quorum-mobile `.agents/tasks/2026-07-20-mobile-adopt-shared-applyedit-fix-edit-history.md`.