### PR TITLE
fix: improve role name/tag edit UX and focus visuals

### DIFF
--- a/.agents/bugs/.solved/2026-06-12-readonly-channel-receive-side-enforcement-gaps.md
+++ b/.agents/bugs/.solved/2026-06-12-readonly-channel-receive-side-enforcement-gaps.md
@@ -1,7 +1,7 @@
 ---
 type: bug
 title: "Read-only channel receive-side enforcement is incomplete (sticker/embed bypass; cache-only for posts)"
-status: open
+status: resolved (2026-07-21) — both platforms enforce read-only for post/embed/sticker on live + durable paths with force-signed sends. Desktop shipped 2026-07-19; mobile in quorum-mobile PR #160 (d3c6113). See tasks/.done/2026-07-19-readonly-channel-completion-durable-embed-sticker.md.
 created: 2026-06-12
 ai_generated: true
 related_bugs:

--- a/.agents/tasks/.done/2026-07-19-readonly-channel-completion-durable-embed-sticker.md
+++ b/.agents/tasks/.done/2026-07-19-readonly-channel-completion-durable-embed-sticker.md
@@ -1,7 +1,7 @@
 ---
 type: task
 title: "Complete read-only-channel enforcement: durable path + embed/sticker + always-sign read-only posts"
-status: desktop DONE (shipping via PR) — mobile half still open (tracked in quorum-mobile 2026-06-25-space-control-msg-auth-signature-design.md). Bug stays open until both platforms land.
+status: DONE (both platforms) — desktop shipped 2026-07-19; mobile shipped in quorum-mobile PR #160 (d3c6113, 2026-07-19). Closes-bug resolved.
 priority: medium-high
 created: 2026-07-19
 severity: HIGH (authorization bypass — same class as the merged control-message-auth fix)
@@ -40,13 +40,25 @@ new §3f durable path incl. fail-open + thread-reply exemption) — 44/44 pass;
 in a read-only channel and they persist across reload; signing toggle hidden in
 read-only channels).
 
-**Still open:** the **mobile** half (send-side force-sign + composer toggle-disable,
-plus the read-only receive coverage) is being handled alongside the mobile
-control-message-auth work. Coordination note: the receive-side "drop unsigned
-read-only post" and the send-side force-sign MUST land together on mobile, or a
-manager's own unsigned post (repudiable space) gets dropped. Bug
-`2026-06-12-readonly-channel-receive-side-enforcement-gaps.md` stays OPEN until
-mobile lands.
+## ✅ Mobile — DONE (2026-07-19, quorum-mobile PR #160 / d3c6113)
+
+Shipped alongside the mobile control-message-auth work, mirroring desktop:
+
+1. **Receive guard** — `isReadOnlyPostAuthorized` (new module
+   `services/space/spaceMessageAuth.ts`) authorizes the verified ed448 signer via
+   `canManageReadOnlyChannel`, applied to `post`/`embed`/`sticker` on BOTH the
+   live (`WebSocketContext.tsx` ~2430) and batch/durable (~4080) paths. Both drop
+   BEFORE `storage.saveMessage`, so a forged post can't resurrect from disk.
+2. **Send-side force-sign** — `SpaceChatArea.tsx` (~476/496):
+   `skipSigning: isReadOnlyChannel ? false : skipSigning`, so a manager's own post
+   is always signed and never dropped by the receive guard.
+3. **Composer UX** — `SpaceChatArea.tsx` ~823:
+   `signingOptional={!!spaceData?.isRepudiable && !isReadOnlyChannel}` hides the
+   unsigned toggle in read-only channels.
+
+Both platforms now enforce read-only for post/embed/sticker on live + durable
+paths with force-signed sends → bug
+`2026-06-12-readonly-channel-receive-side-enforcement-gaps.md` resolved.
 
 ## Where we are (what's already done)
 
@@ -160,4 +172,4 @@ resolved.
 - **Mobile side:** the full mobile audit + reference list is in `D:/GitHub/Quilibrium/quorum-mobile/.agents/tasks/2026-06-25-space-control-msg-auth-signature-design.md` (gitignored/local) — mirror it for the mobile half of this task.
 - **Cross-repo rules:** `D:/GitHub/Quilibrium/quorum-atlas.md` (esp. iOS-review-only, ship/PR conventions).
 
-*Last updated: 2026-07-19*
+*Last updated: 2026-07-21*

--- a/.agents/tasks/2026-07-19-space-deletion-ghost-cleanup.md
+++ b/.agents/tasks/2026-07-19-space-deletion-ghost-cleanup.md
@@ -6,11 +6,14 @@ priority: high
 created: 2026-07-19
 severity: data-integrity + UX (blocking-leave, no offline; garbage accumulation compounds #108)
 spans-repos:
-  - quorum-desktop
-  - quorum-mobile (mirror — same add-only sync bug, tracked as mobile M2)
+  - quorum-desktop (this task — implement here)
+  - quorum-mobile (mirror — has BOTH the same add-only receive bug AND a
+    mobile-only write-side gap: delete/leave never publish. Tracked separately as
+    the mobile bug below; do NOT implement mobile changes from this desktop task.)
 related:
   - .agents/bugs/2025-12-09-encryption-state-evals-bloat.md (#108 — 2MB/created-space bloat this compounds)
   - .agents/docs/features/action-queue.md (delete-space is "not yet integrated"; recommended pattern lines 731-753)
+  - ../../quorum-mobile/.agents/bugs/2026-07-19-config-sync-add-only-deleted-spaces-linger.md (MOBILE side — shared tombstone/reconciliation contract + mobile-only write-side publish gap; severity high. Any wire/config change here must stay in sync with this.)
   - ../../quorum-mobile/.agents/reports/2026-07-19-signing-key-multidevice-hunt-tracker.md (M2 add-only sync; D7 corrupted-space delete)
 ---
 
@@ -127,11 +130,122 @@ Outcome: the recovery tool can no longer resurrect a space you deleted.
 Outcome: storage stops growing per conversation. Cap/prune `encryption_states`
 history (keep latest N per conversationId). Independent of the above.
 
-## Cross-platform
-Mobile has the identical add-only bug (M2) and no delete-space queueing. Mirror
-the tombstone + reconciliation contract so behaviour matches; `deletedSpaceIds`
-is a config/wire addition both apps must agree on — additive, but confirm with
-the lead alongside #108. Do NOT change the encryption-state blob shape here.
+## Field-tested addendum (2026-07-21, live desktop — verify mobile too)
+
+Three more delete-space defects observed on desktop. #2 and #3 are small,
+independent quick wins that can ship WITHOUT the full action-queue rework (they
+also survive it). #1 is a symptom the Slice 1 rewrite structurally resolves;
+recorded here so it isn't lost.
+
+### A. "Delete failed" toast, but the space is actually deleted (refresh confirms)
+Symptom: deleting a space sometimes shows a failure message, yet after a page
+refresh the space is gone — deletion actually succeeded. The error and the
+persisted state disagree.
+
+Diagnosis (in code): `SpaceService.deleteSpace` (`:563`) does the network work in
+two independent steps before the local wipe:
+1. `enqueueOutbound(async () => [message])` (`:618`) — sends the hub 'leave'
+   envelope **fire-and-forget** (`enqueueOutbound` returns `void`, is not awaited
+   and not inside the caller's try/catch).
+2. `await postHubDelete(...)` (`:619`) — the actual hub delete.
+3. Local wipe + config save + `messageDB.deleteSpace` (`:654-685`).
+
+For the space to be gone on refresh, step 3 (`messageDB.deleteSpace`, `:685`) MUST
+have run — i.e. `deleteSpace` reached completion. So the failure the user sees is
+NOT `postHubDelete` throwing (that would abort before step 3 and leave the DB row,
+which `getSpaces()` would still show on refresh). Two candidate sources, to
+confirm by repro with the console open:
+- **Most likely:** the fire-and-forget leave-envelope send (step 1) fails
+  asynchronously and surfaces a global error toast, while hub-delete + local wipe
+  both succeed. Matches "sometimes fails" (flaky outbound) + "actually deleted".
+- Or a throw AFTER `deleteSpace` returns — in `navigate(...)` / `onSuccess` /
+  `onClose` — caught by the hook's catch and shown as a generic failure.
+
+Fix: Slice 1's pre-seal + optimistic-wipe + durable `delete-space-notify` queue
+makes deletion no longer depend on (and never contradict) the notify result —
+success/failure of propagation is a queue state (offline banner / failed-action),
+not a modal error over an already-completed delete. If a pre-Slice-1 stopgap is
+wanted, stop surfacing the fire-and-forget send failure as a hard "delete failed"
+toast. Belongs to **Slice 1** (and Slice 3 for the corrupted-space path).
+
+### B. After delete, redirect goes to Contacts, not the Spaces list
+Symptom: deleting a space drops you on the DM/contacts list instead of the spaces
+page.
+
+Diagnosis: both delete call sites navigate to a contacts destination.
+`useSpaceManagement.handleDeleteSpace` does `navigate('/')`
+(`useSpaceManagement.ts:146`), and `/` redirects to `/messages` = `DirectMessages`
+(contacts) (`Router.web.tsx:107-114`, `:115-128`). `useSpaceLeaving.leaveSpace`
+does `navigate('/messages')` directly (`useSpaceLeaving.ts:51`). The spaces list
+lives at `/spaces` (`DiscoverPage mode="spaces-empty"`, `Router.web.tsx:143-158`).
+
+Fix: navigate both delete paths to `/spaces` instead. Two one-line changes
+(`useSpaceManagement.ts:146`, `useSpaceLeaving.ts:51`). Independent quick win.
+
+### C. Deleted space lingers in the sidebar/spaces list until refresh
+Symptom: even on an immediately-successful delete, the just-deleted space still
+appears in the spaces list; only a page refresh clears it.
+
+Diagnosis: the sidebar (`SpacesSidebar.tsx:80`) and spaces list read from
+`useSpaces` → query key `['Spaces']` (`buildSpacesKey`), backed by
+`messageDB.getSpaces()`. `deleteSpace` invalidates/updates only the **config**
+query cache (`buildConfigKey`, `SpaceService.ts:681`) and `messageDB.deleteSpace`
+the DB row — but never invalidates the `['Spaces']` query, so React Query serves
+the stale cached list until a hard reload. A `useInvalidateSpaces` hook already
+exists (`hooks/queries/spaces/useInvalidateSpaces.ts`) and is not called here.
+
+Fix: after the local wipe, invalidate `['Spaces']`. `deleteSpace` already receives
+`queryClient`, so add
+`queryClient.invalidateQueries({ queryKey: buildSpacesKey({}) })` alongside the
+existing config-cache update (`:681`), or have the hook call `useInvalidateSpaces`
+after `deleteSpace` resolves. This is also the correct sidebar-update mechanism
+for Slice 1's optimistic path. Independent quick win.
+
+## Cross-platform — READ BEFORE TOUCHING THE CONFIG/WIRE SHAPE
+Mobile is affected too, but **mobile work is tracked separately and is OUT OF
+SCOPE for this desktop task.** Do not edit the mobile repo from here. Mobile has:
+- the identical add-only *receive* reconciliation bug (M2), AND
+- a mobile-only *write-side* gap: `useDeleteSpace`/`useLeaveSpace` never publish
+  the deletion (no `saveConfig` write-back, no hub leave) — see the mobile bug.
+
+Both are captured in
+`../../quorum-mobile/.agents/bugs/2026-07-19-config-sync-add-only-deleted-spaces-linger.md`
+(severity high; write-side section + fix steps added 2026-07-21). When mobile is
+scheduled, it becomes its own task/branch that mirrors this contract.
+
+**Shared-contract obligation (the reason this matters to the desktop implementer):**
+`deletedSpaceIds` is a `UserConfig`/wire addition both apps must agree on. It is
+**additive**, but:
+- Keep it strictly additive + optional-typed so it can't break the mobile client
+  that hasn't shipped its side yet (see the "don't break mobile on shared changes"
+  rule). If the type lives in `quorum-shared`, coordinate that change there.
+- Match the reset-after-successful-sync lifecycle and retention window to whatever
+  mobile will implement, so tombstones aren't dropped before the other device
+  catches up.
+- Confirm the field with the lead alongside #108 before shipping.
+
+Do NOT change the encryption-state blob shape here.
+
+Addendum defects (A/B/C) checked against mobile 2026-07-21 — mobile does NOT
+share them in the same form (delete/leave live in `hooks/chat/useSpaceSettings.ts`
+`useDeleteSpace`/`useLeaveSpace`, triggered from `components/SpaceSettingsModal.tsx`):
+- **A (fail toast vs. actually-deleted): not present.** Mobile delete/leave are
+  **local-only** (no `postHubDelete`, no leave envelope — leave is a stub with a
+  `TODO: Send leave message`). No fire-and-forget network send that can fail while
+  the local delete succeeds, so no toast/state mismatch. Mobile's real gap here is
+  the deeper one: leave/delete never propagate at all — confirmed 2026-07-21 that
+  `useDeleteSpace`/`useLeaveSpace` only wipe local MMKV, with NO `saveConfig`
+  write-back and NO hub leave (whereas mobile create/join DO `saveConfig`,
+  `spaceService.ts:404-407`). Tracked + diagnosed in mobile bug
+  `2026-07-19-config-sync-add-only-deleted-spaces-linger.md` (write-side section
+  added same day; severity raised to high).
+- **B (redirect to contacts): not present in that form.** Mobile navigates via
+  `router.back(); router.back()` (pop within the spaces tab stack —
+  `app/(tabs)/spaces/[id]/index.tsx:171`, `[channelId].tsx:372`), not a hardcoded
+  contacts route. Worth a visual confirm, but no wrong-destination bug in code.
+- **C (stale spaces list): already correct on mobile — mirror it on desktop.**
+  Both mobile mutations do `onSuccess: invalidateQueries(['spaces'])`
+  (`useSpaceSettings.ts:124-126,153-155`). Desktop is the one missing this.
 
 ## Test plan
 1. Online leave: modal closes + sidebar updates instantly; hub-delete fires;
@@ -147,6 +261,13 @@ the lead alongside #108. Do NOT change the encryption-state blob shape here.
 6. Restore button: a tombstoned (deleted) space is NOT offered for restore; a
    genuinely sync-lost, non-tombstoned space still is.
 7. Regression: DM states never touched by reconciliation.
+8. Redirect (B): after deleting a space you land on `/spaces` (spaces list), not
+   the contacts/DM list — from both the settings-modal delete and the leave flow.
+9. Live sidebar (C): a successful delete removes the space from the spaces
+   list/sidebar immediately, with no page refresh.
+10. Toast/state agreement (A): a delete never shows a "failed" toast while the
+    space is actually gone; propagation failures surface as queue/offline state,
+    not as an error over a completed delete.
 
 ## Non-goals / relation to #108
 Does NOT fix the 2MB-per-created-space creation bloat (#108 — separate
@@ -155,4 +276,4 @@ upload limit until #108 lands. This task stops accumulation + fixes the leave UX
 #108 fixes per-space size. Implement on a SEPARATE branch, not
 `fix-multidevice-signing-key`.
 
-*Last updated: 2026-07-19*
+*Last updated: 2026-07-21*

--- a/.agents/tasks/2026-07-20-sync-per-conversation-dm-settings-cross-repo.md
+++ b/.agents/tasks/2026-07-20-sync-per-conversation-dm-settings-cross-repo.md
@@ -1,0 +1,215 @@
+---
+type: task
+title: "Sync per-conversation DM settings across a user's devices (cross-repo)"
+status: design — not implemented
+created: 2026-07-20
+priority: medium
+platforms: quorum-shared + quorum-desktop + quorum-mobile
+related:
+  - quorum-mobile/.agents/tasks/2026-07-20-sync-all-conversation-settings.md (the mobile-side draft this was cross-checked against)
+  - quorum-mobile/.agents/docs/features/dm-mute-behavior-and-pattern.md (the proven UserConfig-map sync pattern to copy)
+  - quorum-mobile/.agents/tasks/.done/2026-06-17-dm-conversation-settings-parity.md (mute + edit-history + receipt-pipeline history)
+  - .agents/docs/config-sync-system.md (desktop config sync)
+  - .agents/docs/features/messages/dm-receipts.md (desktop receipt pipeline)
+---
+
+# Sync per-conversation DM settings across devices
+
+## Problem
+
+Some per-conversation DM settings are **device-local** on both apps: a setting a
+user changes on their phone is invisible on their desktop (and on a second
+device). The state is a mixed bag, verified against the real code on 2026-07-20:
+
+| Setting | Desktop storage | Desktop syncs? | Mobile storage | Mobile syncs? |
+|---|---|---|---|---|
+| DM **mute** | `UserConfig.mutedConversations` | ✅ **yes** | `UserConfig.mutedConversations` | ✅ **yes** |
+| DM **favorite** | `UserConfig.favoriteDMs` | ✅ yes | `UserConfig.favoriteDMs` | ✅ yes |
+| **Save Edit History** | local `Conversation.saveEditHistory` | ❌ no | local `Conversation.saveEditHistory` | ❌ no |
+| **Always sign** (`isRepudiable`) | local `Conversation.isRepudiable` | ❌ no | local `Conversation.isRepudiable` | ❌ no |
+| **Receipt override** (delivery/read) | local `Conversation.deliveryReceipts` / `.readReceipts` | ❌ no | (built + reverted; not present today) | ❌ no |
+
+> **Correction to the incoming draft.** The mobile draft's table claims desktop
+> DM mute is a device-local `Conversation` field that does NOT sync. That is
+> wrong. Desktop mute already lives in `UserConfig.mutedConversations` and syncs
+> (`src/hooks/business/dm/useDMMute.ts:55` reads `config.mutedConversations`; the
+> `save-user-config` action queue uploads it). **Mute and favorites already sync
+> on BOTH platforms** — they are the reference implementation, not the gap. The
+> real gap is the three receipt/signing/edit-history overrides sitting on the
+> local `Conversation` record.
+
+### Where the local-only reads/writes are (evidence)
+
+**Desktop**
+- Write: `src/components/modals/ConversationSettingsModal.tsx:145-157` →
+  `messageDB.saveConversation({ isRepudiable, saveEditHistory, deliveryReceipts, readReceipts })` (IndexedDB, local only).
+- Read `deliveryReceipts`/`readReceipts`: `src/components/direct/DirectMessage.tsx:172-176`
+  (`effective = conversation.deliveryReceipts ?? cfg.deliveryReceipts ?? false`).
+- Read `isRepudiable`: `src/components/direct/DirectMessage.tsx:166` (drives the DM send-path `effectiveSkip` at :405).
+- Read `saveEditHistory`: `src/components/message/MessageEditTextarea.tsx:509`.
+- `ConfigService` never touches conversations — the config upload carries
+  `UserConfig` only. Confirmed: zero `saveConversation`/`conversation` references in `src/services/ConfigService.ts`.
+
+**Mobile**
+- Write: `app/(tabs)/messages/dm/[id].tsx:222-246` → `updateConversationSetting()` →
+  `storage.saveConversation({ ...stored, ...patch })` for `isRepudiable` and `saveEditHistory` (local only).
+- The receipt **pipeline** now exists (shipped 2026-07-19: `feat: DM delivery + read receipt pipeline`, ticks, and **global** receipt toggles that DO sync). Blocker #9 from the old parity task is cleared.
+- Per-conversation receipt override UI/storage was built then reverted, to land here as one coherent cross-device feature.
+
+## Goal
+
+**All per-conversation DM settings sync across a user's devices** (and
+interoperate desktop ↔ mobile) via the already-synced, encrypted `UserConfig`
+blob — one mechanism, not a per-setting bolt-on. Specifically bring these three
+into sync: `saveEditHistory`, `isRepudiable`, and the `deliveryReceipts` /
+`readReceipts` override. Mute and favorites are already done — **leave them
+where they are.**
+
+## Design: a synced map on `UserConfig`, keyed by conversationId
+
+This is the pattern already proven by DM mute (see the mobile
+`dm-mute-behavior-and-pattern.md`) and DM favorites.
+
+```ts
+// quorum-shared UserConfig (additive, all fields optional)
+conversationSettings?: {
+  [conversationId: string]: {
+    saveEditHistory?: boolean;
+    isRepudiable?: boolean;
+    deliveryReceipts?: boolean;   // per-conversation receipt override
+    readReceipts?: boolean;       // absent field = inherit the global/default
+    updatedAt?: number;           // per-ENTRY last-write-wins merge key (see below)
+  };
+};
+```
+
+The type, plus the read/write/merge helpers, live in **quorum-shared** so both
+apps share byte-identical semantics for a synced field (single source of truth —
+the merge must agree across desktop ↔ mobile). Helpers:
+`getConversationSetting`, `setConversationSetting`, `mergeConversationSettings`.
+
+- **Read model:** effective value = per-conversation field `??` global setting
+  (receipts) / `??` default (edit-history=false, sign=on). Absent = inherit.
+  Desktop's `DirectMessage.tsx` and `MessageEditTextarea.tsx` already compute
+  `conv ?? global ?? default`; the change is *where the `conv` value is read
+  from* (the config map, not the `Conversation` record).
+- **Write path:** the existing `saveConfig` / `save-user-config` flow. No new
+  sync transport — putting the fields on `UserConfig` is all that's needed.
+  Same freshness as every config field: the other device refreshes on
+  restart/login/config-pull, NOT live.
+- **Do NOT fold mute in.** `mutedConversations` already works and syncs on both
+  platforms. Migrating a working synced feature into a new shape is risk with no
+  user benefit. Keep it as a sibling array.
+
+### Merge strategy — LOCKED: per-entry last-write-wins
+
+`UserConfig` maps split two ways today:
+- **Coarse whole-blob LWW** (no per-key merge): `mutedConversations`,
+  `notificationSettings`. If device B saves config for any unrelated reason, its
+  older copy of the map overwrites A's concurrent edit.
+- **Per-key merge**: `deviceNames`, `userNotes`, `bookmarks` (handled explicitly
+  in `ConfigService.getConfig`).
+
+**Decision: per-CONVERSATION-entry last-write-wins, keyed by a per-entry
+`updatedAt`** — matching the `userNotes` convention (each note is one entry with
+one `updatedAt`). This is the elegant AND convention-consistent choice:
+
+- Every write bumps that conversation's `updatedAt`; merge keeps the entry with
+  the higher `updatedAt` (missing = 0; tie → keep local, mirroring the config's
+  "equal timestamp → prefer local" rule).
+- An unrelated config save on device B no longer clobbers device A's edit to a
+  *different* conversation — the real failure of coarse LWW is fixed.
+- **Reset-to-global keeps an empty-but-timestamped entry** (`{ updatedAt }`) as
+  its own tombstone: a newer empty entry beats an older non-empty one, so a reset
+  propagates without a separate deletion-tracking array. Empty entries are ~30
+  bytes and bounded by conversation count; no pruning needed.
+- **Not field-level.** Field-level merge (per-field timestamps) would survive the
+  rare "two devices, same conversation, different field, both offline, then sync"
+  case, but requires a `{ value, updatedAt }` shape per field — ugly and divergent
+  from every existing config field. Entry-level accepts the same tiny concurrency
+  tradeoff `userNotes` already accepts. Solid enough, far more elegant.
+
+Implemented once in shared (`mergeConversationSettings`) and called from both
+apps' `getConfig`.
+
+## Cross-repo scope
+
+### 1. quorum-shared (do FIRST, then publish)
+- Add `UserConfig.conversationSettings` (additive, all-optional) to
+  `src/types/user.ts`. **This is the only shared change.**
+- Optionally add a tiny `effectiveConversationSetting(config, conversationId, key, fallback)` helper if worth centralizing the `?? global ?? default` logic across both apps.
+- Additive + optional → safe for mobile, which is pinned to a published build
+  (see `feedback_dont_break_mobile_on_shared_changes`). Follow the canonical
+  order: **shared → publish → desktop → mobile bumps → mobile**. Mobile can read
+  the field untyped via `(config as any)` before it bumps if needed.
+
+### 2. quorum-desktop
+- **Write:** `ConversationSettingsModal.tsx` writes the four fields into
+  `UserConfig.conversationSettings[conversationId]` (via a `save-user-config`
+  enqueue, mirroring `useDMMute`) instead of `messageDB.saveConversation`.
+- **Read:** point `DirectMessage.tsx` (receipts + `isRepudiable`) and
+  `MessageEditTextarea.tsx` (`saveEditHistory`) at the config map, keeping the
+  existing `?? global ?? default` fallback.
+- **Merge:** add the `conversationSettings` per-key merge to
+  `ConfigService.getConfig` (only if the lead picks per-key merge). Desktop's
+  inbound already does a full `{ ...config }` spread (`ConfigService.ts:376`), so
+  a new field survives inbound with no allow-list edit — desktop has **no**
+  read-back-bridge problem (it reads config straight from IndexedDB via
+  `useConfig`).
+- **Migration:** on first run, copy any existing local
+  `Conversation.{saveEditHistory,isRepudiable,deliveryReceipts,readReceipts}`
+  into the map; keep reading the local fields as a fallback for one release.
+
+### 3. quorum-mobile
+- Same move: `dm/[id].tsx` `updateConversationSetting` writes to
+  `UserConfig.conversationSettings` instead of `storage.saveConversation`; the
+  DM send path, composer lock, edit hooks, and receipt gating read effective
+  values from the map.
+- **Add a per-conversation receipt override UI** to `DMSettingsSheet.tsx` (the
+  reverted piece) now that the pipeline exists.
+- **Mobile-specific safety (do not skip):** mobile has the known broken
+  config→`user` read-back bridge (`config-to-user-readback-bridge-missing`). Use
+  the **bookmark pattern** — read `conversationSettings` straight from the MMKV
+  config, not the `user` object — AND add `conversationSettings` to the explicit
+  inbound preservation list in `services/config/configService.ts` `getConfig`
+  (the same list that carries `bookmarks`/`mutedConversations`), so an incoming
+  config can't silently drop it.
+- **Migration:** same as desktop — fold local `Conversation` values into the map
+  on first run, dual-read for one release.
+
+## What goes in quorum-shared (report)
+
+**Exactly one additive change:** `UserConfig.conversationSettings?: { [conversationId]: { saveEditHistory?, isRepudiable?, deliveryReceipts?, readReceipts?, updatedAt? } }` in `quorum-shared/src/types/user.ts`, all fields optional. Optionally a shared `effectiveConversationSetting` helper. Nothing else is a shared/wire change — the transport is the existing encrypted `UserConfig` blob. No new wire message type (unlike the separate `delete-conversation-self` work, which IS a blocked wire type). This means it can ship additively and does not carry the shared-publish blocker class.
+
+## Not in scope
+- DM **mute** and **favorites** — already synced on both platforms; leave as-is.
+- **Global** delivery/read receipt toggles + the ✓/✓✓ pipeline — shipped on both.
+- `delete-conversation-self` self-sync — separate task, blocked on a new wire type.
+- Space (channel) settings sync — DM per-conversation only.
+
+## Open questions for the lead (Telegram) — FYI, not blocking
+1. Merge strategy is LOCKED to per-entry LWW (see above); flag only if the lead
+   wants a different sync architecture.
+2. Desktop ↔ mobile parity in one go, or mobile-first with desktop to follow?
+3. Confirm mute/favorites stay as their own `UserConfig` arrays (not folded into
+   the new map) — recommended, and assumed here.
+
+## Progress
+- **quorum-shared:** ✅ **PR #63 open** → master
+  (`feat/user-config-conversation-settings`): type + helpers + 18 passing tests,
+  feature-only (no version change). Build + vitest green, rebased onto current
+  master. Rides the already-bumped, not-yet-published `2.1.0-36` (npm latest is
+  still `2.1.0-35`; master's `chore: bump to 2.1.0-36` is the segregated bump
+  from other work). My earlier local `chore/bump-shared-2.1.0-36` branch was
+  redundant with master's bump and was deleted. If `2.1.0-36` publishes before
+  #63 merges, bump to `2.1.0-37` as its own commit.
+- **quorum-desktop:** pending shared publish (or local-link build). Rewire
+  `ConversationSettingsModal` (write) + `DirectMessage`/`MessageEditTextarea`
+  (read) to `UserConfig.conversationSettings` via the shared helpers; add
+  `mergeConversationSettings` to `ConfigService.getConfig`; migrate local
+  `Conversation` fields on first run (dual-read one release).
+- **quorum-mobile:** pending; write the aligned mobile task + add the
+  per-conversation receipt override UI (the reverted piece); use the bookmark
+  pattern + add `conversationSettings` to `getConfig`'s inbound preservation list.
+
+*Last updated: 2026-07-20*

--- a/.agents/tasks/2026-07-21-device-registration-ghost-accumulation-cross-platform.md
+++ b/.agents/tasks/2026-07-21-device-registration-ghost-accumulation-cross-platform.md
@@ -1,0 +1,247 @@
+---
+type: task
+title: "Ghost device accumulation on reset/logout — deregister-before-wipe (desktop + mobile)"
+status: PLAN — not started
+priority: medium (UX/hygiene; not a security hole, but pollutes the device list and per-device-signing admissions)
+created: 2026-07-21
+platforms: quorum-desktop + quorum-mobile (+ optional quilibrium-js-sdk-channels hardening)
+related:
+  - .agents/tasks/2026-07-19-per-device-signing-keys-registration-anchored.md (revoke-device tie-in)
+  - .agents/docs/features/onboarding-flow.md (KeyDB id=2 / registration flow)
+  - .agents/reports/2026-06-22-app-lock-password-gate-research.md (reset flow + duress-wipe; KeyDB-not-deleted note)
+---
+
+# Ghost device accumulation on reset/logout
+
+## Symptom (observed)
+
+A test account used across ~3-4 physical devices shows **10+ devices** in the
+device list. The user resets app data and re-logs-in frequently on those
+devices; each cycle adds a device entry that is never removed.
+
+## Root cause (verified in source, both platforms)
+
+Reset/logout **destroys the local device keyset without first removing that
+device's entry from the hub `UserRegistration.device_registrations[]`.** The
+device keyset is the ONLY local handle to its hub entry, so once wiped the entry
+is orphaned (only manual device-list removal can clear it). Each re-login then
+mints a FRESH device keyset (new `inbox_address`) and appends it → ghosts
+accumulate.
+
+Key distinction: a genuinely NEW physical device legitimately has no keyset to
+reuse, so minting there is correct. The bug is exclusively the SAME device
+re-registering after its local keyset was wiped. Any fix must therefore key off
+"the device being wiped," not a reuse/fingerprint heuristic.
+
+### Desktop mechanism
+
+- Reset ([`DangerZone.tsx` `handleResetAppData`](../../src/components/modals/UserSettingsModal/DangerZone.tsx)):
+  `queryClient.clear()` → `indexedDB.deleteDatabase('quorum_db')` →
+  `localStorage.clear()` → `sessionStorage.clear()` → reload.
+  - Deletes `quorum_db` and the **localStorage passkey session**
+    (`passkeys-list`, `${prefix}-master`) → app can no longer auto-resume the
+    account → user is forced to re-onboard/re-import.
+  - Does **NOT** delete the separate `KeyDB` database (SDK: `indexedDB.open('KeyDB', 1)`),
+    so the device/master keys physically survive — but they're bypassed because
+    the session is gone.
+- Re-import path runs the SDK's `buildAndUploadRegistration`
+  (`quilibrium-js-sdk-channels/dist/index.js` ~line 5945): it **always**
+  `NewDeviceKeyset()`, fetches `existing.device_registrations`, and
+  `ConstructUserRegistration(ident, existing, [newDevice])` — appends, never
+  reuses `KeyDB id=2`, never prunes. → +1 ghost per reset+reimport.
+- Note: a plain reload WITHOUT reimport reuses `KeyDB id=2` via
+  [`RegistrationPersister.tsx:158`](../../src/components/context/RegistrationPersister.tsx#L158)
+  and does NOT mint. The reset only triggers the bug because it clears the
+  localStorage session (`App.tsx:84` reads `currentPasskeyInfo` from
+  `localStorage['passkeys-list']`; once null, `App.tsx:132` routes to
+  `OnboardingFlow`, not `RegistrationProvider`) and forces the reimport.
+- Correction (independent review 2026-07-21): the `NewDeviceKeyset()` at
+  `RegistrationPersister.tsx:115` is NOT reachable on a transient network error.
+  It requires `registration.registered === false` (a hub 404 — transient fetch
+  errors throw/suspend, they don't return `registered:false`) AND
+  `loadKeyDecryptData(2)` failing (KeyDB id=2 absent/corrupt). So that line is a
+  permanent-corruption path, not a routine one. The reset→reimport chain via the
+  SDK's `buildAndUploadRegistration` is the real accumulation vector.
+
+### Mobile mechanism
+
+- Mobile is architecturally more resilient: `initializeEncryptionKeys` REUSES
+  the SecureStore device keyset if present (`keyService.ts:527-543`) and
+  `uploadUserRegistration` DEDUPES by `inbox_address` before appending
+  (`keyService.ts:719-722`). So normal re-logins do NOT accumulate.
+- But "Reset App Data" → `signOut()` (`context/AuthContext.tsx:467`) calls
+  `clearAllMMKVStorage()` **and** `clearAllSecureStorage()` — wiping the device
+  keyset (inbox signing/encryption keys, inbox_address, identity, prekey). On
+  re-login, no keyset to reuse → a new one is generated → new `inbox_address` →
+  the dedupe filter can't match the old orphaned entry → append. Same ghost.
+
+## The fix: deregister-before-wipe (symmetric, uses existing machinery)
+
+Reset must remove THIS device from the hub registration **while the keys are
+still present**, then wipe. Both platforms already have the code:
+
+- **Desktop:** `ConstructUserRegistration(userKeyset, remainingDevices, [])` +
+  `uploadRegistration`, exactly as the removeDevice save path in
+  [`useUserSettings.ts:522-534`](../../src/hooks/business/user/useUserSettings.ts#L522-L534).
+  Current device's inbox_address = `keyset.deviceKeyset.inbox_keyset.inbox_address`.
+- **Mobile:** `removeDeviceFromRegistration(userAddress, userPublicKey,
+  userPrivateKey, thisInboxAddress)` already exists (`keyService.ts:873`) — it
+  just isn't called on reset.
+
+### Slice 1 — Desktop (vertical, observable)
+
+1. In `handleResetAppData`, before any wipe: obtain `keyset` (via the
+   registration context) and the current device inbox_address. Build
+   `remainingDevices = device_registrations.filter(d => d.inbox_registration.inbox_address !== thisInbox)`,
+   `ConstructUserRegistration(keyset.userKeyset, remainingDevices, [])`, upload.
+   **CRITICAL (independent review 2026-07-21): the upload MUST be awaited with a
+   bounded timeout BEFORE the wipe/reload — not fire-and-forget.** `uploadRegistration`
+   fires an HTTP request; `window.location.reload()` synchronously cancels
+   in-flight `fetch`/XHR (unless `keepalive`), so a fire-and-forget deregister
+   followed by an immediate reload silently drops the request even online. Use
+   `await Promise.race([uploadDeregister(...), timeout(~3000ms)])`, then wipe.
+   This is the #1 way the fix "passes in tests, fails in the field."
+2. Then run the existing wipe (quorum_db + localStorage + sessionStorage + reload).
+3. (Secondary, optional) also delete `KeyDB` so the reset actually honors its own
+   copy ("delete your private keys") — see "Secondary" below; must run AFTER the
+   deregister since the deregister needs the master key.
+4. **Observable outcome:** on a second device, open the device list; reset device
+   A; A disappears from the list instead of piling up. Re-login on A adds exactly
+   one entry (the new A), total device count stays flat across reset cycles.
+5. Unit test the "reconstruct registration without current device" pure logic
+   (input device list + this inbox → expected remaining list; last-device case).
+
+### Slice 2 — Mobile (mirror)
+
+1. In the reset flow (`ProfileModal.handleResetAppData` → before `signOut()`, or
+   inside `signOut` guarded by a `deregister` flag so ordinary logout can opt in
+   too): read `getPrivateKey()`/`getPublicKey()`/`getInboxAddress()` and call
+   `removeDeviceFromRegistration(...)` before `clearAllSecureStorage()`.
+   Best-effort with timeout.
+2. Then `clearAllMMKVStorage()` + `clearAllSecureStorage()` as today.
+3. **Observable outcome:** same as desktop, verified statically + on a real
+   device pair (mobile: prefer statically-verifiable change per quorum-atlas;
+   confirm on-device with the dual-device preview setup if available).
+
+### Slice 3 — SDK hardening (raise with lead; optional, not required for the fix)
+
+Desktop SDK `buildAndUploadRegistration` should reuse the existing `KeyDB id=2`
+device keyset when present (mirror mobile's `initializeEncryptionKeys` reuse) so
+that re-importing on a device that already holds the account does not mint a
+duplicate even without a reset. Wire-compatible, but it's the lead's SDK repo →
+propose via Telegram, don't self-merge.
+
+## Edge cases / decisions
+
+- **Offline at reset time:** the deregister upload will fail. Reset must NOT be
+  blockable (users often reset precisely when things are broken/offline). Chosen
+  behavior: attempt with a short timeout; on failure, proceed with the wipe
+  anyway and surface a non-blocking notice ("couldn't reach the network; this
+  device may remain listed until you remove it manually"). Accept the rare
+  residual ghost. This keeps the common (online) path clean and reset reliable.
+- **Last device on the account:** mobile's `removeDeviceFromRegistration` refuses
+  to leave 0 devices (`keyService.ts:902-904`); desktop's filter has no such
+  guard. Removing the last device empties `device_registrations`. OPEN: confirm
+  the server accepts an empty device list on upload. If it does, allow reset to
+  remove the last device (fully clean). If it rejects empty, accept a ≤1 residual
+  ghost from single-device accounts — still a massive improvement over 10+.
+  → Verify server behavior before finalizing mobile's last-device path.
+- **No reuse/fingerprint heuristic needed:** deregister removes exactly the
+  device being orphaned; a different real device (never reset) is never touched.
+- **Partial completion — deregister succeeds but wipe fails (blocked delete /
+  other tab):** the device is now off the hub but still local. On the next app
+  open WITHOUT a wipe, `RegistrationPersister` (registered:true path,
+  lines 186-209) finds the current inbox_address missing from
+  `device_registrations` and silently re-appends it — reversing the deregister.
+  Not catastrophic (self-consistent), but means a failed wipe undoes the
+  cleanup. Acceptable; note it so it isn't mistaken for the fix "not working."
+- **`keyset` not ready at reset time (desktop):** `RegistrationContext` default
+  is `keyset: undefined as never` and RegistrationPersister populates it after a
+  ~200ms init. A user who opens Settings and types RESET faster than that could
+  see `keyset === undefined` → guard: if keyset/inbox unavailable, skip the
+  deregister and proceed with the wipe (fall back to old behavior, no crash).
+- **Non-reset ghost vectors (out of scope here, but real — don't claim this fix
+  eliminates ALL accumulation):** (a) the `clickRestore`/"Reauthorize" path in
+  RegistrationPersister can hit `NewDeviceKeyset()` under
+  registered:false + KeyDB-corrupt + repeated passkey denial; (b) pasting a key
+  in Security settings without a reset. Both obscure; neither is fixed by
+  deregister-on-reset. Frame the fix as "stops the reset-driven accumulation,"
+  not "no device can ever be orphaned."
+- **Cleaning up EXISTING ghosts:** manual removal via the existing device-list UI
+  (desktop Security modal, mobile device management). No migration needed; just
+  document it for the test accounts.
+
+## Tie-in: per-device signing keys
+
+Once the send-side of
+[2026-07-19-per-device-signing-keys-registration-anchored.md](2026-07-19-per-device-signing-keys-registration-anchored.md)
+lands, device removal broadcasts `revoke-device` per space. Deregister-on-reset
+should also fire that broadcast (before the wipe), or the reset leaves stale
+per-device signing admissions in other members' `space_member_devices` stores.
+Keep this dependency in mind; it does not block Slices 1-2 (revoke-device
+send-side isn't shipped yet), but the reset deregister and the revoke broadcast
+should share one code path when they converge.
+
+Be precise about scope (independent review 2026-07-21): deregister-on-reset
+removes the device from the HUB `UserRegistration` (so new DMs can't be sealed to
+it) but does NOT clear that device's admission rows already sitting in other
+members' local `space_member_devices` stores — those only clear via a
+`revoke-device` broadcast (not shipped) or some later cleanup. So this fix is
+"complete for the hub registration, not yet for space signing admissions." State
+that plainly rather than implying the ghost is fully erased everywhere.
+
+### Conflict check vs the per-device-signing feature (#244 / #245) — verified 2026-07-21
+
+Question raised: could deregister-on-reset conflict with the per-device signing
+work already merged (#244 interim per-user signing key; #245 desktop receive-side
+of per-device keys)? **Conclusion: no conflict with shipped code; it is a
+convergence point for the future send-side.** Verified against source:
+
+- **DangerZone overlap is harmless.** #245's only `DangerZone.tsx` change was
+  making a *blocked* IDB delete reject instead of silently resolving. This fix
+  adds a deregister step *before* the wipe — orthogonal, stacks cleanly.
+- **Signing admissions are anchored to the master key, not the hub device list
+  this fix mutates.** `quorum-shared/src/utils/deviceKeys.ts:194` verifies via
+  `deriveInboxAddress(userPublicKey) === userAddress` + the master-key signature;
+  it NEVER fetches or checks `UserRegistration.device_registrations[]`. So
+  removing a device from the hub list invalidates no admission and breaks no
+  verification. Different anchor.
+- **No send-side exists to collide with.** `MessageService.ts` has RECEIVE
+  handlers for `announce-keys`/`revoke-device` (~lines 986, 4974) but nothing
+  BROADCASTS them. Send-side is unshipped on both platforms.
+- **Mobile: same.** Its space signing key is per-user (shared via config), not
+  tied to the DM device registration, so `removeDeviceFromRegistration` on reset
+  doesn't touch it.
+
+Two items for the convergence (when send-side + revocation lands — NOT now):
+1. The await-before-wipe discipline must extend to the `revoke-device` broadcast
+   too (don't wipe keys/connection before it propagates — same trap as the
+   registration upload).
+2. Reset revokes the CURRENT device (self-revocation), whereas the per-device
+   plan frames revocation around removing OTHER devices. A device revoking itself
+   right before wiping is a slightly different flow — should be fine (master-
+   signed, LWW) but flag it to the lead when the send-side is designed.
+
+## Files (anticipated)
+
+Desktop:
+- `src/components/modals/UserSettingsModal/DangerZone.tsx` — deregister step +
+  best-effort/timeout + notice; optional KeyDB delete.
+- (wiring) registration context / keyset access into DangerZone.
+- new unit test for the reconstruct-without-current-device logic.
+
+Mobile:
+- `components/ProfileModal.tsx` (`handleResetAppData`) and/or
+  `context/AuthContext.tsx` (`signOut`) — call `removeDeviceFromRegistration`
+  before `clearAllSecureStorage`.
+
+## Secondary (do NOT bundle silently)
+
+Desktop reset copy claims it deletes "your private keys" but `KeyDB` survives
+(only `quorum_db` is deleted). Deleting `KeyDB` on reset would honor the copy and
+is a real hardening, but it interacts with the app-lock / duress-wipe work
+([2026-06-22-app-lock-password-gate-research.md](../../.agents/reports/2026-06-22-app-lock-password-gate-research.md)).
+Decide explicitly (with the lead if needed); don't fold it into the ghost fix
+without calling it out.
+
+*Last updated: 2026-07-21*

--- a/src/components/message/MessageComposer.tsx
+++ b/src/components/message/MessageComposer.tsx
@@ -18,6 +18,7 @@ import { getTextareaSelectionRect } from '../../utils/toolbarPositioning';
 import { rectAnchor, type VirtualElement } from '../ui';
 import { ENABLE_MARKDOWN, ENABLE_MENTION_PILLS } from '../../config/features';
 import { getCaretCoordinates, type CaretCoordinates } from '../../utils/caretCoordinates';
+import { extractVisualTextWithNewlines } from '../../utils/mentionPillDom';
 import { useTypingNotifier } from '../../hooks/business/messages/useTypingNotifier';
 import type { TypingScope } from '@quilibrium/quorum-shared';
 
@@ -486,12 +487,21 @@ export const MessageComposer = forwardRef<
       const selectedText = range.toString();
 
       if (selectedText.length > 0) {
-        // Text is selected - get character positions
-        const preCaretRange = range.cloneRange();
-        preCaretRange.selectNodeContents(editor);
-        preCaretRange.setEnd(range.startContainer, range.startOffset);
-        const start = preCaretRange.toString().length;
-        const end = start + selectedText.length;
+        // Text is selected - get character positions in NEWLINE-AWARE visual
+        // space. `Range.toString()` (and `textContent`) silently drop the
+        // newlines that block elements encode, so measuring with them yields
+        // offsets that don't match the text we hand to the formatter — which is
+        // what collapsed multi-line messages when a word was formatted. Measure
+        // with the same serializer used as the format source so offsets align.
+        const preStart = range.cloneRange();
+        preStart.selectNodeContents(editor);
+        preStart.setEnd(range.startContainer, range.startOffset);
+        const start = extractVisualTextWithNewlines(preStart.cloneContents()).length;
+
+        const preEnd = range.cloneRange();
+        preEnd.selectNodeContents(editor);
+        preEnd.setEnd(range.endContainer, range.endOffset);
+        const end = extractVisualTextWithNewlines(preEnd.cloneContents()).length;
 
         setSelectionRange({ start, end });
 
@@ -521,8 +531,12 @@ export const MessageComposer = forwardRef<
     const handleMarkdownFormat = useCallback(
       (formatFn: FormatFunction) => {
         if (ENABLE_MENTION_PILLS && editorRef.current) {
-          // For contentEditable: use visual text for formatting
-          const visualText = extractVisualText();
+          // For contentEditable: format against the newline-aware visual text so
+          // block line breaks survive. `extractVisualText()` (textContent) drops
+          // them, which is what flattened multi-line messages on format. The
+          // `white-space: pre-wrap` editor then renders the `\n`s in the single
+          // text node we write below, and `extractStorageText()` reads them back.
+          const visualText = extractVisualTextWithNewlines(editorRef.current);
           const result = formatFn(visualText, selectionRange.start, selectionRange.end);
 
           // For now, we'll just insert the formatted text as plain text

--- a/src/components/modals/SpaceSettingsModal/Roles.tsx
+++ b/src/components/modals/SpaceSettingsModal/Roles.tsx
@@ -95,11 +95,11 @@ const Roles: React.FunctionComponent<RolesProps> = ({
                   <div className="flex flex-col">
                     <div>
                       <span
-                        className="font-mono modal-role"
+                        className="font-mono modal-role transition-shadow focus-within:ring-2 focus-within:ring-black/20 dark:focus-within:ring-white/40"
                         style={{ backgroundColor: getRoleColorHex(r.color) }}
                       >
                         <input
-                          className="border-0 bg-transparent outline-none"
+                          className="border-0 bg-transparent outline-none focus-visible:outline-none"
                           style={{
                             width:
                               Math.max(
@@ -107,6 +107,7 @@ const Roles: React.FunctionComponent<RolesProps> = ({
                                 60
                               ) + 'px',
                           }}
+                          onFocus={(e) => e.target.select()}
                           onChange={(e) =>
                             updateRoleDisplayName(
                               i,
@@ -120,7 +121,7 @@ const Roles: React.FunctionComponent<RolesProps> = ({
                     <div className="mt-1">
                       @
                       <input
-                        className="border-0 bg-transparent outline-none font-mono"
+                        className="border-0 bg-transparent outline-none focus-visible:outline-none focus:bg-surface-1 focus:px-2 focus:py-1 focus:rounded transition-all font-mono"
                         style={{
                           width:
                             (roles.find((_, pi) => i == pi)
@@ -129,6 +130,7 @@ const Roles: React.FunctionComponent<RolesProps> = ({
                             11 +
                             'px',
                         }}
+                        onFocus={(e) => e.target.select()}
                         onChange={(e) =>
                           updateRoleTag(i, e.target.value)
                         }

--- a/src/components/user/UserProfile.tsx
+++ b/src/components/user/UserProfile.tsx
@@ -28,6 +28,7 @@ import {
 import { useUserNote, buildUserNoteKey } from '../../hooks/queries/userNotes';
 import { useUserPublicProfile } from '../../hooks/business/user/useUserPublicProfile';
 import { useQueryClient } from '@tanstack/react-query';
+import { buildSpaceKey } from '../../hooks/queries/space/buildSpaceKey';
 import { buildConfigKey } from '../../hooks/queries/config/buildConfigKey';
 import { buildConfigFetcher } from '../../hooks/queries/config/buildConfigFetcher';
 import { validateUserNote, MAX_USER_NOTE_LENGTH } from '../../hooks/business/validation';
@@ -65,8 +66,11 @@ const UserProfile: React.FunctionComponent<{
   const { data: isSpaceOwner } = useSpaceOwner({
     spaceId: props.spaceId || '',
   });
+  // Use the canonical space cache key (buildSpaceKey) so role changes pushed by
+  // the space-manifest handler update role display live, instead of staying
+  // stale until a page refresh.
   const { data: space } = useQuery({
-    queryKey: ['space', props.spaceId],
+    queryKey: buildSpaceKey({ spaceId: props.spaceId || '' }),
     queryFn: async () => {
       if (!props.spaceId) return null;
       return await messageDB.getSpace(props.spaceId);

--- a/src/dev/tests/services/ActionQueueHandlers.unit.test.ts
+++ b/src/dev/tests/services/ActionQueueHandlers.unit.test.ts
@@ -301,7 +301,7 @@ describe('ActionQueueHandlers - Unit Tests', () => {
       });
 
       expect(invalidateSpy).toHaveBeenCalledWith({
-        queryKey: ['space', 'space-123'],
+        queryKey: ['Space', 'space-123'],
       });
     });
   });

--- a/src/dev/tests/utils/mentionPillDom.unit.test.ts
+++ b/src/dev/tests/utils/mentionPillDom.unit.test.ts
@@ -12,7 +12,10 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { extractStorageTextFromEditor } from '../../../utils/mentionPillDom';
+import {
+  extractStorageTextFromEditor,
+  extractVisualTextWithNewlines,
+} from '../../../utils/mentionPillDom';
 
 /** Build a contentEditable editor div from an HTML string. */
 function editor(html: string): HTMLElement {
@@ -86,6 +89,48 @@ describe('extractStorageTextFromEditor — newline reconstruction (the regressio
   it('keeps an unclosed code fence on its own line (the empty-code-box repro)', () => {
     const html = '```<div>code line 1</div><div>code line 2</div>';
     expect(extractStorageTextFromEditor(editor(html))).toBe('```\ncode line 1\ncode line 2');
+  });
+});
+
+describe('extractVisualTextWithNewlines — visible text with line breaks', () => {
+  it('returns plain single-line text unchanged', () => {
+    expect(extractVisualTextWithNewlines(editor('hello world'))).toBe('hello world');
+  });
+
+  it('renders pills as their visible label, not the storage token', () => {
+    const html = `hi ${pill('user', 'QmAddr123', '@Alice')} there`;
+    expect(extractVisualTextWithNewlines(editor(html))).toBe('hi @Alice there');
+  });
+
+  it('reconstructs newlines from <br> and per-line <div> (the format-collapse repro)', () => {
+    expect(extractVisualTextWithNewlines(editor('line1<br>line2<br>line3'))).toBe(
+      'line1\nline2\nline3'
+    );
+    expect(
+      extractVisualTextWithNewlines(editor('line1<div>line2</div><div>line3</div>'))
+    ).toBe('line1\nline2\nline3');
+  });
+
+  it('represents a blank line between paragraphs as a single newline', () => {
+    const html = 'para1<div><br></div><div>para2</div>';
+    expect(extractVisualTextWithNewlines(editor(html))).toBe('para1\n\npara2');
+  });
+
+  it('does NOT trim, so leading/trailing whitespace offsets stay accurate', () => {
+    expect(extractVisualTextWithNewlines(editor('  hi  '))).toBe('  hi  ');
+  });
+
+  it('measures a partial selection (fragment) with newlines preserved', () => {
+    // Simulate Range.cloneContents() over "line1\nlin" of a two-<div> editor:
+    // the fragment carries the leading text node plus a partial second block.
+    const frag = document.createDocumentFragment();
+    frag.appendChild(document.createTextNode('line1'));
+    const div = document.createElement('div');
+    div.textContent = 'lin';
+    frag.appendChild(div);
+    // "line1" + "\n" + "lin" = 9 chars — the offset the toolbar would record.
+    expect(extractVisualTextWithNewlines(frag)).toBe('line1\nlin');
+    expect(extractVisualTextWithNewlines(frag).length).toBe(9);
   });
 });
 

--- a/src/hooks/business/conversations/useDirectMessagesList.ts
+++ b/src/hooks/business/conversations/useDirectMessagesList.ts
@@ -43,17 +43,20 @@ export function useDirectMessagesList(): UseDirectMessagesListReturn {
     );
   }, [messages]);
 
-  // Determine if user has sent messages (auto-accept chat)
-  // Only check once on mount — no need to re-check on every message
+  // Determine if user has sent messages (auto-accept chat).
+  // Re-evaluated whenever the message list changes so the "not accepted yet"
+  // banner clears as soon as the user's reply lands, without a page refresh.
+  // Only ever flips false → true (idempotent), so no cascading re-renders.
   useEffect(() => {
-    const userMessages = messageList.filter(
-      (m) => m.content.senderId === user.currentPasskeyInfo!.address
+    const userAddress = user.currentPasskeyInfo?.address;
+    if (!userAddress) return;
+    const hasUserMessage = messageList.some(
+      (m) => m.content.senderId === userAddress
     );
-    if (userMessages.length > 0) {
+    if (hasUserMessage) {
       setAcceptChat(true);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-only check
-  }, []);
+  }, [messageList, user.currentPasskeyInfo]);
 
   // Initial message loading
   useEffect(() => {

--- a/src/hooks/business/messages/usePinnedMessages.ts
+++ b/src/hooks/business/messages/usePinnedMessages.ts
@@ -9,6 +9,7 @@ import { hasPermission } from '@quilibrium/quorum-shared';
 import { useConfirmationModal } from '../../../components/context/ConfirmationModalProvider';
 import MessagePreview from '../../../components/message/MessagePreview';
 import { t } from '@lingui/core/macro';
+import { buildSpaceKey } from '../../queries/space/buildSpaceKey';
 
 // Configuration constants for pinned messages feature
 const PINNED_MESSAGES_CONFIG = {
@@ -29,9 +30,13 @@ export const usePinnedMessages = (
   const user = usePasskeysContext();
   const { messageDB, actionQueueService } = useMessageDB();
   const { showConfirmationModal } = useConfirmationModal();
-  // Query for space data to check roles and permissions
+  // Query for space data to check roles and permissions.
+  // Uses the canonical space cache key (buildSpaceKey) so role changes pushed
+  // by the space-manifest handler (MessageService setQueryData) update pin
+  // permissions live — without this alignment the pin option stayed stale until
+  // a page refresh because it read a separate ['space', spaceId] cache entry.
   const { data: space } = useQuery({
-    queryKey: ['space', spaceId],
+    queryKey: buildSpaceKey({ spaceId }),
     queryFn: async () => {
       if (!spaceId) return null;
       return await messageDB.getSpace(spaceId);

--- a/src/services/ActionQueueHandlers.ts
+++ b/src/services/ActionQueueHandlers.ts
@@ -24,6 +24,7 @@ import type { SpaceService } from './SpaceService';
 import type { QueryClient, InfiniteData } from '@tanstack/react-query';
 import type { ActionType } from '../types/actionQueue';
 import { buildMessagesKeyPrefix } from '../hooks/queries/messages/buildMessagesKey';
+import { buildSpaceKey } from '../hooks/queries/space/buildSpaceKey';
 import { channel as secureChannel } from '@quilibrium/quilibrium-js-sdk-channels';
 import type { Message } from '@quilibrium/quorum-shared';
 import { DefaultImages } from '../utils';
@@ -149,7 +150,7 @@ export class ActionQueueHandlers {
         this.deps.queryClient
       );
       this.deps.queryClient.invalidateQueries({
-        queryKey: ['space', context.spaceId],
+        queryKey: buildSpaceKey({ spaceId: context.spaceId as string }),
       });
     },
     isPermanentError: (error) => {

--- a/src/utils/mentionPillDom.ts
+++ b/src/utils/mentionPillDom.ts
@@ -122,24 +122,46 @@ export function createPillElement(pillData: PillData, onClick?: () => void): HTM
 }
 
 /**
- * Extract storage format text from a contentEditable editor.
- * Walks the DOM tree and converts pills to their storage representation.
- *
- * Storage formats:
- * - Users: `@<address>`
- * - Roles: `@roleTag` (no brackets)
- * - Channels: `#<channelId>`
- * - Everyone: `@everyone`
- *
- * @param editorElement - The contentEditable div element
- * @returns Text in storage format with mention IDs
- *
- * @example
- * // Editor contains: "Hello " + <pill user Alice 0x123> + " welcome!"
- * const text = extractStorageTextFromEditor(editorRef.current);
- * // => "Hello @<0x123> welcome!"
+ * How a mention pill element is serialized during a DOM walk.
+ * - `storage` → the wire token (`@<address>`, `#<channelId>`, `@roleTag`, `@everyone`)
+ * - `visual`  → the visible label as the user sees it (`@Alice`, `#general`)
  */
-export function extractStorageTextFromEditor(editorElement: HTMLElement): string {
+function serializePillStorage(el: HTMLElement): string {
+  const prefix = el.dataset.mentionType === 'channel' ? '#' : '@';
+  if (el.dataset.mentionType === 'role') {
+    // Roles always use @roleTag format (no brackets)
+    return `@${el.dataset.mentionAddress}`;
+  }
+  if (el.dataset.mentionType === 'everyone') {
+    // @everyone always same format
+    return '@everyone';
+  }
+  // Legacy format: @<address> or #<channelId>
+  return `${prefix}<${el.dataset.mentionAddress}>`;
+}
+
+/**
+ * Walk a contentEditable subtree and serialize it to text, reconstructing the
+ * line breaks that browsers encode as block elements (`<div>`/`<p>`) and `<br>`.
+ *
+ * This is the shared engine behind both {@link extractStorageTextFromEditor}
+ * (pills → wire tokens) and {@link extractVisualTextWithNewlines} (pills →
+ * visible labels). Keeping the newline logic in one place means both callers
+ * agree on character offsets, which is what lets the markdown toolbar map a DOM
+ * selection to string positions without dropping line breaks.
+ *
+ * The returned text is NOT trimmed — callers that need the original composer
+ * behavior (storage) apply `.trim()` themselves; offset math needs the raw
+ * length.
+ *
+ * @param root - The contentEditable element OR a DocumentFragment (e.g. from
+ *   `Range.cloneContents()`), so the same walk measures partial selections.
+ * @param serializePill - How to render a mention pill leaf.
+ */
+function serializeEditorNodes(
+  root: Node,
+  serializePill: (el: HTMLElement) => string
+): string {
   let text = '';
 
   // Block-level tags a contentEditable uses to represent visual lines. Browsers
@@ -148,7 +170,6 @@ export function extractStorageTextFromEditor(editorElement: HTMLElement): string
   // start of every block boundary to reconstruct the original line breaks.
   const BLOCK_TAGS = new Set(['DIV', 'P']);
 
-  // Walk the editor's DOM and serialize to storage text.
   // `isBlock` marks a node that opens a new visual line (a block element that is
   // not the editor's first child) so we can prefix it with a newline.
   const walk = (node: Node, isBlock: boolean) => {
@@ -166,19 +187,9 @@ export function extractStorageTextFromEditor(editorElement: HTMLElement): string
       return;
     }
 
-    // Mention pills serialize to their storage token (no newline).
+    // Mention pills are leaves — serialize per the caller's mode (no newline).
     if (el.dataset?.mentionType && el.dataset?.mentionAddress) {
-      const prefix = el.dataset.mentionType === 'channel' ? '#' : '@';
-      if (el.dataset.mentionType === 'role') {
-        // Roles always use @roleTag format (no brackets)
-        text += `@${el.dataset.mentionAddress}`;
-      } else if (el.dataset.mentionType === 'everyone') {
-        // @everyone always same format
-        text += '@everyone';
-      } else {
-        // Legacy format: @<address> or #<channelId>
-        text += `${prefix}<${el.dataset.mentionAddress}>`;
-      }
+      text += serializePill(el);
       return;
     }
 
@@ -208,7 +219,7 @@ export function extractStorageTextFromEditor(editorElement: HTMLElement): string
 
   // Top-level children: the first child continues the first line (no leading
   // newline); each subsequent block-level child opens a new line.
-  const topChildren = Array.from(editorElement.childNodes);
+  const topChildren = Array.from(root.childNodes);
   topChildren.forEach((child, i) => {
     const opensBlock =
       i > 0 &&
@@ -217,9 +228,49 @@ export function extractStorageTextFromEditor(editorElement: HTMLElement): string
     walk(child, opensBlock);
   });
 
+  return text;
+}
+
+/**
+ * Extract storage format text from a contentEditable editor.
+ * Walks the DOM tree and converts pills to their storage representation.
+ *
+ * Storage formats:
+ * - Users: `@<address>`
+ * - Roles: `@roleTag` (no brackets)
+ * - Channels: `#<channelId>`
+ * - Everyone: `@everyone`
+ *
+ * @param editorElement - The contentEditable div element
+ * @returns Text in storage format with mention IDs
+ *
+ * @example
+ * // Editor contains: "Hello " + <pill user Alice 0x123> + " welcome!"
+ * const text = extractStorageTextFromEditor(editorRef.current);
+ * // => "Hello @<0x123> welcome!"
+ */
+export function extractStorageTextFromEditor(editorElement: HTMLElement): string {
   // Trim outer whitespace (matches the original behavior); the reconstruction
-  // above only adds INTERNAL newlines, which trim() leaves intact.
-  return text.trim();
+  // only adds INTERNAL newlines, which trim() leaves intact.
+  return serializeEditorNodes(editorElement, serializePillStorage).trim();
+}
+
+/**
+ * Extract the *visible* text of a contentEditable subtree, with block/`<br>`
+ * line breaks reconstructed as `\n` and mention pills rendered as their visible
+ * label (e.g. `@Alice`, `#general`).
+ *
+ * Unlike `element.textContent` (which silently drops block-boundary newlines),
+ * this preserves line structure, so the markdown toolbar can format multi-line
+ * text without collapsing it. NOT trimmed — the result is used both as the text
+ * to format and to measure selection offsets, so its raw length must match the
+ * DOM exactly.
+ *
+ * @param root - The contentEditable element, or a `Range.cloneContents()`
+ *   fragment to measure a partial selection offset.
+ */
+export function extractVisualTextWithNewlines(root: Node): string {
+  return serializeEditorNodes(root, (el) => el.textContent || '');
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes two issues in the Space Settings role editor.

### 1. Editing a new role's name/tag
When you create a new role, the name/tag inputs are pre-filled with an auto-generated default (`New Role` / `newrole`) to avoid duplicates. Previously you had to manually clear that text before typing. Now the field text is selected on focus, so the first keystroke replaces it.

### 2. Focus visual regression
The inline name/tag inputs were showing a hard accent-colored rectangle on focus. This was a regression from the accessibility work, which added a global `:focus-visible { outline: 2px solid accent }`; text inputs match `:focus-visible` even on mouse click, so it overrode the inputs' `outline-none`.

- Suppressed that global outline on these specific inline inputs.
- Replaced the old nested focus box on the role name pill (which drew a box *inside* the colored pill) with a soft `focus-within` ring that hugs the pill's rounded shape, removing the box-in-box look.
- The `@tag` field keeps its subtle surface chip (no outer pill, so no nesting issue).

## Testing
- `npx tsc --noEmit` clean
- Manual: create a role, click name/tag → text selected and replaceable; focus shows a clean ring on the pill instead of an accent rectangle.