### PR TITLE
feat: sync per-conversation DM settings across a user's devices

### DIFF
--- a/.agents/tasks/2026-07-20-sync-per-conversation-dm-settings-cross-repo.md
+++ b/.agents/tasks/2026-07-20-sync-per-conversation-dm-settings-cross-repo.md
@@ -1,7 +1,7 @@
 ---
 type: task
 title: "Sync per-conversation DM settings across a user's devices (cross-repo)"
-status: design — not implemented
+status: shared ✅ merged · desktop ✅ implemented (branch, unmerged) · mobile ⏳ pending
 created: 2026-07-20
 priority: medium
 platforms: quorum-shared + quorum-desktop + quorum-mobile
@@ -134,16 +134,21 @@ apps' `getConfig`.
 
 ## Cross-repo scope
 
-### 1. quorum-shared (do FIRST, then publish)
-- Add `UserConfig.conversationSettings` (additive, all-optional) to
-  `src/types/user.ts`. **This is the only shared change.**
-- Optionally add a tiny `effectiveConversationSetting(config, conversationId, key, fallback)` helper if worth centralizing the `?? global ?? default` logic across both apps.
-- Additive + optional → safe for mobile, which is pinned to a published build
-  (see `feedback_dont_break_mobile_on_shared_changes`). Follow the canonical
-  order: **shared → publish → desktop → mobile bumps → mobile**. Mobile can read
-  the field untyped via `(config as any)` before it bumps if needed.
+### 1. quorum-shared ✅ DONE (PRs #63 + #65 merged to master, 2026-07-20/21)
+- Added `UserConfig.conversationSettings` (additive, all-optional) to
+  `src/types/user.ts` + the `ConversationSettingOverrides` type, plus the
+  `getConversationSetting` / `setConversationSetting` / `mergeConversationSettings`
+  helpers in `src/utils/conversationSettingsUtils.ts` (18 tests). #65 exported
+  `ConversationSettingOverrides` from the package root (missed in #63).
+- Additive + optional → safe for mobile (see `feedback_dont_break_mobile_on_shared_changes`).
+- ⚠️ **Not yet published to npm.** Master carries the code but the published
+  `2.1.0-36` tarball predates it. Desktop consumes shared via `link:../quorum-shared`
+  (local repo), so dev/test builds see it now; a desktop **production** ship needs
+  shared published to npm at a pinned version (or CI resolving the link) — confirm
+  how desktop CI resolves `@quilibrium/quorum-shared` before release.
 
-### 2. quorum-desktop
+### 2. quorum-desktop ✅ DONE (branch `feat/sync-conversation-settings`, unmerged)
+See the Progress section for the exact file-by-file changes + review fixes.
 - **Write:** `ConversationSettingsModal.tsx` writes the four fields into
   `UserConfig.conversationSettings[conversationId]` (via a `save-user-config`
   enqueue, mirroring `useDMMute`) instead of `messageDB.saveConversation`.
@@ -160,7 +165,7 @@ apps' `getConfig`.
   `Conversation.{saveEditHistory,isRepudiable,deliveryReceipts,readReceipts}`
   into the map; keep reading the local fields as a fallback for one release.
 
-### 3. quorum-mobile
+### 3. quorum-mobile ⏳ REMAINING — the mobile half (see the checklist in Progress)
 - Same move: `dm/[id].tsx` `updateConversationSetting` writes to
   `UserConfig.conversationSettings` instead of `storage.saveConversation`; the
   DM send path, composer lock, edit hooks, and receipt gating read effective
@@ -195,21 +200,139 @@ apps' `getConfig`.
    the new map) — recommended, and assumed here.
 
 ## Progress
-- **quorum-shared:** ✅ **PR #63 open** → master
-  (`feat/user-config-conversation-settings`): type + helpers + 18 passing tests,
-  feature-only (no version change). Build + vitest green, rebased onto current
-  master. Rides the already-bumped, not-yet-published `2.1.0-36` (npm latest is
-  still `2.1.0-35`; master's `chore: bump to 2.1.0-36` is the segregated bump
-  from other work). My earlier local `chore/bump-shared-2.1.0-36` branch was
-  redundant with master's bump and was deleted. If `2.1.0-36` publishes before
-  #63 merges, bump to `2.1.0-37` as its own commit.
-- **quorum-desktop:** pending shared publish (or local-link build). Rewire
-  `ConversationSettingsModal` (write) + `DirectMessage`/`MessageEditTextarea`
-  (read) to `UserConfig.conversationSettings` via the shared helpers; add
-  `mergeConversationSettings` to `ConfigService.getConfig`; migrate local
-  `Conversation` fields on first run (dual-read one release).
-- **quorum-mobile:** pending; write the aligned mobile task + add the
-  per-conversation receipt override UI (the reverted piece); use the bookmark
-  pattern + add `conversationSettings` to `getConfig`'s inbound preservation list.
+- **quorum-shared:** ✅ **DONE — PRs #63 + #65 merged to master.**
+  - #63 (`feat: add UserConfig.conversationSettings…`): `ConversationSettingOverrides`
+    type + `UserConfig.conversationSettings` + the `getConversationSetting` /
+    `setConversationSetting` / `mergeConversationSettings` helpers + 18 tests.
+  - #65 (`fix: export ConversationSettingOverrides from package root`): one-line
+    addition to the `from './user'` re-export list in `src/types/index.ts` (the
+    type was in `user.ts` but not in the public API). Feature-only, no version bump.
+  - Both ride the not-yet-published `2.1.0-36`. **Still unpublished on npm** — if
+    `2.1.0-36` publishes without these, bump to `2.1.0-37` as its own commit
+    (versioning stays lead-dev's call, see `project_quorum_shared_versioning`).
+- **quorum-desktop:** ✅ **implemented** on branch `feat/sync-conversation-settings`
+  (built against the locally-linked shared dist; npm `2.1.0-36` does NOT yet
+  carry #63, so this must not merge/ship until shared publishes). Changes:
+  - New `useDMConversationSettings` hook (write via `save-user-config` enqueue,
+    optimistic config-cache update + rollback, mirroring `useDMMute`; reactive
+    `getOverride` reader).
+  - `ConversationSettingsModal` writes the 4 fields into
+    `UserConfig.conversationSettings` (dropped the `messageDB.saveConversation`
+    write); load dual-reads config override → legacy local `Conversation`.
+  - `DirectMessage` now consumes `useConfig` and dual-reads `isRepudiable` +
+    delivery/read receipts from the synced map (reactive to modal saves).
+  - `MessageEditTextarea` dual-reads `saveEditHistory` (DM branch) from the map.
+  - `ConfigService.getConfig` merges `conversationSettings` via shared
+    `mergeConversationSettings` (per-entry LWW), beside the `deviceNames` merge.
+  - `useMigrateConversationSettings` (mounted in `Layout`): one-time per-user
+    sweep folding legacy local `Conversation` fields into the map with a low
+    `updatedAt` so any genuine edit wins; guarded by a localStorage flag.
+  - Added `conversationSettings?: { [conversationId]: ConversationSettingOverrides }`
+    to the desktop-local `UserConfig` in `src/db/messages.ts`, mirroring shared's
+    `UserConfig` field exactly (desktop still keeps its own `UserConfig` type — see
+    `project_quorum_shared_migration`). Initially typed with `ConversationSettingsMap`
+    as a workaround while #65's export was pending; reverted to the shared-aligned
+    form once #65 merged.
+  - **Post-review fixes (multi-agent /code-review high):**
+    - **MessageService reader sites (was a miss).** `MessageService.ts` reads
+      the effective receipt + edit-history settings on the RECEIVE path, direct
+      from the local `Conversation` record — three sites the modal no longer
+      writes to: receipt-intercept at (old) lines 3297-3298 and 5002-5003, and
+      edit-history-on-receive at ~1455. All three now dual-read the synced map
+      first (`getConversationSetting(userConfig?.conversationSettings, …) ?? local
+      ?? global`). **Mobile port MUST update the equivalent receive-path readers,
+      not just the modal/composer.**
+    - **Reactivity revert.** `DirectMessage` and the modal load originally read
+      the override from `getConfig()`/IndexedDB, where an optimistic save isn't
+      persisted yet → the just-saved value visibly reverted for a cycle. Both now
+      read the override from the reactive `useConfig` snapshot (`getOverride` in
+      the modal); `getConfig` is kept only for global defaults.
+    - Verified `mergeConversationSettings(local, undefined)` returns local
+      untouched (a newer mobile blob lacking the field can't wipe desktop
+      settings). Merge is strict `>` LWW, tie → local, so migration `updatedAt=1`
+      always loses to a real edit.
+  - **Known minor (accepted, documented):** migration skips a conversation if
+    the synced map already has ANY entry for it, so a field present only in the
+    legacy local record won't cross-device-propagate if a partial entry pre-exists
+    (dual-read still serves it locally). The optimistic-update rollback under the
+    `config:<addr>` dedup key can drop a second rapid save's optimistic value —
+    inherited verbatim from `useDMMute`/`useDMFavorites`, not new here.
+  - Typecheck + lint (no new warnings) + web build all green (re-verified after
+    the #65 type revert).
+  - **Files touched (desktop):** `src/hooks/business/dm/useDMConversationSettings.ts`
+    (new), `src/hooks/business/dm/useMigrateConversationSettings.ts` (new),
+    `src/components/modals/ConversationSettingsModal.tsx`,
+    `src/components/direct/DirectMessage.tsx`,
+    `src/components/message/MessageEditTextarea.tsx`,
+    `src/services/MessageService.ts` (3 receive-path readers),
+    `src/services/ConfigService.ts` (merge), `src/components/Layout.tsx` (mount
+    migration), `src/db/messages.ts` (type).
+- **quorum-mobile:** ⏳ **PENDING — the remaining half. Execute-ready checklist below.**
 
-*Last updated: 2026-07-20*
+  Prereq: bump mobile's `@quilibrium/quorum-shared` pin to a published version
+  that carries #63 + #65 (or the code won't have the helpers). Until then mobile
+  can read the field untyped via `(config as any).conversationSettings`.
+
+  1. **Write** — `app/(tabs)/messages/dm/[id].tsx` `updateConversationSetting()`:
+     write to `UserConfig.conversationSettings[conversationId]` via `setConversationSetting`
+     + the existing `saveConfig` flow, instead of `storage.saveConversation({...stored, ...patch})`.
+  2. **Read (dual-read, mirror desktop)** — effective value =
+     `getConversationSetting(config.conversationSettings, id, key) ?? legacy local Conversation field ?? global ?? default`, at EVERY site:
+     - DM send path / composer signing lock (`isRepudiable`).
+     - Edit hooks (`saveEditHistory`).
+     - Receipt gating.
+     - ⚠️ **Receive-path readers in mobile's MessageService equivalent** — this was
+       the desktop miss (3 sites: receipt-intercept ×2 + edit-history-on-receive).
+       Find mobile's equivalent of `interceptControlMessages` gating and the
+       received-edit `saveEditHistory` check and dual-read them too. **Do not
+       update only the modal/composer.**
+  3. **Per-conversation receipt override UI** — re-add to `DMSettingsSheet.tsx`
+     (the piece built + reverted on 2026-07-19); the receipt pipeline already exists.
+  4. **Merge** — call shared `mergeConversationSettings(local, remote)` in mobile's
+     `services/config/configService.ts` `getConfig`, beside the bookmark/mute merges.
+  5. **Inbound preservation (belt-and-suspenders)** — mobile's `getConfig` already
+     spreads `...decryptedConfig` (line ~397), so `conversationSettings` survives
+     inbound today. Still add it to the explicit round-trip list next to
+     `mutedConversations`/`bookmarks` (the `config-to-user-readback-bridge-missing`
+     guard) so no future refactor silently drops it.
+  6. **Migration** — one-time sweep folding local `Conversation.{isRepudiable,
+     saveEditHistory,deliveryReceipts,readReceipts}` into the map with a low
+     `updatedAt` (desktop uses `1`); dual-read the legacy fields for one release.
+  7. Keep mute (`mutedConversations`) + favorites (`favoriteDMs`) exactly as-is.
+
+## Interop & shipping — desktop-shipped, mobile-pending (verified 2026-07-21)
+
+**Shipping desktop without mobile is safe. Mixed desktop↔mobile works.** The
+feature is additive and mobile is forward-compatible:
+
+- **Two different users (desktop A ↔ mobile B DMing):** zero impact.
+  `conversationSettings` is a *per-user device-sync* field carried in each user's
+  own encrypted `UserConfig` blob — it is NOT part of the DM wire protocol.
+  Signing/receipts between A and B are unchanged; the only change is *where desktop
+  reads its own setting from* (config map vs local `Conversation` record), not what
+  it transmits.
+- **Same user on desktop + mobile:** no breakage. Mobile **preserves** the field
+  it doesn't understand — `services/config/configService.ts:397` spreads
+  `...decryptedConfig` on inbound, and `saveConfig` (`:507`) encrypts/uploads the
+  whole `config` object as-is (no whitelist reconstruction). So mobile round-trips
+  `conversationSettings` back to the server intact and never clobbers it. Expected
+  non-behavior until mobile ships: a setting changed on desktop won't take *effect*
+  on mobile (mobile still reads its device-local record), and vice-versa.
+- **One transient edge case (self-healing, not data loss):** a stale mobile that
+  hasn't pulled desktop's latest can upload a newer-timestamped blob whose
+  `conversationSettings` is absent, briefly regressing the *server* copy. But
+  desktop's `ConfigService.getConfig` merges `mergeConversationSettings(localWithSettings,
+  remoteWithout)` → keeps local (verified: helper returns `{...local}` when remote
+  is empty), and re-publishes on its next config write. The active desktop never
+  loses its settings; only a brand-new third device pulling during that window
+  would miss them until the next desktop save.
+
+## Ship order (updated)
+1. ✅ shared #63 + #65 merged.
+2. ⏳ Publish shared to npm (lead-dev) — needed for desktop's production build and
+   for mobile to pin. Desktop dev/test already works via `link:`.
+3. ⏳ Merge desktop `feat/sync-conversation-settings` (safe to merge before mobile;
+   see Interop). Confirm CI shared resolution first.
+4. ⏳ mobile: bump shared pin → implement the checklist above → ship.
+
+*Last updated: 2026-07-21*

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -22,6 +22,7 @@ import { useNavigationHotkeys } from '@/hooks/platform/interactions/useNavigatio
 import { useSidebar } from './context/SidebarProvider';
 import { OfflineBanner } from './ui/OfflineBanner';
 import { useMutedConversationsSync } from '../hooks/business/dm/useMutedConversationsSync';
+import { useMigrateConversationSettings } from '../hooks/business/dm/useMigrateConversationSettings';
 
 const Layout: React.FunctionComponent<{
   children: React.ReactNode;
@@ -57,6 +58,7 @@ const Layout: React.FunctionComponent<{
 
   // Sync muted conversations to NotificationService for desktop notification filtering
   useMutedConversationsSync();
+  useMigrateConversationSettings();
 
   const [toast, setToast] = React.useState<{
     id?: string;

--- a/src/components/direct/DirectMessage.tsx
+++ b/src/components/direct/DirectMessage.tsx
@@ -1,4 +1,4 @@
-import { logger, formatAddress } from '@quilibrium/quorum-shared';
+import { logger, formatAddress, getConversationSetting } from '@quilibrium/quorum-shared';
 import React, {
   useEffect,
   useRef,
@@ -52,6 +52,7 @@ import {
 } from '../primitives';
 import { BookmarksPanel } from '../bookmarks/BookmarksPanel';
 import { useBookmarks } from '../../hooks/business/bookmarks';
+import { useConfig } from '../../hooks/queries/config';
 import { useUserPublicProfile } from '../../hooks/business/user/useUserPublicProfile';
 import { MobileDrawer } from '../ui';
 import { DMUserProfileSidebar } from './DMUserProfileSidebar';
@@ -150,6 +151,11 @@ const DirectMessage: React.FC<{}> = () => {
   // Get current user address for bookmarks
   const userAddress = user?.currentPasskeyInfo?.address || '';
 
+  // Synced per-conversation settings map (reactive to optimistic saves from the
+  // settings modal). Used to derive effective signing / receipt behavior below.
+  const { data: config } = useConfig({ userAddress });
+  const conversationSettings = config?.conversationSettings;
+
   // Only show the bookmark icon when there's at least one bookmark in this
   // DM. Global view lives on /bookmarks.
   const { filterByConversation } = useBookmarks({ userAddress });
@@ -163,15 +169,30 @@ const DirectMessage: React.FC<{}> = () => {
   React.useEffect(() => {
     (async () => {
       try {
-        const convIsRepudiable = conversation?.conversation?.isRepudiable;
         const cfg = await getConfig({
           address: user.currentPasskeyInfo!.address,
           userKey: keyset.userKeyset,
         });
+        // Dual-read: synced config override first, then the legacy local
+        // Conversation record (migration fallback), then global / default.
+        // Read the override from the reactive useConfig snapshot (not `cfg` from
+        // getConfig) so an optimistic save from the settings modal — which lands
+        // in the query cache before the action queue persists to IndexedDB — is
+        // reflected immediately instead of reverting for a render cycle.
+        const settings = conversationSettings;
+        const convIsRepudiable =
+          getConversationSetting(settings, conversationId, 'isRepudiable') ??
+          conversation?.conversation?.isRepudiable;
         const userNonRepudiable = cfg?.nonRepudiable ?? true;
-        const effectiveDeliveryReceipts = conversation?.conversation?.deliveryReceipts ?? cfg?.deliveryReceipts ?? false;
+        const convDeliveryReceipts =
+          getConversationSetting(settings, conversationId, 'deliveryReceipts') ??
+          conversation?.conversation?.deliveryReceipts;
+        const convReadReceipts =
+          getConversationSetting(settings, conversationId, 'readReceipts') ??
+          conversation?.conversation?.readReceipts;
+        const effectiveDeliveryReceipts = convDeliveryReceipts ?? cfg?.deliveryReceipts ?? false;
         const effectiveReadReceipts = effectiveDeliveryReceipts
-          ? (conversation?.conversation?.readReceipts ?? cfg?.readReceipts ?? false)
+          ? (convReadReceipts ?? cfg?.readReceipts ?? false)
           : false;
         setDeliveryReceipts(effectiveDeliveryReceipts);
         setReadReceipts(effectiveReadReceipts);
@@ -192,6 +213,8 @@ const DirectMessage: React.FC<{}> = () => {
     conversation?.conversation?.isRepudiable,
     conversation?.conversation?.deliveryReceipts,
     conversation?.conversation?.readReceipts,
+    conversationSettings,
+    conversationId,
     keyset.userKeyset,
     getConfig,
     user.currentPasskeyInfo,

--- a/src/components/message/MessageEditTextarea.tsx
+++ b/src/components/message/MessageEditTextarea.tsx
@@ -15,7 +15,7 @@ import { usePasskeysContext, channel as secureChannel } from '@quilibrium/quilib
 import { DefaultImages } from '../../utils';
 import { isTouchDevice } from '../../utils/platform';
 import { ENABLE_MARKDOWN, ENABLE_DM_ACTION_QUEUE, ENABLE_MENTION_PILLS } from '../../config/features';
-import { createIPFSCIDRegex, extractMentionsFromText, applyEdit } from '@quilibrium/quorum-shared';
+import { createIPFSCIDRegex, extractMentionsFromText, applyEdit, getConversationSetting } from '@quilibrium/quorum-shared';
 import { useMentionInput, type MentionOption, useMentionPillEditor } from '../../hooks/business/mentions';
 import { getCaretCoordinates, type CaretCoordinates } from '../../utils/caretCoordinates';
 
@@ -496,8 +496,23 @@ export function MessageEditTextarea({
         try {
           const conversationId = `${currentSpaceId}/${currentChannelId}`;
           if (isDM) {
-            const conversationData = await messageDB.getConversation({ conversationId });
-            saveEditHistoryEnabled = conversationData?.conversation?.saveEditHistory ?? false;
+            // Dual-read: synced config override first, then the legacy local
+            // Conversation record (migration fallback for one release).
+            const address = currentPasskeyInfo?.address;
+            const cfg = address
+              ? await messageDB.getUserConfig({ address })
+              : undefined;
+            const override = getConversationSetting(
+              cfg?.conversationSettings,
+              conversationId,
+              'saveEditHistory'
+            );
+            if (typeof override !== 'undefined') {
+              saveEditHistoryEnabled = override;
+            } else {
+              const conversationData = await messageDB.getConversation({ conversationId });
+              saveEditHistoryEnabled = conversationData?.conversation?.saveEditHistory ?? false;
+            }
           } else {
             const space = await messageDB.getSpace(currentSpaceId);
             saveEditHistoryEnabled = space?.saveEditHistory ?? false;

--- a/src/components/modals/ConversationSettingsModal.tsx
+++ b/src/components/modals/ConversationSettingsModal.tsx
@@ -4,7 +4,6 @@ import { t } from '@lingui/core/macro';
 import { useMessageDB } from '../context/useMessageDB';
 import { useConversation } from '../../hooks/queries/conversation/useConversation';
 import { useConversations } from '../../hooks';
-import { DefaultImages } from '../../utils';
 import { isFeatureEnabled } from '../../utils/platform';
 import {
   Modal,
@@ -15,12 +14,11 @@ import {
   Tooltip,
   Spacer,
 } from '../primitives';
-import { useQueryClient } from '@tanstack/react-query';
-import { buildConversationKey } from '../../hooks/queries/conversation/buildConversationKey';
 import { useConfirmation } from '../../hooks/ui/useConfirmation';
 import ConfirmationModal from './ConfirmationModal';
 import { usePasskeysContext } from '@quilibrium/quilibrium-js-sdk-channels';
 import { useDMMute } from '../../hooks/business/dm/useDMMute';
+import { useDMConversationSettings } from '../../hooks/business/dm/useDMConversationSettings';
 
 type ConversationSettingsModalProps = {
   conversationId: string;
@@ -34,12 +32,11 @@ const ConversationSettingsModal: React.FC<ConversationSettingsModalProps> = ({
   visible,
 }) => {
   const { data: conversation } = useConversation({ conversationId });
-  const { messageDB, getConfig, keyset, deleteConversation, deleteEncryptionStates } =
+  const { getConfig, keyset, deleteConversation, deleteEncryptionStates } =
     useMessageDB();
   const { currentPasskeyInfo } = usePasskeysContext();
   const navigate = useNavigate();
   const { data: convPages } = useConversations({ type: 'direct' });
-  const queryClient = useQueryClient();
 
   const [nonRepudiable, setNonRepudiable] = React.useState<boolean>(true);
   const [saveEditHistory, setSaveEditHistory] = React.useState<boolean>(false);
@@ -51,6 +48,9 @@ const ConversationSettingsModal: React.FC<ConversationSettingsModalProps> = ({
   // DM mute hook
   const { isMuted, toggleMute } = useDMMute();
   const muted = isMuted(conversationId);
+
+  // Per-conversation synced settings (save-edit-history, always-sign, receipts)
+  const { saveSettings, getOverride } = useDMConversationSettings();
 
   // Feature flag: only show edit history toggle if enabled via environment variable
   const showEditHistoryToggle = isFeatureEnabled('ENABLE_EDIT_HISTORY');
@@ -100,17 +100,32 @@ const ConversationSettingsModal: React.FC<ConversationSettingsModalProps> = ({
           userKey: keyset.userKeyset,
         });
 
-        const convIsRepudiable = conversation?.conversation?.isRepudiable;
-        if (typeof convIsRepudiable !== 'undefined') {
-          setNonRepudiable(!convIsRepudiable);
+        // Dual-read: synced config override first (via the reactive useConfig
+        // snapshot, so an optimistic save is reflected), then the legacy local
+        // Conversation record (migration fallback for one release), then global.
+        const isRepudiableOverride =
+          getOverride(conversationId, 'isRepudiable') ??
+          conversation?.conversation?.isRepudiable;
+        if (typeof isRepudiableOverride !== 'undefined') {
+          setNonRepudiable(!isRepudiableOverride);
         } else {
           setNonRepudiable(cfg?.nonRepudiable ?? true);
         }
         // Load saveEditHistory setting (defaults to false)
-        setSaveEditHistory(conversation?.conversation?.saveEditHistory ?? false);
+        setSaveEditHistory(
+          getOverride(conversationId, 'saveEditHistory') ??
+            conversation?.conversation?.saveEditHistory ??
+            false
+        );
         // Load per-conversation receipt overrides (undefined = use global)
-        setConvDeliveryReceipts(conversation?.conversation?.deliveryReceipts);
-        setConvReadReceipts(conversation?.conversation?.readReceipts);
+        setConvDeliveryReceipts(
+          getOverride(conversationId, 'deliveryReceipts') ??
+            conversation?.conversation?.deliveryReceipts
+        );
+        setConvReadReceipts(
+          getOverride(conversationId, 'readReceipts') ??
+            conversation?.conversation?.readReceipts
+        );
         // Load global receipt settings for display
         setGlobalDeliveryReceipts(cfg?.deliveryReceipts ?? false);
         setGlobalReadReceipts(cfg?.readReceipts ?? false);
@@ -127,38 +142,20 @@ const ConversationSettingsModal: React.FC<ConversationSettingsModalProps> = ({
     conversationId,
     currentPasskeyInfo,
     getConfig,
+    getOverride,
     keyset.userKeyset,
   ]);
 
   const saveRepudiability = React.useCallback(async () => {
     try {
-      const existing = await messageDB.getConversation({ conversationId });
-      const baseConv = existing.conversation ?? {
-        conversationId,
-        address: conversationId.split('/')[0],
-        icon: conversation?.conversation?.icon || DefaultImages.UNKNOWN_USER,
-        displayName: conversation?.conversation?.displayName || t`Unknown User`,
-        type: 'direct' as const,
-        timestamp: Date.now(),
-      };
-
-      const updatedConv = {
-        ...baseConv,
+      // Write to the synced config map (source of truth). Undefined receipt
+      // values clear the override (reset-to-global). The config save propagates
+      // across the user's devices; no local Conversation write is needed.
+      await saveSettings(conversationId, {
         isRepudiable: !nonRepudiable,
-        saveEditHistory: saveEditHistory,
+        saveEditHistory,
         deliveryReceipts: convDeliveryReceipts,
         readReceipts: convReadReceipts,
-      };
-
-      // Remove undefined receipt keys so IndexedDB doesn't store them
-      if (updatedConv.deliveryReceipts === undefined) delete updatedConv.deliveryReceipts;
-      if (updatedConv.readReceipts === undefined) delete updatedConv.readReceipts;
-
-      await messageDB.saveConversation(updatedConv);
-
-      // Invalidate conversation query to update DirectMessage component
-      await queryClient.invalidateQueries({
-        queryKey: buildConversationKey({ conversationId }),
       });
 
       onClose();
@@ -172,10 +169,8 @@ const ConversationSettingsModal: React.FC<ConversationSettingsModalProps> = ({
     convDeliveryReceipts,
     convReadReceipts,
     conversationId,
-    messageDB,
-    conversation,
+    saveSettings,
     onClose,
-    queryClient,
   ]);
 
   const handleDeleteClick = React.useCallback(

--- a/src/db/messages.ts
+++ b/src/db/messages.ts
@@ -1,6 +1,6 @@
 import { logger, isValidIPFSCID } from '@quilibrium/quorum-shared';
 import { channel } from '@quilibrium/quilibrium-js-sdk-channels';
-import type { Conversation, Message, Space, Bookmark, BroadcastSpaceTag, ChannelThread, UserNote, FarcasterLink, SpaceMemberDevice } from '@quilibrium/quorum-shared';
+import type { Conversation, Message, Space, Bookmark, BroadcastSpaceTag, ChannelThread, UserNote, FarcasterLink, SpaceMemberDevice, ConversationSettingOverrides } from '@quilibrium/quorum-shared';
 import { BOOKMARKS_CONFIG } from '@quilibrium/quorum-shared';
 import type { SpaceNotificationSettings } from '../types/notifications';
 import type { IconColor } from '../components/space/IconPicker/types';
@@ -91,6 +91,12 @@ export type UserConfig = {
   favoriteDMs?: string[];
   // Muted DMs — no unread indicators or notifications.
   mutedConversations?: string[];
+  // Per-conversation DM setting overrides (save-edit-history, always-sign,
+  // delivery/read receipts), keyed by conversationId. Synced cross-device via
+  // the UserConfig blob; merged per-entry last-write-wins in ConfigService.
+  conversationSettings?: {
+    [conversationId: string]: ConversationSettingOverrides;
+  };
   // Personal "block user", scoped per space: addresses whose messages the
   // viewer hides from their OWN stream. Viewer-side only (no moderation effect,
   // no permission needed) — distinct from the role-gated moderation mute

--- a/src/hooks/business/dm/useDMConversationSettings.ts
+++ b/src/hooks/business/dm/useDMConversationSettings.ts
@@ -1,0 +1,133 @@
+/**
+ * Hook for per-conversation DM settings that sync across a user's devices.
+ *
+ * The overrides (save-edit-history, always-sign, delivery/read receipts) live on
+ * IndexedDB `user_config.conversationSettings`, keyed by conversationId, and sync
+ * via the encrypted config blob — the same mechanism as DM mute. Reading and
+ * writing go through the shared `conversationSettingsUtils` helpers so desktop
+ * and mobile agree byte-for-byte on the map semantics.
+ *
+ * Uses the Action Queue for offline support and crash recovery, mirroring
+ * `useDMMute`.
+ */
+
+import { useCallback } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { t } from '@lingui/core/macro';
+import {
+  logger,
+  getConversationSetting,
+  setConversationSetting,
+  type ConversationSettingKey,
+} from '@quilibrium/quorum-shared';
+import { useMessageDB } from '../../../components/context/useMessageDB';
+import { usePasskeysContext } from '@quilibrium/quilibrium-js-sdk-channels';
+import { useConfig, buildConfigKey } from '../../queries/config';
+import { showError } from '../../../utils/toast';
+
+/** Patch shape for a per-conversation save: any subset of the override keys. */
+export type ConversationSettingsPatch = Partial<
+  Record<ConversationSettingKey, boolean | undefined>
+>;
+
+interface UseDMConversationSettingsReturn {
+  /**
+   * Read one per-conversation override from the synced config. Returns
+   * `undefined` when unset — the caller then falls back to the local
+   * `Conversation` record (legacy), the global setting, or the default.
+   */
+  getOverride: (
+    conversationId: string,
+    key: ConversationSettingKey
+  ) => boolean | undefined;
+  /**
+   * Persist a patch of overrides for a conversation. A key set to `undefined`
+   * clears that override (reset-to-global). Bumps the entry's `updatedAt` so
+   * the change wins last-write-wins merge across devices.
+   */
+  saveSettings: (
+    conversationId: string,
+    patch: ConversationSettingsPatch
+  ) => Promise<void>;
+}
+
+export function useDMConversationSettings(): UseDMConversationSettingsReturn {
+  const { messageDB, actionQueueService, keyset } = useMessageDB();
+  const { currentPasskeyInfo } = usePasskeysContext();
+  const userAddress = currentPasskeyInfo?.address;
+  const queryClient = useQueryClient();
+
+  // Get user config from React Query cache (reactive to optimistic updates).
+  const { data: config } = useConfig({ userAddress: userAddress || '' });
+
+  const getOverride = useCallback(
+    (
+      conversationId: string,
+      key: ConversationSettingKey
+    ): boolean | undefined =>
+      getConversationSetting(config?.conversationSettings, conversationId, key),
+    [config?.conversationSettings]
+  );
+
+  const saveSettings = useCallback(
+    async (
+      conversationId: string,
+      patch: ConversationSettingsPatch
+    ): Promise<void> => {
+      if (!userAddress || !keyset) return;
+
+      try {
+        // Cache-first read so rapid saves compose (see useDMMute). Falls back to
+        // IndexedDB when the cache is cold.
+        const currentConfig =
+          queryClient.getQueryData<typeof config>(
+            buildConfigKey({ userAddress })
+          ) ?? (await messageDB.getUserConfig({ address: userAddress }));
+
+        const updatedConfig = {
+          ...currentConfig,
+          address: userAddress,
+          spaceIds: currentConfig?.spaceIds || [],
+          conversationSettings: setConversationSetting(
+            currentConfig?.conversationSettings,
+            conversationId,
+            patch
+          ),
+        };
+
+        // Optimistically update React Query cache for instant UI feedback.
+        queryClient.setQueryData(buildConfigKey({ userAddress }), updatedConfig);
+
+        // Queue config save in background (offline support, crash recovery).
+        // Fire-and-forget: the optimistic cache update already gave the UI its
+        // feedback. Awaiting would block the next save and widen the race window.
+        actionQueueService
+          .enqueue(
+            'save-user-config',
+            { config: updatedConfig },
+            `config:${userAddress}` // Dedup key — collapses rapid saves
+          )
+          .catch((err) => {
+            logger.error(
+              '[DMConversationSettings] enqueue failed, rolling back',
+              err
+            );
+            queryClient.setQueryData(
+              buildConfigKey({ userAddress }),
+              currentConfig
+            );
+            showError(t`Failed to save conversation settings`);
+          });
+      } catch (error) {
+        console.error(
+          '[DMConversationSettings] Error saving conversation settings:',
+          error
+        );
+        throw error;
+      }
+    },
+    [userAddress, keyset, messageDB, queryClient, actionQueueService]
+  );
+
+  return { getOverride, saveSettings };
+}

--- a/src/hooks/business/dm/useMigrateConversationSettings.ts
+++ b/src/hooks/business/dm/useMigrateConversationSettings.ts
@@ -1,0 +1,115 @@
+/**
+ * One-time migration of legacy device-local per-conversation DM settings into
+ * the synced `UserConfig.conversationSettings` map.
+ *
+ * Before this feature, `saveEditHistory` / `isRepudiable` / `deliveryReceipts` /
+ * `readReceipts` lived on the local IndexedDB `Conversation` record and never
+ * synced. The read sites still fall back to those local fields (dual-read), so
+ * nothing is lost without this hook — but a user's existing choices would not
+ * propagate to their other devices until they re-saved each conversation. This
+ * sweep folds any existing local values into the synced map once, so they
+ * propagate automatically.
+ *
+ * Seeded entries get a deliberately low `updatedAt` (MIGRATION_TS) so that any
+ * genuine future edit on any device — and any already-synced entry — wins the
+ * last-write-wins merge. Runs once per user, guarded by a localStorage flag.
+ * Conversations already present in the synced map are left untouched.
+ */
+
+import { useEffect, useRef } from 'react';
+import { usePasskeysContext } from '@quilibrium/quilibrium-js-sdk-channels';
+import {
+  logger,
+  setConversationSetting,
+  type ConversationSettingsMap,
+} from '@quilibrium/quorum-shared';
+import { useMessageDB } from '../../../components/context/useMessageDB';
+import { useQueryClient } from '@tanstack/react-query';
+import { buildConfigKey } from '../../queries/config';
+
+/** Schema version — bump to re-run the migration if the shape ever changes. */
+const MIGRATION_KEY_PREFIX = 'dmConvSettingsMigrated:v1:';
+/** Low timestamp so any real edit (or already-synced entry) beats a seeded one. */
+const MIGRATION_TS = 1;
+
+export function useMigrateConversationSettings(): void {
+  const { messageDB, actionQueueService, keyset } = useMessageDB();
+  const { currentPasskeyInfo } = usePasskeysContext();
+  const userAddress = currentPasskeyInfo?.address;
+  const queryClient = useQueryClient();
+  const ranRef = useRef(false);
+
+  useEffect(() => {
+    if (!userAddress || !keyset || ranRef.current) return;
+
+    const flagKey = `${MIGRATION_KEY_PREFIX}${userAddress}`;
+    if (localStorage.getItem(flagKey)) return;
+    ranRef.current = true;
+
+    (async () => {
+      try {
+        const config = await messageDB.getUserConfig({ address: userAddress });
+        const existing: ConversationSettingsMap =
+          config?.conversationSettings ?? {};
+
+        const { conversations } = await messageDB.getConversations({
+          type: 'direct',
+        });
+
+        let map: ConversationSettingsMap = existing;
+        let migrated = 0;
+
+        for (const conv of conversations) {
+          const id = conv.conversationId;
+          if (!id || existing[id]) continue; // already synced — don't overwrite
+
+          const patch: Record<string, boolean | undefined> = {};
+          if (typeof conv.isRepudiable !== 'undefined')
+            patch.isRepudiable = conv.isRepudiable;
+          if (typeof conv.saveEditHistory !== 'undefined')
+            patch.saveEditHistory = conv.saveEditHistory;
+          if (typeof conv.deliveryReceipts !== 'undefined')
+            patch.deliveryReceipts = conv.deliveryReceipts;
+          if (typeof conv.readReceipts !== 'undefined')
+            patch.readReceipts = conv.readReceipts;
+
+          if (Object.keys(patch).length === 0) continue;
+
+          map = setConversationSetting(map, id, patch, MIGRATION_TS);
+          migrated++;
+        }
+
+        if (migrated > 0) {
+          const updatedConfig = {
+            ...config,
+            address: userAddress,
+            spaceIds: config?.spaceIds || [],
+            conversationSettings: map,
+          };
+          queryClient.setQueryData(
+            buildConfigKey({ userAddress }),
+            updatedConfig
+          );
+          await actionQueueService.enqueue(
+            'save-user-config',
+            { config: updatedConfig },
+            `config:${userAddress}`
+          );
+          logger.log(
+            `[DMConversationSettings] migrated ${migrated} local conversation setting(s) into synced config`
+          );
+        }
+
+        localStorage.setItem(flagKey, String(Date.now()));
+      } catch (error) {
+        // Non-fatal: dual-read fallback keeps local values working. Don't set
+        // the flag, so the sweep retries next launch.
+        ranRef.current = false;
+        logger.error(
+          '[DMConversationSettings] migration sweep failed',
+          error
+        );
+      }
+    })();
+  }, [userAddress, keyset, messageDB, actionQueueService, queryClient]);
+}

--- a/src/services/ConfigService.ts
+++ b/src/services/ConfigService.ts
@@ -1,7 +1,7 @@
 // ConfigService.ts - Extracted from MessageDB.tsx with ZERO modifications
 // This service handles user configuration management
 
-import { logger, int64ToBytes } from '@quilibrium/quorum-shared';
+import { logger, int64ToBytes, mergeConversationSettings } from '@quilibrium/quorum-shared';
 import { MessageDB, UserConfig } from '../db/messages';
 import { QuorumApiClient } from '../api/baseTypes';
 import type { Bookmark, Space } from '@quilibrium/quorum-shared';
@@ -292,6 +292,14 @@ export class ConfigService {
     );
     config.deviceNames = deviceNamesMerge.deviceNames;
     config.deletedDeviceNameAddresses = deviceNamesMerge.deletedDeviceNameAddresses;
+
+    // Merge per-conversation DM settings: per-entry last-write-wins by updatedAt
+    // (see mergeConversationSettings). Prevents an unrelated remote config save
+    // from clobbering another conversation's local override.
+    config.conversationSettings = mergeConversationSettings(
+      storedConfig?.conversationSettings,
+      config.conversationSettings
+    );
 
     // Merge user notes from remote
     const deletedNoteAddresses = config.deletedUserNoteAddresses ?? [];

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -24,6 +24,7 @@ import {
   verifyDeviceKeyStatement,
   MESSAGE_EDIT_WINDOW_MS,
   applyEdit,
+  getConversationSetting,
   type ControlMessageContent,
   type DeviceKeyStatement,
 } from '@quilibrium/quorum-shared';
@@ -1446,13 +1447,23 @@ export class MessageService {
       let saveEditHistoryEnabled: boolean;
 
       if (isDM) {
-        // For DMs, check conversation setting
+        // For DMs, dual-read: synced config override first, then the legacy
+        // local Conversation record (migration fallback for one release).
         const conversationId = `${spaceId}/${channelId}`;
         const conversation = await messageDB.getConversation({
           conversationId,
         });
+        const userConfig = currentUserAddress
+          ? await messageDB.getUserConfig({ address: currentUserAddress })
+          : undefined;
         saveEditHistoryEnabled =
-          conversation?.conversation?.saveEditHistory ?? false;
+          getConversationSetting(
+            userConfig?.conversationSettings,
+            conversationId,
+            'saveEditHistory'
+          ) ??
+          conversation?.conversation?.saveEditHistory ??
+          false;
       } else {
         // For spaces, check space setting
         const space = await messageDB.getSpace(spaceId);
@@ -3294,8 +3305,13 @@ export class MessageService {
           const conversation = await this.messageDB.getConversation({
             conversationId,
           });
-          const effectiveDeliveryReceipts = conversation.conversation?.deliveryReceipts ?? !!userConfig?.deliveryReceipts;
-          const effectiveReadReceipts = conversation.conversation?.readReceipts ?? !!userConfig?.readReceipts;
+          // Dual-read: synced config override first, then legacy local record.
+          const effectiveDeliveryReceipts =
+            getConversationSetting(userConfig?.conversationSettings, conversationId, 'deliveryReceipts') ??
+            conversation.conversation?.deliveryReceipts ?? !!userConfig?.deliveryReceipts;
+          const effectiveReadReceipts =
+            getConversationSetting(userConfig?.conversationSettings, conversationId, 'readReceipts') ??
+            conversation.conversation?.readReceipts ?? !!userConfig?.readReceipts;
           if (this.interceptControlMessages(decryptedContent, session.user_address, self_address, effectiveDeliveryReceipts, effectiveReadReceipts, queryClient)) {
             // delivery-ack control message — encryption state saved, but don't save/display the message
             return;
@@ -4999,8 +5015,13 @@ export class MessageService {
         // Process delivery receipt data (intercept ack control messages, extract piggybacked acks, buffer for acking)
         const userConfig = await this.messageDB.getUserConfig({ address: self_address });
         const senderAddress = conversationId.split('/')[0];
-        const effectiveDeliveryReceipts = conversation.conversation?.deliveryReceipts ?? !!userConfig?.deliveryReceipts;
-        const effectiveReadReceipts = conversation.conversation?.readReceipts ?? !!userConfig?.readReceipts;
+        // Dual-read: synced config override first, then legacy local record.
+        const effectiveDeliveryReceipts =
+          getConversationSetting(userConfig?.conversationSettings, conversationId, 'deliveryReceipts') ??
+          conversation.conversation?.deliveryReceipts ?? !!userConfig?.deliveryReceipts;
+        const effectiveReadReceipts =
+          getConversationSetting(userConfig?.conversationSettings, conversationId, 'readReceipts') ??
+          conversation.conversation?.readReceipts ?? !!userConfig?.readReceipts;
         if (this.interceptControlMessages(decryptedContent, senderAddress, self_address, effectiveDeliveryReceipts, effectiveReadReceipts, queryClient)) {
           // delivery-ack control message — encryption state saved, but don't save/display the message
           return;


### PR DESCRIPTION
## What

Moves the four per-conversation DM settings — **always-sign** (`isRepudiable`), **save-edit-history**, and the **delivery/read receipt** overrides — off the device-local `Conversation` record and onto the synced `UserConfig.conversationSettings` map (keyed by conversationId). They now propagate across a user's devices via the existing encrypted config blob, using the shared `conversationSettings` helpers so desktop and mobile stay byte-identical on the semantics.

Mute (`mutedConversations`) and favorites (`favoriteDMs`) already sync and are intentionally left as-is.

## Changes

- **New `useDMConversationSettings` hook** — writes via the `save-user-config` action queue with an optimistic config-cache update + rollback (mirrors `useDMMute`); exposes a reactive `getOverride` reader.
- **Write** — `ConversationSettingsModal` writes the four fields into the map (drops the `saveConversation` write).
- **Read (dual-read for one release)** — `config override ?? legacy local Conversation ?? global ?? default` at every site: the modal load, `DirectMessage` (signing + receipts), `MessageEditTextarea` (edit history), and the **`MessageService` receive-path readers** (receipt intercept ×2 + received-edit history).
- **Merge** — `ConfigService.getConfig` merges `conversationSettings` per-entry last-write-wins via the shared `mergeConversationSettings` helper, beside the existing `deviceNames` merge.
- **Migration** — `useMigrateConversationSettings` (mounted in `Layout`): one-time per-user sweep folding legacy local `Conversation` values into the map with a low `updatedAt` so any genuine edit wins.

## Dependencies & compatibility

- Depends on the merged quorum-shared work (conversationSettings type + helpers). Desktop consumes it via the local `link:`; shared must be published to npm before a production release.
- Additive and forward-compatible with mobile: mobile preserves the unknown field through its config round-trip, so shipping desktop ahead of the mobile half is safe.

## Verification

Typecheck, lint (no new warnings), and web build all green.