### PR TITLE
feat: per-device signing keys (desktop send-side) [DO NOT DEPLOY until mobile receive-side live]

### DIFF
--- a/.agents/docs/cryptographic-architecture.md
+++ b/.agents/docs/cryptographic-architecture.md
@@ -427,10 +427,22 @@ byte builder, `verifyDeviceKeyStatement`, and a `deviceKeys`-aware
 `space_member_devices` store + the two control-message handlers, resolver wired
 into all four auth paths). This is **additive and behavior-neutral**: until the
 **send-side flip** ships on both platforms, every device still signs with the
-interim join-bound key, so nothing user-visible changes yet. Remaining:
-send-side (per-device signing + on-connect announce + Security-modal revocation)
-on desktop + mobile, mobile receive-side, then retire the interim `signing`
-slot. A non-destructive bound on `announce-keys` flooding is tracked in
+interim join-bound key, so nothing user-visible changes yet.
+
+**Progress (2026-07-21):** desktop's **send-side** landed on a branch
+(`feat/per-device-signing-keys-send`): an on-connect `announce-keys` broadcast,
+a Security-modal `revoke-device` broadcast, and — using **Option A** — a fresh
+device no longer adopts the shared `signing` slot on config sync, so it signs
+with its own per-device `inbox` key (`getSigningKey` still reads `signing ??
+inbox`, so existing devices are untouched and nothing regresses). Only devices
+set up *after* the flip sign per-device. **Release gate:** this must NOT deploy
+to prod until mobile's receive-side is live — a prod mobile client on an older
+build would silently drop a secondary desktop device's control ops. Member-sync
+statement carriage is deferred (the stored `SpaceMemberDevice` keeps no verbatim
+signature to re-verify; on-connect re-announce covers the common case, and the
+gap converges away on the hub-log migration). Remaining: mobile receive + send,
+then retire the interim `signing` slot. A non-destructive bound on
+`announce-keys` flooding is tracked in
 [`.agents/bugs/2026-07-20-announce-keys-flooding-unbounded-admissions.md`](../bugs/2026-07-20-announce-keys-flooding-unbounded-admissions.md).
 
 ---
@@ -588,4 +600,4 @@ secureChannel.UnsealSyncEnvelope(
 ---
 
 
-_Last Updated: 2026-07-20_
+_Last Updated: 2026-07-21_

--- a/.agents/tasks/2026-07-19-per-device-signing-keys-registration-anchored.md
+++ b/.agents/tasks/2026-07-19-per-device-signing-keys-registration-anchored.md
@@ -1,7 +1,7 @@
 ---
 type: task
 title: "Durable multi-device: per-device space signing keys, admitted via master-identity-signed device statements"
-status: IN PROGRESS — shared core (#62) + desktop receive-side done; mobile receive + both-platform send-side pending (staged, see release order)
+status: IN PROGRESS — shared core (#62) + desktop receive-side done + desktop SEND-side done on branch feat/per-device-signing-keys-send (Option A, PR to main NOT prod); mobile receive + send pending (staged, see release order)
 priority: high (follow-up to the interim signing-split fix)
 created: 2026-07-19
 severity: HIGH (security-critical — touches the verified-signer auth boundary)
@@ -395,6 +395,18 @@ send-side flip on BOTH platforms is staged — see "Production release order".
    release order below. Observable (the real test): fresh second device (no
    shared `signing`) deletes/edits/pins from day one; deleting that device from
    Security settings makes its subsequent control ops drop on other clients.
+   ▸ DESKTOP DONE (branch `feat/per-device-signing-keys-send`, **Option A**
+   chosen 2026-07-21): `announceDeviceKeys` (on-connect, per space) +
+   `broadcastDeviceRevocations` (Security-modal removeDevice) +
+   `signDeviceKeyStatement` on `MessageService`; ConfigService stops adopting the
+   shared `signing` slot on sync so a fresh device falls through to its own
+   `inbox` key (`getSigningKey` read `signing ?? inbox` UNCHANGED → existing
+   devices don't regress); 6 send-side unit tests (envelope shape, cross-platform
+   byte-identity of the signed payload, revoke fan-out). Member-sync statement
+   carriage DEFERRED (stored `SpaceMemberDevice` has no verbatim signature to
+   re-verify; on-connect re-announce covers the common case, converges on
+   hub-log). Merge to main (for local desktop↔mobile testing), DO NOT deploy to
+   prod until mobile receive-side is live.
 4. **Cleanup** — retire `signing` slot fallback, rewrite
    `cryptographic-architecture.md` multi-device section, resolve the mobile
    bug report, file the join-binding hardening follow-up.
@@ -481,4 +493,4 @@ the only step with a blast radius, and it is bounded:
 - `revoke-device` fan-out cost for users in many spaces (batch per connect).
 - Desktop DB migration bump mechanics for the new store.
 
-*Last updated: 2026-07-20*
+*Last updated: 2026-07-21*

--- a/src/components/context/MessageDB.tsx
+++ b/src/components/context/MessageDB.tsx
@@ -237,6 +237,7 @@ type MessageDBContextValue = {
   ) => Promise<void>;
   requestSync: (spaceId: string) => Promise<void>;
   sendVerifyKickedStatuses: (spaceId: string) => Promise<number>;
+  broadcastDeviceRevocations: (deviceInboxAddresses: string[]) => Promise<void>;
   deleteConversation: (
     conversationId: string,
     currentPasskeyInfo: {
@@ -549,6 +550,18 @@ const MessageDBProvider: FC<MessageDBContextProps> = ({ children }) => {
           config.spaceIds.includes(s.spaceId)
         )) {
           requestSync(space.spaceId);
+          // Re-announce this device's per-space signing key on connect so
+          // receivers that missed a prior announce self-heal. Idempotent,
+          // fire-and-forget; behaviour-neutral until the send-side flip is
+          // live on both platforms (per-device-signing task, Option A).
+          messageServiceRef.current
+            ?.announceDeviceKeys(space.spaceId, keyset)
+            .catch((err) =>
+              logger.warn('[DeviceKeys] announce on connect failed', {
+                err,
+                spaceId: space.spaceId,
+              })
+            );
         }
       }, 10000);
     }
@@ -705,6 +718,20 @@ const MessageDBProvider: FC<MessageDBContextProps> = ({ children }) => {
       return syncService.sendVerifyKickedStatuses(spaceId);
     },
     [syncService]
+  );
+
+  // Broadcast master-signed revoke-device tombstones for removed devices across
+  // every space (Security-modal device removal). Uses the context keyset so
+  // callers only supply the removed devices' DM inbox addresses.
+  const broadcastDeviceRevocations = React.useCallback(
+    async (deviceInboxAddresses: string[]) => {
+      if (!keyset?.userKeyset || !keyset?.deviceKeyset) return;
+      await messageServiceRef.current?.broadcastDeviceRevocations(
+        deviceInboxAddresses,
+        keyset
+      );
+    },
+    [keyset]
   );
 
   const informSyncData = React.useCallback(
@@ -1458,6 +1485,7 @@ const MessageDBProvider: FC<MessageDBContextProps> = ({ children }) => {
         updateUserProfile,
         requestSync,
         sendVerifyKickedStatuses,
+        broadcastDeviceRevocations,
         deleteConversation,
         actionQueueService,
         receiptService,
@@ -1498,6 +1526,7 @@ const MessageDBContext = createContext<MessageDBContextValue>({
   updateUserProfile: () => undefined as never,
   requestSync: () => undefined as never,
   sendVerifyKickedStatuses: () => undefined as never,
+  broadcastDeviceRevocations: () => undefined as never,
   deleteConversation: () => undefined as never,
   actionQueueService: undefined as never,
   receiptService: null,

--- a/src/dev/tests/services/MessageService.unit.test.tsx
+++ b/src/dev/tests/services/MessageService.unit.test.tsx
@@ -26,7 +26,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { MessageService, MessageServiceDependencies } from '@/services/MessageService';
-import { deriveInboxAddress } from '@quilibrium/quorum-shared';
+import { deriveInboxAddress, buildDeviceKeyStatementBytes } from '@quilibrium/quorum-shared';
 import { channel_raw } from '@quilibrium/quilibrium-js-sdk-channels';
 import { QueryClient } from '@tanstack/react-query';
 
@@ -1665,6 +1665,146 @@ describe('MessageService - Unit Tests', () => {
       };
       await (messageService as any).processDeviceKeyStatement(statement, SPACE);
       expect(save).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Send-side: broadcasting announce-keys / revoke-device statements. Asserts
+  // the desktop WIRING (envelope shape, which key is announced, byte-identity of
+  // the signed payload). The statement verify logic is covered by shared's
+  // deviceKeys.test.ts and the receive-side wiring above.
+  // ---------------------------------------------------------------------------
+  describe('10. Per-device signing keys (send-side)', () => {
+    const SPACE = 'space-send';
+    const USER_PUB = '11'.repeat(57);
+    const USER_ADDRESS = deriveInboxAddress(USER_PUB);
+    const SIGNING_PUB = '22'.repeat(57); // shared join key held in the `signing` slot
+    const INBOX_PUB = '44'.repeat(57); // this device's own per-device inbox key
+    const DEVICE_INBOX = 'dev-inbox-send';
+
+    // Master ed448 key + this device's DM inbox address, as a keyset would carry.
+    const keyset = {
+      userKeyset: {
+        user_key: {
+          public_key: Array(57).fill(0x11), // hex === USER_PUB
+          private_key: Array(57).fill(0x99),
+        },
+      },
+      deviceKeyset: { inbox_keyset: { inbox_address: DEVICE_INBOX } },
+    } as any;
+
+    beforeEach(() => {
+      // enqueueOutbound normally defers; run the callback inline so sendHubMessage
+      // is exercised. Reconstruct so MessageService captures this impl.
+      mockDeps.enqueueOutbound = vi.fn(async (cb: any) => cb());
+      // Default: a shared `signing` slot exists (existing 2nd device / join device).
+      mockDeps.messageDB.getSpaceKey = vi.fn(async (_s: string, keyId: string) =>
+        keyId === 'signing'
+          ? { keyId: 'signing', publicKey: SIGNING_PUB, privateKey: 'pk' }
+          : keyId === 'inbox'
+            ? { keyId: 'inbox', publicKey: INBOX_PUB, privateKey: 'ik' }
+            : null
+      );
+      vi.mocked(channel_raw.js_sign_ed448).mockReturnValue(
+        JSON.stringify('mock-signature') as any
+      );
+      messageService = new MessageService(mockDeps);
+    });
+
+    it('broadcasts a well-formed announce-keys control envelope for the signed key', async () => {
+      await messageService.announceDeviceKeys(SPACE, keyset);
+
+      expect(mockDeps.sendHubMessage).toHaveBeenCalledTimes(1);
+      const [sentSpaceId, sentJson] = (mockDeps.sendHubMessage as any).mock.calls[0];
+      expect(sentSpaceId).toBe(SPACE);
+      const sent = JSON.parse(sentJson);
+      expect(sent.type).toBe('control');
+      expect(sent.message).toMatchObject({
+        type: 'announce-keys',
+        userAddress: USER_ADDRESS,
+        userPublicKey: USER_PUB,
+        spaceId: SPACE,
+        deviceInboxAddress: DEVICE_INBOX,
+        // Announces getSigningKey() = `signing ?? inbox`; here the shared slot.
+        spaceKeyPublicKey: SIGNING_PUB,
+      });
+      expect(typeof sent.message.signature).toBe('string');
+      expect(sent.message.signature.length).toBeGreaterThan(0);
+    });
+
+    it('signs the canonical shared bytes with the master key (cross-platform gate)', async () => {
+      await messageService.announceDeviceKeys(SPACE, keyset);
+
+      const sent = JSON.parse((mockDeps.sendHubMessage as any).mock.calls[0][1]);
+      const signCall = (channel_raw.js_sign_ed448 as any).mock.calls.at(-1);
+      // The signed message MUST be exactly buildDeviceKeyStatementBytes(statement)
+      // — if desktop and mobile serialize differently, signatures fail silently.
+      expect(signCall[1]).toBe(
+        Buffer.from(
+          buildDeviceKeyStatementBytes(sent.message),
+          'utf-8'
+        ).toString('base64')
+      );
+      // ...signed with the MASTER private key, not the space key.
+      expect(signCall[0]).toBe(
+        Buffer.from(
+          new Uint8Array(keyset.userKeyset.user_key.private_key)
+        ).toString('base64')
+      );
+    });
+
+    it('announces the own per-device inbox key when there is no shared signing slot', async () => {
+      // Fresh second device after the Option A flip: no `signing` slot.
+      mockDeps.messageDB.getSpaceKey = vi.fn(async (_s: string, keyId: string) =>
+        keyId === 'inbox'
+          ? { keyId: 'inbox', publicKey: INBOX_PUB, privateKey: 'ik' }
+          : null
+      );
+      messageService = new MessageService(mockDeps);
+
+      await messageService.announceDeviceKeys(SPACE, keyset);
+      const sent = JSON.parse((mockDeps.sendHubMessage as any).mock.calls[0][1]);
+      expect(sent.message.spaceKeyPublicKey).toBe(INBOX_PUB);
+    });
+
+    it('does not announce when the space has no signing key at all', async () => {
+      mockDeps.messageDB.getSpaceKey = vi.fn().mockResolvedValue(null);
+      messageService = new MessageService(mockDeps);
+
+      await messageService.announceDeviceKeys(SPACE, keyset);
+      expect(mockDeps.sendHubMessage).not.toHaveBeenCalled();
+    });
+
+    it('broadcasts a revoke-device per space for each removed device', async () => {
+      mockDeps.messageDB.getSpaces = vi
+        .fn()
+        .mockResolvedValue([{ spaceId: 's1' }, { spaceId: 's2' }]);
+
+      await messageService.broadcastDeviceRevocations(['dev-a', 'dev-b'], keyset);
+
+      // 2 spaces x 2 devices = 4 tombstone broadcasts.
+      expect(mockDeps.sendHubMessage).toHaveBeenCalledTimes(4);
+      const [sentSpaceId, sentJson] = (mockDeps.sendHubMessage as any).mock.calls[0];
+      const sent = JSON.parse(sentJson);
+      // The hub routing spaceId must match the spaceId bound in the signed statement.
+      expect(sentSpaceId).toBe(sent.message.spaceId);
+      expect(sent.type).toBe('control');
+      expect(sent.message).toMatchObject({
+        type: 'revoke-device',
+        userAddress: USER_ADDRESS,
+        userPublicKey: USER_PUB,
+        deviceInboxAddress: 'dev-a',
+      });
+      expect(typeof sent.message.signature).toBe('string');
+    });
+
+    it('does nothing when no devices were removed', async () => {
+      mockDeps.messageDB.getSpaces = vi
+        .fn()
+        .mockResolvedValue([{ spaceId: 's1' }]);
+
+      await messageService.broadcastDeviceRevocations([], keyset);
+      expect(mockDeps.sendHubMessage).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/hooks/business/user/useUserSettings.ts
+++ b/src/hooks/business/user/useUserSettings.ts
@@ -89,7 +89,7 @@ export const useUserSettings = (
     address: currentPasskeyInfo?.address!,
   });
   const { keyset } = useRegistrationContext();
-  const { messageDB, actionQueueService, getConfig, updateUserProfile, setTypingConfig } = useMessageDB();
+  const { messageDB, actionQueueService, getConfig, updateUserProfile, setTypingConfig, broadcastDeviceRevocations } = useMessageDB();
   const queryClient = useQueryClient();
   const uploadRegistration = useUploadRegistration();
 
@@ -531,6 +531,16 @@ export const useUserSettings = (
       await uploadRegistration({
         address: currentPasskeyInfo.address,
         registration: updatedRegistration,
+      });
+
+      // Broadcast master-signed revoke-device tombstones for the removed
+      // devices across every space, so receivers stop admitting their
+      // per-device signing keys. pendingTombstones holds exactly the removed
+      // devices' DM inbox addresses (the revocation handle). Fire-and-forget;
+      // failures are logged inside the service (offline receivers catch up on
+      // the next re-announce). Cleared alongside the other tombstones below.
+      broadcastDeviceRevocations(pendingTombstones).catch((err) => {
+        logger.warn('[UserSettings] broadcastDeviceRevocations failed', err);
       });
 
       // Clear the removed devices list after successful save

--- a/src/services/ConfigService.ts
+++ b/src/services/ConfigService.ts
@@ -124,24 +124,16 @@ export class ConfigService {
           }
 
           for (const key of space.keys) {
+            // Per-device-signing flip (Option A): a fresh device no longer
+            // adopts the shared `signing` slot. It signs with its own
+            // per-device `inbox` key (getSigningKey falls through to it) and
+            // announces that key via announce-keys. Skipping the synced
+            // `signing` key here — and NOT deriving one from `inbox` below —
+            // is what puts a fresh second device on its own key. Devices set
+            // up before this flip keep any previously-saved `signing` slot
+            // untouched (getSigningKey still reads it), so nothing regresses.
+            if (key.keyId === 'signing') continue;
             await this.messageDB.saveSpaceKey(key);
-          }
-
-          // Preserve the join-bound key as the per-USER SIGNING identity before
-          // the `inbox` (mailbox) slot is overwritten below with a fresh
-          // per-DEVICE keypair. Receivers verify control messages against the
-          // join key, so a second device must keep signing with it. A
-          // post-migration uploader carries an explicit `signing` slot (already
-          // saved by the loop above); older uploads only carry `inbox`, so
-          // derive `signing` from it.
-          if (!space.keys.find((k) => k.keyId === 'signing')) {
-            const syncedInbox = space.keys.find((k) => k.keyId === 'inbox');
-            if (syncedInbox) {
-              await this.messageDB.saveSpaceKey({
-                ...syncedInbox,
-                keyId: 'signing',
-              });
-            }
           }
 
           const reg = (await this.apiClient.getSpace(space.spaceId)).data;

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -22,11 +22,15 @@ import {
   shouldSignEdit,
   canManageReadOnlyChannel,
   verifyDeviceKeyStatement,
+  buildDeviceKeyStatementBytes,
+  deriveInboxAddress,
   MESSAGE_EDIT_WINDOW_MS,
   applyEdit,
   getConversationSetting,
   type ControlMessageContent,
   type DeviceKeyStatement,
+  type AnnounceKeysStatement,
+  type RevokeDeviceStatement,
 } from '@quilibrium/quorum-shared';
 import { MessageDB, EncryptionState, EncryptedMessage } from '../db/messages';
 import type { SpaceMemberRow } from '../db/messages';
@@ -1083,6 +1087,130 @@ export class MessageService {
       (await this.messageDB.getSpaceKey(spaceId, 'signing')) ??
       (await this.messageDB.getSpaceKey(spaceId, 'inbox'))
     );
+  }
+
+  /**
+   * Master-sign a device-key statement. The signature covers ONLY
+   * buildDeviceKeyStatementBytes (shared, byte-identical across platforms — the
+   * hard gate), NOT the JSON envelope, so desktop and mobile verify each other's
+   * statements. Domain-prefixed bytes can never collide with config-upload or
+   * registration signatures made by the same master key.
+   */
+  private signDeviceKeyStatement(
+    statement: DeviceKeyStatement,
+    keyset: { userKeyset: secureChannel.UserKeyset }
+  ): string {
+    const bytes = buildDeviceKeyStatementBytes(statement);
+    const sig = ch.js_sign_ed448(
+      Buffer.from(
+        new Uint8Array(keyset.userKeyset.user_key.private_key)
+      ).toString('base64'),
+      Buffer.from(bytes, 'utf-8').toString('base64')
+    );
+    return Buffer.from(JSON.parse(sig), 'base64').toString('hex');
+  }
+
+  /**
+   * Broadcast this device's per-space signing-key admission (announce-keys),
+   * master-signed so receivers admit the key it ACTUALLY signs with. We announce
+   * getSigningKey() (= `signing ?? inbox`): the join device announces the join
+   * key; a fresh second device (no shared `signing` slot — see the Option A flip
+   * in ConfigService) announces its own per-device `inbox` key. Idempotent and
+   * cheap — sent on space connect; receivers that missed it self-heal on the next
+   * connect. Behaviour-neutral until the send-side flip is live on both platforms
+   * (see the per-device-signing task's staged release order). Fire-and-forget.
+   */
+  async announceDeviceKeys(
+    spaceId: string,
+    keyset: {
+      userKeyset: secureChannel.UserKeyset;
+      deviceKeyset: secureChannel.DeviceKeyset;
+    }
+  ): Promise<void> {
+    try {
+      const signingKey = await this.getSigningKey(spaceId);
+      if (!signingKey?.publicKey) return;
+
+      const userPublicKey = Buffer.from(
+        new Uint8Array(keyset.userKeyset.user_key.public_key)
+      ).toString('hex');
+      const deviceInboxAddress =
+        keyset.deviceKeyset?.inbox_keyset?.inbox_address;
+      if (!deviceInboxAddress) return;
+
+      const statement: AnnounceKeysStatement = {
+        type: 'announce-keys',
+        userAddress: deriveInboxAddress(userPublicKey),
+        userPublicKey,
+        spaceId,
+        deviceInboxAddress,
+        spaceKeyPublicKey: signingKey.publicKey,
+        timestamp: Date.now(),
+        signature: '',
+      };
+      statement.signature = this.signDeviceKeyStatement(statement, keyset);
+
+      // Serialize eagerly so the enqueued closure captures the finished string,
+      // not the live (mutable) statement object.
+      const envelope = JSON.stringify({ type: 'control', message: statement });
+      this.enqueueOutbound(async () => [
+        await this.sendHubMessage(spaceId, envelope),
+      ]);
+    } catch (err) {
+      logger.warn('[DeviceKeys] announceDeviceKeys failed', { err, spaceId });
+    }
+  }
+
+  /**
+   * Broadcast a master-signed revoke-device tombstone for each removed device
+   * across every space the user is in (triggered by the Security-modal device
+   * removal). LWW-tombstoned by receivers; a re-added device gets fresh DM keys →
+   * new tag, so a same-tag re-admit needs a newer-ts announce only the master key
+   * can mint. Offline desktop receivers catch up on the announcing device's next
+   * re-announce (P2P has no control-message replay — converges on the hub-log
+   * migration). Fire-and-forget per statement; per-space failures are logged.
+   */
+  async broadcastDeviceRevocations(
+    deviceInboxAddresses: string[],
+    keyset: {
+      userKeyset: secureChannel.UserKeyset;
+      deviceKeyset: secureChannel.DeviceKeyset;
+    }
+  ): Promise<void> {
+    if (deviceInboxAddresses.length === 0) return;
+
+    const userPublicKey = Buffer.from(
+      new Uint8Array(keyset.userKeyset.user_key.public_key)
+    ).toString('hex');
+    const userAddress = deriveInboxAddress(userPublicKey);
+    const spaces = await this.messageDB.getSpaces();
+
+    for (const space of spaces) {
+      for (const deviceInboxAddress of deviceInboxAddresses) {
+        try {
+          const statement: RevokeDeviceStatement = {
+            type: 'revoke-device',
+            userAddress,
+            userPublicKey,
+            spaceId: space.spaceId,
+            deviceInboxAddress,
+            timestamp: Date.now(),
+            signature: '',
+          };
+          statement.signature = this.signDeviceKeyStatement(statement, keyset);
+
+          const envelope = JSON.stringify({ type: 'control', message: statement });
+          this.enqueueOutbound(async () => [
+            await this.sendHubMessage(space.spaceId, envelope),
+          ]);
+        } catch (err) {
+          logger.warn('[DeviceKeys] revoke broadcast failed', {
+            err,
+            spaceId: space.spaceId,
+          });
+        }
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
## ⚠️ DO NOT DEPLOY TO PROD UNTIL MOBILE RECEIVE-SIDE IS LIVE

Safe to **merge to `main`** (needed for local desktop↔mobile multi-device testing), but **do not run the deploy** until mobile's receive-side is live. A prod mobile client on an older build would silently drop a secondary desktop device's control ops during the rollout window. Merging to `main` does not touch prod (deploy is a separate gh-pages step).

## What

Desktop **send-side** of the durable multi-device per-device signing keys feature. Receive-side merged in #245. This is **additive and behaviour-neutral until the flip is live on both platforms** — every device still signs with the interim join-bound key today.

Spec: `.agents/tasks/2026-07-19-per-device-signing-keys-registration-anchored.md`.

## How

- **`announceDeviceKeys`** (`MessageService`) — on space connect, broadcast a **master-signed** `announce-keys` control envelope admitting the key the device actually signs with (`getSigningKey` = `signing ?? inbox`). Signed bytes come from shared's `buildDeviceKeyStatementBytes`, so desktop and mobile verify byte-identical (silent-auth-break guard).
- **`broadcastDeviceRevocations`** (`MessageService`, exposed via context) — master-signed `revoke-device` tombstones for each removed device across every space, wired into the Security-modal device-removal flow.
- **Option A signing flip** (`ConfigService`) — a fresh device no longer adopts the shared `signing` slot on config sync, so it signs with its own per-device `inbox` key. The `signing ?? inbox` **read is unchanged**, so existing devices keep the shared key and **do not regress**. Only devices set up *after* the flip sign per-device.

## Chosen approach: Option A (vs signing with own inbox immediately)

The correctness bug (2nd-device deletes dropped) is already fixed by the interim shared-key fix (#244). This is a security *upgrade* (per-device revocation, no key copying), so we don't disturb working setups: existing multi-device users keep the shared key; only fresh device setups go per-device. Smallest blast radius.

## Deferred (intentional)

- **Member-sync statement carriage** — the stored `SpaceMemberDevice` keeps no verbatim signature to re-verify, so peer-gossiped statements can't be re-verified without a schema change. On-connect re-announce covers the common case, and the gap converges away on the hub-log transport migration.

## Tests

6 new send-side unit tests (envelope shape, cross-platform byte-identity of the signed payload, revoke fan-out, no-op paths). Full suite green; `tsc` + `lint` clean.

## Review

Independent security-focused code review run on the diff (auth-boundary): no critical/high findings; signing correctness and Option A safety confirmed. The two suggested defensive tweaks (eager-serialize before enqueue, routing assertion in the revoke test) are applied.
