### PR TITLE
fix: admit per-device signing keys at the signature-strip gate

### DIFF
--- a/.agents/tasks/2026-07-19-per-device-signing-keys-registration-anchored.md
+++ b/.agents/tasks/2026-07-19-per-device-signing-keys-registration-anchored.md
@@ -1,7 +1,7 @@
 ---
 type: task
 title: "Durable multi-device: per-device space signing keys, admitted via master-identity-signed device statements"
-status: IN PROGRESS — shared core (#62) + desktop receive-side (#245) + desktop SEND-side (#249 MERGED to main, Option A) done; mobile receive+send done on quorum-mobile PR #168 (OPEN, not merged — user UI-tests cross-device first). Cleanup (retire signing slot) + prod deploy still pending (staged, see release order)
+status: IN PROGRESS — shared core (#62) + desktop receive-side (#245) + desktop SEND-side (#249 MERGED, Option A) + desktop GATE FIX (#250 OPEN — signature-strip gate ignored device admissions) done; mobile receive+send on quorum-mobile PR #168 (OPEN). Desktop↔desktop VALIDATED live; mobile↔desktop blocked by transport divergence. Cleanup (retire signing slot) + prod deploy pending (staged, see release order)
 priority: high (follow-up to the interim signing-split fix)
 created: 2026-07-19
 severity: HIGH (security-critical — touches the verified-signer auth boundary)
@@ -444,6 +444,55 @@ testing the new path. Desktop just needs to be on `main` (has the receive-side).
 If step 2 works, receivers are admitting the per-device key via the announce; if
 step 5 works, the tombstone is being honoured. Both green ⇒ cross-device flow is
 validated and mobile PR #168 can merge.
+
+## Test results (2026-07-21 — live cross-device testing)
+
+**Desktop ↔ desktop (same account, 2 devices + a separate observer account): ✅ VALIDATED.**
+Delete / edit / pin from a second desktop device land on the other device AND on
+the observer account. Confirmed the GENUINE per-device path (logs: announced key
+→ ADMITTED → "signature accepted via per-device key" for post/edit/pin), not the
+interim shared-key path. This is transport-independent (both on desktop P2P).
+
+**Bug found + fixed during testing → desktop PR #250 (OPEN).**
+Symptom: a second device's messages were rejected "invalid address for signature"
+— post shown unsigned, edit/pin/delete dropped. Reproduced desktop↔desktop, so
+NOT the transport. Root cause: the two legacy signature-strip gates in
+`MessageService`'s receive loop (streaming ~3910 + batch ~4917, from the
+#241/#243 verified-signer work) compare the signing key ONLY to the member join
+binding and never consulted the per-device admissions store — so a valid
+per-device signature was stripped BEFORE the device-aware resolver ran. #245
+wired the resolver into the auth FUNCTIONS but missed these pre-auth gates. Fix:
+`isAdmittedDeviceKey` (non-revoked admission, inboxAddress match,
+userAddress===sender), consulted on join-mismatch; both gates accept it. 4
+regression tests; validated by the live desktop↔desktop test. **Lesson: when
+adding a reverse-lookup admission path, audit ALL pre-auth signature gates, not
+just the auth functions.**
+
+**Mobile receive + send → quorum-mobile PR #168 (OPEN).**
+Receive-side validated: mobile admits per-device keys from every device
+(confirmed via diagnostic logs before trimming) + 8 unit tests + static analysis.
+**Mobile does NOT need the desktop gate fix** (static-verified): it has no
+pre-auth strip gate — `verifySpaceMessageSignature` checks only crypto validity,
+and every control path (`authorizeSpaceControlMessage` / `isReadOnlyPostAuthorized`
+/ `shouldStripEveryoneMention`) resolves via the device-aware resolver. Diagnostic
+logs trimmed to one high-signal line ("signature accepted via per-device key",
+receiver-side) + genuine failures, after raw logs proved too noisy.
+
+**Mobile ↔ desktop: NOT tested** — blocked by the known P2P-vs-hub-log transport
+divergence (separate from this feature). Clean test topologies until hub-log
+converges: desktop↔desktop and mobile↔mobile (same transport each).
+
+**Observations surfaced during testing (separate from this feature):**
+- Announce-keys accumulate in the mobile hub log and replay on every connect →
+  a flood of LWW "stale" re-admissions. Functionally correct (dedup), storage/perf
+  only. Ref `.agents/bugs/2026-07-20-announce-keys-flooding-unbounded-admissions.md`.
+- Multiple device registrations accrue per account across resets/re-logins. Ref
+  `.agents/tasks/2026-07-21-device-registration-ghost-accumulation-cross-platform.md`.
+- **Cross-platform device-management LIST divergence:** a real, ACTIVE desktop
+  device did not appear in mobile's device-management list (mobile HAD admitted
+  that device's announce-keys, so the admissions store knew it — only the
+  registration-list UI differed). Registration fetch/display differs per platform.
+  NOT a per-device-signing blocker; worth a separate investigation.
 
 ## Production release order (revised 2026-07-20 — STAGED, supersedes the earlier "ship together" decision)
 

--- a/src/dev/tests/services/MessageService.unit.test.tsx
+++ b/src/dev/tests/services/MessageService.unit.test.tsx
@@ -1807,4 +1807,58 @@ describe('MessageService - Unit Tests', () => {
       expect(mockDeps.sendHubMessage).not.toHaveBeenCalled();
     });
   });
+
+  // The signature-strip gate (streaming + batch receive paths) must treat an
+  // admitted per-device key as bound to its member, or a valid second-device
+  // signature is stripped before the verified-signer resolver runs — the
+  // "invalid address for signature" regression. isAdmittedDeviceKey is that
+  // second lookup path.
+  describe('11. Per-device signing keys (signature-gate binding)', () => {
+    const SPACE = 'space-gate';
+    const ALICE = 'addr-alice-gate';
+    const BOB = 'addr-bob-gate';
+    const SIGNING_ADDR = 'QmDeviceSigningAddr';
+
+    const admission = (over = {}) => ({
+      spaceId: SPACE,
+      userAddress: ALICE,
+      deviceInboxAddress: 'dev-1',
+      inboxAddress: SIGNING_ADDR,
+      spaceKeyPublicKey: 'k',
+      timestamp: 1,
+      revoked: false,
+      ...over,
+    });
+
+    const call = (sender: string, addr: string) =>
+      (messageService as any).isAdmittedDeviceKey(SPACE, sender, addr);
+
+    it('accepts a non-revoked admitted key bound to the sender', async () => {
+      mockDeps.messageDB.getSpaceMemberDevices = vi
+        .fn()
+        .mockResolvedValue([admission()]);
+      expect(await call(ALICE, SIGNING_ADDR)).toBe(true);
+    });
+
+    it('rejects a revoked admission', async () => {
+      mockDeps.messageDB.getSpaceMemberDevices = vi
+        .fn()
+        .mockResolvedValue([admission({ revoked: true })]);
+      expect(await call(ALICE, SIGNING_ADDR)).toBe(false);
+    });
+
+    it('rejects an admission belonging to a different user', async () => {
+      mockDeps.messageDB.getSpaceMemberDevices = vi
+        .fn()
+        .mockResolvedValue([admission()]);
+      expect(await call(BOB, SIGNING_ADDR)).toBe(false);
+    });
+
+    it('rejects when no admission matches the signing address', async () => {
+      mockDeps.messageDB.getSpaceMemberDevices = vi
+        .fn()
+        .mockResolvedValue([admission()]);
+      expect(await call(ALICE, 'QmSomeOtherAddr')).toBe(false);
+    });
+  });
 });

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -1017,9 +1017,6 @@ export class MessageService {
 
     if (verdict.action === 'admit') {
       await this.messageDB.saveSpaceMemberDevice(verdict.device);
-      logger.log(
-        `[DeviceKeys] ADMITTED ${statement.type} device=${statement.deviceInboxAddress.slice(0, 12)} signingAddr=${verdict.device.inboxAddress.slice(0, 12)} user=${statement.userAddress.slice(0, 12)} space=${statement.spaceId.slice(0, 12)}`
-      );
     } else if (verdict.action === 'revoke') {
       // Tombstone: keep the row marked revoked so a later STALE announce is
       // rejected by LWW; a strictly-newer announce (re-added device) re-admits.
@@ -1032,14 +1029,8 @@ export class MessageService {
         timestamp: verdict.timestamp,
         revoked: true,
       });
-      logger.log(
-        `[DeviceKeys] REVOKED device=${verdict.deviceInboxAddress.slice(0, 12)} user=${verdict.userAddress.slice(0, 12)} space=${verdict.spaceId.slice(0, 12)}`
-      );
-    } else {
-      logger.warn(
-        `[DeviceKeys] REJECTED ${statement?.type} reason=${verdict.reason} device=${statement?.deviceInboxAddress?.slice(0, 12)} space=${contextSpaceId.slice(0, 12)}`
-      );
     }
+    // reject → drop
   }
 
   /**
@@ -1186,9 +1177,6 @@ export class MessageService {
       this.enqueueOutbound(async () => [
         await this.sendHubMessage(spaceId, envelope),
       ]);
-      logger.log(
-        `[DeviceKeys] announced key device=${deviceInboxAddress.slice(0, 12)} signingKey=${signingKey.publicKey.slice(0, 12)} space=${spaceId.slice(0, 12)}`
-      );
     } catch (err) {
       logger.warn('[DeviceKeys] announceDeviceKeys failed', { err, spaceId });
     }
@@ -3948,27 +3936,19 @@ export class MessageService {
                 !isUpdateProfile &&
                 participant?.inbox_address !== inboxAddress &&
                 !!participant?.inbox_address;
-              const admittedDeviceKey =
+              const inboxMismatch =
                 joinMismatch &&
-                (await this.isAdmittedDeviceKey(
+                !(await this.isAdmittedDeviceKey(
                   space.spaceId,
                   decryptedContent.content.senderId,
                   inboxAddress
                 ));
-              if (joinMismatch && admittedDeviceKey) {
-                logger.log(
-                  `[DeviceKeys] signature accepted via per-device key signingAddr=${inboxAddress.slice(0, 12)} sender=${String(decryptedContent.content.senderId).slice(0, 12)} type=${decryptedContent.content.type}`
-                );
-              }
-              const inboxMismatch = joinMismatch && !admittedDeviceKey;
               const messageIdMismatch =
                 decryptedContent.messageId !==
                 Buffer.from(messageId).toString('hex');
 
               if (inboxMismatch || messageIdMismatch) {
-                logger.warn(
-                  `[DeviceKeys] invalid address for signature — signingAddr=${inboxAddress.slice(0, 12)} joinAddr=${String(participant?.inbox_address).slice(0, 12)} sender=${String(decryptedContent.content.senderId).slice(0, 12)} type=${decryptedContent.content.type} messageIdMismatch=${messageIdMismatch}`
-                );
+                logger.warn(t`invalid address for signature`);
                 decryptedContent.publicKey = undefined;
                 decryptedContent.signature = undefined;
               } else {
@@ -4970,26 +4950,18 @@ export class MessageService {
                     const joinMismatch =
                       participant?.inbox_address !== inboxAddress &&
                       !!participant?.inbox_address;
-                    const admittedDeviceKey =
+                    const inboxMismatch =
                       joinMismatch &&
-                      (await this.isAdmittedDeviceKey(
+                      !(await this.isAdmittedDeviceKey(
                         space.spaceId,
                         message.content.senderId,
                         inboxAddress
                       ));
-                    if (joinMismatch && admittedDeviceKey) {
-                      logger.log(
-                        `[DeviceKeys] (batch) signature accepted via per-device key signingAddr=${inboxAddress.slice(0, 12)} sender=${String(message.content.senderId).slice(0, 12)} type=${message.content.type}`
-                      );
-                    }
                     if (
-                      (joinMismatch && !admittedDeviceKey) ||
+                      inboxMismatch ||
                       message.messageId !==
                         Buffer.from(messageId).toString('hex')
                     ) {
-                      logger.warn(
-                        `[DeviceKeys] (batch) invalid address for signature — signingAddr=${inboxAddress.slice(0, 12)} joinAddr=${String(participant?.inbox_address).slice(0, 12)} sender=${String(message.content.senderId).slice(0, 12)} type=${message.content.type}`
-                      );
                       message.publicKey = undefined;
                       message.signature = undefined;
                     } else {

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -1017,6 +1017,9 @@ export class MessageService {
 
     if (verdict.action === 'admit') {
       await this.messageDB.saveSpaceMemberDevice(verdict.device);
+      logger.log(
+        `[DeviceKeys] ADMITTED ${statement.type} device=${statement.deviceInboxAddress.slice(0, 12)} signingAddr=${verdict.device.inboxAddress.slice(0, 12)} user=${statement.userAddress.slice(0, 12)} space=${statement.spaceId.slice(0, 12)}`
+      );
     } else if (verdict.action === 'revoke') {
       // Tombstone: keep the row marked revoked so a later STALE announce is
       // rejected by LWW; a strictly-newer announce (re-added device) re-admits.
@@ -1029,8 +1032,35 @@ export class MessageService {
         timestamp: verdict.timestamp,
         revoked: true,
       });
+      logger.log(
+        `[DeviceKeys] REVOKED device=${verdict.deviceInboxAddress.slice(0, 12)} user=${verdict.userAddress.slice(0, 12)} space=${verdict.spaceId.slice(0, 12)}`
+      );
+    } else {
+      logger.warn(
+        `[DeviceKeys] REJECTED ${statement?.type} reason=${verdict.reason} device=${statement?.deviceInboxAddress?.slice(0, 12)} space=${contextSpaceId.slice(0, 12)}`
+      );
     }
-    // reject → drop
+  }
+
+  /**
+   * Whether a message's signing-key address is admitted for the claimed sender
+   * via a non-revoked per-device statement — the second lookup path the
+   * inbox-binding signature gate must honour (alongside the member's join
+   * binding), or a valid second-device signature gets stripped before the
+   * verified-signer resolver ever runs.
+   */
+  private async isAdmittedDeviceKey(
+    spaceId: string,
+    senderId: string,
+    signingInboxAddress: string
+  ): Promise<boolean> {
+    const devices = await this.messageDB.getSpaceMemberDevices(spaceId);
+    return devices.some(
+      (d) =>
+        !d.revoked &&
+        d.inboxAddress === signingInboxAddress &&
+        d.userAddress === senderId
+    );
   }
 
   private async isSpaceControlAuthorized(
@@ -1156,6 +1186,9 @@ export class MessageService {
       this.enqueueOutbound(async () => [
         await this.sendHubMessage(spaceId, envelope),
       ]);
+      logger.log(
+        `[DeviceKeys] announced key device=${deviceInboxAddress.slice(0, 12)} signingKey=${signingKey.publicKey.slice(0, 12)} space=${spaceId.slice(0, 12)}`
+      );
     } catch (err) {
       logger.warn('[DeviceKeys] announceDeviceKeys failed', { err, spaceId });
     }
@@ -3907,16 +3940,35 @@ export class MessageService {
               // the signature is verified below as normal. Without the guard
               // this threw a TypeError that the outer catch swallowed, silently
               // dropping the message on non-repudiable spaces.
-              const inboxMismatch =
+              // A signing key not matching the member's join binding is still
+              // valid if it's an admitted per-device key (multi-device). Only
+              // consult the device store when there IS a mismatch, so the common
+              // single-key path pays nothing.
+              const joinMismatch =
                 !isUpdateProfile &&
                 participant?.inbox_address !== inboxAddress &&
-                participant?.inbox_address;
+                !!participant?.inbox_address;
+              const admittedDeviceKey =
+                joinMismatch &&
+                (await this.isAdmittedDeviceKey(
+                  space.spaceId,
+                  decryptedContent.content.senderId,
+                  inboxAddress
+                ));
+              if (joinMismatch && admittedDeviceKey) {
+                logger.log(
+                  `[DeviceKeys] signature accepted via per-device key signingAddr=${inboxAddress.slice(0, 12)} sender=${String(decryptedContent.content.senderId).slice(0, 12)} type=${decryptedContent.content.type}`
+                );
+              }
+              const inboxMismatch = joinMismatch && !admittedDeviceKey;
               const messageIdMismatch =
                 decryptedContent.messageId !==
                 Buffer.from(messageId).toString('hex');
 
               if (inboxMismatch || messageIdMismatch) {
-                logger.warn(t`invalid address for signature`);
+                logger.warn(
+                  `[DeviceKeys] invalid address for signature — signingAddr=${inboxAddress.slice(0, 12)} joinAddr=${String(participant?.inbox_address).slice(0, 12)} sender=${String(decryptedContent.content.senderId).slice(0, 12)} type=${decryptedContent.content.type} messageIdMismatch=${messageIdMismatch}`
+                );
                 decryptedContent.publicKey = undefined;
                 decryptedContent.signature = undefined;
               } else {
@@ -4913,12 +4965,31 @@ export class MessageService {
                     // ed448 signature is ALWAYS verified: keeping an unverified
                     // signature would let a forged control message carry a real
                     // mod's (public) key and pass the handler's reverse lookup.
+                    // A key that isn't the join binding is still valid if it's an
+                    // admitted per-device key (multi-device).
+                    const joinMismatch =
+                      participant?.inbox_address !== inboxAddress &&
+                      !!participant?.inbox_address;
+                    const admittedDeviceKey =
+                      joinMismatch &&
+                      (await this.isAdmittedDeviceKey(
+                        space.spaceId,
+                        message.content.senderId,
+                        inboxAddress
+                      ));
+                    if (joinMismatch && admittedDeviceKey) {
+                      logger.log(
+                        `[DeviceKeys] (batch) signature accepted via per-device key signingAddr=${inboxAddress.slice(0, 12)} sender=${String(message.content.senderId).slice(0, 12)} type=${message.content.type}`
+                      );
+                    }
                     if (
-                      (participant?.inbox_address !== inboxAddress &&
-                        participant?.inbox_address) ||
+                      (joinMismatch && !admittedDeviceKey) ||
                       message.messageId !==
                         Buffer.from(messageId).toString('hex')
                     ) {
+                      logger.warn(
+                        `[DeviceKeys] (batch) invalid address for signature — signingAddr=${inboxAddress.slice(0, 12)} joinAddr=${String(participant?.inbox_address).slice(0, 12)} sender=${String(message.content.senderId).slice(0, 12)} type=${message.content.type}`
+                      );
                       message.publicKey = undefined;
                       message.signature = undefined;
                     } else {


### PR DESCRIPTION
## The bug

A second device's per-device-signed messages were rejected with **"invalid address for signature"** — the post showed unsigned and control messages (edit/pin/delete) were silently dropped. Confirmed **desktop-to-desktop** (transport-independent), so it's a real receive-side bug, not the mobile↔desktop transport issue.

## Root cause

The receive-side (#245) wired the device-key-aware resolver into the **auth functions**, but there are two earlier **signature-strip gates** in the message decrypt loop (streaming [~3910] and batch/sync [~4917]) that predate this work. They strip a message's `publicKey`/`signature` when the signing key's address ≠ the member's join binding (`participant.inbox_address`) — and they **never consulted the per-device admissions store**. So a valid second-device signature got nuked *before* the resolver (which would have accepted it) ran.

## Fix

- **`isAdmittedDeviceKey(spaceId, sender, signingAddr)`** — the second lookup path: a non-revoked admission whose `inboxAddress` matches and `userAddress === sender`. Consulted **only** when there's a join-binding mismatch, so the common single-key path costs nothing.
- Both gates now accept an admitted per-device key instead of stripping it.
- **`[DeviceKeys]` diagnostics** at each decision point (announce sent, statement verdict admit/revoke/reject, gate accept vs strip) for rollout monitoring — verbose per-message accept-logs are intended to be trimmed at cleanup.
- 4 regression tests for `isAdmittedDeviceKey`. Full suite **67/67**, tsc + lint clean.

## Validation

Confirmed by real desktop↔desktop testing (same account, second device + a separate observer account). The logs show the full flow: `announced key` → `ADMITTED announce-keys` → `signature accepted via per-device key` for `post`, `edit-message`, and `pin`, all landing on the other clients.

## Mobile

**Mobile does not need this fix** (verified statically): its receive path has no equivalent pre-auth strip gate — `verifySpaceMessageSignature` checks only crypto validity, and every control path (`authorizeSpaceControlMessage`, `isReadOnlyPostAuthorized`, `shouldStripEveryoneMention`) resolves the signer through the device-admission-aware resolver. So per-device keys are handled correctly there by construction.

## Release note

Part of the staged per-device-signing rollout — same gate as before: safe to merge to `main`; do not deploy to prod until the cross-device flow is broadly validated.
