### PR TITLE
feat: read receipt double-check icon

### DIFF
--- a/.agents/docs/features/messages/dm-receipts.md
+++ b/.agents/docs/features/messages/dm-receipts.md
@@ -241,13 +241,13 @@ The receipt indicator in `Message.tsx` follows this priority:
 
 | Condition | Display |
 |---|---|
-| `readAt` set | ✓✓ (two `<Icon name="check">` with `-6px` margin overlap) |
+| `readAt` set | ✓✓ (single `<Icon name="checks-custom">` — a custom double-check SVG) |
 | `deliveredAt` set | ✓ (single `<Icon name="check">`) |
 | Otherwise | Nothing |
 
 **Settings gate persistence, not display.** Once `deliveredAt` or `readAt` is persisted to IndexedDB, the checkmark is always visible — even if the user later turns the setting OFF. This means past receipts (received while the setting was ON) remain visible. Turning the setting OFF only stops new acks from being processed and persisted.
 
-Both ✓ and ✓✓ use the same `.delivered` CSS class with `color: var(--color-text-muted)` and 12px icons. The `.read` modifier adds the negative margin to overlap the two check icons.
+Both ✓ and ✓✓ use the same `.delivered` CSS class with `color: var(--color-text-muted)` and 12px icons. The read state (`.read`) is now a single custom `checks-custom` icon — the double-check is baked into one SVG, so the old negative-margin overlap of two icons is gone.
 
 `readAt`, `deliveredAt`, `showDeliveryReceipts`, and `showReadReceipts` are all included in the `React.memo` comparison to trigger re-renders when they change.
 
@@ -282,7 +282,7 @@ Both toggles are also available as per-conversation overrides in Conversation Se
 
 - **Gate persistence, not display**: Both delivery and read acks are only persisted when the user's respective setting is ON. Once persisted, checkmarks are always visible (even after toggling OFF). This preserves the user's past receipts while preventing new ones from accumulating when the setting is OFF.
 
-- **Two check icons instead of IconChecks**: The `IconChecks` Tabler icon exists in quorum-shared's icon map but renders too small at `xs` size. Two adjacent `<Icon name="check">` with `-6px` margin overlap gives better visual clarity.
+- **Custom `checks-custom` icon instead of IconChecks**: The `IconChecks` Tabler icon renders too small/cramped at `xs`. Originally this was worked around with two adjacent `<Icon name="check">` overlapped by `-6px` margin. Replaced (2026-07-23) with a single custom double-check SVG (`checks-custom`) added to the shared Icon primitive. It's stroke-based (matching Tabler) and each tick spans the same 15 viewBox units as `check`, so at `xs` each tick is exactly the size of a single delivered check — but the two ticks sit closer together for a cleaner read indicator. This was the first **stroke-based** custom icon, so `CustomIconDef` gained `stroke`/`strokeWidth` support in `customIcons.ts` (previous custom icons were all fill-based).
 
 - **No-ack rule**: `read-ack` control messages (like `delivery-ack`) are intercepted before `saveMessage` and never trigger delivery or read ack buffering. The `type === 'post'` guard in the defense-in-depth check prevents infinite ack loops.
 
@@ -312,3 +312,5 @@ Both toggles are also available as per-conversation overrides in Conversation Se
 *Updated: 2026-05-18 — Added "Standalone-ack ratchet cost" to Known Limitations, cross-linking to the typing-indicators DR cost investigation.*
 
 *Updated: 2026-05-20 — Removed stale references to a non-existent `src/types/deliveryReceipt.ts` (wire types are inline literals, not a dedicated file). Documented the actual flat wire format and the piggybacked envelope fields. Added a forward-pointer to the receipts-shared-migration task that will lift these types into `@quilibrium/quorum-shared`.*
+
+*Updated: 2026-07-23 — Read indicator (✓✓) now renders a single custom `checks-custom` icon (a redesigned double-check SVG in the shared Icon primitive) instead of two overlapped `check` icons. Added stroke support to `CustomIconDef`.*

--- a/src/components/message/Message.scss
+++ b/src/components/message/Message.scss
@@ -279,17 +279,15 @@
   &.delivered {
     display: inline-flex;
     align-items: center;
-    vertical-align: text-bottom;
+    vertical-align: middle;
     margin-left: 4px;
     color: var(--color-text-muted);
 
+    // Single ✓ (delivered) and double ✓✓ (read, `checks-custom`) are two icons
+    // authored in the same 24×24 box, so they MUST render at the same size.
     svg {
-      width: 12px;
-      height: 12px;
-    }
-
-    &.read svg + svg {
-      margin-left: -6px;
+      width: 16px;
+      height: 16px;
     }
   }
 
@@ -323,10 +321,13 @@
 // where the header — and its indicators — is collapsed. Trails the last word.
 .message-inline-indicators {
   display: inline-flex;
-  align-items: center;
+  // Trailing indicators (esp. the ✓/✓✓ receipt) sit at the bottom of the text
+  // line on both compact and non-compact rows. flex-end bottom-aligns the icons
+  // within the row; text-bottom drops the row itself to the text baseline.
+  align-items: flex-end;
   gap: $s-1-5; // 6px
   margin-left: $s-1-5; // separate from the preceding word
-  vertical-align: baseline;
+  vertical-align: text-bottom;
 
   // Receipt carries its own left margin in the header; inside the group the
   // container gap handles spacing, so drop it to keep the rhythm even.

--- a/src/components/message/Message.tsx
+++ b/src/components/message/Message.tsx
@@ -1050,14 +1050,13 @@ export const Message = React.memo(
                   if (message.readAt) {
                     receiptIndicator = (
                       <span className="message-status delivered read">
-                        <Icon name="check" size="xs" />
-                        <Icon name="check" size="xs" />
+                        <Icon name="checks-custom" size="sm" />
                       </span>
                     );
                   } else if (message.deliveredAt) {
                     receiptIndicator = (
                       <span className="message-status delivered">
-                        <Icon name="check" size="xs" />
+                        <Icon name="check" size="sm" />
                       </span>
                     );
                   }
@@ -1109,9 +1108,12 @@ export const Message = React.memo(
                     )}
                     {receiptIndicator}
                   </span>
-                ) : (
-                  receiptIndicator
-                );
+                ) : receiptIndicator ? (
+                  // Non-compact rows only carry the receipt inline. Wrap it in the
+                  // same flex-centered container as the compact case so the ✓/✓✓
+                  // aligns identically on both row types (bare inline sat too low).
+                  <span className="message-inline-indicators">{receiptIndicator}</span>
+                ) : null;
 
                 // Whether the compact trailing group has anything to show — used by
                 // the media (embed/sticker) branches, which render it as a small row


### PR DESCRIPTION
Replaces the DM read-receipt indicator (previously two overlapped `check` icons) with a single redesigned `checks-custom` double-check glyph added to the shared Icon primitive.

Highlights:
- New stroke-based custom-icon support in `quorum-shared` (`checks-custom`); this repo consumes it.
- Single delivered `check` and the double read check now render at the same 16px size (same 24×24 container).
- Receipt bottom-aligns consistently on both author and grouped rows via the shared inline-indicators wrapper.

Requires quorum-shared master (icon added there); run its build so the desktop app picks up the compiled icon.