### PR TITLE
fix: DM session reset must keep inbox routing, or the peer's messages vanish

### DIFF
--- a/src/dev/tests/services/EncryptionService.unit.test.tsx
+++ b/src/dev/tests/services/EncryptionService.unit.test.tsx
@@ -103,10 +103,14 @@ describe('EncryptionService - Unit Tests', () => {
       // ✅ VERIFY: All 3 states deleted
       expect(mockDeps.messageDB.deleteEncryptionState).toHaveBeenCalledTimes(3);
 
-      // ✅ VERIFY: Inbox mappings deleted for states with inboxId
-      expect(mockDeps.messageDB.deleteInboxMapping).toHaveBeenCalledTimes(2);
-      expect(mockDeps.messageDB.deleteInboxMapping).toHaveBeenCalledWith('inbox-1');
-      expect(mockDeps.messageDB.deleteInboxMapping).toHaveBeenCalledWith('inbox-2');
+      // ✅ VERIFY: inbox routing is PRESERVED.
+      // The peer still holds a confirmed session pointing at our existing
+      // conversation inbox and keeps writing to it — it cannot know we reset.
+      // Dropping the mapping makes those frames unroutable (silently discarded
+      // as RX-NOSTATE) while our next send mints a new inbox the peer never
+      // learns about, leaving the conversation permanently one-way. Mobile's
+      // resetSession keeps mappings for exactly this reason.
+      expect(mockDeps.messageDB.deleteInboxMapping).not.toHaveBeenCalled();
 
       // ✅ VERIFY: Latest state deleted
       expect(mockDeps.messageDB.deleteLatestState).toHaveBeenCalledWith(conversationId);

--- a/src/services/EncryptionService.ts
+++ b/src/services/EncryptionService.ts
@@ -46,18 +46,34 @@ export class EncryptionService {
   }
 
   /**
-   * Deletes all encryption states, inbox mappings, and cache for a conversation.
+   * Resets the Double Ratchet for a conversation: forgets the ratchet states so
+   * the next send re-initialises, while KEEPING the inbox routing intact.
+   *
+   * The routing must survive. Our peer still holds a confirmed session pointing
+   * at our existing conversation inbox and will keep writing to that address —
+   * it has no way to learn we reset. If we drop the mapping, those frames arrive
+   * at an address we no longer recognise and are silently discarded
+   * (`RX-NOSTATE`), and our next send mints a BRAND-NEW inbox the peer never
+   * hears about. The result is a permanently one-way conversation: our messages
+   * reach the peer (fresh init envelopes to their device inbox) while every
+   * message they send disappears. Measured live 2026-07-25: immediately after a
+   * desktop reset, mobile kept posting to the old inbox with a still-confirmed
+   * session and desktop logged `RX-NOSTATE` for every frame.
+   *
+   * This mirrors mobile's `encryptionService.resetSession`, which states the
+   * same rule explicitly: it deletes ratchet states but deliberately keeps
+   * conversation inbox keypairs ("the addresses are still valid for receiving")
+   * and inbox mappings ("routing still needs to work"). The desktop reset action
+   * added 2026-07-17 mirrored the deletion but not those exclusions.
    */
   async deleteEncryptionStates({ conversationId }: { conversationId: string }) {
     try {
       const states = await this.messageDB.getEncryptionStates({ conversationId });
       for (const state of states) {
         await this.messageDB.deleteEncryptionState(state);
-        if (state.inboxId) {
-          try {
-            await this.messageDB.deleteInboxMapping(state.inboxId);
-          } catch { /* ignore */ }
-        }
+        // Intentionally NOT deleting the inbox mapping — see above. Without the
+        // mapping the peer's in-flight session becomes unroutable and the
+        // conversation dies in one direction with no recovery path.
       }
       try {
         await this.messageDB.deleteLatestState(conversationId);


### PR DESCRIPTION
## The bug

Resetting a DM session deleted the conversation's inbox **mappings** along with its ratchet states. That breaks the conversation one-way, permanently.

The peer still holds a confirmed session pointing at our existing conversation inbox and keeps writing to that address — it has no way to learn we reset. With the mapping gone, those frames arrive at an address we no longer recognise and are silently discarded, while our own next send mints a **brand-new inbox the peer never hears about**.

Our messages still reach them (fresh init envelopes to their device inbox), so the conversation looks half-alive: everything we send lands, everything they send disappears.

## Evidence

Measured live on an instrumented build. Immediately after a desktop reset, the peer kept posting to the old inbox with a still-confirmed session (`acc=true`), and desktop logged "no state for this inbox" for **every** frame — including the very first message after the reset.

This is the mechanism behind the long-standing *"reset fixes DMs, then they break again"* pattern. The reset never fixed the inbound direction at all; it silently killed it.

## Why mobile doesn't have this

Mobile's `resetSession` has always been correct — it deletes ratchet states but deliberately keeps conversation inbox keypairs (*"the addresses are still valid for receiving"*) and inbox mappings (*"routing still needs to work"*). The desktop reset action mirrored the deletion but not those exclusions.

## Change

One behavioural change: stop deleting inbox mappings on reset. Ratchet states and latest-state are still cleared, so the next send re-initialises as intended.

The existing unit test asserted the mappings *were* deleted — it encoded the bug. It now pins the invariant instead.

## Verification

- 488 tests pass
- 0 type errors
- Reset still forces re-initialisation; only the routing survives