### PR TITLE
fix: stop deleting DM frames that would decrypt moments later

### DIFF
--- a/src/dev/tests/utils/frameRetry.unit.test.ts
+++ b/src/dev/tests/utils/frameRetry.unit.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import {
+  FRAME_RETRY_MAX_ATTEMPTS,
+  FRAME_RETRY_TTL_MS,
+  UndecryptableFrameTracker,
+  frameKey,
+} from '../../../utils/frameRetry';
+
+const NOW = 1_784_979_000_000;
+
+describe('frameKey', () => {
+  it('distinguishes two frames that share a timestamp', () => {
+    // The defect this exists for: server timestamps are NOT unique, so frame
+    // identity must come from content.
+    expect(frameKey('QmInbox', '{"envelope":"aaa"}')).not.toBe(
+      frameKey('QmInbox', '{"envelope":"bbb"}')
+    );
+  });
+
+  it('is stable for the same frame on the same inbox', () => {
+    expect(frameKey('QmInbox', '{"envelope":"aaa"}')).toBe(
+      frameKey('QmInbox', '{"envelope":"aaa"}')
+    );
+  });
+
+  it('separates identical payloads arriving on different inboxes', () => {
+    expect(frameKey('QmA', 'same')).not.toBe(frameKey('QmB', 'same'));
+  });
+});
+
+describe('UndecryptableFrameTracker', () => {
+  it('keeps a frame for retry instead of deleting it on first failure', () => {
+    const t = new UndecryptableFrameTracker();
+    // This is the whole point: a frame that fails now may decrypt once the
+    // ratchet advances and stores the skipped keys.
+    expect(t.recordFailure('f1', NOW)).toBe(false);
+  });
+
+  it('gives up once the attempt budget is spent', () => {
+    const t = new UndecryptableFrameTracker();
+    for (let i = 1; i < FRAME_RETRY_MAX_ATTEMPTS; i++) {
+      expect(t.recordFailure('f1', NOW)).toBe(false);
+    }
+    expect(t.recordFailure('f1', NOW)).toBe(true); // budget exhausted -> delete
+  });
+
+  it('gives up once the frame is older than the TTL, even with attempts left', () => {
+    const t = new UndecryptableFrameTracker();
+    expect(t.recordFailure('f1', NOW)).toBe(false);
+    expect(t.recordFailure('f1', NOW + FRAME_RETRY_TTL_MS)).toBe(true);
+  });
+
+  it('forgets a frame once it finally decrypts, so its budget resets', () => {
+    const t = new UndecryptableFrameTracker();
+    t.recordFailure('f1', NOW);
+    t.recordFailure('f1', NOW);
+    t.clear('f1');
+    expect(t.size()).toBe(0);
+    expect(t.recordFailure('f1', NOW)).toBe(false); // fresh budget
+  });
+
+  it('tracks frames independently', () => {
+    const t = new UndecryptableFrameTracker();
+    for (let i = 1; i < FRAME_RETRY_MAX_ATTEMPTS; i++) t.recordFailure('f1', NOW);
+    expect(t.recordFailure('f2', NOW)).toBe(false); // f1's budget must not affect f2
+  });
+
+  it('stays bounded under a flood of distinct undecryptable frames', () => {
+    const t = new UndecryptableFrameTracker(FRAME_RETRY_MAX_ATTEMPTS, FRAME_RETRY_TTL_MS, 50);
+    for (let i = 0; i < 5000; i++) t.recordFailure(`ghost-${i}`, NOW);
+    expect(t.size()).toBeLessThanOrEqual(50);
+  });
+});

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -283,6 +283,30 @@ export class MessageService {
     await this.deleteInboxMessages(receivingInbox, [message.timestamp], this.apiClient);
   }
 
+  /**
+   * Acknowledge a DM frame we have successfully decrypted, by deleting it from
+   * the server inbox.
+   *
+   * The confirmed-session path never did this: it relied on the
+   * delete-on-first-decrypt-failure above to clear the inbox, so a frame that
+   * SUCCEEDED was simply left there. That was invisible while failures were
+   * deleted immediately, but once frames are retained for retry the server
+   * keeps redelivering them and each redelivery is decrypted again — measured
+   * live at 12 repeat decrypts of a single frame. Acking on success stops the
+   * redelivery at the source.
+   *
+   * Never allowed to throw: a failed ack just means the frame is redelivered
+   * and skipped again, which is strictly better than losing the message we
+   * already decrypted.
+   */
+  private async ackProcessedFrame(receivingInbox: unknown, timestamp: number): Promise<void> {
+    try {
+      await this.deleteInboxMessages(receivingInbox, [timestamp], this.apiClient);
+    } catch (err) {
+      logger.warn('[MessageService] failed to ack a processed DM frame (will be redelivered)', err);
+    }
+  }
+
   constructor(dependencies: MessageServiceDependencies) {
     this.messageDB = dependencies.messageDB;
     this.threadService = new ThreadService(this.messageDB);
@@ -3677,6 +3701,7 @@ export class MessageService {
               true
             );
             this.undecryptableFrames.clear(undecryptableKey);
+            await this.ackProcessedFrame(freshKeys.receiving_inbox, message.timestamp);
             return {
               outcome: 'ok' as const,
               content,
@@ -3762,6 +3787,7 @@ export class MessageService {
               true
             );
             this.undecryptableFrames.clear(undecryptableKey);
+            await this.ackProcessedFrame(freshKeys.receiving_inbox, message.timestamp);
             return {
               outcome: 'ok' as const,
               content,

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -81,6 +81,7 @@ import { TypingService, type TypingMessage } from '@quilibrium/quorum-shared';
 import { ENABLE_DM_ACTION_QUEUE } from '../config/features';
 import { dmRatchetMutex } from '../utils/keyedMutex';
 import { isStaleInitEnvelope } from '../utils/initEnvelopeGuard';
+import { UndecryptableFrameTracker, frameKey } from '../utils/frameRetry';
 import { ThreadService } from './ThreadService';
 import type { Ref } from '../types/ref';
 import type { SpaceInfoMap, SyncInfoMap } from '../types/spaceRefs';
@@ -203,6 +204,8 @@ export class MessageService {
     timestamps: number[],
     apiClient: QuorumApiClient
   ) => Promise<void>;
+  /** Retry budget for DM frames that fail to decrypt — see frameRetry.ts. */
+  private undecryptableFrames = new UndecryptableFrameTracker();
   private navigate: (path: string, options?: any) => void;
   private spaceInfo: Ref<SpaceInfoMap>;
   private syncInfo: Ref<SyncInfoMap>;
@@ -240,6 +243,45 @@ export class MessageService {
 
   // Cooldown guard: prevents rapid re-broadcasts when a space owner spam-updates their tag
   private pendingTagRebroadcast = new Set<string>();
+
+  /**
+   * A DM frame failed to decrypt. Decide whether to keep it on the server for
+   * another attempt, or give up and delete it.
+   *
+   * Frames routinely fail simply because our receiving chain has not yet
+   * ratcheted into the sender's current chain; the DH ratchet then stores the
+   * skipped message keys and the SAME frame decrypts. Deleting on the first
+   * failure destroyed those frames permanently — verified 2026-07-25 by
+   * replaying real captured frames against real captured states: 5 of 6
+   * deleted frames were decryptable against a state this client held ~35s
+   * later.
+   *
+   * Retaining is safe for the inbox: the inbound loop already catches handler
+   * errors and continues, so a kept frame does not block the ones behind it.
+   * The attempt/TTL budget preserves the original protection against a
+   * genuinely poisonous frame lingering forever.
+   */
+  private async retainOrDropUndecryptableFrame(
+    branch: string,
+    message: { inboxAddress?: string; encryptedContent: string; timestamp: number },
+    receivingInbox: unknown
+  ): Promise<void> {
+    const key = frameKey(message.inboxAddress, message.encryptedContent);
+    if (!this.undecryptableFrames.recordFailure(key)) {
+      // Keep it: the server redelivers anything not acked-by-delete, so the
+      // frame comes back and is retried once the session has moved on.
+      return;
+    }
+    logger.warn(
+      '[MessageService] giving up on an undecryptable DM frame after the retry budget — deleting',
+      {
+        branch,
+        inbox: message.inboxAddress?.slice(0, 16),
+        frameTimestamp: message.timestamp,
+      }
+    );
+    await this.deleteInboxMessages(receivingInbox, [message.timestamp], this.apiClient);
+  }
 
   constructor(dependencies: MessageServiceDependencies) {
     this.messageDB = dependencies.messageDB;
@@ -3588,6 +3630,12 @@ export class MessageService {
         const fresh =
           freshStates.find((s) => s.inboxId === message.inboxAddress) ?? found;
         const freshKeys = JSON.parse(fresh.state);
+        // A frame that previously failed and was retained has now come back
+        // and is about to be retried; on success we stop tracking it below.
+        const undecryptableKey = frameKey(
+          message.inboxAddress,
+          message.encryptedContent
+        );
         if (freshKeys.sending_inbox.inbox_public_key === '') {
           try {
             const result =
@@ -3628,6 +3676,7 @@ export class MessageService {
               },
               true
             );
+            this.undecryptableFrames.clear(undecryptableKey);
             return {
               outcome: 'ok' as const,
               content,
@@ -3646,10 +3695,10 @@ export class MessageService {
             // encrypting to a session the receiver had torn down.
             // (https://signal.org/docs/specifications/doubleratchet/)
             logger.error('[MessageService] DM decrypt failed (ConfirmDoubleRatchetSenderSession) — skipping frame, keeping session', decryptError);
-            await this.deleteInboxMessages(
-              freshKeys.receiving_inbox,
-              [message.timestamp],
-              this.apiClient
+            await this.retainOrDropUndecryptableFrame(
+              'Confirm',
+              message,
+              freshKeys.receiving_inbox
             );
             return { outcome: 'handled' as const };
           }
@@ -3712,6 +3761,7 @@ export class MessageService {
               },
               true
             );
+            this.undecryptableFrames.clear(undecryptableKey);
             return {
               outcome: 'ok' as const,
               content,
@@ -3727,10 +3777,10 @@ export class MessageService {
             // encrypting to a session the receiver had torn down.
             // (https://signal.org/docs/specifications/doubleratchet/)
             logger.error('[MessageService] DM decrypt failed (DoubleRatchetInboxDecrypt) — skipping frame, keeping session', decryptError);
-            await this.deleteInboxMessages(
-              freshKeys.receiving_inbox,
-              [message.timestamp],
-              this.apiClient
+            await this.retainOrDropUndecryptableFrame(
+              'InboxDecrypt',
+              message,
+              freshKeys.receiving_inbox
             );
             return { outcome: 'handled' as const };
           }

--- a/src/utils/frameRetry.ts
+++ b/src/utils/frameRetry.ts
@@ -1,0 +1,117 @@
+/**
+ * Retry window for DM frames that fail to decrypt.
+ *
+ * A frame can fail purely because our receiving chain has not yet ratcheted
+ * into the sender's current chain. Seconds later the DH ratchet runs and
+ * stores the skipped message keys — and the SAME frame then decrypts.
+ *
+ * Deleting the frame from the server inbox on the FIRST failure (the previous
+ * behaviour, in place since the original MessageService) threw those frames
+ * away permanently. Measured live 2026-07-25 by replaying real captured
+ * frames against real captured states: 5 of 6 frames desktop had deleted were
+ * decryptable against a state desktop itself held ~35s later, and emptying
+ * that state's skipped-keys map made them fail again — proving the keys the
+ * frames needed did arrive, just after the frames were destroyed.
+ *
+ * So: keep the frame (the server redelivers anything not acked-by-delete, so
+ * it comes back and gets retried), and only give up after the attempt budget
+ * or the time budget is exhausted. That preserves the original protection
+ * against a genuinely poisonous frame sitting in the inbox forever, without
+ * discarding frames that were merely early.
+ *
+ * Pure and unit-tested; no I/O, no timers. Extractable to quorum-shared.
+ */
+
+/** Give up on a frame after this many failed decrypt attempts. */
+export const FRAME_RETRY_MAX_ATTEMPTS = 8;
+
+/** Give up on a frame this long after we first saw it, whatever the count. */
+export const FRAME_RETRY_TTL_MS = 5 * 60_000;
+
+/** Cap the tracker so a flood of undecryptable frames cannot grow it forever. */
+export const FRAME_RETRY_MAX_TRACKED = 500;
+
+/**
+ * Stable identity for a sealed frame.
+ *
+ * NOT the timestamp: two DISTINCT live frames were observed sharing one
+ * server timestamp (2026-07-25 capture), so timestamps cannot identify a
+ * frame. Identity has to come from the content itself. FNV-1a over
+ * inbox + length + payload; a 32-bit digest is ample for a bounded,
+ * short-lived retry tracker, and length is mixed in to cut collisions.
+ */
+export function frameKey(inboxAddress: string | undefined, encryptedContent: string): string {
+  const s = `${inboxAddress ?? ''}|${encryptedContent}`;
+  let h = 0x811c9dc5;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return `${s.length.toString(36)}:${(h >>> 0).toString(16)}`;
+}
+
+type Entry = { attempts: number; firstSeen: number };
+
+/**
+ * Tracks per-frame decrypt failures and decides when a frame is hopeless.
+ *
+ * Deliberately has no timers: it is driven entirely by the calls the receive
+ * path already makes, so it cannot leak work or fire during teardown.
+ */
+export class UndecryptableFrameTracker {
+  private entries = new Map<string, Entry>();
+
+  constructor(
+    private readonly maxAttempts: number = FRAME_RETRY_MAX_ATTEMPTS,
+    private readonly ttlMs: number = FRAME_RETRY_TTL_MS,
+    private readonly maxTracked: number = FRAME_RETRY_MAX_TRACKED
+  ) {}
+
+  /**
+   * Record a failed decrypt.
+   * @returns true when the frame should be DELETED from the server inbox
+   *          (budget exhausted), false to keep it for another attempt.
+   */
+  recordFailure(key: string, now: number = Date.now()): boolean {
+    const existing = this.entries.get(key);
+    const entry: Entry = existing ?? { attempts: 0, firstSeen: now };
+    entry.attempts += 1;
+
+    const exhausted = entry.attempts >= this.maxAttempts;
+    const expired = now - entry.firstSeen >= this.ttlMs;
+    if (exhausted || expired) {
+      this.entries.delete(key);
+      return true;
+    }
+
+    this.entries.set(key, entry);
+    this.pruneExpired(now);
+    return false;
+  }
+
+  /** A frame finally decrypted — stop tracking it. */
+  clear(key: string): void {
+    this.entries.delete(key);
+  }
+
+  /** Visible for tests/diagnostics. */
+  size(): number {
+    return this.entries.size;
+  }
+
+  /**
+   * Drop expired entries, and if still over the cap drop the oldest. Bounded
+   * so a flood of permanently-undecryptable frames (e.g. ghost-device traffic)
+   * cannot grow the map without limit.
+   */
+  private pruneExpired(now: number): void {
+    for (const [k, v] of this.entries) {
+      if (now - v.firstSeen >= this.ttlMs) this.entries.delete(k);
+    }
+    if (this.entries.size <= this.maxTracked) return;
+    const byAge = [...this.entries.entries()].sort((a, b) => a[1].firstSeen - b[1].firstSeen);
+    for (const [k] of byAge.slice(0, this.entries.size - this.maxTracked)) {
+      this.entries.delete(k);
+    }
+  }
+}

--- a/src/utils/frameRetry.ts
+++ b/src/utils/frameRetry.ts
@@ -22,10 +22,18 @@
  * Pure and unit-tested; no I/O, no timers. Extractable to quorum-shared.
  */
 
-/** Give up on a frame after this many failed decrypt attempts. */
-export const FRAME_RETRY_MAX_ATTEMPTS = 8;
+/**
+ * Attempt ceiling. Deliberately generous: redelivery is FAST (measured gaps of
+ * 0.5-10s), so a small attempt budget burns out long before the receiving chain
+ * catches up. Live measurement: a frame recovered on its 7th attempt, ~30s in,
+ * while an 8-attempt budget was fully spent in ~35s — several frames were given
+ * up moments before they would have decrypted. TIME is the meaningful bound
+ * here, not attempt count; this cap only exists to stop unbounded work on a
+ * single frame.
+ */
+export const FRAME_RETRY_MAX_ATTEMPTS = 40;
 
-/** Give up on a frame this long after we first saw it, whatever the count. */
+/** The real bound: give up this long after we first saw the frame. */
 export const FRAME_RETRY_TTL_MS = 5 * 60_000;
 
 /** Cap the tracker so a flood of undecryptable frames cannot grow it forever. */


### PR DESCRIPTION
## The bug

A DM frame can fail to decrypt purely because our receiving chain has not yet ratcheted into the sender's current chain. Seconds later the DH ratchet runs, stores the skipped message keys, and the **same frame decrypts**.

Both decrypt catch blocks deleted the frame from the server inbox on the **first** failure, so those frames were destroyed before they could ever succeed — a permanent, silent, single-message loss with no resend.

## Evidence (measured, not inferred)

Real captured frames were replayed against real captured ratchet states offline:

- **5 of 6 deleted frames decrypted** against a state this client itself held ~35s later
- Emptying that state's skipped-keys map made them fail again — proving the keys those frames needed **did** arrive, just after the frames were gone

Then verified live on the instrumented build: three frames recovered after previously failing (19.6s / 3 attempts, 20.2s / 3 attempts, 40.9s / 6 attempts). Under the old code all three were lost.

This is the mechanism behind the "isolated single-frame wire loss" residual left open in the DM delivery investigation. It was not wire loss.

## Change

Three commits:

1. **Retain for retry.** Frames are kept (the server redelivers anything not acked-by-delete) and deleted only once an attempt or time budget is spent — preserving the original protection against a genuinely poisonous frame. Retaining is safe: the inbound loop already catches handler errors and continues, so a kept frame does not block the ones behind it.
2. **Ack on successful decrypt.** The confirmed-session path never acked a frame it decrypted, relying on delete-on-failure to clear the inbox. Harmless before; with retention it caused repeat redelivery (measured: one frame decrypted 12 times). Now acked.
3. **Widen the budget.** Redelivery is fast (0.5–10s gaps), so a small attempt budget burns out before the chain catches up — a frame recovered on attempt 7 while an 8-attempt budget was fully spent in ~35s. Time is the meaningful bound, not attempt count.

Frame identity comes from a content hash, **not** the timestamp: two distinct live frames were observed sharing one server timestamp.

## Known limitation

The delete API is timestamp-only, and timestamps are not unique per frame, so any delete can in principle take a sibling with it. Net deletes are not higher than before this PR (failure-deletes removed as success-deletes added), but a proper fix needs the API to accept a frame identity.

## Verification

- 497 tests pass, including 9 new unit tests for the retry window
- 0 type errors
- Behaviour lives in a pure, unit-tested util alongside `keyedMutex` and `initEnvelopeGuard`