### PR TITLE
fix: send with the NEWEST session for a device, so a peer's reset propagates

### DIFF
--- a/src/dev/tests/utils/sessionSelection.unit.test.ts
+++ b/src/dev/tests/utils/sessionSelection.unit.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { orderSessionsForSend } from '../../../utils/sessionSelection';
+
+const TAG = 'QmPeerDevice';
+const row = (timestamp: number, inbox: string, sendReady = true) => ({
+  timestamp,
+  state: JSON.stringify({
+    ratchet_state: `rs-${inbox}`,
+    receiving_inbox: { inbox_address: `recv-${inbox}` },
+    sending_inbox: { inbox_address: inbox, inbox_public_key: sendReady ? `pub-${inbox}` : '' },
+    tag: TAG,
+  }),
+});
+
+/** How the send path actually consumes this: first match for the tag wins. */
+const pick = (rows: Parameters<typeof orderSessionsForSend>[0]) =>
+  orderSessionsForSend(rows).find((s) => s.tag === TAG);
+
+describe('orderSessionsForSend', () => {
+  it('picks the NEWEST send-ready session after the peer resets', () => {
+    // The stale row is first in insertion order; the old code took it and kept
+    // sending to an inbox the peer had abandoned.
+    const stale = row(1_000, 'abandoned-inbox');
+    const fresh = row(2_000, 'peer-new-inbox');
+    expect(pick([stale, fresh])?.sending_inbox.inbox_address).toBe('peer-new-inbox');
+  });
+
+  it('is independent of insertion order', () => {
+    const stale = row(1_000, 'abandoned-inbox');
+    const fresh = row(2_000, 'peer-new-inbox');
+    expect(pick([fresh, stale])?.sending_inbox.inbox_address).toBe('peer-new-inbox');
+  });
+
+  it('prefers a send-ready session over a newer unconfirmed one', () => {
+    // Send-ready skips init-envelope wrapping, so it wins even if older.
+    const ready = row(1_000, 'ready-inbox', true);
+    const unconfirmed = row(9_000, 'unconfirmed-inbox', false);
+    expect(pick([unconfirmed, ready])?.sending_inbox.inbox_address).toBe('ready-inbox');
+  });
+
+  it('falls back to the newest unconfirmed session when none are send-ready', () => {
+    const older = row(1_000, 'a', false);
+    const newer = row(3_000, 'b', false);
+    expect(pick([older, newer])?.sending_inbox.inbox_address).toBe('b');
+  });
+
+  it('skips unparseable rows instead of breaking the send', () => {
+    const broken = { timestamp: 9_999, state: 'not json' };
+    const good = row(1_000, 'good-inbox');
+    expect(pick([broken, good])?.sending_inbox.inbox_address).toBe('good-inbox');
+  });
+
+  it('does not mutate the caller array', () => {
+    const rows = [row(1_000, 'a'), row(2_000, 'b')];
+    const before = rows.map((r) => r.timestamp);
+    orderSessionsForSend(rows);
+    expect(rows.map((r) => r.timestamp)).toEqual(before);
+  });
+
+  it('returns an empty array for no rows', () => {
+    expect(orderSessionsForSend([])).toEqual([]);
+  });
+});

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -81,6 +81,7 @@ import { TypingService, type TypingMessage } from '@quilibrium/quorum-shared';
 import { ENABLE_DM_ACTION_QUEUE } from '../config/features';
 import { dmRatchetMutex } from '../utils/keyedMutex';
 import { isStaleInitEnvelope } from '../utils/initEnvelopeGuard';
+import { orderSessionsForSend } from '../utils/sessionSelection';
 import { UndecryptableFrameTracker, frameKey } from '../utils/frameRetry';
 import { ThreadService } from './ThreadService';
 import type { Ref } from '../types/ref';
@@ -925,7 +926,7 @@ export class MessageService {
       const response = await this.messageDB.getEncryptionStates({
         conversationId,
       });
-      const sets = response.map((e) => JSON.parse(e.state));
+      const sets = orderSessionsForSend(response);
 
       // For established sessions, we only need selfUserAddress (SDK only uses user_address field)
       const minimalSelf = { user_address: selfUserAddress } as secureChannel.UserRegistration;
@@ -2969,7 +2970,7 @@ export class MessageService {
           }
 
           response = await this.messageDB.getEncryptionStates({ conversationId });
-          const sets = response.map((e) => JSON.parse(e.state));
+          const sets = orderSessionsForSend(response);
 
           let sessions: secureChannel.SealedMessageAndMetadata[] = [];
           // Edit inherit rule: sign iff the edited message was signed, so an
@@ -3151,7 +3152,7 @@ export class MessageService {
         }
 
         response = await this.messageDB.getEncryptionStates({ conversationId });
-        const sets = response.map((e) => JSON.parse(e.state));
+        const sets = orderSessionsForSend(response);
 
         let sessions: secureChannel.SealedMessageAndMetadata[] = [];
         // Sign DM unless explicitly skipped (skip if already signed via preBuiltMessage)
@@ -6358,7 +6359,7 @@ export class MessageService {
           }
 
           response = await this.messageDB.getEncryptionStates({ conversationId });
-          const sets = response.map((e) => JSON.parse(e.state));
+          const sets = orderSessionsForSend(response);
 
           let sessions: secureChannel.SealedMessageAndMetadata[] = [];
 

--- a/src/utils/sessionSelection.ts
+++ b/src/utils/sessionSelection.ts
@@ -1,0 +1,63 @@
+/**
+ * Ordering stored DM sessions so the SEND path picks the right one.
+ *
+ * Several stored rows legitimately share one device tag: a session we created by
+ * sending first can coexist with one created by RECEIVING the peer's init
+ * envelope. The send path selects with `sets.find((s) => s.tag === inbox)`,
+ * which takes whatever comes first — so the ORDER of this array decides which
+ * session every outgoing message uses.
+ *
+ * The rule is: send-ready rows first, and among those the NEWEST.
+ *
+ * Recency is the part that was missing, and it breaks resets. When the peer
+ * resets they mint a new receiving inbox and announce it in a fresh init
+ * envelope — but they cannot delete our old row, so we hold BOTH a stale
+ * confirmed row (pointing at an inbox they have abandoned) and the new one.
+ * Both look send-ready, and the stale one comes first in insertion order, so it
+ * won every time: every message we sent went to a dead inbox and was silently
+ * discarded by the peer as having no session for it, while their messages kept
+ * arriving normally.
+ *
+ * A reset is meant to be ONE-SIDED — one user resets, their next message carries
+ * the new session, and both sides converge. That only works if the peer's send
+ * path adopts the newest session. Observed live 2026-07-25: after a reset on one
+ * device, that device's direction worked and the other direction was completely
+ * dead, and the failure flipped sides depending on who reset. Mobile has the
+ * same rule in `selectSendState`.
+ */
+
+type Ordered = { ts: number; set: Record<string, unknown> };
+
+function isSendReady(set: Record<string, unknown> | undefined): boolean {
+  const sending = set?.sending_inbox as { inbox_public_key?: string } | undefined;
+  return Boolean(sending?.inbox_public_key);
+}
+
+/**
+ * Parse stored encryption-state rows into session objects, ordered so that the
+ * first match for a given tag is the one to send with.
+ */
+// Returns `any[]` deliberately: this replaces `response.map((e) => JSON.parse(e.state))`,
+// whose element type was `any`. Narrowing it here would ripple type errors through
+// every call site for no safety gain — the ordering is the change, not the typing.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function orderSessionsForSend<T extends { timestamp?: number; state: string }>(
+  rows: T[]
+): any[] {
+  return rows
+    .map((r): Ordered | null => {
+      try {
+        return { ts: r.timestamp ?? 0, set: JSON.parse(r.state) };
+      } catch {
+        return null; // unparseable row — skip rather than break the send
+      }
+    })
+    .filter((x): x is Ordered => x !== null)
+    .sort((a, b) => {
+      const ar = isSendReady(a.set) ? 1 : 0;
+      const br = isSendReady(b.set) ? 1 : 0;
+      if (ar !== br) return br - ar; // send-ready first (skips init wrapping)
+      return b.ts - a.ts; // then newest, so a peer's reset is adopted
+    })
+    .map((x) => x.set);
+}


### PR DESCRIPTION
Mirror of quorum-mobile #179. Together they make a one-sided reset actually work.

## The bug

A reset is meant to be **one-sided**: one user resets, their next message carries a fresh init envelope, and both sides converge. In practice the direction *away* from the resetter worked and the direction *toward* them was completely dead — and **the dead side flipped depending on who reset**.

Reset from desktop → mobile→desktop died. Reset from mobile → desktop→mobile died, 0 of 5 landing, with no read receipts in either direction.

## Cause

Several stored rows legitimately share one device tag. All four send sites selected with:

```js
sets.find((s) => s.tag === inbox)
```

taking whatever came first in insertion order, with **no regard for recency**.

When the peer resets they mint a new receiving inbox and announce it in their init envelope — but they cannot delete our old row. So we hold both a **stale confirmed row**, pointing at an inbox they have abandoned, and the fresh one. Both look send-ready and the stale one is first, so it won every time. Every message went to a dead inbox and was silently discarded by the peer as having no session for it, while their messages kept arriving normally.

Receipts travel the same path, which is why read receipts stopped in both directions.

## Change

All four sites build their candidate list identically (`response.map((e) => JSON.parse(e.state))`), so the ordering is fixed once in a pure helper: **send-ready rows first, then newest**. `find` then yields the right session at every site with no other change.

The helper returns `any[]` deliberately, matching the `JSON.parse` it replaces — narrowing it would ripple type errors through every call site for no safety gain, since the ordering is the change, not the typing.

## Verification

- 504 tests pass, including 7 new ones: the stale-confirmed-vs-fresh case, order-independence, send-ready preferred over a newer unconfirmed row, unparseable rows skipped rather than breaking the send, and non-mutation of the caller's array
- 0 type errors