### PR TITLE
fix: refuse ancient init envelopes even when no session rows exist

### DIFF
--- a/src/dev/tests/utils/initEnvelopeGuard.unit.test.ts
+++ b/src/dev/tests/utils/initEnvelopeGuard.unit.test.ts
@@ -9,43 +9,69 @@ const HOUR = 3_600_000;
 
 describe('isStaleInitEnvelope', () => {
   it('accepts the first init for a tag (no existing rows)', () => {
-    expect(isStaleInitEnvelope(NOW, [])).toBe(false);
+    expect(isStaleInitEnvelope(NOW, [], undefined, NOW)).toBe(false);
   });
 
   it('accepts a fresh envelope newer than every existing row (normal reset)', () => {
-    expect(isStaleInitEnvelope(NOW, [NOW - 5 * HOUR, NOW - HOUR])).toBe(false);
+    expect(isStaleInitEnvelope(NOW, [NOW - 5 * HOUR, NOW - HOUR], undefined, NOW)).toBe(false);
   });
 
   it('rejects an exact redelivery of the envelope that created a current row', () => {
     // Init-created rows are saved with the envelope timestamp itself.
-    expect(isStaleInitEnvelope(NOW - HOUR, [NOW - HOUR])).toBe(true);
+    expect(isStaleInitEnvelope(NOW - HOUR, [NOW - HOUR], undefined, NOW)).toBe(true);
   });
 
   it('rejects an envelope hours older than the current session (zombie)', () => {
-    expect(isStaleInitEnvelope(NOW - 5 * HOUR, [NOW - HOUR])).toBe(true);
+    expect(isStaleInitEnvelope(NOW - 5 * HOUR, [NOW - HOUR], undefined, NOW)).toBe(true);
   });
 
   it('rejects a 60-day-old envelope (observed live)', () => {
-    expect(isStaleInitEnvelope(NOW - 60 * 24 * HOUR, [NOW - HOUR])).toBe(true);
+    expect(isStaleInitEnvelope(NOW - 60 * 24 * HOUR, [NOW - HOUR], undefined, NOW)).toBe(true);
   });
 
   it('tolerates small clock skew (envelope slightly older than newest row)', () => {
     // Rows updated by sends carry local Date.now(); a fresh server-stamped
     // envelope may trail a skewed local clock by a few seconds.
-    expect(isStaleInitEnvelope(NOW - 30_000, [NOW])).toBe(false);
+    expect(isStaleInitEnvelope(NOW - 30_000, [NOW], undefined, NOW)).toBe(false);
   });
 
   it('rejects just past the tolerance boundary and accepts just inside it', () => {
     const newest = NOW;
     const inside = newest - INIT_ENVELOPE_STALENESS_TOLERANCE_MS + 1_000;
     const outside = newest - INIT_ENVELOPE_STALENESS_TOLERANCE_MS - 1_000;
-    expect(isStaleInitEnvelope(inside, [newest])).toBe(false);
-    expect(isStaleInitEnvelope(outside, [newest])).toBe(true);
+    expect(isStaleInitEnvelope(inside, [newest], undefined, NOW)).toBe(false);
+    expect(isStaleInitEnvelope(outside, [newest], undefined, NOW)).toBe(true);
   });
 
   it('compares against the NEWEST row when several exist', () => {
     const rows = [NOW - 10 * HOUR, NOW - HOUR];
-    expect(isStaleInitEnvelope(NOW - 2 * HOUR, rows)).toBe(true);
-    expect(isStaleInitEnvelope(NOW, rows)).toBe(false);
+    expect(isStaleInitEnvelope(NOW - 2 * HOUR, rows, undefined, NOW)).toBe(true);
+    expect(isStaleInitEnvelope(NOW, rows, undefined, NOW)).toBe(false);
+  });
+});
+
+describe('isStaleInitEnvelope — absolute age bound (no rows to compare against)', () => {
+  const NOW2 = 1_784_988_800_000;
+  const HOUR2 = 3_600_000;
+
+  it('refuses an ancient envelope even when we hold NO rows', () => {
+    // The reset hole: a reset deletes every row, so rule 1 ("no rows -> not
+    // stale") accepted anything. Observed live replacing a just-reset session
+    // with a 26-hour-old redelivered envelope.
+    expect(isStaleInitEnvelope(NOW2 - 26 * HOUR2, [], undefined, NOW2)).toBe(true);
+  });
+
+  it('still accepts a genuinely fresh envelope when we hold no rows', () => {
+    expect(isStaleInitEnvelope(NOW2 - 1_000, [], undefined, NOW2)).toBe(false);
+  });
+
+  it('tolerates clock skew well beyond the 2-minute relative tolerance', () => {
+    expect(isStaleInitEnvelope(NOW2 - 5 * 60_000, [], undefined, NOW2)).toBe(false);
+  });
+
+  it('refuses an ancient envelope even when rows exist and would not flag it', () => {
+    // Rows themselves stale/older than the envelope: relative rules pass, but
+    // the envelope is still a zombie.
+    expect(isStaleInitEnvelope(NOW2 - 26 * HOUR2, [NOW2 - 40 * HOUR2], undefined, NOW2)).toBe(true);
   });
 });

--- a/src/utils/initEnvelopeGuard.ts
+++ b/src/utils/initEnvelopeGuard.ts
@@ -25,11 +25,33 @@
  */
 export const INIT_ENVELOPE_STALENESS_TOLERANCE_MS = 120_000;
 
+/**
+ * Absolute age bound, applied even when we hold NO rows for the tag.
+ *
+ * Rule 1 below ("no existing rows -> not stale") left a hole exactly where we
+ * are most vulnerable: a session RESET deletes every row, so for a moment there
+ * is nothing to compare against and ANY redelivered envelope is accepted. The
+ * server redelivers anything whose ack-by-delete failed, so old init envelopes
+ * sit on the inbox indefinitely - observed live 2026-07-25 replacing a
+ * just-reset session with envelopes 94,125 seconds (26 hours) old, and the
+ * master report saw 60-day-old ones. The zombie installs itself as the session,
+ * the peer's real traffic no longer matches, and the reset the user just
+ * performed is silently undone.
+ *
+ * A legitimate init envelope is seconds old. Ten minutes is five times the skew
+ * tolerance and still refuses everything observed.
+ */
+export const INIT_ENVELOPE_MAX_AGE_MS = 10 * 60_000;
+
 export function isStaleInitEnvelope(
   envelopeTimestamp: number,
   existingRowTimestamps: number[],
-  toleranceMs: number = INIT_ENVELOPE_STALENESS_TOLERANCE_MS
+  toleranceMs: number = INIT_ENVELOPE_STALENESS_TOLERANCE_MS,
+  now: number = Date.now(),
+  maxAgeMs: number = INIT_ENVELOPE_MAX_AGE_MS
 ): boolean {
+  // Rule 0: absolute age. Holds even with no rows — see INIT_ENVELOPE_MAX_AGE_MS.
+  if (now - envelopeTimestamp > maxAgeMs) return true;
   if (existingRowTimestamps.length === 0) return false;
   if (existingRowTimestamps.includes(envelopeTimestamp)) return true;
   const newest = Math.max(...existingRowTimestamps);


### PR DESCRIPTION
## The hole

The staleness guard's rule 1 was *"no existing rows for the tag → not stale"*. But a session **reset deletes every row**, so for a window there is nothing to compare against and **any** redelivered init envelope is accepted.

The server redelivers anything whose ack-by-delete failed, so old init envelopes sit on an inbox indefinitely. That makes reset — the user's recovery action — the moment of maximum vulnerability.

## Observed live, immediately after a desktop reset

```
SESSION REPLACED by init envelope  envelopeAgeSeconds: 94125  replacedRows: 0
SESSION REPLACED by init envelope  envelopeAgeSeconds: 94089  replacedRows: 1
SESSION REPLACED by init envelope  envelopeAgeSeconds: -0     replacedRows: 1
```

Two envelopes **26 hours old** installed themselves into the freshly-reset state before the peer's real init arrived. The resulting churn left the pairing desynced, and the peer's frames then landed on an inbox with no state:

```
DM frame for unknown inbox — no encryption state, dropping unread
```

The reset the user had just performed was silently undone.

The master report had already seen 60-day-old envelopes doing exactly this; the guard that shipped for it only covered the case where rows still existed.

## Change

Adds an absolute age bound applied **before** the relative rules, so it holds with zero rows: an init envelope older than 10 minutes is refused outright.

A legitimate init envelope is seconds old. Ten minutes is five times the existing clock-skew tolerance and still refuses everything observed.

## Note on the existing tests

They used a hardcoded past timestamp as their fake clock while the function read the real one. They now pass that clock explicitly — otherwise the new bound correctly flags the fixtures themselves as ancient.

## Verification

- 508 tests pass, including 4 new ones: ancient-with-no-rows refused, fresh-with-no-rows still accepted, 5-minute skew tolerated, ancient refused even when rows exist that would not flag it
- 0 type errors