### PR TITLE
fix: receipt truthfulness desktop

### DIFF
--- a/src/components/context/MessageDB.tsx
+++ b/src/components/context/MessageDB.tsx
@@ -25,6 +25,12 @@ import {
   ActionQueueHandlers,
 } from '../../services';
 import { ReceiptService, TypingService } from '@quilibrium/quorum-shared';
+import {
+  advanceReadWatermark,
+  isReadAckTimestampValid,
+  resolveDeliveryAckPatch,
+  resolveReadAckPatch,
+} from '@quilibrium/quorum-shared';
 import { ActionQueueProvider } from './ActionQueueContext';
 import {
   buildConversationsKey,
@@ -1085,6 +1091,11 @@ const MessageDBProvider: FC<MessageDBContextProps> = ({ children }) => {
     if (prev.spaces && !spaces) typingServiceRef.current?.onSettingDisabled('space');
   }, []);
 
+  // How far the peer has read, per DM conversation. In-memory only: it exists to
+  // bridge the ~5s gap between a read ack and the delivery acks it outran, so a
+  // restart mid-window costs at most a few ✓✓ that the next read ack restores.
+  const readWatermarksRef = useRef<Map<string, number>>(new Map());
+
   // ReceiptService — batched ack buffer with piggyback + standalone flush
   const receiptService = useMemo(() => {
     if (!selfAddress) return null;
@@ -1103,33 +1114,44 @@ const MessageDBProvider: FC<MessageDBContextProps> = ({ children }) => {
         );
       },
       onAckProcessed: (messageIds: string[]) => {
-        // Update deliveredAt on sender's messages in React Query cache + IndexedDB
+        // Delivery acks are the source of truth for "it arrived". If a read ack
+        // already covered the message, this also completes the ✓✓ upgrade.
         const now = Date.now();
+        const ids = new Set(messageIds);
+
+        // Walk each cached conversation once rather than once per messageId — the
+        // query key carries the conversation, which the ack itself does not.
+        const cached = queryClient.getQueriesData<
+          InfiniteData<{ messages: Message[]; nextCursor?: number; prevCursor?: number }>
+        >({ queryKey: ['Messages'] });
+
+        for (const [queryKey, oldData] of cached) {
+          if (!oldData?.pages) continue;
+
+          // ['Messages', spaceId, channelId] — for DMs both are the partner address
+          const readWatermark = readWatermarksRef.current.get(String(queryKey[1] ?? '')) ?? 0;
+
+          let changed = false;
+          const newPages = oldData.pages.map((page) => {
+            let pageChanged = false;
+            const newMessages = page.messages.map((msg) => {
+              if (!ids.has(msg.messageId)) return msg;
+              const patch = resolveDeliveryAckPatch(msg, { readWatermark, now });
+              if (!patch) return msg;
+              changed = true;
+              pageChanged = true;
+              return { ...msg, ...patch } as Message;
+            });
+            return pageChanged ? { ...page, messages: newMessages } : page;
+          });
+
+          if (changed) queryClient.setQueryData(queryKey, { ...oldData, pages: newPages });
+        }
+
         for (const messageId of messageIds) {
-          // Update React Query cache — use 'Messages' prefix (capital M) to match all conversations
-          queryClient.setQueriesData(
-            { queryKey: ['Messages'] },
-            (oldData: InfiniteData<{ messages: Message[]; nextCursor?: number; prevCursor?: number }> | undefined) => {
-              if (!oldData?.pages) return oldData;
-
-              let changed = false;
-              const newPages = oldData.pages.map((page) => {
-                const newMessages = page.messages.map((msg) => {
-                  if (msg.messageId === messageId && !msg.deliveredAt) {
-                    changed = true;
-                    return { ...msg, deliveredAt: now } as Message;
-                  }
-                  return msg;
-                });
-                return changed ? { ...page, messages: newMessages } : page;
-              });
-
-              return changed ? { ...oldData, pages: newPages } : oldData;
-            }
-          );
-
-          // Persist to IndexedDB
-          messageDB.updateMessageDeliveredAt(messageId, now);
+          messageDB.updateMessageDeliveredAt(messageId, now, readWatermarksRef.current).catch(() => {
+            // Best effort — React Query cache is already updated
+          });
         }
       },
       onReadFlush: (address: string, highWaterMark: { messageId: string; timestamp: number }) => {
@@ -1146,10 +1168,20 @@ const MessageDBProvider: FC<MessageDBContextProps> = ({ children }) => {
         );
       },
       onReadAckProcessed: (upToMessageId: string, upToTimestamp: number, conversationAddress: string) => {
-        // Update readAt (and deliveredAt if missing) on own messages up to timestamp
         const now = Date.now();
-        // DM conversationId is "address/address"
-        const conversationId = `${conversationAddress}/${conversationAddress}`;
+
+        // A peer sending an unbounded timestamp would otherwise mark our entire
+        // outbound history read.
+        if (!isReadAckTimestampValid(upToTimestamp, now)) return;
+
+        // Remember how far they have read, so delivery acks still in flight can
+        // finish the upgrade when they land (see onAckProcessed).
+        readWatermarksRef.current.set(
+          conversationAddress,
+          advanceReadWatermark(readWatermarksRef.current.get(conversationAddress) ?? 0, upToTimestamp)
+        );
+
+        const ctx = { upToMessageId, upToTimestamp, now };
 
         // Update React Query cache — scope to this conversation only (not all conversations)
         const conversationKey = buildMessagesKeyPrefix({ spaceId: conversationAddress, channelId: conversationAddress });
@@ -1160,22 +1192,16 @@ const MessageDBProvider: FC<MessageDBContextProps> = ({ children }) => {
 
             let changed = false;
             const newPages = oldData.pages.map((page) => {
+              let pageChanged = false;
               const newMessages = page.messages.map((msg) => {
-                if (
-                  msg.content?.senderId === selfAddress &&
-                  msg.createdDate <= upToTimestamp &&
-                  !msg.readAt
-                ) {
-                  changed = true;
-                  return {
-                    ...msg,
-                    readAt: now,
-                    deliveredAt: msg.deliveredAt || now,
-                  } as Message;
-                }
-                return msg;
+                if (msg.content?.senderId !== selfAddress) return msg;
+                const patch = resolveReadAckPatch(msg, ctx);
+                if (!patch) return msg;
+                changed = true;
+                pageChanged = true;
+                return { ...msg, ...patch } as Message;
               });
-              return changed ? { ...page, messages: newMessages } : page;
+              return pageChanged ? { ...page, messages: newMessages } : page;
             });
 
             return changed ? { ...oldData, pages: newPages } : oldData;
@@ -1183,9 +1209,11 @@ const MessageDBProvider: FC<MessageDBContextProps> = ({ children }) => {
         );
 
         // Persist to IndexedDB — DM spaceId and channelId are both the address
-        messageDB.updateMessagesReadAt(conversationAddress, conversationAddress, selfAddress, upToTimestamp, now).catch(() => {
-          // Best effort — React Query cache is already updated
-        });
+        messageDB
+          .updateMessagesReadAt(conversationAddress, conversationAddress, selfAddress, upToMessageId, upToTimestamp, now)
+          .catch(() => {
+            // Best effort — React Query cache is already updated
+          });
       },
     });
 

--- a/src/db/messages.ts
+++ b/src/db/messages.ts
@@ -1,4 +1,5 @@
 import { logger, isValidIPFSCID } from '@quilibrium/quorum-shared';
+import { resolveDeliveryAckPatch, resolveReadAckPatch } from '@quilibrium/quorum-shared';
 import { channel } from '@quilibrium/quilibrium-js-sdk-channels';
 import type { Conversation, Message, Space, Bookmark, BroadcastSpaceTag, ChannelThread, UserNote, FarcasterLink, SpaceMemberDevice, ConversationSettingOverrides } from '@quilibrium/quorum-shared';
 import { BOOKMARKS_CONFIG } from '@quilibrium/quorum-shared';
@@ -455,7 +456,17 @@ export class MessageDB {
     });
   }
 
-  async updateMessageDeliveredAt(messageId: string, deliveredAt: number): Promise<void> {
+  /**
+   * DM delivery receipt: stamp deliveredAt on one sent message. Also completes a
+   * read upgrade when a read ack already covered it — the read debounce (5s) is
+   * shorter than the delivery one (10s), so read acks usually land first.
+   * `readWatermarks` is keyed by conversation (spaceId); omit it to skip that.
+   */
+  async updateMessageDeliveredAt(
+    messageId: string,
+    deliveredAt: number,
+    readWatermarks?: ReadonlyMap<string, number>
+  ): Promise<void> {
     await this.init();
     return new Promise((resolve, reject) => {
       const tx = this.db!.transaction('messages', 'readwrite');
@@ -464,9 +475,10 @@ export class MessageDB {
 
       request.onsuccess = () => {
         const msg = request.result;
-        if (msg && !msg.deliveredAt) {
-          msg.deliveredAt = deliveredAt;
-          store.put(msg);
+        if (msg) {
+          const readWatermark = readWatermarks?.get(msg.spaceId) ?? 0;
+          const patch = resolveDeliveryAckPatch(msg, { readWatermark, now: deliveredAt });
+          if (patch) store.put({ ...msg, ...patch });
         }
         resolve();
       };
@@ -474,10 +486,18 @@ export class MessageDB {
     });
   }
 
+  /**
+   * DM read receipt: stamp readAt on own messages up to a high-water mark.
+   *
+   * Only messages with a genuine deliveredAt are marked — a read ack must never
+   * invent a delivery, or messages lost in transport get ✓✓ they never earned.
+   * The HWM message itself is exempt: reading it proves it arrived.
+   */
   async updateMessagesReadAt(
     spaceId: string,
     channelId: string,
     ownAddress: string,
+    upToMessageId: string,
     upToTimestamp: number,
     readAt: number
   ): Promise<void> {
@@ -491,18 +511,15 @@ export class MessageDB {
         [spaceId, channelId, upToTimestamp]
       );
       const request = index.openCursor(range);
+      const ctx = { upToMessageId, upToTimestamp, now: readAt };
 
       request.onsuccess = () => {
         const cursor = request.result;
         if (cursor) {
           const msg = cursor.value;
-          if (msg.content?.senderId === ownAddress && !msg.readAt) {
-            msg.readAt = readAt;
-            // Reading implies delivery
-            if (!msg.deliveredAt) {
-              msg.deliveredAt = readAt;
-            }
-            cursor.update(msg);
+          if (msg.content?.senderId === ownAddress) {
+            const patch = resolveReadAckPatch(msg, ctx);
+            if (patch) cursor.update({ ...msg, ...patch });
           }
           cursor.continue();
         } else {

--- a/src/dev/tests/db/receiptReconciliation.test.ts
+++ b/src/dev/tests/db/receiptReconciliation.test.ts
@@ -1,0 +1,196 @@
+import 'fake-indexeddb/auto';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { MessageDB } from '../../../db/messages';
+import type { Message } from '@quilibrium/quorum-shared';
+
+/**
+ * Receipt truthfulness at the storage layer.
+ *
+ * The invariant under test: a read ack may never invent a delivery. Read acks
+ * carry only a high-water mark ("read up to Y"), so expanding them across the
+ * whole range used to stamp delivered+read on messages that never landed.
+ */
+
+const ME = 'QmMyAddress';
+const PEER = 'QmPeerAddress';
+
+describe('MessageDB - DM receipt reconciliation', () => {
+  let db: MessageDB;
+
+  beforeEach(async () => {
+    const FDBFactory = (await import('fake-indexeddb/lib/FDBFactory')).default;
+    globalThis.indexedDB = new FDBFactory();
+
+    db = new MessageDB();
+    await db.init();
+  });
+
+  /** A DM has spaceId === channelId === the partner address. */
+  async function saveDm(
+    over: { messageId: string; createdDate: number; senderId?: string; deliveredAt?: number; readAt?: number }
+  ) {
+    const message = {
+      messageId: over.messageId,
+      spaceId: PEER,
+      channelId: PEER,
+      createdDate: over.createdDate,
+      content: { senderId: over.senderId ?? ME, text: 'hi' },
+      deliveredAt: over.deliveredAt,
+      readAt: over.readAt,
+    } as unknown as Message;
+
+    await db.saveMessage(message, over.createdDate, PEER, 'dm', '', 'Peer', ME);
+  }
+
+  const readAck = (upToMessageId: string, upToTimestamp: number, at = 9_000) =>
+    db.updateMessagesReadAt(PEER, PEER, ME, upToMessageId, upToTimestamp, at);
+
+  describe('read acks', () => {
+    it('does NOT mark an undelivered message as read or delivered', async () => {
+      // The core bug: this message never landed, so it has no deliveredAt.
+      await saveDm({ messageId: 'lost', createdDate: 400 });
+      await saveDm({ messageId: 'hwm', createdDate: 500, deliveredAt: 800 });
+
+      await readAck('hwm', 500);
+
+      const lost = await db.getMessageById('lost');
+      expect(lost?.readAt).toBeUndefined();
+      expect(lost?.deliveredAt).toBeUndefined();
+    });
+
+    it('marks a delivered in-range message as read', async () => {
+      await saveDm({ messageId: 'm1', createdDate: 400, deliveredAt: 800 });
+
+      await readAck('hwm', 500);
+
+      const m1 = await db.getMessageById('m1');
+      expect(m1?.readAt).toBe(9_000);
+      expect(m1?.deliveredAt).toBe(800); // untouched — the real delivery time
+    });
+
+    it('stamps both on the high-water-mark message, since reading proves arrival', async () => {
+      await saveDm({ messageId: 'hwm', createdDate: 500 });
+
+      await readAck('hwm', 500);
+
+      const hwm = await db.getMessageById('hwm');
+      expect(hwm?.readAt).toBe(9_000);
+      expect(hwm?.deliveredAt).toBe(9_000);
+    });
+
+    it('leaves the peer\'s own messages alone', async () => {
+      await saveDm({ messageId: 'theirs', createdDate: 400, senderId: PEER });
+
+      await readAck('hwm', 500);
+
+      const theirs = await db.getMessageById('theirs');
+      expect(theirs?.readAt).toBeUndefined();
+    });
+
+    it('ignores delivered messages newer than the high-water mark', async () => {
+      await saveDm({ messageId: 'newer', createdDate: 600, deliveredAt: 800 });
+
+      await readAck('hwm', 500);
+
+      const newer = await db.getMessageById('newer');
+      expect(newer?.readAt).toBeUndefined();
+    });
+
+    it('reproduces the reported bug: lost messages stay blank, neighbours upgrade', async () => {
+      // Ten sent messages; #4 and #7 never landed on the recipient.
+      for (let n = 1; n <= 10; n++) {
+        const lost = n === 4 || n === 7;
+        await saveDm({
+          messageId: `m${n}`,
+          createdDate: n * 100,
+          deliveredAt: lost ? undefined : 800,
+        });
+      }
+
+      await readAck('m10', 1000);
+
+      const results = await Promise.all(
+        Array.from({ length: 10 }, (_, i) => db.getMessageById(`m${i + 1}`))
+      );
+      const readIds = results.filter((m) => m?.readAt !== undefined).map((m) => m!.messageId);
+
+      expect(readIds).toEqual(['m1', 'm2', 'm3', 'm5', 'm6', 'm8', 'm9', 'm10']);
+      expect(results[3]?.readAt).toBeUndefined(); // m4 lost
+      expect(results[3]?.deliveredAt).toBeUndefined();
+      expect(results[6]?.readAt).toBeUndefined(); // m7 lost
+      expect(results[6]?.deliveredAt).toBeUndefined();
+    });
+  });
+
+  describe('delivery acks', () => {
+    it('stamps deliveredAt when no read ack has arrived', async () => {
+      await saveDm({ messageId: 'm1', createdDate: 400 });
+
+      await db.updateMessageDeliveredAt('m1', 9_000);
+
+      const m1 = await db.getMessageById('m1');
+      expect(m1?.deliveredAt).toBe(9_000);
+      expect(m1?.readAt).toBeUndefined();
+    });
+
+    it('completes the upgrade when a read ack already covered the message', async () => {
+      // The common out-of-order case: read debounce (5s) beats delivery (10s).
+      await saveDm({ messageId: 'm1', createdDate: 400 });
+
+      await db.updateMessageDeliveredAt('m1', 9_000, new Map([[PEER, 500]]));
+
+      const m1 = await db.getMessageById('m1');
+      expect(m1?.deliveredAt).toBe(9_000);
+      expect(m1?.readAt).toBe(9_000);
+    });
+
+    it('does not mark read when the message is newer than the watermark', async () => {
+      await saveDm({ messageId: 'm2', createdDate: 600 });
+
+      await db.updateMessageDeliveredAt('m2', 9_000, new Map([[PEER, 500]]));
+
+      const m2 = await db.getMessageById('m2');
+      expect(m2?.deliveredAt).toBe(9_000);
+      expect(m2?.readAt).toBeUndefined();
+    });
+  });
+
+  describe('ack ordering', () => {
+    it('converges on delivered+read when the read ack arrives first', async () => {
+      await saveDm({ messageId: 'm1', createdDate: 400 });
+
+      // Read ack lands first — nothing to write yet, delivery is unconfirmed.
+      await readAck('hwm', 500);
+      expect((await db.getMessageById('m1'))?.readAt).toBeUndefined();
+
+      // Delivery ack lands second and completes the upgrade.
+      await db.updateMessageDeliveredAt('m1', 9_000, new Map([[PEER, 500]]));
+
+      const m1 = await db.getMessageById('m1');
+      expect(m1?.deliveredAt).toBe(9_000);
+      expect(m1?.readAt).toBe(9_000);
+    });
+
+    it('converges on delivered+read when the delivery ack arrives first', async () => {
+      await saveDm({ messageId: 'm1', createdDate: 400 });
+
+      await db.updateMessageDeliveredAt('m1', 800);
+      await readAck('hwm', 500);
+
+      const m1 = await db.getMessageById('m1');
+      expect(m1?.deliveredAt).toBe(800);
+      expect(m1?.readAt).toBe(9_000);
+    });
+
+    it('leaves a permanently lost message blank in both orders', async () => {
+      await saveDm({ messageId: 'lost', createdDate: 400 });
+
+      await readAck('hwm', 500);
+      await readAck('hwm2', 600); // a later read ack must not rescue it either
+
+      const lost = await db.getMessageById('lost');
+      expect(lost?.readAt).toBeUndefined();
+      expect(lost?.deliveredAt).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Problem

Read acks carry a **high-water mark** ("read up to timestamp Y"). We expanded that into *"every own message at or below Y was read AND delivered"*, backfilling `deliveredAt`.

Messages that never landed on the recipient sit in that range too, so we stamped them delivered+read — telling the user a lost message had been seen. The recipient can never contradict it: it never rendered the missing message, so it does not know one exists. The false claim is manufactured entirely sender-side.

Concretely: ten messages sent, #4 and #7 lost in transit. The peer reads #10, sends one ack, and all ten light up as read.

## Fix

Delivery acks carry real per-message IDs, so they are the source of truth.

> A message may be marked **read** only if it was already confirmed **delivered**. A read ack never manufactures a delivery.

Both ack paths now call the shared reconciliation helpers (`resolveReadAckPatch` / `resolveDeliveryAckPatch`, added in quorum-shared #66).

### The ordering trap

The read debounce (5s) is shorter than the delivery one (10s), so a read ack usually arrives *before* the delivery acks for the same messages. Gating on `deliveredAt` alone would drop the upgrade and silently break read receipts for anyone who reads without replying.

Read acks now advance a per-conversation watermark, and the delivery ack completes the upgrade for anything at or below it — whichever ack lands second finishes the job. The watermark is in-memory only: it bridges a ~5s window, so a restart mid-window costs at most a few read markers that the next ack restores. No schema change.

The high-water-mark message itself is exempt, since reading it proves it arrived.

## Also in this change

- **Guards inbound read-ack timestamps.** A peer sending `MAX_SAFE_INTEGER` would otherwise mark the entire outbound history read. 60s clock-skew tolerance.
- **Delivery-ack cache sweep ran once per messageId** across every cached conversation; now once per conversation with a `Set` lookup.
- **Both sweeps shared one `changed` flag across pages**, so every page after the first was rebuilt needlessly. Now per-page, matching mobile.
- **`updateMessageDeliveredAt` rejection was unhandled.**

## Result

A lost message now shows nothing while its neighbours show the read marker, so transport loss is visible instead of hidden.

## Verification

- `tsc --noEmit` → exit 0, zero errors
- `vitest --run` → **520 passed / 34 files** (was 508/33)
- `yarn build` → exit 0
- New `src/dev/tests/db/receiptReconciliation.test.ts` (12 tests), **confirmed to catch the bug**: temporarily restoring the old logic fails exactly the 4 bug-specific tests (undelivered stays blank, the 10-message #4/#7 scenario, read-ack-first convergence, lost message blank in both orders); all 12 pass with the fix.

**Outstanding:** the two-device runtime check has not been run (local dev environment is currently unstable for unrelated reasons). Worth confirming after merge: normal conversation still reaches the read marker both ways; reading without replying still upgrades; a forced loss leaves the lost message blank.

## Follow-up

Mobile carries the identical faulty logic. It has a hard prerequisite first — an outgoing `messageId` mismatch that already breaks its delivery acks — or receipts would appear to vanish on that route.