### PR TITLE
fix: order DM sessions in the offline action-queue send path too (#254 follow-up)

### DIFF
--- a/src/dev/tests/services/ActionQueueHandlers.unit.test.ts
+++ b/src/dev/tests/services/ActionQueueHandlers.unit.test.ts
@@ -732,6 +732,95 @@ describe('ActionQueueHandlers - Unit Tests', () => {
       );
       expect(channel.DoubleRatchetInboxEncrypt).not.toHaveBeenCalled();
     });
+
+    // Regression: #254 made all four ONLINE send sites order sessions send-ready-first
+    // then newest, so a peer's reset is adopted. This offline-only action-queue copy of
+    // the same logic was missed, so a DM composed while offline still selected by raw
+    // insertion order and could be encrypted for an inbox the peer had abandoned —
+    // silently discarded on arrival. Both rows below share one tag, which is legitimate
+    // (a row created by sending can coexist with one created by receiving).
+    it('encrypts an offline-queued DM with the NEWEST session when rows share a tag', async () => {
+      const { channel } = await import('@quilibrium/quilibrium-js-sdk-channels');
+
+      const session = (timestamp: number, inbox: string) => ({
+        timestamp,
+        state: JSON.stringify({
+          tag: 'inbox-other',
+          sending_inbox: { inbox_address: inbox, inbox_public_key: `pub-${inbox}` },
+          receiving_inbox: { inbox_address: `recv-${inbox}` },
+          ratchet_state: {},
+        }),
+      });
+
+      // Stale row FIRST in insertion order — what the pre-fix code would have picked.
+      mockDeps.messageDB.getEncryptionStates = vi
+        .fn()
+        .mockResolvedValue([
+          session(1_000, 'abandoned-inbox'),
+          session(2_000, 'peer-new-inbox'),
+        ]);
+      handlers = new ActionQueueHandlers(mockDeps);
+
+      await handlers.getHandler('send-dm')!.execute({
+        address: 'recipient',
+        signedMessage: createTestMessage(),
+        messageId: 'msg-newest',
+        selfUserAddress: 'self-addr',
+      });
+
+      // NOTE: targetInboxes is not de-duplicated, so two rows sharing a tag drive two
+      // encrypt calls. That is pre-existing behaviour and orthogonal to this fix —
+      // what matters here is that EVERY call uses the newest session, never the stale one.
+      const calls = vi.mocked(channel.DoubleRatchetInboxEncrypt).mock.calls;
+      expect(calls.length).toBeGreaterThan(0);
+      for (const [, sets] of calls) {
+        expect(sets[0].sending_inbox.inbox_address).toBe('peer-new-inbox');
+      }
+    });
+
+    it('prefers a send-ready session over a newer unconfirmed one when offline-queued', async () => {
+      const { channel } = await import('@quilibrium/quilibrium-js-sdk-channels');
+
+      // Newest row is unconfirmed; picking it would needlessly re-wrap in an init
+      // envelope even though a usable confirmed session exists.
+      mockDeps.messageDB.getEncryptionStates = vi.fn().mockResolvedValue([
+        {
+          timestamp: 9_000,
+          state: JSON.stringify({
+            tag: 'inbox-other',
+            sending_inbox: { inbox_address: 'unconfirmed', inbox_public_key: '' },
+            receiving_inbox: { inbox_address: 'recv-unconfirmed' },
+            ratchet_state: {},
+          }),
+        },
+        {
+          timestamp: 1_000,
+          state: JSON.stringify({
+            tag: 'inbox-other',
+            sending_inbox: { inbox_address: 'ready', inbox_public_key: 'pub-ready' },
+            receiving_inbox: { inbox_address: 'recv-ready' },
+            ratchet_state: {},
+          }),
+        },
+      ]);
+      handlers = new ActionQueueHandlers(mockDeps);
+
+      await handlers.getHandler('send-dm')!.execute({
+        address: 'recipient',
+        signedMessage: createTestMessage(),
+        messageId: 'msg-ready',
+        selfUserAddress: 'self-addr',
+      });
+
+      const calls = vi.mocked(channel.DoubleRatchetInboxEncrypt).mock.calls;
+      expect(calls.length).toBeGreaterThan(0);
+      for (const [, sets] of calls) {
+        expect(sets[0].sending_inbox.inbox_address).toBe('ready');
+      }
+      expect(
+        channel.DoubleRatchetInboxEncryptForceSenderInit
+      ).not.toHaveBeenCalled();
+    });
   });
 
   describe('14. reaction-dm Handler', () => {

--- a/src/services/ActionQueueHandlers.ts
+++ b/src/services/ActionQueueHandlers.ts
@@ -28,6 +28,7 @@ import { buildSpaceKey } from '../hooks/queries/space/buildSpaceKey';
 import { channel as secureChannel } from '@quilibrium/quilibrium-js-sdk-channels';
 import type { Message } from '@quilibrium/quorum-shared';
 import { DefaultImages } from '../utils';
+import { orderSessionsForSend } from '../utils/sessionSelection';
 
 export interface HandlerDependencies {
   messageDB: MessageDB;
@@ -594,11 +595,17 @@ export class ActionQueueHandlers {
         conversationId,
       });
 
-      // Get encryption states - these contain all the inbox info we need for established sessions
+      // Get encryption states - these contain all the inbox info we need for established sessions.
+      // Ordered send-ready-first-then-newest, exactly as the four online send sites do (#254):
+      // several stored rows legitimately share one device tag, and `find` below takes the FIRST
+      // match, so the order decides which session an offline-queued DM is encrypted with. Without
+      // this, a message queued while offline after the peer reset picks a stale row and is sent to
+      // an inbox the peer has abandoned — silently discarded on arrival, exactly the failure #254
+      // fixed everywhere else.
       const response = await this.deps.messageDB.getEncryptionStates({
         conversationId,
       });
-      const sets = response.map((e) => JSON.parse(e.state));
+      const sets = orderSessionsForSend(response);
 
       // For established sessions, we only need selfUserAddress (SDK only uses user_address field)
       const minimalSelf = { user_address: selfUserAddress } as secureChannel.UserRegistration;


### PR DESCRIPTION
## What

`#254` made the DM send path select the newest send-ready session for a device, so a peer's one-sided reset gets adopted instead of every message going to an inbox they have abandoned. It patched the four online send sites in `MessageService`, but missed the hand-duplicated copy of the same logic in the action-queue `sendDm` handler, which still selected by raw insertion order.

## Scope — deliberately narrow

That handler is reached **only** when a DM is composed while offline and flushed on reconnect:

```
ENABLE_DM_ACTION_QUEUE && hasEstablishedSessions && !isOnline
```

Online sends take the legacy path, which already has the fix. So this is not a fix for any currently-reported delivery failure — but it is exactly the window in which a peer is most likely to have reset unseen, which is the case #254 exists for.

## Tests

Two regression tests in `ActionQueueHandlers.unit.test.ts`, both **verified red** against the pre-fix selection before being committed:
- picks the newest session when two rows legitimately share one device tag
- prefers a send-ready session over a newer unconfirmed one (avoids needless init-envelope re-wrapping)

`tsc` clean, `eslint` clean, full suite 522/522.

## Deliberately not changed

`InvitationService.ts:98` has a visually identical `response.map((e) => JSON.parse(e.state))`, but it is space invite template/eval state rather than DM sessions, and it pairs `sets[0]` with `response[0]` — reordering there would break invite generation.

## Noted, not fixed

`targetInboxes` is not de-duplicated, so two rows sharing a tag drive two encrypt-and-send calls for the same target. Pre-existing, orthogonal to this change, and called out in the test comments.