### PR TITLE
fix: report a failed DM decrypt as a decrypt failure, not a JSON syntax error

### DIFF
--- a/src/dev/tests/services/MessageService.decryptError.unit.test.ts
+++ b/src/dev/tests/services/MessageService.decryptError.unit.test.ts
@@ -1,0 +1,89 @@
+/**
+ * A failed DM decrypt must report itself as a decrypt failure.
+ *
+ * The crypto core does not throw on AEAD failure — it returns the error string
+ * in the plaintext slot. Parsing that with JSON.parse produced
+ * `SyntaxError: Unexpected token 'D', "Decryption"... is not valid JSON`, which
+ * reads like a serialization bug in our own code and was the visible face of
+ * every DM decrypt failure in the logs for months (captured live 2026-07-26,
+ * frame fp=a204cc78).
+ *
+ * These tests pin the diagnosis, not the control flow: a decrypt failure must
+ * still THROW, so the caller's existing catch still skips the frame, keeps the
+ * session, and never persists the advanced state.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  parseDecryptedMessage,
+  DmDecryptError,
+} from '../../../services/MessageService';
+
+describe('parseDecryptedMessage', () => {
+  it('reports the core\'s AEAD failure as a DmDecryptError, not a SyntaxError', () => {
+    expect(() =>
+      parseDecryptedMessage('Decryption failed: aead::Error', 'InboxDecrypt')
+    ).toThrow(DmDecryptError);
+
+    try {
+      parseDecryptedMessage('Decryption failed: aead::Error', 'InboxDecrypt');
+      expect.unreachable('must throw');
+    } catch (err) {
+      // The whole point: the message names the real problem and the branch.
+      expect((err as Error).message).toContain('failed to decrypt');
+      expect((err as Error).message).toContain('InboxDecrypt');
+      expect((err as Error).message).toContain('aead::Error');
+      expect((err as Error).name).toBe('DmDecryptError');
+      expect(err).not.toBeInstanceOf(SyntaxError);
+    }
+  });
+
+  it('carries the branch so a failure names which decrypt path produced it', () => {
+    for (const branch of ['Confirm', 'InboxDecrypt', 'InitEnvelope']) {
+      try {
+        parseDecryptedMessage('Decryption failed: aead::Error', branch);
+        expect.unreachable('must throw');
+      } catch (err) {
+        expect((err as DmDecryptError).branch).toBe(branch);
+        expect((err as DmDecryptError).detail).toBe(
+          'Decryption failed: aead::Error'
+        );
+      }
+    }
+  });
+
+  it('still throws, so callers keep skipping the frame and discarding state', () => {
+    // Behaviour must be unchanged — only the diagnosis improves. If this ever
+    // returns instead of throwing, a failed frame would be treated as a real
+    // message and the advanced ratchet state would be persisted, which the
+    // Double Ratchet spec forbids.
+    expect(() => parseDecryptedMessage('Decryption failed', 'Confirm')).toThrow();
+  });
+
+  it('parses a genuine decrypted payload unchanged', () => {
+    const message = { messageId: 'abc', content: { type: 'post', text: 'hi' } };
+    expect(parseDecryptedMessage(JSON.stringify(message), 'InboxDecrypt')).toEqual(
+      message
+    );
+  });
+
+  it('does not mistake ordinary content beginning with "Decryption" for a failure', () => {
+    // The sentinel is matched at the START of the raw payload, and a real
+    // payload is always JSON — so a message whose TEXT begins with the word
+    // must still parse normally.
+    const message = {
+      messageId: 'abc',
+      content: { type: 'post', text: 'Decryption failed on my end, resend?' },
+    };
+    expect(parseDecryptedMessage(JSON.stringify(message), 'InboxDecrypt')).toEqual(
+      message
+    );
+  });
+
+  it('still surfaces genuinely malformed JSON as a parse error', () => {
+    // Not our sentinel — a real serialization problem must not be disguised as
+    // a decrypt failure either.
+    expect(() => parseDecryptedMessage('{"unterminated', 'InboxDecrypt')).toThrow(
+      SyntaxError
+    );
+  });
+});

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -99,6 +99,46 @@ const INIT_PAYLOAD_SALVAGE_MAX_AGE_MS = 10 * 60 * 1000;
 const isReadOnlyGatedType = (type: string): boolean =>
   READ_ONLY_GATED_TYPES.has(type);
 
+/**
+ * A failed Double Ratchet decrypt, reported as itself.
+ *
+ * The crypto core does NOT throw when a frame fails to authenticate. It returns
+ * the plaintext slot filled with an error string ("Decryption failed:
+ * aead::Error"), so the first thing that touches it is `JSON.parse`, which dies
+ * with `SyntaxError: Unexpected token 'D', "Decryption"... is not valid JSON`.
+ *
+ * That message is actively misleading: it reads like a serialization bug in our
+ * own code, and it has been the visible face of every DM decrypt failure in the
+ * logs for months. Nothing downstream changes — the error still lands in the
+ * same catch, the frame is still skipped, the session is still kept, and the
+ * state is still never persisted (the throw happens before the save, per the
+ * Double Ratchet spec's "discard changes on failure"). Only the diagnosis
+ * improves.
+ */
+export class DmDecryptError extends Error {
+  constructor(
+    readonly detail: string,
+    readonly branch: string
+  ) {
+    super(`DM frame failed to decrypt (${branch}): ${detail}`);
+    this.name = 'DmDecryptError';
+  }
+}
+
+/** The sentinel the crypto core returns in the message slot on AEAD failure. */
+const DECRYPT_FAILURE_SENTINEL = 'Decryption failed';
+
+/**
+ * Parse a decrypted Double Ratchet payload, converting the core's
+ * failure-as-plaintext into a `DmDecryptError` instead of a `SyntaxError`.
+ */
+export function parseDecryptedMessage(raw: string, branch: string): Message {
+  if (typeof raw === 'string' && raw.startsWith(DECRYPT_FAILURE_SENTINEL)) {
+    throw new DmDecryptError(raw.trim(), branch);
+  }
+  return JSON.parse(raw) as Message;
+}
+
 // Type definitions for the service
 export interface MessageServiceDependencies {
   messageDB: MessageDB;
@@ -3342,7 +3382,7 @@ export class MessageService {
         let conversationId = session.user_address + '/' + session.user_address;
 
         let updatedUserProfile: secureChannel.UserProfile | undefined;
-        decryptedContent = JSON.parse(session.message);
+        decryptedContent = parseDecryptedMessage(session.message, 'InitEnvelope');
 
         if (session.user_address == self_address) {
           conversationId =
@@ -3813,7 +3853,7 @@ export class MessageService {
                 JSON.parse(fresh.state),
                 JSON.parse(message.encryptedContent)
               );
-            const content = JSON.parse(result.message);
+            const content = parseDecryptedMessage(result.message, 'Confirm');
             if (content?.content?.type === 'delete-conversation') {
               logger.warn(
                 '[MessageService] ⚠️ RESET SIGNAL received (delete-conversation, Confirm branch) — wiping encryption states',
@@ -3904,7 +3944,7 @@ export class MessageService {
                 tag: freshKeys.tag,
               });
             }
-            const content = JSON.parse(result.message);
+            const content = parseDecryptedMessage(result.message, 'InboxDecrypt');
             if (content?.content?.type === 'delete-conversation') {
               logger.warn(
                 '[MessageService] ⚠️ RESET SIGNAL received (delete-conversation, InboxDecrypt branch) — wiping encryption states',


### PR DESCRIPTION
## The problem

The crypto core does **not** throw when a DM frame fails to authenticate. It returns the error string in the plaintext slot, so the first thing to touch it was `JSON.parse`:

```
[MessageService] DM decrypt failed (DoubleRatchetInboxDecrypt) — skipping frame, keeping session {fp: 'a204cc78'}
SyntaxError: Unexpected token 'D', "Decryption"... is not valid JSON
    at JSON.parse (<anonymous>)
    at MessageService.ts:4178:34
```

That reads like a serialization bug in our own code. It is the visible face of **every** DM decrypt failure in the logs, and it has been misleading everyone reading them for months.

Captured live 2026-07-26: frame `a204cc78` was an emoji reaction that arrived, failed AEAD, and silently never rendered on the peer. Offline replay against the real wasm core confirmed the sealed layer opened fine and the inner ratchet decrypt was what failed.

## The change

`parseDecryptedMessage` detects the core's sentinel and throws a `DmDecryptError` naming the real cause and the branch that produced it (`InitEnvelope` / `Confirm` / `InboxDecrypt`). Wired into all three decrypt-result parse sites.

## Deliberately NOT a behaviour change

It still **throws**, so every caller's existing catch still skips the frame, keeps the session, and never persists the advanced state — the throw precedes the save, per the Double Ratchet spec's discard-changes-on-failure rule. Genuinely malformed JSON still surfaces as a `SyntaxError`, so a real serialization bug is not disguised either.

## Tests

6 unit tests, including that ordinary message text beginning with the word "Decryption" is not mistaken for a failure.

`tsc` clean, full suite **528/528**. The two eslint warnings in this file (`pubBytes`/`privBytes`, L4015) are pre-existing and untouched by this diff.