### PR TITLE
docs: entry point for the resurfaced DM bug + correct two misleading statuses

### DIFF
--- a/.agents/INDEX.md
+++ b/.agents/INDEX.md
@@ -169,7 +169,8 @@ This is the main index for all documentation, bug reports, and task management.
 - [Read-only channel receive-side enforcement is incomplete](bugs/.solved/2026-06-12-readonly-channel-receive-side-enforcement-gaps.md)
 - [Sync path hardcodes `'post'` in the signature messageId recompute → non-post signatures nulled](bugs/.solved/2026-06-14-sync-path-hardcodes-post-type-nulls-nonpost-signatures.md)
 - [Composer flattens multi-line paste into a single line](bugs/.solved/2026-06-25-composer-paste-strips-newlines.md)
-- [DM message delivery is unreliable (master report)](bugs/.solved/2026-07-02-dm-message-delivery-unreliable-master.md)
+- **[⚠️ ENTRY POINT — DM delivery broken again on desktop↔desktop](bugs/2026-07-26-dm-desktop-to-desktop-resurfaced.md)** — start here for anything DM-not-arriving; the master report below is REOPENED
+- [DM message delivery is unreliable (master report)](bugs/.solved/2026-07-02-dm-message-delivery-unreliable-master.md) — ⚠️ REOPENED 2026-07-26, mechanism catalogue only
 - [DM frames still drop with `aead::Error` (remaining half of the delivery bug)](bugs/.solved/2026-07-17-dm-aead-error-frame-drops.md)
 - [FIX SPEC: DM decrypt failure destroys the session](bugs/.solved/2026-07-17-dm-decrypt-failure-destroys-session-FIX-SPEC.md)
 - [Bug: Emoji Picker Grid Has Empty Space on Right Side in Mobile Drawer](bugs/.solved/emoji-picker-mobile-drawer-empty-space.md)

--- a/.agents/bugs/.solved/2026-07-02-dm-message-delivery-unreliable-master.md
+++ b/.agents/bugs/.solved/2026-07-02-dm-message-delivery-unreliable-master.md
@@ -1,7 +1,7 @@
 ---
 type: bug
 title: "DM messages between users intermittently never arrive (master report)"
-status: RESOLVED 2026-07-17 — THREE mechanisms found, fixed, and live-verified. (1) Session destruction on decrypt failure: fixed, PR #235. (2) Unserialized ratchet state read-modify-write: fixed, PR #236/#237. (3) Stale init-envelope redelivery silently replacing healthy sessions — THE DOMINANT killer, explains the recurring "reset works, then dies on refresh" pattern: fixed on branch chore/dm-reset-signal-logging (staleness guard). Residual: isolated single-frame wire loss with no auto-resend — tracked in the auto-heal task. This report is the consolidated summary + diagnosis archive.
+status: ⚠️ REOPENED 2026-07-26 — THE SYMPTOM RESURFACED on desktop↔desktop (0 of 10 delivered, both directions). This file stays in .solved/ only because many documents link to this path; treat it as a MECHANISM CATALOGUE, not a status report. Current entry point: .agents/bugs/2026-07-26-dm-desktop-to-desktop-resurfaced.md. Its "desktop↔desktop is healthy" premise is FALSIFIED. Previously: RESOLVED 2026-07-17 — THREE mechanisms found, fixed, and live-verified. (1) Session destruction on decrypt failure: fixed, PR #235. (2) Unserialized ratchet state read-modify-write: fixed, PR #236/#237. (3) Stale init-envelope redelivery silently replacing healthy sessions — THE DOMINANT killer, explains the recurring "reset works, then dies on refresh" pattern: fixed on branch chore/dm-reset-signal-logging (staleness guard). Residual: isolated single-frame wire loss with no auto-resend — tracked in the auto-heal task. This report is the consolidated summary + diagnosis archive.
 created: 2026-07-02
 severity: high
 repo: quorum-desktop (primary; mobile has the same patterns — see "Remaining gaps")
@@ -16,6 +16,14 @@ related:
 ---
 
 # DM message delivery is unreliable (master report)
+
+> ⚠️ **REOPENED 2026-07-26 — DO NOT READ THIS AS "FIXED".** The symptom returned on
+> desktop↔desktop. This document remains valuable as the catalogue of mechanisms
+> found and fixed in July, and every mechanism in it is still real. But its status,
+> its "residual" framing, and anything resting on "desktop↔desktop is healthy" are
+> out of date. **Start at
+> [.agents/bugs/2026-07-26-dm-desktop-to-desktop-resurfaced.md](../2026-07-26-dm-desktop-to-desktop-resurfaced.md)**
+> for current state, the instrumentation rig, and open leads.
 
 **One-line:** for ~6 months, DMs intermittently never arrived, with no error, no retry, and no
 signal to either user; once a conversation direction "went bad" it stayed dead until a manual

--- a/.agents/bugs/2026-07-26-dm-desktop-to-desktop-resurfaced.md
+++ b/.agents/bugs/2026-07-26-dm-desktop-to-desktop-resurfaced.md
@@ -1,0 +1,232 @@
+---
+type: bug
+title: "DM delivery broken again on desktop↔desktop (the 2026-07-02 master report is NOT closed)"
+status: OPEN — root cause NOT established. Two client-side leads open (init-envelope age bound; four session-prune sites), plus two upstream causes already filed (quorum-mobile issue #183). One real regression of ours was found and fixed (#259). One confidently-argued mechanism was RETRACTED the same day — read §5 before trusting anything here.
+created: 2026-07-26
+severity: high (silent, user-visible message and reaction loss)
+repo: quorum-desktop (cross-repo — mobile shares the accounts and the upstream causes)
+area: DM Double Ratchet / session lifecycle / transport
+entrypoint: true
+related:
+  - ".agents/bugs/.solved/2026-07-02-dm-message-delivery-unreliable-master.md (the mechanism catalogue — filed as solved, but the symptom RESURFACED; read it for history, not for status)"
+  - ".agents/docs/dm-ratchet-upstream-divergences.md (the 8 shipped divergences, lead-dev facing)"
+  - ".agents/tasks/2026-07-17-dm-dead-session-autoheal.md (heal action 2 is exactly this failure; downgraded on an assumption this bug disproves)"
+  - ".agents/docs/debugging/dm-architecture-and-debug-playbook.md (DM internals)"
+  - "quorum-mobile/.agents/bugs/2026-07-24-dm-desktop-frames-undecryptable-state-divergence.md (3000-line master, rounds 1-29 — PART I is current, PART II is archive)"
+  - "quorum-mobile/.agents/bugs/2026-07-24-dm-session-confirm-row-mismatch-x3dh-every-send.md (contains the authoritative SDK reading)"
+  - "https://github.com/QuilibriumNetwork/quorum-mobile/issues/183 (the two UPSTREAM root causes — not fixable in this repo)"
+---
+
+# DM delivery is broken again, desktop↔desktop
+
+> **START HERE if you are a fresh agent.** This file is the current entry point
+> for the DM-not-arriving investigation. Two things you would otherwise get
+> wrong within your first ten minutes:
+>
+> 1. **`.agents/bugs/.solved/2026-07-02-dm-message-delivery-unreliable-master.md`
+>    is filed as SOLVED. The symptom has resurfaced.** That document is an
+>    excellent mechanism catalogue and a poor status report. Do not conclude the
+>    bug is fixed because it lives in `.solved/`.
+> 2. **The mobile master says "desktop↔desktop has no issues."** That was true
+>    when written and is now **falsified** — see §2. Several conclusions in both
+>    masters rest on it.
+>
+> **Docs in `.agents/` are written by agents after the fact and can be wrong.
+> When a doc and the code disagree, the code wins.** This exact instruction
+> caught a wrong conclusion in this investigation on 2026-07-26 (§5).
+
+---
+
+## §1. Current state (2026-07-26, end of day)
+
+| | state |
+|---|---|
+| Before reset | desktop↔desktop **0 of 10 delivered, both directions**, permanent |
+| After manual reset | all messages deliver |
+| Later the same evening | delivers, but **laggy**; some frames land minutes late |
+| Reactions | occasionally late; earlier in the day, permanently lost |
+
+**The user's reproduction pattern, in their words:** desktop↔desktop works after
+a reset; they then use the *same two accounts* on mobile for a few days; on
+returning to desktop it is broken again. This has not yet been reproduced
+deliberately — it is the single most valuable thing to capture.
+
+---
+
+## §2. What is PROVEN (measured, not argued)
+
+From the 2026-07-26 dual-capture (both clients instrumented, joined by envelope
+fingerprint), independently re-derived by a second agent from the raw logs:
+
+- **Frames arrive and cannot be decrypted.** 21 of 21 of the peer's message
+  frames reached the receiver and failed AEAD. **Not transport loss** in that
+  direction.
+- **568 failures were only 36 distinct frames**, redelivered ~16× each. Raw
+  failure counts massively overstate distinct events — always de-duplicate by
+  fingerprint before reasoning about volume.
+- **15 of those 36 were never sent during the capture** — pre-existing stuck
+  frames from before the window.
+- **The two directions fail differently.** The peer reached us on one inbox;
+  our sends went to seven inboxes and the receiver was listening on **none** of
+  them. One side dies loudly (AEAD failures), the other silently (addressed at
+  inboxes nobody reads).
+- **A client can hold a dead session beside a healthy one** and keep listening
+  on both forever. One inbox took 90 frames healthily while another failed
+  everything it received. **Nothing detects this.**
+- **Our init-envelope guards were NOT involved**: zero `STALE init envelope
+  IGNORED`, zero `SESSION REPLACED` across the whole failing capture.
+- **The `#253` timestamp-collision theory is refuted** for these captures: the
+  `[DM-ack collision]` detector was armed and fired **zero** times. (Caveat: it
+  only sees collisions among frames that *arrived*.)
+- **The upstream crate fork is real and reproducible.** An agent ran
+  `quorum-mobile/.agents/scripts/dr-advanced-start-fork.mjs` against the real
+  wasm: a receiver whose first processed frame sits at position ≥2 has the
+  sender's direction **permanently** dead; position 1 self-heals after one loss.
+
+---
+
+## §3. What is RULED OUT (do not re-investigate without new evidence)
+
+- **Desktop's Confirm-vs-InboxDecrypt branch predicate is CORRECT.** See §5 —
+  this was the day's biggest wrong turn. Verified against the SDK:
+  `ConfirmDoubleRatchetSenderSession` throws when `inbox_public_key !== ''`,
+  `DoubleRatchetInboxDecrypt` throws when `=== ''`, and the predicate selects
+  exactly the function whose precondition holds. `DoubleRatchetInboxDecrypt`
+  **already unwraps init-wrapped frames itself** (`channel.ts` ~L1174).
+- **The `SyntaxError: ... is not valid JSON` in DM decrypt logs is not a
+  serialization bug.** The crypto core returns its error string in the plaintext
+  slot instead of throwing, so `JSON.parse` chokes on it. It means *AEAD
+  failure*. Fixed to report itself honestly in PR #260.
+- **#235, #252, #256, #258 and the per-device-signing group (#244/#245/#249/#250)
+  are exonerated** for this failure. The signing work is space-scoped
+  (`sendHubMessage(spaceId)`, `participant`/`space.spaceId` gates) and does not
+  touch DM frame signing.
+
+---
+
+## §4. OPEN LEADS, ranked
+
+1. **The init-envelope absolute age bound vs an offline receiver.**
+   `INIT_ENVELOPE_MAX_AGE_MS = 10 minutes` (`src/utils/initEnvelopeGuard.ts`),
+   and rule 0 fires **before** the no-rows check, unconditionally. Refused
+   envelopes are **deleted server-side**. The guard's stated assumption is *"a
+   legitimate init envelope is seconds old"* — true only if the receiver is
+   online. A legitimate envelope minted while desktop was closed for days is
+   days old on arrival and is destroyed. **This fits the "away for days, come
+   back broken" pattern exactly.** Do NOT simply raise the bound: it exists
+   because 26-hour and 60-day-old zombie envelopes were observed resurrecting
+   dead sessions. The real flaw is that wall-clock age is a bad proxy for
+   staleness when the receiver has been away.
+   **Cheap test:** close desktop, reset + send from the peer, wait >10 min,
+   reopen desktop, watch for `STALE init envelope IGNORED`.
+2. **Four session-prune sites deleting healthy sessions.** Three in the send
+   paths (`MessageService.ts`, submit/edit/retry — run on *every send*) and one
+   in a `useEffect` in `src/components/direct/DirectMessage.tsx` that fires
+   **whenever registration data changes**. All delete any session whose `tag` is
+   absent from the current device-registration fetch, which is a *cached* React
+   Query read. Mobile-created rows carry a non-device-inbox tag, so mobile use
+   on the same accounts is a plausible trigger. All four were silent (three
+   unlogged, one below capture level) and are now instrumented.
+3. **UPSTREAM — quorum-mobile issue #183.** (a) the crate fork above;
+   (b) the node write path silently dropping frames that were signed and handed
+   to an open socket, reproduced phone↔phone at 32% one direction. Neither is
+   fixable here.
+4. **No dead-session detection.** See §2. The detector should require
+   *retry-exhaustion on a session with zero successes*, never first-failure —
+   the healing-lag class recovered 51/51 in the mobile rounds and must not
+   trigger a reset.
+
+---
+
+## §5. RETRACTED — argued confidently on 2026-07-26, then disproved
+
+**Claim:** *"Desktop's receive path dispatches on its own stored state rather
+than the arriving frame's shape, so an init envelope from an unconfirmed peer is
+routed to `DoubleRatchetInboxDecrypt`, fails AEAD forever, and deadlocks the
+conversation permanently."*
+
+**Why it was wrong:** the SDK's `DoubleRatchetInboxDecrypt` already detects
+`user_address` and unwraps the inner message before decrypting, and the two SDK
+functions have complementary preconditions that desktop's predicate matches
+exactly. Independently refuted by a reviewer, which also found that an
+unconfirmed sender addresses its frames to the *device* inbox, so they never
+reach that branch at all.
+
+**How it happened:** the mechanism was built from app code plus doc claims and
+presented as settled before reading the protocol authority (the SDK). The log
+evidence was sound; the interpretation ran ahead of it.
+
+**The lesson, which cost real time twice today:** *absence of a log line is not
+evidence of absence of an event until you have checked that the line covers
+every path the event can take.* Two destructive paths were invisible during the
+failing capture — the stale-init refusal (downgraded to `debug` three days
+earlier) and all four prune sites. A third variant: **a capture stopped too
+early scores in-flight frames as losses.** A "5-frame loss" on 2026-07-26 was
+purely capture truncation; the frames arrived after the log was saved.
+
+---
+
+## §6. THE RIG — how to capture (read before booking any test time)
+
+**Branch: `diag/dm-frame-join`** (local, never merge — it logs real key
+material). Rebased over `main`. Never merge it; rebase it forward.
+
+The startup marker **enumerates the probes the build carries**:
+
+```
+[DM-diag] armed (desktop dm-frame-join) rig=6 probes=recv-wire,send-wire+ts,recv-branch,xpdump,prune
+```
+
+**No marker, no round** — a capture from a stale build is invalid, and this has
+silenced a whole round before. Check the `rig=` number matches on **both**
+clients: on 2026-07-26 one client was two builds behind and had no prune probes,
+making its silence unreadable.
+
+| probe | what it answers |
+|---|---|
+| `[DM-send wire] fp= to= sentAt=` | did we send it, to which inbox, when |
+| `[DM-recv wire] fp= inbox= ts= path=init\|dr` | did it arrive, on which inbox, via which receive path |
+| `[DM-recv branch] fp= branch=` | Confirm or InboxDecrypt, and why |
+| `[XPDUMP]` | full ratchet state + sealed frame, for offline replay |
+| `[DM-prune ui\|send]` | a session was DELETED, and which tag |
+| `[DM-ack collision]` | a delete-by-timestamp would have taken a sibling frame |
+
+**Capture protocol**
+1. Both clients on the diag build, hard-reload, confirm the marker and matching
+   `rig=` on both.
+2. Console: **empty text filter, level = Warnings + Errors.** Every probe is
+   `warn`/`error`; `logger.debug` never reaches the console at all (shared
+   logger `minLevel` is `log`).
+3. Send numbered messages so content maps to frames.
+4. **Wait 2-3 minutes before saving.** Otherwise in-flight frames score as
+   losses.
+5. Save both consoles. Record what you *saw on screen* — **device observation
+   outranks the rig**; that is how a 21-frame phantom loss was caught on mobile.
+
+**Offline replay** — the highest-value tool, needs zero device time:
+```
+node E:/GitHub/Quilibrium/quorum-mobile/.agents/scripts/dr-replay.mjs <desktop.log>
+```
+Reassembles `[XPDUMP]` chunks and re-runs the real failing decrypt against the
+real wasm core. It reports whether the seal opened, whether the frame was init
+-wrapped, and whether the ratchet failed.
+
+> ⚠️ `[XPDUMP]` lines contain **REAL KEY MATERIAL**. Throwaway test accounts
+> only. Keep the logs local — never paste raw log regions into a GitHub issue
+> (round data goes upstream as curated tables). Delete them when this closes.
+
+---
+
+## §7. Shipped 2026-07-26
+
+| PR | state | what |
+|---|---|---|
+| #259 | **merged** | `orderSessionsForSend` in the offline action-queue send path — #254 patched four online sites and missed this fifth one. Offline-composed DMs only, so not the cause of this bug, but a genuine incomplete rollout. |
+| #260 | open | a failed DM decrypt reports itself as a decrypt failure instead of a JSON `SyntaxError`. Diagnosis only, no behaviour change. |
+
+**Noted, not fixed:** `targetInboxes` is not de-duplicated, so two rows sharing
+a tag cause the same frame to be encrypted and sent twice to one target.
+
+---
+
+*Last updated: 2026-07-26*

--- a/.agents/tasks/2026-07-17-dm-dead-session-autoheal.md
+++ b/.agents/tasks/2026-07-17-dm-dead-session-autoheal.md
@@ -1,7 +1,7 @@
 ---
 type: task
 title: "DM delivery auto-heal — detect via missing delivery receipts, resend / repair without manual reset"
-status: pending, DOWNGRADED 2026-07-17 — original justification (silent session death) fixed by PR #238. Reassess after a 1-2 week normal-use soak: if sent-but-never-delivered messages (single grey check) basically never occur, archive this or shrink to the cheapest slice (manual resend affordance on stuck messages). Build the full automatic ladder only if real usage shows losses.
+status: ⚠️ RE-RAISED 2026-07-26 — the downgrade assumed dead directions were fixed by PR #238. They are not: desktop↔desktop reproduced 0/10 both directions, and a client was observed holding a DEAD session beside a healthy one with nothing detecting it. Heal action 2 below is exactly this case. Detector must require retry-exhaustion with ZERO successes on the session (never first-failure — the healing-lag class recovered 51/51 in the mobile rounds). Context: .agents/bugs/2026-07-26-dm-desktop-to-desktop-resurfaced.md. Previously: pending, DOWNGRADED 2026-07-17 — original justification (silent session death) fixed by PR #238. Reassess after a 1-2 week normal-use soak: if sent-but-never-delivered messages (single grey check) basically never occur, archive this or shrink to the cheapest slice (manual resend affordance on stuck messages). Build the full automatic ladder only if real usage shows losses.
 created: 2026-07-17
 related:
   - ".agents/bugs/.solved/2026-07-02-dm-message-delivery-unreliable-master.md (three-mechanism resolution; residual single-frame loss)"


### PR DESCRIPTION
Debugging of the DM-not-arriving issue continues over the coming days across fresh sessions. Today a fresh agent picking it up would have gone wrong twice within ten minutes:

- the master report sits in `.solved/` while the symptom has **resurfaced**
- the mobile master's load-bearing premise, *"desktop↔desktop has no issues"*, is **falsified**

## Added

**`.agents/bugs/2026-07-26-dm-desktop-to-desktop-resurfaced.md`** — the entry point:
- what is **proven** (measured, fingerprint-joined, independently re-derived), what is **ruled out**, and open leads **ranked**
- the mechanism that was argued confidently and then **retracted** the same day, and how that happened
- the full rig: branch, the `rig=` marker that makes a capture state its own capabilities, a probe table, the capture protocol, and offline replay
- what shipped (#259 merged, #260 open)

## Corrected

- **Master report** — `REOPENED` in status plus a banner. Deliberately left in `.solved/`: many documents link to that path and moving it would break them.
- **Autoheal task** — re-raised. Its July downgrade rested on an assumption this disproves, and its heal action 2 is precisely this failure.
- **INDEX** — entry point listed first; master marked reopened.

## Two capture lessons recorded, each of which cost real time today

1. Absence of a log line is not evidence of absence until you have checked the line covers every path the event can take. Two destructive paths were invisible during the failing capture.
2. A capture stopped while frames are in flight scores them as **losses**. A "5-frame loss" today was pure truncation.

Docs only — no code changes.