### PR TITLE
Headless DM harness: drive the real client in Node (no browser)

### DIFF
--- a/.agents/bugs/2026-07-26-dm-desktop-to-desktop-captures.md
+++ b/.agents/bugs/2026-07-26-dm-desktop-to-desktop-captures.md
@@ -1019,3 +1019,76 @@ crate. The ablation shows the bucket is load-bearing; reading the crate's skippe
 -key lookup is what will show why. Ablation also cannot rule out that the bucket
 contents are themselves wrong (written badly earlier) rather than the lookup
 being wrong — both are consistent with this data, and both are upstream.
+
+---
+
+## §2k. Synthetic corroboration (2026-07-27) — a FRESH session cannot be made to fail
+
+Tool: [`dr-position-table.mjs`](../tools/dm-debug/dr-position-table.mjs). Builds
+pristine sessions from real X3DH material and drives the real wasm through six
+delivery regimes, scoring first-attempt failure by chain position — the same
+quantity the live rig measures. No device time, no logs, seconds per run.
+
+### Finding AF — 1920 synthetic frames, zero failures at every position
+
+| regime | pos 0 | pos 1 | pos 2 | pos 3+ |
+|---|---|---|---|---|
+| strict alternation, 1 frame/turn | 0% | — | — | — |
+| strict alternation, 4-frame burst | 0% | 0% | 0% | 0% |
+| crossing sends, 1 frame/turn | 0% | 0% | — | — |
+| crossing sends, 4-frame burst | 0% | 0% | 0% | 0% |
+| crossing + reordered delivery | 0% | 0% | 0% | 0% |
+| strict alternation + reordered | 0% | 0% | 0% | 0% |
+
+20 independent runs of the most realistic regime: **0/20 showed any failure.**
+
+**This was run before §2j existed and read at the time as a puzzle. It is not
+one.** Every session the harness builds is FRESH, so its skipped-keys map never
+develops the poisoning bucket finding AE identifies. The harness was testing the
+one condition under which the bug is known not to fire. **Finding AF is therefore
+independent synthetic corroboration of finding AC, and nothing more.**
+
+> ⛔ **Do not cite AF as evidence the crate is clean.** It measures a fresh
+> session. Both AC (real devices, post-reset) and AF (synthetic) say the same
+> thing: no accumulated map, no failure.
+
+### Finding AG — init-wrapping cannot affect the inner decrypt, by construction
+
+Established by *reading* [`channel.ts:976-1043`](../../../quilibrium-js-sdk-channels/src/channel/channel.ts#L976),
+not by measuring. In `DoubleRatchetInboxEncrypt` the inner `DoubleRatchetEncrypt`
+call happens at L987, **before** the `state.sent_accept` branch at L988, and its
+result is identical on both sides of it — only the outer `js_encrypt_inbox_message`
+sealing differs.
+
+So the init-wrap/plain choice **structurally cannot** change the inner ratchet
+ciphertext. This corroborates the rig=10 controlled experiment (finding Y) from a
+completely different direction, and it is cheaper: a code read, not a capture
+round. Worth remembering as a method — the TypeScript half of the SDK is readable
+and several questions that were answered with device time were answerable there.
+
+### Finding AH — a responder that sends before receiving forks PERMANENTLY
+
+Scenario X in the script, included only because it is fork-shaped. If the
+responder encrypts before it has ever decrypted anything, its entire first burst
+(4/4 frames) is undecryptable and **never recovers** across any number of
+redeliveries — unlike every failure in this investigation, which is transient.
+
+**The app cannot reach this state** (a responder learns a conversation exists by
+receiving), so this is not a cause of anything on file. Recorded because it is
+adjacent to [#183](https://github.com/QuilibriumNetwork/quorum-mobile/issues/183)
+item 1, and because a permanent fork produced from clean X3DH material in four
+lines of driver code may interest the lead.
+
+### The experiment this tool is now positioned to run — NOT YET BUILT
+
+§2i names the open test and this harness is the natural place for it:
+
+> *age a session deliberately (or replay one forward) and see whether failure
+> rate tracks `skipped` independently of elapsed time.*
+
+Captured evidence cannot separate those confounds, because failures also create
+skipped keys. A **synthetic** harness can, because it controls both independently:
+grow the map without ageing the session, age the session without growing the map.
+That would turn the feedback-loop hypothesis in §2i into a conclusion or kill it,
+and it would test whether the poisoning bucket ever arises **naturally** or only
+appears in states that got there by some other route.

--- a/.agents/bugs/2026-07-26-dm-desktop-to-desktop-resurfaced.md
+++ b/.agents/bugs/2026-07-26-dm-desktop-to-desktop-resurfaced.md
@@ -1,21 +1,22 @@
 ---
 type: bug
 title: "DM delivery broken again on desktop↔desktop (the 2026-07-02 master report is NOT closed)"
-status: ROOT CAUSE FOUND 2026-07-27, upstream in the channel crate. Not fixable in this repo; all client-side work is DONE AND MERGED. Frame decryption failure is a deterministic function of position in the DH sending chain: positions 0-2 fail ~100%, position 3+ never fails, both directions. Failures are TRANSIENT — the same bytes decrypt on redelivery — so this is LATENCY WITH A LONG TAIL, not demonstrated message loss. It explains every symptom: lag, the inverted typing indicator, and messages arriving so late they are assumed lost. TEN app-level mechanisms have been proposed and killed (§3), including every form of forked ratchet and, by controlled experiment, frame shape itself. Three client defects were found and are MERGED to main (§7). Evidence is filed upstream at quorum-mobile#183. A fresh agent's next action is in §5 — it is NOT more local capturing.
+status: ROOT CAUSE FOUND 2026-07-27, upstream in the channel crate (finding AE). When a session's `skipped_keys_map` holds a bucket under the receiver's CURRENT receiving header key, the crate's decrypt takes that bucket and fails on a frame it could otherwise derive the key for. 63 of 65 captured failures across 6 rounds decrypt when ONLY that bucket is deleted and nothing else changes. It builds up with use, every failure adds another key, and a reset clears it — which is why a conversation degrades over days and works again after a reset. ⚠️ The older framing ("failure is a deterministic function of chain position, 0-2 fail, 3+ never") is a SYMPTOM description and was RETIRED by finding AD — a fresh session shows those same positions behaving normally; position is where the failure lands, not what causes it. Failures are TRANSIENT — the same bytes decrypt on redelivery — so this is LATENCY WITH A LONG TAIL, not demonstrated message loss. TEN app-level mechanisms have been proposed and killed (§3). Three client defects were found and are MERGED to main (§7). Evidence is filed upstream at quorum-mobile#183. A fresh agent's next action is in §5 — it is NOT more local capturing, and §5 now lists a client-side mitigation that only became possible once AE was known.
 created: 2026-07-26
 severity: medium — user-visible lag and apparent loss; no permanent loss demonstrated since the init-envelope fix (see §1)
 repo: quorum-desktop (cross-repo — mobile shares the accounts and the upstream causes)
 area: DM Double Ratchet / session lifecycle / transport
 entrypoint: true
 related:
-  - ".agents/bugs/2026-07-26-dm-desktop-to-desktop-captures.md (ALL round evidence, findings A-AB across 7 capture rounds — this file cites it by letter)"
+  - ".agents/bugs/2026-07-26-dm-desktop-to-desktop-captures.md (ALL round evidence, findings A-AH across 8 capture rounds + offline ablation and synthetic harness rounds — this file cites it by letter)"
   - ".agents/bugs/.solved/2026-07-02-dm-message-delivery-unreliable-master.md (mechanism catalogue — filed as solved, but the symptom RESURFACED; read it for history, not status)"
   - ".agents/docs/dm-ratchet-upstream-divergences.md (the 8 shipped divergences, lead-dev facing)"
   - ".agents/tasks/2026-07-17-dm-dead-session-autoheal.md (heal action 2 is exactly this failure)"
   - ".agents/docs/debugging/dm-architecture-and-debug-playbook.md (DM internals)"
+  - ".agents/tasks/2026-07-27-headless-dm-harness.md (headless bench: drives the REAL client in Node, both sides, no browser — see §5 and §6)"
   - "quorum-mobile/.agents/bugs/2026-07-24-dm-desktop-frames-undecryptable-state-divergence.md (3000-line master, rounds 1-29)"
   - "quorum-mobile/.agents/bugs/2026-07-24-dm-session-confirm-row-mismatch-x3dh-every-send.md (authoritative SDK reading)"
-  - "https://github.com/QuilibriumNetwork/quorum-mobile/issues/183 (the two UPSTREAM causes — not fixable here)"
+  - "https://github.com/QuilibriumNetwork/quorum-mobile/issues/183 (the upstream causes, lead-dev facing. Item 1a IS finding AE. Body rewritten 2026-07-27 and the old comment folded into it — the body is now the whole story)"
 ---
 
 # DM delivery is broken again, desktop↔desktop
@@ -69,10 +70,28 @@ the key the receiver is currently using, makes the crate fail frames it could
 decrypt. It builds up with use, every failure adds another, and a reset clears it
 — which is why the conversation degrades over days and works again after a reset.
 
+> **Bench refinement (headless harness, 2026-07-27):** "builds up with use" is NOT
+> message-count alone. A run of the REAL client headless in Node (both sides, fresh
+> accounts, 60–82 concurrent msgs each way) accumulated **zero** skipped keys and
+> **zero** failures — a controlled confirmation that a fresh session does not fail,
+> narrowing the accumulation trigger to time / cross-platform / reset, NOT volume.
+> A first run *did* fail, but a fresh-account control falsified it as stale queued
+> frames from account reuse (the redelivery mode), not load. See §5 "headless
+> harness" and [the harness task](../tasks/2026-07-27-headless-dm-harness.md).
+
 ---
 
 ## §2. What is established (evidence: [captures archive](2026-07-26-dm-desktop-to-desktop-captures.md))
 
+- **THE ROOT CAUSE: a poisoning bucket in the skipped-keys map.** A bucket under
+  the receiver's *current* receiving header key makes the crate fail frames it
+  could decrypt. 63/65 captured failures, 6 rounds, both clients, decrypt when
+  only that bucket is removed. Upstream, in the crate. *(AE, §4 lead 0)*
+- **A FRESH session does not exhibit the failure.** Post-reset, positions 0-2
+  went from 12/12 failing to 2/15, and one client logged 0 failures against 60
+  the round before. Independently corroborated synthetically: 1920 frames on
+  fresh sessions across six delivery regimes, zero failures. **So chain position
+  alone is not sufficient to cause anything.** *(AC, AF)*
 - **Frames arrive and cannot be decrypted.** Not transport loss. Fingerprint-
   joined across both clients; 21/21 in one round, 16/38 in another. *(§2, F, L)*
 - **Raw failure counts massively overstate events.** Failed frames are never
@@ -124,39 +143,60 @@ Hypotheses 1, 4 and 6 all died of this.
 
 ## §4. Leads — one still live, the rest closed
 
-**0. THE MECHANISM — the first frames of every DH sending chain cannot be
-decrypted on arrival.** *(measured rig=9; archive findings T, U, V)*
+**0. THE ROOT CAUSE — a skipped-keys bucket under the receiver's CURRENT
+receiving header key.** *(finding AE, archive §2j — offline ablation, no devices)*
+
+When `skipped_keys_map` contains a bucket indexed by the receiver's **current**
+receiving header key, the crate's decrypt path takes that bucket and fails,
+instead of falling through to normal chain-key derivation. The message key it
+needs is derivable; it never gets there.
 
 ```
-position in sending chain:  0     1     2     3+
-A->B failure rate:        100%   86%   67%    0%
-B->A failure rate:        100%  100%   60%    0%
+baseline, exactly as captured ...................  0 / 65 decrypt
+drop ONLY skipped_keys_map[current_recv_header] .. 63 / 65 decrypt   ← the bucket
+drop ONLY the next-recv-header bucket (control) ..  0 / 65
+keep only the current-recv-header bucket .........  0 / 65
+previous_sending_chain_length = 0 ................  0 / 65
+current_receiving_chain_length = 0 ...............  0 / 65
+swap current ↔ next receiving header key .........  0 / 65
 ```
 
-Both directions, no exceptions above position 2. Failures are **transient** —
-nearly all failed frames decrypt on a later redelivery, and every recovery count
-in this file is a **lower bound** because captures are saved at ~2 minutes
-(finding AB). This accounts for every symptom on record: the inverted typing
-indicator (`typing-start` is the first frame after reading the peer's message, so
-it always occupies position 0), the lag in tight conversation, and messages that
-look lost because the redelivery had not landed yet.
+**Not "fewer keys is better":** in a representative case the map held 62 keys
+across 20 buckets and the poisoning bucket held **3**. Deleting those 3 decrypts
+the frame; deleting the other 59 changes nothing. Frame and state are otherwise
+byte-identical between the failing and succeeding runs.
 
-**Where it is NOT:** app code does not implement the ratchet. It selects a
-session, calls `DoubleRatchetInboxEncrypt`, and hands arriving frames to
-`DoubleRatchetInboxDecrypt`. Eight app-level mechanisms have been proposed and
-killed (§3), including every form of forked ratchet (row 8, proven with the DH
-epoch attached). What remains is the ratchet implementation itself — adjacent to
-the upstream behaviour in §2, though ours is transient where that one is
-permanent, so *related, not identical*.
+**It explains every symptom on record**, including the oldest one nothing else
+ever did: works after a reset (the reset discards the map), degrades over days
+(every failure adds another skipped key — a feedback loop), redelivery recovers
+(the state has moved past that header key by then), and failures cluster at chain
+positions 0-2 (that is where a receiver consults skipped keys after a DH turn).
 
-**Now supported by a controlled experiment.** rig=10 removed init-wrapping — the
-last app-controlled property of an outgoing frame — and the position table did not
-move (§3 row 10). Ten app-level hypotheses are dead, every form of forked ratchet
-is excluded with the DH epoch attached, and frame shape is excluded by
-manipulation rather than by argument.
-→ **Filed upstream 2026-07-27**:
-[#183 comment](https://github.com/QuilibriumNetwork/quorum-mobile/issues/183#issuecomment-5090004304).
-Nothing further is actionable in this repo; see §5.
+> ⚠️ **The position table is a SYMPTOM, not the mechanism — finding AD.** An
+> earlier version of this lead read *"THE MECHANISM — the first frames of every DH
+> sending chain cannot be decrypted"* with a 100/86/67/0% table. **That framing is
+> retired.** A fresh session shows the same positions behaving normally (finding
+> AC: positions 0-2 went from 12/12 failing to 2/15 after a reset, and one client
+> logged zero failures against 60 the round before). Position is where the failure
+> *lands*; the bucket is what *causes* it. Correct this wherever you find it.
+
+**Where it is NOT:** app code does not implement the ratchet. Ten app-level
+mechanisms are dead (§3), every form of forked ratchet is excluded with the DH
+epoch attached, and frame shape is excluded twice over — by the rig=10 controlled
+experiment, and structurally by reading the SDK (finding AG: in
+`DoubleRatchetInboxEncrypt` the inner `DoubleRatchetEncrypt` call happens *before*
+the `sent_accept` branch and is identical on both sides of it, so init-wrapping
+cannot alter the inner ciphertext).
+
+**Still open, and both upstream:** whether the *lookup* consults a bucket it
+shouldn't, or the bucket *contents* were written wrong earlier. Ablation cannot
+separate them; reading the crate would, and there is no Rust source in the SDK
+repo (only `channelwasm_bg.wasm`).
+→ **Filed upstream** as **item 1a** of [#183](https://github.com/QuilibriumNetwork/quorum-mobile/issues/183), the
+issue's lead item. The body was rewritten 2026-07-27 to put it first, correct the
+desktop↔desktop attribution previously given to the fork, and absorb the standalone
+comment (since deleted). **That body is now the whole upstream story.**
+**Not fixable here — but see §5 option B, which AE newly makes possible.**
 
 **1. ~~The init-envelope absolute age bound.~~ FIXED AND MERGED** 2026-07-27 (§7).
 Kept here only for the reasoning, which generalises: wall-clock age was the wrong
@@ -176,13 +216,19 @@ registration data changes. All delete sessions whose `tag` is absent from a
 *cached* React Query read; mobile-created rows carry a non-device-inbox tag.
 
 **3. UPSTREAM — [quorum-mobile#183](https://github.com/QuilibriumNetwork/quorum-mobile/issues/183)
-— now the only live lead.** (a) the crate fork; (b) the node write path dropping
-frames handed to an open socket, 32% one direction phone↔phone. Neither is
-fixable here. Its body was corrected 07-26 to retract a "desktop is immune"
-claim, and our position table was added as a
-[comment](https://github.com/QuilibriumNetwork/quorum-mobile/issues/183#issuecomment-5090004304)
-on 07-27. **If you produce new d↔d evidence, add it there — the lead dev reads
-that issue, not this file.**
+— the only live lead.** Body rewritten 2026-07-27 and the standalone comment
+folded into it, so the body is the whole story. Its shape:
+
+- **item 1** — crate, skipped-key handling around the DH ratchet step
+  - **1a** = finding AE, the poisoning bucket. What our live traffic shows.
+  - **1b** = the advanced-start fork. Deterministic repro, but its live impact
+    is now stated as UNQUANTIFIED — the d↔d failure once cited for it is
+    attributed to 1a, and no production failure is cleanly 1b-shaped.
+- **item 2** — the node write path dropping frames handed to an open socket,
+  32% one direction phone↔phone.
+
+Neither is fixable here. **If you produce new d↔d evidence, add it there — the
+lead dev reads that issue, not this file.**
 
 **4. No dead-session detection.** The detector must require *retry-exhaustion on
 a session with zero successes*, never first-failure — the healing-lag class
@@ -194,9 +240,15 @@ Given this bug's history, prompt is the safer first step. Do not build without i
 
 ## §5. Next action
 
-**Everything this repo can do about the root cause has been done.** The mechanism
-is measured, the app is exhausted as an explanation, the three real client defects
-are merged, and the evidence is filed upstream. Read that before opening an editor.
+**Nothing this repo can do will FIX the root cause** — it is in a crate we have no
+source for. The app is exhausted as an explanation, the three real client defects
+are merged, and the evidence is filed upstream.
+
+⚠️ **But "cannot fix the cause" is not "cannot fix the symptom", and finding AE
+changed what is possible here.** An earlier version of this section said
+"everything this repo can do has been done"; that predated AE. **Option B below is
+now a candidate for removing the user-visible symptom without any upstream fix,
+and it can be validated offline for free before any app code is written.**
 
 ### FIRST: three tools that answer questions without a capture round
 
@@ -209,6 +261,7 @@ cause needed **none of that** and arrived last. Do not repeat that ordering.
 | `dr-ablate.mjs` | **what CAUSES a failure** — re-runs a real captured decrypt while changing ONE state property at a time; a load-bearing property announces itself by making the frame decrypt | a saved log |
 | `dr-replay.mjs` | is this failure genuine and reproducible, or an app-level race | a saved log |
 | `dr-advanced-start-fork.mjs` | reproduces the upstream crate's advanced-start fork from a pristine X3DH pair | **nothing** — no log, no devices |
+| `dr-position-table.mjs` | drives **fresh** sessions through six delivery regimes and scores failure by chain position. 1920 frames, zero failures — corroborates AC, and is ⛔ **not** evidence the crate is clean (a fresh session has no poisoning bucket). Its unrealised value is the session-ageing test below | **nothing** |
 
 ```
 node .agents/tools/dm-debug/dr-ablate.mjs <log> [...more logs]
@@ -224,6 +277,39 @@ Old logs live wherever the operator saved them (historically a `logs/` folder on
 the Desktop, with an `OLD/` subfolder for previous rounds). They contain **real
 ratchet key material** — keep them local.
 
+### AND: a headless harness that drives the REAL client — `src/dev/tests/harness/`
+
+New 2026-07-27. The offline tools above replay/ablate a *captured* failure; this
+runs the **whole real desktop client** (real `MessageService` + `MessageDB` on
+fake-indexeddb + ws transport + wasm core) in Node — both sides of a conversation
+in one process, one clock, any volume, unattended. NOT a reimplementation: inbound
+frames go through the real `handleNewMessage`, outbound through the real
+`submitMessage` → action queue → socket. It registers throwaway accounts on the
+live relay; needs **no devices, no browser, and no diag branch** — it instruments
+from the outside and writes `[XPDUMP]` records `dr-ablate`/`dr-replay` read
+unchanged.
+
+```
+yarn harness dm-basic     # two bots exchange DMs both ways; merged both-sides log
+yarn harness dm-volume    # concurrent bidirectional load, samples skipped_keys
+yarn harness dm-receive   # a bot decrypts a DM you send from a browser
+```
+
+On any decrypt failure a bot auto-writes `logs/<ts>-<bot>.xpdump.log` → feed
+straight to `dr-ablate.mjs`.
+
+**Use it to:** run controlled experiments in minutes instead of booking a round
+(the fresh-vs-reused-account control that produced the §1 bench refinement took
+~5 min); regression-test a fix once one lands; measure the transport claim
+(item 2) by counting send-vs-arrive over hours.
+
+**Cannot (yet):** it is the desktop protocol + service layer, **not the UI and
+not mobile**, and it has **not reproduced the AGED-session failure** — volume does
+not age a session (§1 refinement). The open next step is `importSession.ts`: lift a
+real degraded `EncryptionState` row out of a browser (plain JSON in IndexedDB;
+`dr-replay` already loads these) and keep it alive on the bench. Full plan +
+env gotchas: [headless DM harness task](../tasks/2026-07-27-headless-dm-harness.md).
+
 ### If you are here because the user reports DM lag or a missing message
 
 That is the known symptom of the unresolved upstream cause. **Do not start a new
@@ -233,9 +319,8 @@ option B below.
 
 ### A. Waiting on upstream — the honest default
 
-The position table is filed at
-[#183 comment](https://github.com/QuilibriumNetwork/quorum-mobile/issues/183#issuecomment-5090004304)
-(2026-07-27). It bears on that issue's item 1: the fork needs establishment-phase
+The root cause is filed as item 1a of [#183](https://github.com/QuilibriumNetwork/quorum-mobile/issues/183)
+(body rewritten 2026-07-27). It bears on item 1b: the fork needs establishment-phase
 frame loss as a trigger, and our data shows chain-start frames fail on first
 attempt essentially always, so the trigger is systematic rather than incidental.
 
@@ -244,17 +329,51 @@ attempt essentially always, so the trigger is systematic rather than incidental.
 captures contain live ratchet state, they live only on the operator's machine, and
 they are not going in a public issue.
 
-### B. Mitigation we control — the best remaining value here
+### B. Mitigation we control — now TWO options, and B1 is new
+
+**B1. Prune the poisoning bucket and retry.** *(possible only since finding AE;
+UNVALIDATED, proposed 2026-07-27)*
+
+AE proves that deleting **one** bucket makes 63 of 65 real captured failures
+decrypt immediately. The ratchet state is plain JSON that JavaScript can read and
+modify — `dr-ablate.mjs` already does exactly this mutation
+(`{ ...rs, skipped_keys_map: m }` after deleting `m[current_receiving_header_key]`),
+and the app already parses the same state on every send (`orderSessionsForSend`
+does `JSON.parse(r.state)`). So on decrypt failure the receive path could retry
+once with that single bucket removed.
+
+If it holds, **the user-visible symptom goes away while the crate bug stays
+unfixed.** That is a materially better outcome than option B2, which only makes
+recovery faster.
+
+**Validate it offline first — this is free and requires no app code.** `dr-ablate`
+already runs against every captured failure on disk. What must be checked before
+building anything:
+
+1. Does pruning only that bucket ever break a frame that would otherwise succeed?
+   (Run the variant across all captured *successes*, not just failures.)
+2. What is lost by discarding those keys — could a genuinely out-of-order message
+   that needed them become permanently undecryptable? In the representative case
+   the bucket held 3 keys of 62, and pruning would happen only on failure, but
+   that is an argument, not evidence.
+3. Do the 2 of 65 that never recover behave differently? (They sit on near-empty
+   maps and are most likely genuine replays.)
+
+**Do not ship this without 1 and 2 answered.** It is a workaround for someone
+else's bug and it deliberately discards key material.
+
+**B2. Trigger redelivery on decrypt failure instead of waiting for it.**
 
 **Recovery already works; it is just slow.** Failed frames decrypt on redelivery,
 and the whole user-visible symptom is how long that takes. If redelivery were
 triggered **on decrypt failure** rather than waited for, most of the lag and the
-inverted typing indicator would disappear *without* the upstream fix.
+inverted typing indicator would shrink *without* the upstream fix.
 
-This is unbuilt and unscoped. It is mitigation, not a cure, and it must not
-weaken the retention that makes recovery possible in the first place. Start from
+Unbuilt and unscoped. It is mitigation, not a cure, and it must not weaken the
+retention that makes recovery possible in the first place. Start from
 `UndecryptableFrameTracker` (`src/utils/frameRetry.ts`) and the skip-and-keep path
-in the receive handler.
+in the receive handler. **B1 subsumes most of B2's value if B1 validates — try B1
+first, it is cheaper to test.**
 
 ### C. The one fix never exercised live
 
@@ -270,6 +389,28 @@ it costs no attention.
 The original report — works after a reset, use the same accounts on mobile for
 days, return to desktop broken. Nobody has reproduced it on purpose. It remains
 the single most valuable capture available, and no round so far has attempted it.
+
+### E. Separate the confounds behind the feedback-loop hypothesis
+
+§2i's story — "map grows → more failures → map grows" — is a **hypothesis, not a
+conclusion.** `skipped` is confounded with session age, DH epoch count and total
+traffic, and because failures *create* skipped keys, cause and effect are circular
+on captured evidence. §2i names the test: *age a session deliberately and see
+whether failure rate tracks `skipped` independently of elapsed time.*
+
+Captured evidence cannot do this. A **synthetic** harness can, because it controls
+both independently: grow the map without ageing the session, age the session
+without growing the map. `dr-position-table.mjs` is the natural home. It would
+also answer whether the poisoning bucket ever arises **naturally**, or only in
+states that reached it by some other route — which bears directly on the
+lookup-vs-contents question §2j says ablation cannot settle. **No device time.**
+
+> **Better vehicle, in progress:** [2026-07-27-headless-dm-harness.md](../tasks/2026-07-27-headless-dm-harness.md)
+> (branch `feat/headless-dm-harness`) re-hosts the REAL `MessageService` in Node
+> over the same wasm core with `fake-indexeddb`. That can age a session through
+> the actual app paths at machine speed, which is strictly better than ageing a
+> synthetic two-party ratchet. Prefer it once slice 1 lands; use
+> `dr-position-table.mjs` only if you need an answer before then.
 
 ### Structural facts to carry into ANY code change here
 
@@ -287,6 +428,14 @@ the single most valuable capture available, and no round so far has attempted it
 ---
 
 ## §6. THE RIG — how to capture (read before booking any test time)
+
+> **Before booking a two-browser round, ask if the headless harness can answer it
+> instead** (§5, `src/dev/tests/harness/`). For anything below the UI — protocol,
+> session lifecycle, transport counts, reproducing/measuring a failure mode — it
+> runs both sides in one Node process with no devices and no attention cost. Book a
+> manual round only for UI behaviour, mobile, or a genuinely aged real session the
+> harness cannot yet synthesise. The two-browser rig below remains the tool for
+> those.
 
 **Branch: `diag/dm-frame-join`** (local, never merge — it logs real key
 material). Rebase it forward onto main before every round:

--- a/.agents/tasks/2026-07-27-headless-dm-harness.md
+++ b/.agents/tasks/2026-07-27-headless-dm-harness.md
@@ -1,0 +1,287 @@
+---
+type: task
+title: "Headless DM harness — drive the real client in Node to debug DM transport without two browsers"
+status: IN PROGRESS — slice 1
+created: 2026-07-27
+branch: feat/headless-dm-harness
+area: DM transport / testing infrastructure
+related:
+  - .agents/bugs/2026-07-26-dm-desktop-to-desktop-resurfaced.md (the investigation this replaces the manual rig for; §6 THE RIG)
+  - .agents/bugs/2026-07-26-dm-desktop-to-desktop-captures.md (round evidence the harness output must feed)
+  - .agents/tools/dm-debug/ (dr-ablate, dr-replay, dr-position-table — the log analyzers the harness feeds)
+  - .agents/tasks/2026-07-21-device-registration-ghost-accumulation-cross-platform.md (why bots reuse a persisted device keyset)
+---
+
+# Headless DM harness
+
+## Why
+
+Every DM-transport question today costs a manual round: two browsers, hand-typed
+numbered messages, save both consoles at the same instant, reassemble chunked
+`[XPDUMP]` lines, glance back 20 min later for loss. The operator IS the
+bottleneck (`.agents/bugs/2026-07-26-...-resurfaced.md` §6). This harness moves
+the cost from *human attention* to *machine time*: one Node process hosts the
+**real** `MessageService`, both sides, one clock, arbitrary volume, unattended.
+
+It is NOT a reimplementation of the protocol. It re-hosts the real client:
+
+| layer | browser | harness |
+|---|---|---|
+| crypto | SDK wasm core | same wasm core |
+| storage | IndexedDB | `fake-indexeddb` (already a devDependency) |
+| transport | `fetch` + `WebSocket` | Node 22 native `fetch` + `WebSocket` |
+| logic | `src/services/MessageService.ts` | **the same file, imported** |
+
+If a bug lives in the app, the harness hits it. Output is a JSONL log that feeds
+`.agents/tools/dm-debug/dr-ablate.mjs` unchanged.
+
+## Scope (this task)
+
+- Transport only. DM send/receive between bots. NO adversarial/security scenarios
+  (deliberate, per operator decision 2026-07-27 — revisit separately).
+- Desktop client only. Not mobile, not the UI layer.
+
+## Non-goals / honest limits
+
+- Does not exercise React rendering, scroll, receipt icons — protocol + service layer only.
+- Not mobile; RN-specific bugs stay on-device.
+- A bot is a real device on the account → multi-device fan-out topology, not
+  identical to a pure two-desktop case (but two bots + no browser IS clean d↔d).
+- May NOT reproduce the aged-session degradation (§ slice 4). If synthetic volume
+  doesn't age the session, that is itself a useful negative result (trigger is
+  time or cross-platform, not volume) — and slice 4 falls back to importing a
+  real degraded `EncryptionState` row from a browser.
+
+## Placement (decided 2026-07-27)
+
+No new root folder. Scenarios live in the dev test tree (already tsconfig-excluded,
+already the Vitest home). Log analyzers stay next to the dr-* tools.
+
+```
+src/dev/tests/harness/          NEW — scenarios + bot rig
+  README.md                     how to run (what other devs read)
+  .env.example                  committed, placeholders only
+  .env.local                    gitignored (.env.local + *.local.*)
+  identity.ts                   ed448 hex → user keyset + device keyset (+ persist)
+  transport.ts                  fetch + WebSocket, the {type:'listen'} subscription
+  storage.ts                    fake-indexeddb → real MessageDB
+  deps.ts                       the ~17 MessageServiceDependencies stubs
+  bot.ts                        assembles one client: .send() .on() .dumpState()
+  log.ts                        structured JSONL, one clock, both sides
+  importSession.ts              (slice 4) load an aged EncryptionState from a browser
+  dm-basic.scenario.test.ts
+  dm-volume.scenario.test.ts
+  dm-reconnect.scenario.test.ts
+  logs/                         gitignored (real key material)
+
+.agents/tools/dm-debug/         unchanged — dr-ablate/replay/position-table
+vitest.harness.config.ts        NEW root config: node env, real WS + webcrypto, long timeout
+package.json                    "harness": "vitest --config vitest.harness.config.ts"
+```
+
+### Why a separate Vitest config
+`src/dev/tests/setup.ts` deliberately MOCKS `WebSocket` and `crypto` for unit
+tests — the opposite of what the harness needs. Harness config: `environment:
+'node'`, real `WebSocket`, real `webcrypto`, `fake-indexeddb` installed globally,
+`testTimeout` in the hours. Reuses the Vite transform pipeline so lingui macros
+and `.web.ts` resolution work when `MessageService` is imported (plain node can't
+do this — which is exactly why the existing dr-*.mjs only import the SDK, never a
+service).
+
+## Instrumentation — does NOT need the `diag/dm-frame-join` branch (decided 2026-07-27)
+
+The manual rig's probes (`[DM-send branch]`, `[XPDUMP]`, etc.) live only on
+`diag/dm-frame-join` because a browser is a black box: the only way to see inside
+is to make `MessageService` log its own guts — which smears real key material into
+the service and is why that branch is never merged.
+
+The harness runs IN-PROCESS with full access, so it instruments from the OUTSIDE
+against clean `main`:
+- owns transport → sees every frame (the sealed message)
+- owns `MessageDB` → reads any `EncryptionState` row before/after any decrypt
+- gets `DmDecryptError` directly (main already throws it, carrying raw + branch)
+
+So the harness WRITES the `[XPDUMP]` records itself, from data it already holds,
+in the exact format `dr-replay`/`dr-ablate` parse — and can dump state on EVERY
+frame, not just failures (full `dr-position-table` data). No inline service
+logging, no key material in service code, clean-main build.
+
+Only genuinely-internal signals the external view can't see: which of the 5 send
+sites / which decrypt branch fired. Already ruled out as causal (§3 rows 4, 8, 10;
+the load-bearing signal is ratchet STATE, which the harness controls). If ever
+needed, add 2 narrow mergeable log hooks to the harness build — NOT the diag branch.
+
+→ Harness stays on `feat/headless-dm-harness` off clean `main`.
+
+## Keys & safety (baked into README)
+
+- Throwaway accounts ONLY, never a real identity.
+- `.env.local` gitignored; `.env.example` placeholders only. Never read/commit real keys.
+- `logs/` gitignored — contains real ratchet key material (same warning as §6).
+- Each bot persists its device keyset to a gitignored state file and REUSES it, so
+  runs don't spawn new device registrations (feeds ghost-accumulation otherwise).
+- Talks to PRODUCTION `api.quorummessenger.com` (same as browsers). Real frames on
+  the live relay. Throwaway accounts make this acceptable.
+
+```
+# .env.example
+BOT_A_PRIVATE_KEY=          # 114-char ed448 hex, throwaway account only
+BOT_B_PRIVATE_KEY=
+QUORUM_API_URL=https://api.quorummessenger.com
+QUORUM_WS_URL=wss://api.quorummessenger.com/ws
+```
+
+## Confirmed API surface (src/api/baseTypes.ts)
+
+`QuorumApiClient`: `getUser` / `postUser` (register) / `getInbox` / `postInbox` /
+`deleteInbox` / `getUserSettings`. Identity: `channel.NewUserKeyset(ed448)` +
+`NewDeviceKeyset()` + `ConstructUserRegistration(userKeyset, existingDevs, [dev])`
+→ `postUser`. Inbox address = base58btc(sha256(inbox_key.public_key)). Subscribe =
+send `{type:'listen', inbox_addresses:[...]}` over the WS.
+
+## Slices (each ends in something observable — no diff-reading required)
+
+### Slice 1 — identity + transport + register  [DONE 2026-07-27, verified on prod]
+`yarn harness ping` → a bot generates or loads a throwaway keyset, `postUser`
+registers it, opens the WS, sends `listen`, prints its inbox address + "connected".
+- Files: shim.ts, setup.harness.ts, env.ts, identity.ts, transport.ts,
+  ping.scenario.test.ts, smoke.scenario.test.ts (offline CI-safe),
+  vitest.harness.config.ts, package.json `harness` script, .env.example, README,
+  .gitignore lines.
+- Needs NO keys from operator (harness generates a throwaway account).
+- **Verified live:** minted + registered a throwaway account on prod; relay
+  confirmed 1 device; WS connected + subscribed; 2nd run reused the persisted
+  device (no new registration). `.state/` gitignored & confirmed.
+- **Gotchas found & solved (for the next dev):**
+  - SDK browser bundle assigns `window.Buffer` at import → needs a window shim in
+    its OWN module imported before the SDK (ESM hoisting). See shim.ts.
+  - Installed npm package ships NO wasm; init from the sibling SDK source repo's
+    `src/wasm/channelwasm_bg.wasm` (same file viteStaticCopy uses). See setup.harness.ts.
+  - `js_generate_ed448` returns `{private_key, public_key}` with NO `type` field;
+    add `type:'ed448'` (matches RegistrationPersister). See identity.ts withEd448Type.
+  - from-hex pubkey derivation = `js_get_pubkey_ed448(base64(privBytes))` → base64.
+
+### Slice 2 — one bot receives a real DM  [DONE 2026-07-27, VERIFIED on prod]
+**Proven live:** a DM typed in a browser ("hello fomr browser") arrived at the
+headless bot and was decrypted by the real `MessageService.handleNewMessage`
+(init-envelope path: `SESSION REPLACED by init envelope` → `✅ decrypted`). No
+second browser. Note: DMs queue on the relay inbox, so a message sent while the
+bot was offline was delivered on the bot's next `listen` + decrypted on re-run.
+Bot subscribes; operator sends it a DM FROM A BROWSER; harness decrypts and prints
+the plaintext. This is the proof the whole stack is wired to production.
+- Files: storage.ts, deps.ts, bot.ts, dm-receive.scenario.test.ts,
+  integration-check.scenario.test.ts (offline: MessageDB opens + MessageService imports).
+- **Built & verified so far:** MessageDB opens on fake-indexeddb; full MessageService
+  import graph loads; a bot assembles the REAL MessageService + real deps, connects,
+  listens, tears down cleanly (4s smoke, no crash). Receive path drives the real
+  `handleNewMessage`; decrypted messages captured by teeing `messageDB.saveMessage`
+  (the seam every DM receive path funnels through — faithful, no reimplementation).
+- **Remaining:** operator sends one DM from a browser → confirm plaintext prints.
+- **Env decisions locked (for the next dev):**
+  - Environment is **jsdom** (the quorum-shared UI barrel touches `window` at import),
+    NOT node. Harness must NOT load the unit-test setup.ts (it mocks WebSocket/crypto).
+  - jsdom's WebSocket is a non-networking stub and undici's WS **hangs** under jsdom;
+    transport imports the **`ws`** package explicitly (added as devDependency).
+  - Harness vitest config mirrors the main config's react+lingui babel plugin, or
+    MessageService's `@lingui/*/macro` imports fail to compile.
+- **Run:** `yarn harness dm-receive` (waits 120s; override HARNESS_WAIT_MS).
+
+### Slice 3 — two bots talk, no browser  [DONE 2026-07-27, VERIFIED live]
+`yarn harness dm-basic` → bot A and bot B exchange numbered DMs both directions;
+merged, timestamped, both-sides JSONL written to logs/.
+- Files: bot.ts (+ ActionQueueService/Handlers wiring + `send()`), log.ts,
+  dm-basic.scenario.test.ts. Tunables: HARNESS_ROUNDS, HARNESS_SETTLE_MS.
+- **Proven live:** A→B ×3 all received, B→A replies ×3 all received back — full
+  round trip through the REAL send path (submitMessage → action queue → sendDm →
+  sendDirectMessages → enqueueOutbound → socket) and REAL receive path. Merged
+  log shows each round trip in ~700ms, one clock, no skew.
+- **Send-path wiring notes (for the next dev):**
+  - First message (no session) takes submitMessage's LEGACY enqueueOutbound path;
+    once a session exists, subsequent messages route through the ActionQueue —
+    which THROWS if `setActionQueueService` was not called. Both are wired now.
+  - `send-dm` handler never touches configService/spaceService (only space
+    handlers do), so ActionQueueHandlers is built without them.
+  - Service layer calls lingui `t` macros → setup activates an empty 'en' locale
+    or they throw "without setting a locale".
+- **Deferred to slice 4:** the `[XPDUMP]`-on-failure emitter that feeds
+  `dr-ablate` unchanged. Fresh sessions don't fail, so there is nothing to dump
+  until aging (slice 4) produces failures — that is where it becomes exercisable.
+
+### Slice 4 — volume + aging (the open question)  [PARTIAL 2026-07-27]
+`yarn harness dm-volume` — concurrent bidirectional load (the out-of-order
+generator), sampling `skipped_keys_map` over the run. Files: dm-volume.scenario,
+inspect.ts (ratchet-state sampler), xpdump.ts (dr-ablate-format failure capture,
+auto-wired into bot on any decrypt failure), xpdump-format.scenario (format check).
+
+- **FINDING — volume alone does NOT age a session.** Fresh accounts, concurrent
+  bidirectional load, 60–82 msgs each way: skipped_keys = 0 throughout, 0
+  failures, all delivered. Confirms §1 "a fresh session does not fail" with a
+  controlled bench experiment, and answers the open question in the negative for
+  the volume axis: the trigger is time / cross-platform / reset, NOT message count.
+- **Controlled experiment that made the point** (the kind the manual rig can't run,
+  ~5 min total): run 1 on accounts REUSED from dm-basic showed many AEAD failures;
+  run 2 on FRESH accounts, identical load, showed zero; run 3 re-ran the reused
+  pair and they no longer failed. → run 1's failures were STALE QUEUED FRAMES from
+  account reuse (redelivery against a new session), not load-induced. My initial
+  "harness reproduces the bug" read was FALSIFIED by the fresh-account control —
+  logged here as exactly the interpretation-discipline §3 demands.
+- **XPDUMP emitter DONE & verified:** on any decrypt failure the bot writes
+  `logs/<ts>-<bot>.xpdump.log` in `[XPDUMP] n/1/1 {json}` format; dr-ablate's exact
+  reader parses it (xpdump-format check). So `node .agents/tools/dm-debug/dr-ablate.mjs
+  <harness-xpdump-log>` runs unchanged when failures occur.
+- **REMAINING — importSession.ts (needs operator):** volume doesn't age a session,
+  so to study a genuinely degraded ratchet, lift a real aged `EncryptionState` row
+  out of a browser (it's plain JSON in IndexedDB; dr-replay already loads these) and
+  keep it alive on the bench. This is the next high-value step and needs a browser
+  export from the operator.
+
+## Follow-ups (post-slice-4)
+
+### Canonical test users (operator's two real accounts) — DONE 2026-07-27
+`.env.local` `BOT_A_PRIVATE_KEY` / `BOT_B_PRIVATE_KEY` drive the operator's two
+real test users via `canonical.ts` (`createUserA/B`, `createCanonicalPair({drain})`).
+Context: user A owns the test spaces + the shared space with real users, so these
+are the accounts for future SPACE work. Guidance (README): canonical pair for
+realistic-state / space tests; throwaways for clean DM baselines. Two safety
+refinements: (1) env-key bots persist **device-only** to `.state/` — the account
+private key is never copied out of `.env.local`; (2) `drainInbox()` clears queued
+frames to avoid the stale-frame confound on reused accounts.
+
+### #1 regression test — end-to-end reset → recover — DONE 2026-07-27, non-overlap verified
+`yarn harness dm-reset-recover`. Audited existing coverage FIRST (operator asked
+not to duplicate unit tests): the offline ratchet lock
+(ActionQueueHandlers.unit.test.ts:674), sent_accept plumbing
+(sessionSelection.unit.test.ts:81), and isStaleInitEnvelope (18 pure-function
+cases) are ALREADY unit-tested with the SDK mocked. So harness copies of those
+would be pure overlap — SKIPPED. Built only the emergent behavior unit tests can't
+reach: wipe one side's session mid-conversation, verify a fresh re-init recovers
+the conversation both ways (real crypto, real two-party). Passes; a real AEAD
+failure occurs during the transition (XPDUMP-capturable). Also added
+`bot.wipeSessions()` and `refreshSubscriptions()` (listen on new session inboxes
+as they are created — mirrors the app's setResubscribe).
+
+### #2 — spaces (bot joins a space, posts, interacts) — TO SPEC
+Operator's MAIN current use case: **messages not landing in spaces**. Spec the
+spaces build around that specific issue before implementing. Needs triple-ratchet
+session establishment + SpaceService/SyncService + channel send; user A's space
+ownership is why the canonical pair matters here.
+
+## Progress log
+
+- 2026-07-27: branch `feat/headless-dm-harness` created; plan written.
+- 2026-07-27: slice 1 DONE — throwaway account registered on prod, WS connect +
+  subscribe, persisted/idempotent device. Verified live.
+- 2026-07-27: slice 2 DONE — real browser-sent DM decrypted headlessly by the real
+  MessageService. Env locked: jsdom + `ws` package + fake-indexeddb + wasm-from-sibling.
+- 2026-07-27: slice 3 DONE — two bots exchange DMs both directions, no browser, via
+  the real send + receive paths. Merged both-sides JSONL log. The two-browser loop
+  is replaced.
+- 2026-07-27: slice 4 PARTIAL — dm-volume + ratchet sampler + XPDUMP emitter (format
+  verified against dr-ablate). FINDING: volume alone does not age a session (fresh
+  accounts, concurrent load, 0 skipped keys, 0 failures); run-1 failures were stale
+  queued frames from account reuse, falsified by the fresh-account control. REMAINING:
+  importSession.ts to lift a real aged session from a browser (needs operator export).
+- 2026-07-27: follow-ups — canonical test users (BOT_A/BOT_B via .env, device-only
+  persistence, drain option) + #1 reset→recover regression test (non-overlap audited
+  vs existing unit tests). Next: spec #2 (spaces) around the "messages not landing in
+  spaces" issue.

--- a/.agents/tasks/2026-07-27-headless-space-harness.md
+++ b/.agents/tasks/2026-07-27-headless-space-harness.md
@@ -1,0 +1,148 @@
+---
+type: task
+title: "Headless SPACE harness — reproduce & measure desktop↔desktop space message delivery lag/loss"
+status: SPEC — not yet started. Review before building.
+created: 2026-07-27
+area: Spaces / mesh sync / triple ratchet / testing infrastructure
+builds_on: .agents/tasks/2026-07-27-headless-dm-harness.md (DM harness — slices 1-4 done; reuse its identity/transport/storage/bot machinery)
+related:
+  - "quorum-mobile/.agents/bugs/2026-07-20-mobile-desktop-message-transport-delay-loss-master.md (master; §0 space-receive fixes are MOBILE; desktop differs)"
+  - "quorum-mobile/.agents/bugs/2026-07-26-spaces-log-append-ack-ignored-silent-write-loss.md (MOBILE hub-log ack — desktop does NOT use hub-log; carries the open triple-ratchet late-join question)"
+  - ".agents/bugs/2026-01-09-config-sync-space-loss-race-condition.md"
+  - ".agents/bugs/2026-06-13-space-members-missing-no-join-row.md"
+  - ".agents/docs/data-management-architecture-guide.md (desktop sync architecture)"
+---
+
+# Headless SPACE harness (spec)
+
+## The problem this targets (operator's words)
+
+> "Sometimes user A posts a message in a space and user B, connected on a
+> different browser, doesn't see it. Or the message lands with a lag."
+
+Desktop↔desktop. Today this is **anecdotal** — nobody can trigger it on demand,
+so it has never been measured. The DM harness proved the approach; this extends
+it to spaces so we can **reproduce and measure** space delivery: post N messages
+from A, count how many reach B and how long each takes, unattended, repeatably.
+
+## Recon findings (established against the real code 2026-07-27)
+
+1. **Desktop does NOT use the mobile hub-log path.** The two mobile space bugs
+   above are about `log-append` / `log-append-ack` in `WebSocketContext.tsx` —
+   **zero occurrences in desktop `src`**. So the mobile send-loss root cause does
+   not transfer. Desktop's own space-send-loss is UNKNOWN and unmeasured.
+2. **Desktop spreads space messages by a hash-based delta mesh sync**
+   (`SyncService`, "new hash-based delta protocol"). B receives A's post only when
+   a sync reconciles them. Flow: `requestSync` (broadcast, on connect/periodic) →
+   `initiateSync` (pick a peer) → `handleSyncInitiateV2` (manifest) → delta
+   exchange (`directSync` / `synchronizeAll`) → `informSyncData`. The "hub"
+   (`sendHubMessage`) carries sync COORDINATION, not the messages.
+   → **Hypothesis to test first: the lag/loss is a sync-trigger/coverage gap** —
+   B doesn't sync promptly (or with the right peer) after A posts, so the message
+   is invisible until a reconnect/restart forces catch-up ("flush on restart").
+3. **Space membership uses a Triple Ratchet group session**, established via
+   `secureChannel.EstablishTripleRatchetSessionForSpace` (SpaceService.ts:350, :855).
+   Create/invite/join all exist as real methods:
+   `SpaceService.createSpace` (:128), `createChannel` (:1189),
+   `InvitationService.sendInviteToUser` (:150), `joinInviteLink` (:510).
+4. **Open crypto question inherited from the mobile report:** does the Triple
+   Ratchet have a late-join fork like the DM Double Ratchet? UNKNOWN. The harness
+   can eventually probe this the way `dr-*` probes the double ratchet.
+
+## The core challenge (this is the risk that sizes the build)
+
+For the DM harness, the ~17 space/sync `MessageServiceDependencies` were stubbed
+as no-ops. **For spaces they become load-bearing** and must be wired for real:
+`synchronizeAll`, `informSyncData`, `initiateSync`, `directSync`,
+`handleSyncInitiateV2`, `handleSyncManifest`, `sendHubMessage`, plus real
+`SpaceService` + `SyncService`. That is the bulk of the work.
+
+Second challenge: **a fresh harness device must become a functioning member** of
+a space (hold the Triple Ratchet session + manifest + member list). Two ways in:
+
+- **Path A — self-contained (RECOMMENDED FIRST).** The harness CREATES a fresh
+  test space (bot A), bot B joins via a real invite. Everything happens in-harness
+  with real methods; fully deterministic; no dependence on external state.
+- **Path B — the operator's real test space.** Bot loads user A's existing space
+  (A owns it, both are members, real users present). Higher fidelity, but a fresh
+  device must RESTORE the space's Triple Ratchet session — the hard part — and it
+  shares a live space with real people. Do this AFTER Path A works.
+
+## Slices (each ends in something observable; risky steps annotated)
+
+### Slice S0 — recon spike (do FIRST, before committing to the design)
+Drive `SpaceService.createSpace` + `createChannel` from one headless bot and
+confirm a space is created on the relay and reads back.
+- **Expected:** `getSpace(spaceId)` returns the manifest we just wrote.
+- **Most likely failure + signal:** create needs config/keyset wiring the DM deps
+  don't provide → throws in `submitUpdateSpace` or a missing dep. Countermove:
+  wire the minimum ConfigService/SpaceService deps.
+- **Assumption recon couldn't resolve:** whether create/join need anything
+  passkey-interactive. DM send did NOT (ed448 `js_sign_ed448`); assume spaces are
+  the same and VERIFY here. If they do → Path A blocked, reassess.
+- **Observable:** `yarn harness space-create` prints a live spaceId + channel.
+
+### Slice S1 — two bots in one space, B receives ONE post
+Bot A creates space + channel; bot B joins via `InvitationService` invite; both
+establish the Triple Ratchet session; A posts one message to the channel; B
+receives it via the real sync path.
+- **Expected:** B's captured messages include A's post.
+- **Most likely failure + signal:** B never syncs → B.captured stays empty though
+  A's post persisted on A. Signal: no `sync-initiate`/manifest traffic in B's log.
+  Countermove: confirm `requestSync` fires on B after join/connect; wire the sync
+  deps that were no-ops.
+- **Observable:** `yarn harness space-basic` → "B received A's post".
+- **This is the make-or-break slice.** If B can receive one synced post, the rest
+  is measurement.
+
+### Slice S2 — measure delivery rate + lag (the deliverable)
+A posts N messages to the channel; measure how many B receives and the lag of
+each (post time → B-persist time). Sample sync activity. Repeatable, unattended.
+- **Observable:** `yarn harness space-volume` → "B received 87/100, median lag 4s,
+  13 missing at T+2min". Merged both-sides JSONL log (reuse `log.ts`).
+- This is the number that turns the anecdote into a measured bug — and the
+  regression test once a fix lands.
+
+### Slice S3 — stress the sync-trigger hypothesis
+Vary the conditions the recon flagged: post while B is mid-sync; post then force a
+reconnect; multiple members; post bursts. Find the condition under which B does
+NOT get the message without a restart — the reproduction.
+- **Observable:** a named condition that reliably drops/lags a post, + its log.
+
+### Slice S4 (optional, later) — Path B: the operator's real test space
+Bot restores user A's existing space session and joins the live test space with
+real members. Higher fidelity; needs the Triple-Ratchet-session-restore work.
+
+## Reuse from the DM harness (already built)
+
+identity/transport/storage/env/canonical/log/xpdump/`ratchetStats` sampler all
+carry over unchanged. The bot gains a space-member mode and channel send/receive;
+`deps.ts` gains the real sync wiring (currently no-op). The jsdom + `ws` +
+fake-indexeddb + wasm-from-sibling + lingui-locale environment is unchanged.
+
+## Non-goals
+
+- Mobile (the hub-log bugs are mobile's; this is desktop↔desktop).
+- The UI. Protocol + service layer only.
+- Fixing the bug. This REPRODUCES and MEASURES it; the fix is a separate task
+  informed by what S2/S3 find.
+
+## Operator decisions (answered 2026-07-27)
+
+- **Creating throwaway spaces on production: approved** (same footprint as making a
+  test space in a browser).
+- **User A already owns a throwaway space.** The harness can DISCOVER it from A's
+  config (`getUserSettings` + `decryptUserConfig` with A's key) and reuse it —
+  avoids creating new spaces. BUT: a fresh harness device still has to establish
+  its space Triple Ratchet session from empty storage. For A (owner) that's
+  bootstrappable from the owner key; for B (member) restoring an EXISTING
+  membership on a fresh device WITHOUT re-joining is the hard, unknown part.
+  → Therefore **S0/S1 still start self-contained** (harness creates a space, B
+  joins via invite — both sessions established cleanly). **Reusing A's existing
+  throwaway space is the Path B refinement** (S4), which additionally exercises
+  fresh-device session-restore. Aim for reuse once the clean path works.
+- **Path B concrete target** (user A's existing throwaway space, provided 2026-07-27):
+  - spaceId: `QmbdLB6bAAdiparnE3iByhJcv5W3t3tDpx15BzCQdeG2z7`
+  - channelId: `QmYomM8EAeaCZJN8GFJjxTvKEfUDNErDdgtn2JjsKfjZpJ`
+  - A is the owner (its key is `BOT_A_PRIVATE_KEY` in .env.local). These are
+    addresses, not secrets. Use for S4 once S0-S1 prove session establishment.

--- a/.agents/tools/dm-debug/README.md
+++ b/.agents/tools/dm-debug/README.md
@@ -35,6 +35,7 @@ repo; set `SDK_DIR=` if yours is elsewhere.
 | `dr-replay.mjs` | Reassembles `[XPDUMP]` chunks from a log and re-runs the real failing decrypt. Reports whether the seal opened, whether the frame was init-wrapped, and whether the ratchet failed. Use to confirm a failure is genuine and reproducible rather than an app-level race. |
 | `dr-ablate.mjs` | **Finds what CAUSES a failure.** Re-runs the same decrypt while changing ONE property of the ratchet state at a time, so a load-bearing property announces itself by making the frame decrypt. |
 | `dr-advanced-start-fork.mjs` | Needs no log at all. Builds pristine sessions from one X3DH pair and drives a case matrix to reproduce the upstream crate's advanced-start fork in seconds. This is the runnable evidence behind item 1 of [quorum-mobile#183](https://github.com/QuilibriumNetwork/quorum-mobile/issues/183). |
+| `dr-position-table.mjs` | Needs no log. Builds **fresh** sessions and scores first-attempt failure by chain position across six delivery regimes. Result: 1920 frames, zero failures — which corroborates finding AC rather than contradicting anything, because a fresh session has no poisoning skipped-keys bucket. ⛔ Not evidence the crate is clean. Its real value is unrealised: it is the natural home for the synthetic session-ageing test named in archive §2i. |
 
 ```
 node .agents/tools/dm-debug/dr-replay.mjs <saved-console.log>

--- a/.agents/tools/dm-debug/dr-position-table.mjs
+++ b/.agents/tools/dm-debug/dr-position-table.mjs
@@ -1,0 +1,240 @@
+// ============================================================================
+// Does the MEASURED position-dependent DM decrypt failure reproduce OFFLINE?
+//
+// THE LIVE MEASUREMENT this script tries to reproduce (desktop<->desktop,
+// rig=9, archive findings T/U/V):
+//
+//     position in sending chain:   0       1       2      3+
+//     A->B first-attempt failure:  100%    86%     67%    0%
+//     B->A first-attempt failure:  100%    100%    60%    0%
+//
+//   ...and the failures are TRANSIENT — nearly all decrypt on redelivery.
+//
+// ANSWER (2026-07-27): NO. It does not reproduce. Six delivery regimes, 1920
+// frames across 20 independent runs: ZERO first-attempt failures at every
+// position.
+//
+// ⚠ AND THE REASON IS NOW KNOWN — finding AE, same day, via dr-ablate.mjs: the
+// failure needs a `skipped_keys_map` bucket under the receiver's CURRENT
+// receiving header key, which only accumulates in an AGED session. Every session
+// this script builds is FRESH, so it tests precisely the condition under which
+// the bug is known NOT to fire. The negative result is therefore CORROBORATION
+// of finding AC (a fresh session does not fail) from an independent synthetic
+// direction — not a puzzle.
+//
+// ⛔ DO NOT quote this as "the crate is clean". That is not what it measures.
+//
+// THE EXPERIMENT THIS SCRIPT IS NOW POSITIONED TO RUN — archive §2i names it as
+// the open test: synthetically AGE a session (drive it forward until the
+// skipped-keys map grows) and see whether failure rate tracks `skipped`
+// INDEPENDENTLY of elapsed time and epoch count. Captured evidence cannot
+// separate those confounds, because failures also create skipped keys. A
+// synthetic harness can, because it controls both. UNBUILT — see §2i.
+//
+// ONE POSITIVE FINDING, in a scenario that cannot occur in the app: if the
+// RESPONDER sends before it has ever received anything, its whole first burst
+// is permanently undecryptable — never recovers on any number of redeliveries.
+// That is fork-shaped, and adjacent to issue #183 item 1. The app cannot reach
+// this state (a responder learns the conversation exists by receiving), so it
+// is filed as a curiosity, not a cause. See scenario X below.
+//
+// Run:  node .agents/tools/dm-debug/dr-position-table.mjs
+// Needs the SDK repo as a sibling checkout; override with SDK_DIR=...
+// ============================================================================
+import { readFileSync } from 'node:fs';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+// .agents/tools/dm-debug -> repo -> the sibling SDK checkout, same as dr-ablate.
+const SDK_DIR =
+  process.env.SDK_DIR ??
+  resolve(dirname(fileURLToPath(import.meta.url)), '../../../../quilibrium-js-sdk-channels');
+const ch = await import(pathToFileURL(resolve(SDK_DIR, 'src/channel/channelwasm.js')).href);
+ch.initSync(readFileSync(resolve(SDK_DIR, 'src/wasm/channelwasm_bg.wasm')));
+
+const b64 = (s) => Buffer.from(s, 'base64');
+const bytes = (b) => [...new Uint8Array(b)];
+const sk = (v) => (typeof v === 'string' ? bytes(b64(v)) : v);
+
+function newPair() {
+  const aIdent = JSON.parse(ch.js_generate_x448());
+  const aEph = JSON.parse(ch.js_generate_x448());
+  const bIdent = JSON.parse(ch.js_generate_x448());
+  const bPre = JSON.parse(ch.js_generate_x448());
+  const A = sk(JSON.parse(ch.js_sender_x3dh(JSON.stringify({
+    sending_identity_private_key: aIdent.private_key,
+    sending_ephemeral_private_key: aEph.private_key,
+    receiving_identity_key: bIdent.public_key,
+    receiving_signed_pre_key: bPre.public_key, session_key_length: 96,
+  }))));
+  const B = sk(JSON.parse(ch.js_receiver_x3dh(JSON.stringify({
+    sending_identity_private_key: bIdent.private_key,
+    sending_signed_private_key: bPre.private_key,
+    receiving_identity_key: aIdent.public_key,
+    receiving_ephemeral_key: aEph.public_key, session_key_length: 96,
+  }))));
+  return {
+    alice: ch.js_new_double_ratchet(JSON.stringify({
+      session_key: A.slice(0, 32), sending_header_key: A.slice(32, 64),
+      next_receiving_header_key: A.slice(64, 96), is_sender: true,
+      sending_ephemeral_private_key: aEph.private_key, receiving_ephemeral_key: bPre.public_key,
+    })),
+    bob: ch.js_new_double_ratchet(JSON.stringify({
+      session_key: B.slice(0, 32), sending_header_key: B.slice(32, 64),
+      next_receiving_header_key: B.slice(64, 96), is_sender: false,
+      sending_ephemeral_private_key: bPre.private_key, receiving_ephemeral_key: aEph.public_key,
+    })),
+  };
+}
+
+// `current_sending_chain_length` BEFORE encrypt == the position this frame takes.
+// ⚠ Always pair position with the epoch (root_key) — sLen resets to 0 on every
+// DH step, so on its own it proves nothing (bug doc §3 row 7).
+const posOf = (s) => JSON.parse(s).current_sending_chain_length;
+const epochOf = (s) => String(JSON.parse(s).root_key).slice(0, 6);
+
+const enc = (state, text) => {
+  const pos = posOf(state), epoch = epochOf(state);
+  const r = JSON.parse(ch.js_double_ratchet_encrypt(JSON.stringify({
+    ratchet_state: state, message: bytes(Buffer.from(text, 'utf-8')),
+  })));
+  return [r.ratchet_state, { env: r.envelope, pos, epoch, text }];
+};
+
+// Signal spec: on failure the state mutation is DISCARDED. Mirrors the app
+// since PR #235 — never persist a failed decrypt's state.
+const dec = (state, envelope) => {
+  try {
+    const r = JSON.parse(ch.js_double_ratchet_decrypt(JSON.stringify({
+      ratchet_state: state, envelope,
+    })));
+    const msg = Buffer.from(new Uint8Array(r.message)).toString('utf-8');
+    if (msg.startsWith('Decryption failed') || msg.includes('aead')) return [state, false];
+    return [r.ratchet_state, true];
+  } catch { return [state, false]; }
+};
+
+// ---------------------------------------------------------------------------
+// crossing        — both sides encrypt before either decrypts (real concurrency)
+// burst           — frames per turn (a live post drags typing + delivery + read acks)
+// reorder         — shuffle delivery order within a turn
+// responderOpens  — let the RESPONDER send at round 1 before receiving anything.
+//                   IMPOSSIBLE in the app; included only to document scenario X.
+// ---------------------------------------------------------------------------
+function run({ rounds = 12, burst = 1, crossing = false, reorder = false, responderOpens = false }) {
+  let { alice, bob } = newPair();
+  const log = [];
+  const pending = { A: [], B: [] };
+  let recovered = 0;
+
+  const mk = (state, dir, r) => {
+    const kinds = ['post', 'typing-start', 'delivery-ack', 'read-ack'];
+    const out = [];
+    for (let i = 0; i < burst; i++) {
+      let f; [state, f] = enc(state, `${dir}-r${r}-${kinds[i % 4]}`);
+      f.dir = dir; out.push(f);
+    }
+    return [state, out];
+  };
+  const deliver = (state, frames, dir) => {
+    const failed = [];
+    for (const f of (reorder ? [...frames].reverse() : frames)) {
+      let ok; [state, ok] = dec(state, f.env);
+      f.firstOk = ok; log.push(f);
+      if (!ok) failed.push(f);
+    }
+    pending[dir].push(...failed);
+    return state;
+  };
+  const retry = (state, dir) => {
+    const still = [];
+    for (const f of pending[dir]) {
+      let ok; [state, ok] = dec(state, f.env);
+      if (ok) { recovered++; f.recovered = true; } else still.push(f);
+    }
+    pending[dir] = still;
+    return state;
+  };
+
+  for (let r = 1; r <= rounds; r++) {
+    // A responder cannot open a conversation. Round 1 is initiator-only unless
+    // we are deliberately testing scenario X.
+    const cross = crossing && (responderOpens || r > 1);
+    let aF, bF;
+    if (cross) {
+      [alice, aF] = mk(alice, 'A', r);
+      [bob, bF] = mk(bob, 'B', r);
+      bob = deliver(bob, aF, 'A');
+      alice = deliver(alice, bF, 'B');
+    } else {
+      [alice, aF] = mk(alice, 'A', r);
+      bob = deliver(bob, aF, 'A');
+      [bob, bF] = mk(bob, 'B', r);
+      alice = deliver(alice, bF, 'B');
+    }
+    bob = retry(bob, 'A'); alice = retry(alice, 'B');
+  }
+  for (let i = 0; i < 8; i++) { bob = retry(bob, 'A'); alice = retry(alice, 'B'); }
+
+  return { log, recovered, dead: pending.A.length + pending.B.length };
+}
+
+function table(log, dir) {
+  const b = new Map();
+  for (const f of log.filter((x) => x.dir === dir)) {
+    const k = f.pos >= 3 ? '3+' : String(f.pos);
+    const c = b.get(k) ?? { ok: 0, fail: 0 };
+    f.firstOk ? c.ok++ : c.fail++;
+    b.set(k, c);
+  }
+  return ['0', '1', '2', '3+'].map((k) => {
+    const c = b.get(k);
+    if (!c) return `${k}: —`.padEnd(14);
+    return `${k}: ${Math.round((c.fail / (c.ok + c.fail)) * 100)}% (${c.fail}/${c.ok + c.fail})`.padEnd(14);
+  }).join('');
+}
+
+console.log('First-attempt AEAD failure rate by position in the sender\'s DH chain.');
+console.log('This is the same quantity the live rig measured.\n');
+console.log('  LIVE TARGET   A->B   0: 100%   1: 86%    2: 67%   3+: 0%');
+console.log('                B->A   0: 100%   1: 100%   2: 60%   3+: 0%');
+console.log('='.repeat(74));
+
+for (const [name, cfg] of [
+  ['S1  strict alternation, 1 frame/turn', { burst: 1 }],
+  ['S2  strict alternation, 4-frame burst', { burst: 4 }],
+  ['S3  crossing sends, 1 frame/turn', { burst: 1, crossing: true }],
+  ['S4  crossing sends, 4-frame burst', { burst: 4, crossing: true }],
+  ['S5  crossing + reordered delivery', { burst: 4, crossing: true, reorder: true }],
+  ['S6  strict alternation + reordered', { burst: 4, reorder: true }],
+]) {
+  const { log, recovered, dead } = run({ rounds: 12, ...cfg });
+  const failed = log.filter((f) => !f.firstOk).length;
+  console.log(`\n${name}`);
+  console.log(`  A->B  ${table(log, 'A')}`);
+  console.log(`  B->A  ${table(log, 'B')}`);
+  console.log(`  ${log.length} frames, ${failed} first-attempt failures` +
+    (failed ? `, ${recovered} recovered, ${dead} permanently dead` : ''));
+}
+
+console.log('\n' + '='.repeat(74));
+console.log('REPEATABILITY — 20 independent runs of the most realistic regime (S4)');
+console.log('='.repeat(74));
+let frames = 0, dirty = 0, dead = 0;
+for (let i = 0; i < 20; i++) {
+  const r = run({ rounds: 12, burst: 4, crossing: true });
+  frames += r.log.length;
+  if (r.log.some((f) => !f.firstOk)) dirty++;
+  dead += r.dead;
+}
+console.log(`  ${frames} frames  |  runs with any failure: ${dirty}/20  |  permanently dead: ${dead}`);
+
+console.log('\n' + '='.repeat(74));
+console.log('SCENARIO X — responder sends before ever receiving (CANNOT happen in the app)');
+console.log('='.repeat(74));
+const x = run({ rounds: 10, burst: 4, crossing: true, responderOpens: true });
+const xf = x.log.filter((f) => !f.firstOk).length;
+console.log(`  ${x.log.length} frames, ${xf} first-attempt failures, ` +
+  `${x.recovered} recovered, ${x.dead} PERMANENTLY dead`);
+console.log('  Note the permanence: unlike the live desktop failures, these never');
+console.log('  recover. Fork-shaped, adjacent to issue #183 item 1.');

--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,10 @@ ios/
 # backup files
 *.bak
 
+# DM harness — real private keys / ratchet key material, keep local
+src/dev/tests/harness/.state/
+src/dev/tests/harness/logs/
+
 # custom
 .claude/settings.local.json
 .mcp.json

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "scan-docs": "node src/dev/docs/utils/scanMarkdownFiles.cjs",
     "test": "vitest",
     "test:run": "vitest --run",
+    "harness": "vitest --run --config vitest.harness.config.ts",
     "mobile": "cd mobile && expo start --dev-client",
     "mobile:clear": "cd mobile && expo start --dev-client --clear",
     "mobile:tunnel": "cd mobile && expo start --dev-client --tunnel",
@@ -97,6 +98,7 @@
     "@types/prismjs": "^1.26.5",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
+    "@types/ws": "^8.18.1",
     "@vitejs/plugin-react": "^5.2.0",
     "@vitest/ui": "^4.1.0",
     "autoprefixer": "^10.4.20",
@@ -121,7 +123,8 @@
     "vite": "^8.0.0",
     "vite-plugin-node-polyfills": "^0.26.0",
     "vite-plugin-static-copy": "^3.3.0",
-    "vitest": "^4.1.0"
+    "vitest": "^4.1.0",
+    "ws": "^8"
   },
   "resolutions": {
     "@quilibrium/quilibrium-js-sdk-channels": "^2.1.0-2"

--- a/src/dev/tests/harness/.env.example
+++ b/src/dev/tests/harness/.env.example
@@ -1,0 +1,15 @@
+# Headless DM harness config. Copy to `.env.local` (gitignored) and fill in.
+#
+# ⚠️ THROWAWAY ACCOUNTS ONLY. These are real ed448 account private keys. Never
+# put a real identity's key here, and never commit .env.local.
+#
+# Keys are OPTIONAL. With none set, the harness generates its own throwaway
+# accounts (all that slices 1-3 need). Set them only to drive existing test users.
+
+# 114-char ed448 private key hex (no 0x). Leave blank to auto-generate.
+BOT_A_PRIVATE_KEY=
+BOT_B_PRIVATE_KEY=
+
+# Relay endpoints. Defaults are production; override to point at a staging relay.
+QUORUM_API_URL=https://api.quorummessenger.com
+QUORUM_WS_URL=wss://api.quorummessenger.com/ws

--- a/src/dev/tests/harness/README.md
+++ b/src/dev/tests/harness/README.md
@@ -1,0 +1,134 @@
+# Headless DM harness
+
+Drive the **real** Quorum desktop client in Node — no browser, no UI — to debug
+DM transport. One process hosts both sides of a conversation, on one clock, at any
+volume, unattended. Output is a log the existing `dr-*` analyzers read directly.
+
+It is **not** a reimplementation of the protocol. It re-hosts the real client:
+the SDK wasm crypto core, `fake-indexeddb` for storage, Node's native `fetch` +
+`WebSocket` for transport, and the real `src/services/MessageService.ts` for
+logic. If a bug lives in the app, the harness hits it.
+
+> Replaces the two-browser manual rig (see
+> `.agents/bugs/2026-07-26-dm-desktop-to-desktop-resurfaced.md` §6) for everything
+> below the UI layer.
+
+## Quick start
+
+```bash
+# optional: only needed to drive your existing test users
+cp src/dev/tests/harness/.env.example src/dev/tests/harness/.env.local
+
+yarn harness ping        # slice 1: a bot registers, connects, subscribes
+yarn harness             # run every scenario
+```
+
+No `.env.local` is required — with no keys the harness generates its own throwaway
+accounts, which is all the transport scenarios need.
+
+## Canonical test users (your two accounts)
+
+Set these in `.env.local` (gitignored) to drive your two real test accounts:
+
+```
+BOT_A_PRIVATE_KEY=<114-char ed448 hex>   # user A — owner of test spaces + the shared space
+BOT_B_PRIVATE_KEY=<114-char ed448 hex>   # user B
+```
+
+Then in a scenario:
+
+```ts
+import { createCanonicalPair, createUserA, createUserB } from './canonical';
+const { a, b } = await createCanonicalPair();          // both, as your real users
+const { a, b } = await createCanonicalPair({ drain: true }); // clear queued frames first
+```
+
+**When to use the canonical pair vs throwaways:**
+
+| use the canonical pair | use throwaway `createBot('name')` |
+|---|---|
+| realistic state (real history, real sessions) | clean-slate baselines, deterministic mechanism tests |
+| **space work** — user A owns the test spaces + the shared space, so only these accounts can post/interact there | DM send/receive/reset mechanics where history is noise |
+| reproducing a "used for days, came back broken" condition | anything that must start from zero |
+
+Two things to know about the canonical pair:
+- **Stale-frame noise.** These accounts carry lots of history and queued frames;
+  reusing them in a DM test can surface stale-frame redelivery (the run-1 finding).
+  Pass `{ drain: true }` to clear each device inbox first, or prefer throwaways.
+- **Extra device.** The harness registers itself as a *new device* on the account
+  (merged with your real browser/mobile devices — it does not clobber them). Its
+  device keyset persists to `.state/user-a.json` / `user-b.json`. Your **account
+  private key is never written to `.state/`** — only the device keyset is; the
+  account key is re-derived from `.env.local` each run.
+
+## ⚠️ Safety
+
+- **Test accounts only** — throwaway bots, or dedicated test users like the two
+  above. Never put a personal identity's key in `.env.local`.
+- `.env.local`, `.state/`, and `logs/` are gitignored — they hold **real private
+  keys / ratchet key material**. Never commit them; keep logs local.
+- The harness talks to **production** (`api.quorummessenger.com`) by default, same
+  as the browser app. Runs create real registrations and real frames on the live
+  relay. Override `QUORUM_API_URL` / `QUORUM_WS_URL` to point elsewhere.
+- Each bot **persists its device keyset** to `.state/<name>.json` and reuses it, so
+  re-runs do not spawn new device registrations (which would feed the
+  device-registration ghost-accumulation problem).
+
+## Why it does NOT need the `diag/dm-frame-join` branch
+
+That branch smears probe logging (and real key material) into `MessageService`
+because a browser is a black box. The harness runs in-process with full access —
+it owns the transport and the DB — so it writes the `[XPDUMP]`-format records
+itself, from the outside, against clean `main`. Richer data (state on every frame,
+not just failures), no key material in service code. See the task file for detail.
+
+## Layout
+
+| file | role |
+|---|---|
+| `env.ts` | config + `.env.local` reader (throwaway keys optional) |
+| `identity.ts` | ed448 key → registered user + device keyset (generate or from-hex) |
+| `canonical.ts` | your two `.env` test users (createUserA/B, createCanonicalPair) |
+| `transport.ts` | REST client + WebSocket (`{type:'listen'}` subscribe) |
+| `bot.ts` | assembles the real MessageService + MessageDB + transport (send/receive/wipe/drain) |
+| `deps.ts` | MessageServiceDependencies wiring (real for DM, no-op for space/sync) |
+| `storage.ts` | MessageDB on fake-indexeddb |
+| `inspect.ts` | read ratchet state (skipped-keys count) out of a bot's MessageDB |
+| `xpdump.ts` | dr-ablate-format capture on decrypt failure |
+| `log.ts` | structured both-sides JSONL run log |
+| `*.scenario.test.ts` | runnable scenarios (this is what `yarn harness` runs) |
+| `.state/` | persisted device keysets (gitignored) |
+| `logs/` | structured run logs (gitignored) |
+
+Log analyzers stay in `.agents/tools/dm-debug/` (`dr-ablate`, `dr-replay`,
+`dr-position-table`) — the harness feeds them, it does not replace them.
+
+## Scenarios
+
+| command | what it does |
+|---|---|
+| `yarn harness smoke` | offline: crypto + identity pipeline (no relay) |
+| `yarn harness integration-check` | offline: MessageDB opens, MessageService imports |
+| `yarn harness ping` | a bot registers, connects, subscribes (hits prod) |
+| `yarn harness dm-receive` | waits for a DM you send from a browser, decrypts it |
+| `yarn harness dm-basic` | two bots exchange numbered DMs, no browser (HARNESS_ROUNDS) |
+| `yarn harness dm-volume` | concurrent bidirectional load; samples skipped-keys growth |
+| `yarn harness dm-reset-recover` | wipe a session mid-conversation, verify it re-inits and recovers |
+
+On any decrypt failure a bot writes `logs/<ts>-<bot>.xpdump.log` in `[XPDUMP]`
+format, so the existing offline analyzers run on it unchanged:
+
+```bash
+node .agents/tools/dm-debug/dr-ablate.mjs   logs/<ts>-<bot>.xpdump.log
+node .agents/tools/dm-debug/dr-replay.mjs   logs/<ts>-<bot>.xpdump.log
+```
+
+## Status
+
+- Slice 1 (identity + transport + register) — DONE, verified on prod.
+- Slice 2 (receive a real browser DM, decrypt headlessly) — DONE, verified on prod.
+- Slice 3 (two bots talk, no browser) — DONE, verified live. Replaces the two-browser loop.
+- Slice 4 (volume + XPDUMP capture) — DONE. Finding: volume alone does not age a
+  session. Remaining: importSession.ts (lift a real aged session from a browser).
+
+See `.agents/tasks/2026-07-27-headless-dm-harness.md` for the full slice plan.

--- a/src/dev/tests/harness/bot.ts
+++ b/src/dev/tests/harness/bot.ts
@@ -1,0 +1,181 @@
+// A full headless client: the real MessageService + MessageDB (fake-indexeddb) +
+// ActionQueueService + the ws transport + a registered identity, wired together
+// the way MessageDB.tsx wires them in the browser — minus React.
+//
+// Inbound frames from the socket are handed to the REAL
+// MessageService.handleNewMessage. Outbound is the REAL submitMessage → action
+// queue → sendDm → sendDirectMessages → enqueueOutbound → socket. Every message
+// the real code persists is captured by teeing messageDB.saveMessage (the single
+// seam every DM path funnels through), so a scenario observes exactly what the
+// real code produced — no reimplemented routing or crypto.
+import { QueryClient } from '@tanstack/react-query';
+import type { Message, UserRegistration } from '@quilibrium/quorum-shared';
+import { MessageService } from '../../../services/MessageService';
+import type { MessageServiceDependencies } from '../../../services/MessageService';
+import { ActionQueueService } from '../../../services/ActionQueueService';
+import { ActionQueueHandlers } from '../../../services/ActionQueueHandlers';
+import type { HandlerDependencies } from '../../../services/ActionQueueHandlers';
+import type { EncryptedMessage, MessageDB } from '../../../db/messages';
+import { makeMessageDB } from './storage';
+import { makeApiClient, WsTransport } from './transport';
+import { makeDeps, deleteInboxMessages } from './deps';
+import { XpdumpLog } from './xpdump';
+import { loadOrCreateBot, type Bot as Identity } from './identity';
+
+export interface HarnessBot {
+  identity: Identity;
+  transport: WsTransport;
+  messageService: MessageService;
+  /** The bot's live MessageDB — for reading ratchet state (see inspect.ts). */
+  messageDB: MessageDB;
+  /** Every message the real code persisted, in arrival order. */
+  captured: Message[];
+  /** handleNewMessage failures (e.g. DmDecryptError), for aging measurement. */
+  errors: { t: number; message: string; frame: unknown }[];
+  /** Fires as each message is persisted (received OR locally saved on send). */
+  onDecrypted?: (m: Message) => void;
+  /** Fires on a receive-path failure, with the frame that failed. */
+  onError?: (message: string, frame: unknown) => void;
+  /** Send a DM to another account address via the real submitMessage path. */
+  send(toAddress: string, text: string): Promise<void>;
+  /** Delete all local DM sessions — simulates a reset/wipe. Returns rows removed. */
+  wipeSessions(): Promise<number>;
+  /** Fetch + delete queued frames on the device inbox (clears stale-frame confound). */
+  drainInbox(): Promise<number>;
+  start(): Promise<void>;
+  stop(): void;
+}
+
+export async function createBot(
+  name: string,
+  opts: { privateKeyHex?: string } = {}
+): Promise<HarnessBot> {
+  const apiClient = makeApiClient();
+  const identity = await loadOrCreateBot(name, apiClient, opts);
+  const messageDB = await makeMessageDB();
+  const transport = new WsTransport();
+  const queryClient = new QueryClient();
+
+  const messageService = new MessageService(
+    makeDeps({ messageDB, apiClient, transport }) as unknown as MessageServiceDependencies
+  );
+  // Lazily created on the first decrypt failure (dr-ablate-format capture).
+  let xpdump: XpdumpLog | undefined;
+
+  // Listen on the device inbox + every current session inbox — mirrors the app's
+  // setResubscribe, so frames on newly-created session inboxes (e.g. after a
+  // reset/re-init) actually arrive.
+  const refreshSubscriptions = async () => {
+    const states = await messageDB.getAllEncryptionStates();
+    transport.listen([identity.inboxAddress, ...states.map((s) => s.inboxId)]);
+  };
+
+  // Action queue: the send path routes through it once a session is established.
+  // send-dm never touches configService/spaceService (only the space handlers do),
+  // so those are safely absent.
+  const actionQueueService = new ActionQueueService(messageDB);
+  actionQueueService.setUserKeyset(identity.keyset);
+  const handlers = new ActionQueueHandlers({
+    messageDB,
+    messageService,
+    queryClient,
+    getUserKeyset: () => actionQueueService.getUserKeyset(),
+  } as unknown as HandlerDependencies);
+  actionQueueService.setHandlers(handlers);
+  messageService.setActionQueueService(actionQueueService);
+  actionQueueService.start();
+
+  const bot: HarnessBot = {
+    identity,
+    transport,
+    messageService,
+    messageDB,
+    captured: [],
+    errors: [],
+    send: async (toAddress: string, text: string) => {
+      const self = (await apiClient.getUser(identity.address))?.data as UserRegistration;
+      const counterparty = (await apiClient.getUser(toAddress))?.data as UserRegistration;
+      if (!self || !counterparty) {
+        throw new Error(`missing registration (self=${!!self} counterparty=${!!counterparty})`);
+      }
+      const passkeyInfo = {
+        credentialId: '',
+        address: identity.address,
+        publicKey: Buffer.from(
+          new Uint8Array(identity.keyset.userKeyset.user_key.public_key)
+        ).toString('hex'),
+        completedOnboarding: true,
+      };
+      await messageService.submitMessage(
+        toAddress,
+        text,
+        self,
+        counterparty,
+        queryClient,
+        passkeyInfo,
+        identity.keyset
+      );
+      // A send may have created a new session inbox — subscribe to it.
+      await refreshSubscriptions();
+    },
+    wipeSessions: async () => {
+      const rows = await messageDB.getAllEncryptionStates();
+      for (const r of rows) await messageDB.deleteEncryptionState(r);
+      return rows.length;
+    },
+    drainInbox: async () => {
+      const res = await apiClient.getInbox(identity.inboxAddress);
+      const timestamps = (res?.data ?? []).map((m) => m.timestamp);
+      if (timestamps.length) {
+        await deleteInboxMessages(
+          identity.keyset.deviceKeyset.inbox_keyset,
+          timestamps,
+          apiClient
+        );
+      }
+      return timestamps.length;
+    },
+    start: async () => {
+      await transport.connect();
+      await refreshSubscriptions();
+    },
+    stop: () => {
+      actionQueueService.stop();
+      transport.close();
+    },
+  };
+
+  // Capture seam: tee saveMessage. Faithful — this is the real Message object the
+  // real code chose to persist (both received DMs and locally-saved sent DMs).
+  const origSave = messageDB.saveMessage.bind(messageDB);
+  (messageDB as unknown as { saveMessage: MessageDB['saveMessage'] }).saveMessage =
+    async (message: Message, ...rest: unknown[]) => {
+      bot.captured.push(message);
+      bot.onDecrypted?.(message);
+      return (origSave as (...a: unknown[]) => Promise<void>)(message, ...rest);
+    };
+
+  transport.onMessage(async (frame) => {
+    try {
+      await messageService.handleNewMessage(
+        identity.address,
+        identity.keyset,
+        frame as unknown as EncryptedMessage,
+        queryClient
+      );
+    } catch (err) {
+      const message = (err as Error)?.message ?? String(err);
+      bot.errors.push({ t: Date.now(), message, frame });
+      // Auto-capture the failing (state, frame) pair in dr-ablate format.
+      if (!xpdump) xpdump = new XpdumpLog(name, Date.now());
+      try {
+        await xpdump.capture(messageDB, frame as Record<string, unknown>, Date.now());
+      } catch { /* capture is best-effort */ }
+      bot.onError?.(message, frame);
+    }
+    // Processing a frame may have created a new session inbox — keep subscriptions current.
+    await refreshSubscriptions();
+  });
+
+  return bot;
+}

--- a/src/dev/tests/harness/canonical.ts
+++ b/src/dev/tests/harness/canonical.ts
@@ -1,0 +1,47 @@
+// The two canonical test users, loaded from BOT_A_PRIVATE_KEY / BOT_B_PRIVATE_KEY
+// in .env.local. These are the operator's REAL, history-rich test accounts
+// (owners of test spaces; both members of a shared space with real users, owned
+// by user A). Use them when a scenario needs realistic state — and above all for
+// space work, where user A's ownership matters.
+//
+// For clean-slate DM baselines prefer throwaway bots (createBot('name')) instead:
+// these accounts carry lots of history and queued frames, so reusing them in a DM
+// test can surface stale-frame redelivery noise (see the run-1 finding). Pass
+// { drain: true } to clear the device inbox first when you want a cleaner start.
+import { createBot, type HarnessBot } from './bot';
+import { config } from './env';
+
+export function hasCanonicalKeys(): boolean {
+  return Boolean(config.botKeys.A && config.botKeys.B);
+}
+
+/** user A — owner of the shared/general test space. Device persisted as user-a. */
+export function createUserA(): Promise<HarnessBot> {
+  if (!config.botKeys.A) throw new Error('BOT_A_PRIVATE_KEY not set in .env.local');
+  return createBot('user-a', { privateKeyHex: config.botKeys.A });
+}
+
+export function createUserB(): Promise<HarnessBot> {
+  if (!config.botKeys.B) throw new Error('BOT_B_PRIVATE_KEY not set in .env.local');
+  return createBot('user-b', { privateKeyHex: config.botKeys.B });
+}
+
+/**
+ * Both canonical users, started. `drain: true` clears each device inbox of queued
+ * frames first — use it when you want a cleaner start on these reused accounts.
+ */
+export async function createCanonicalPair(
+  opts: { drain?: boolean } = {}
+): Promise<{ a: HarnessBot; b: HarnessBot }> {
+  if (!hasCanonicalKeys()) {
+    throw new Error(
+      'Set BOT_A_PRIVATE_KEY and BOT_B_PRIVATE_KEY in src/dev/tests/harness/.env.local'
+    );
+  }
+  const [a, b] = await Promise.all([createUserA(), createUserB()]);
+  if (opts.drain) {
+    const [da, db] = await Promise.all([a.drainInbox(), b.drainInbox()]);
+    if (da || db) console.log(`[canonical] drained inbox: A=${da} B=${db} frame(s)`);
+  }
+  return { a, b };
+}

--- a/src/dev/tests/harness/deps.ts
+++ b/src/dev/tests/harness/deps.ts
@@ -1,0 +1,122 @@
+// The MessageServiceDependencies a bot needs. For DM traffic the space/sync
+// dependencies are never exercised, so they are loud no-ops (they log if a DM
+// path ever reaches them — a signal something unexpected happened). The few that
+// DM receive/send DO use are wired faithfully to the app's own implementations:
+//   - deleteInboxMessages: signs + POSTs /inbox/delete (copied from MessageDB.tsx)
+//   - deleteEncryptionStates: get + delete the conversation's rows via MessageDB
+//   - enqueueOutbound: run the action and push its frames to the socket
+//   - addOrUpdateConversation: persist the conversation row (the UI/query-cache
+//     half is irrelevant headlessly)
+import { channel, channel_raw } from '@quilibrium/quilibrium-js-sdk-channels';
+import { logger } from '@quilibrium/quorum-shared';
+import type { QueryClient } from '@tanstack/react-query';
+import type { MessageDB } from '../../../db/messages';
+import type { QuorumApiClient } from '../../../api/baseTypes';
+import type { WsTransport } from './transport';
+
+type Ref<T> = { current: T };
+
+/** Faithful copy of MessageDB.tsx deleteInboxMessages (signs the delete). */
+export async function deleteInboxMessages(
+  inboxKeyset: channel.InboxKeyset,
+  timestamps: number[],
+  apiClient: QuorumApiClient
+): Promise<void> {
+  const del = {
+    inbox_address: inboxKeyset.inbox_address,
+    timestamps,
+    inbox_public_key: Buffer.from(
+      new Uint8Array(inboxKeyset.inbox_key.public_key)
+    ).toString('hex'),
+    inbox_signature: Buffer.from(
+      JSON.parse(
+        channel_raw.js_sign_ed448(
+          Buffer.from(new Uint8Array(inboxKeyset.inbox_key.private_key)).toString('base64'),
+          Buffer.from(
+            inboxKeyset.inbox_address + timestamps.map((t) => `${t}`).join('')
+          ).toString('base64')
+        )
+      ) as string,
+      'base64'
+    ).toString('hex'),
+  } as channel.DeleteMessages;
+  await apiClient.deleteInbox(del);
+}
+
+export interface DepsInput {
+  messageDB: MessageDB;
+  apiClient: QuorumApiClient;
+  transport: WsTransport;
+}
+
+/** Build the dependency object MessageService's constructor expects. */
+export function makeDeps(input: DepsInput) {
+  const { messageDB, apiClient, transport } = input;
+
+  const noop = (label: string) => async (...args: unknown[]) => {
+    logger.warn(`[harness] unexpected DM dep call: ${label}`, { argc: args.length });
+  };
+
+  return {
+    messageDB,
+    apiClient,
+
+    // Run the outbound action and push each resulting frame to the socket, so
+    // delivery/read receipts and re-listens actually leave the bot.
+    enqueueOutbound: (action: () => Promise<string[]>) => {
+      void (async () => {
+        try {
+          const frames = await action();
+          for (const f of frames) transport.send(f);
+        } catch (err) {
+          logger.warn('[harness] enqueueOutbound action failed', { err });
+        }
+      })();
+    },
+
+    deleteInboxMessages,
+
+    deleteEncryptionStates: async ({ conversationId }: { conversationId: string }) => {
+      const rows = await messageDB.getEncryptionStates({ conversationId });
+      for (const r of rows) await messageDB.deleteEncryptionState(r);
+    },
+
+    addOrUpdateConversation: async (
+      _queryClient: QueryClient,
+      address: string,
+      timestamp: number,
+      _lastReadTimestamp: number,
+      updatedUserProfile?: Partial<channel.UserProfile>
+    ) => {
+      const conversationId = address + '/' + address;
+      try {
+        const existing = await messageDB.getConversation({ conversationId });
+        if (existing?.conversation) {
+          await messageDB.saveConversation({
+            ...existing.conversation,
+            displayName:
+              updatedUserProfile?.display_name ?? existing.conversation.displayName,
+            icon: updatedUserProfile?.user_icon ?? existing.conversation.icon,
+            timestamp: Math.max(timestamp, existing.conversation.timestamp),
+          });
+        }
+      } catch (err) {
+        logger.warn('[harness] addOrUpdateConversation persist failed', { err });
+      }
+    },
+
+    navigate: () => {},
+    spaceInfo: { current: {} } as Ref<Record<string, channel.SpaceRegistration>>,
+    syncInfo: { current: {} } as Ref<Record<string, unknown>>,
+
+    // Space/sync surface — not reached by DM traffic. Loud no-ops.
+    synchronizeAll: noop('synchronizeAll'),
+    informSyncData: noop('informSyncData'),
+    initiateSync: noop('initiateSync'),
+    directSync: noop('directSync'),
+    saveConfig: noop('saveConfig'),
+    sendHubMessage: (async () => '' ) as unknown as (spaceId: string, message: string) => Promise<string>,
+    handleSyncInitiateV2: noop('handleSyncInitiateV2'),
+    handleSyncManifest: noop('handleSyncManifest'),
+  };
+}

--- a/src/dev/tests/harness/dm-basic.scenario.test.ts
+++ b/src/dev/tests/harness/dm-basic.scenario.test.ts
@@ -1,0 +1,82 @@
+// SLICE 3 — two bots exchange numbered DMs, NO browser. The two-browser loop,
+// replaced: one process, both sides, one clock, a merged transcript.
+//
+//   yarn harness dm-basic
+//
+// Bot A and bot B are throwaway accounts (persisted + reused). A sends numbered
+// messages; B replies to each. Everything the real code decrypts on each side is
+// captured and written to a merged JSONL log under logs/.
+import { test, expect } from 'vitest';
+import { createBot } from './bot';
+import { RunLog } from './log';
+
+const ROUNDS = Number(process.env.HARNESS_ROUNDS ?? 5);
+const SETTLE_MS = Number(process.env.HARNESS_SETTLE_MS ?? 8000);
+
+function textOf(m: { content?: { type?: string; text?: string } }): string {
+  return m.content?.type === 'post' ? (m.content.text ?? '') : `<${m.content?.type}>`;
+}
+
+test(
+  'dm-basic: two bots exchange numbered DMs with no browser',
+  async () => {
+    const startedAt = Date.now();
+    const log = new RunLog('dm-basic', startedAt);
+
+    const [alice, bob] = await Promise.all([
+      createBot('alice-bot'),
+      createBot('bob-bot'),
+    ]);
+    log.add(Date.now(), 'harness', 'note', {
+      alice: alice.identity.address,
+      bob: bob.identity.address,
+    });
+
+    // Bob auto-replies to each post it receives.
+    let bobReplies = 0;
+    bob.onDecrypted = (m) => {
+      if (m.content?.type !== 'post') return;
+      const text = textOf(m);
+      if (text.startsWith('A→B')) {
+        log.add(Date.now(), 'bob', 'recv', { text });
+        const n = text.split('#')[1] ?? '?';
+        bobReplies += 1;
+        void bob.send(alice.identity.address, `B→A #${n}`).catch((e) =>
+          console.error('[dm-basic] bob reply failed:', (e as Error).message)
+        );
+      }
+    };
+
+    let aliceGotReplies = 0;
+    alice.onDecrypted = (m) => {
+      if (m.content?.type === 'post' && textOf(m).startsWith('B→A')) {
+        aliceGotReplies += 1;
+        log.add(Date.now(), 'alice', 'recv', { text: textOf(m) });
+      }
+    };
+
+    await Promise.all([alice.start(), bob.start()]);
+    console.log(`[dm-basic] alice=${alice.identity.address.slice(0, 12)} bob=${bob.identity.address.slice(0, 12)}`);
+
+    for (let i = 1; i <= ROUNDS; i++) {
+      log.add(Date.now(), 'alice', 'send', { text: `A→B #${i}` });
+      await alice.send(bob.identity.address, `A→B #${i}`);
+      await new Promise((r) => setTimeout(r, 1200));
+    }
+
+    // Let the last replies land.
+    await new Promise((r) => setTimeout(r, SETTLE_MS));
+
+    alice.stop();
+    bob.stop();
+
+    console.log(`[dm-basic] A→B sent=${ROUNDS}  B received=${bobReplies}  A got replies=${aliceGotReplies}`);
+    console.log(`[dm-basic] merged log: ${log.file}`);
+
+    // Proof of a real round trip: at least one A→B arrived at B and at least one
+    // B→A reply arrived back at A, all through the real send/receive code.
+    expect(bobReplies).toBeGreaterThan(0);
+    expect(aliceGotReplies).toBeGreaterThan(0);
+  },
+  180_000
+);

--- a/src/dev/tests/harness/dm-receive.scenario.test.ts
+++ b/src/dev/tests/harness/dm-receive.scenario.test.ts
@@ -1,0 +1,56 @@
+// SLICE 2 — one bot receives a REAL DM sent from your browser, decrypts it with
+// the real MessageService, and prints the plaintext.
+//
+//   yarn harness dm-receive
+//
+// What to do while it runs:
+//   1. It prints the bot's ACCOUNT address and then waits.
+//   2. In a browser signed into a throwaway test user, start a new DM to that
+//      account address and send a message.
+//   3. The bot decrypts it headlessly and prints the text.
+//
+// Wait window defaults to 120s; override with HARNESS_WAIT_MS. If nothing
+// arrives the test still passes (it can't force you to send) and logs that none
+// came — so it never blocks CI.
+import { test, expect } from 'vitest';
+import { createBot } from './bot';
+
+const WAIT_MS = Number(process.env.HARNESS_WAIT_MS ?? 120_000);
+
+test(
+  'dm-receive: a browser-sent DM decrypts headlessly',
+  async () => {
+    const bot = await createBot('recv-bot');
+    console.log('\n' + '='.repeat(64));
+    console.log(`  Send a DM from your browser to this account address:`);
+    console.log(`    ${bot.identity.address}`);
+    console.log(`  Waiting up to ${Math.round(WAIT_MS / 1000)}s ...`);
+    console.log('='.repeat(64) + '\n');
+
+    const firstMessage = new Promise<void>((resolve) => {
+      bot.onDecrypted = (m) => {
+        const text =
+          m.content?.type === 'post' ? m.content.text : `<${m.content?.type}>`;
+        const sender = m.content?.senderId ?? '(unknown)';
+        console.log(`[dm-receive] ✅ decrypted from ${sender.slice(0, 12)}: ${text}`);
+        resolve();
+      };
+    });
+
+    await bot.start();
+    console.log(`[dm-receive] listening on inbox ${bot.identity.inboxAddress.slice(0, 16)}…`);
+
+    const timeout = new Promise<void>((resolve) => setTimeout(resolve, WAIT_MS));
+    await Promise.race([firstMessage, timeout]);
+
+    bot.stop();
+
+    if (bot.captured.length === 0) {
+      console.log('[dm-receive] no message arrived in the wait window (nothing to assert).');
+    } else {
+      console.log(`[dm-receive] captured ${bot.captured.length} message(s) total.`);
+      expect(bot.captured.length).toBeGreaterThan(0);
+    }
+  },
+  WAIT_MS + 30_000
+);

--- a/src/dev/tests/harness/dm-reset-recover.scenario.test.ts
+++ b/src/dev/tests/harness/dm-reset-recover.scenario.test.ts
@@ -1,0 +1,74 @@
+// #1 — end-to-end reset → recover. The user-facing "works after a reset"
+// behavior, which NO unit test covers (the unit tests mock the SDK and check the
+// guard/selection LOGIC in isolation; this drives the real two-party init-envelope
+// path with real crypto).
+//
+// Non-overlap note: the offline ratchet lock and sent_accept plumbing are already
+// unit-tested (ActionQueueHandlers.unit.test.ts, sessionSelection.unit.test.ts),
+// and isStaleInitEnvelope has 18 pure-function cases. This test deliberately does
+// NOT re-assert any of that — it asserts the emergent behavior: after one side's
+// session is wiped, a fresh re-init recovers the conversation.
+//
+//   yarn harness dm-reset-recover
+import { test, expect } from 'vitest';
+import { createBot } from './bot';
+
+const SETTLE_MS = Number(process.env.HARNESS_SETTLE_MS ?? 6000);
+
+function isPost(m: { content?: { type?: string; text?: string } }, prefix: string): boolean {
+  return m.content?.type === 'post' && (m.content.text ?? '').startsWith(prefix);
+}
+
+test(
+  'dm-reset-recover: a wiped session re-initialises and the conversation recovers',
+  async () => {
+    // Throwaway bots: this tests the reset MECHANISM, so a clean slate is what we
+    // want (no history, no stale-frame noise).
+    const [alice, bob] = await Promise.all([
+      createBot('reset-alice'),
+      createBot('reset-bob'),
+    ]);
+
+    let bobGotBefore = false;
+    let bobGotAfter = false;
+    let aliceGotRecover = false;
+    bob.onDecrypted = (m) => {
+      if (isPost(m, 'before')) bobGotBefore = true;
+      if (isPost(m, 'after')) bobGotAfter = true;
+    };
+    alice.onDecrypted = (m) => {
+      if (isPost(m, 'recover')) aliceGotRecover = true;
+    };
+
+    await Promise.all([alice.start(), bob.start()]);
+
+    // 1. Establish + confirm normal delivery.
+    await alice.send(bob.identity.address, 'before-reset #1');
+    await new Promise((r) => setTimeout(r, SETTLE_MS));
+    expect(bobGotBefore).toBe(true);
+
+    // 2. Reset: wipe Bob's sessions (simulates a wipe/prune/reset).
+    const removed = await bob.wipeSessions();
+    console.log(`[dm-reset-recover] wiped ${removed} session row(s) on Bob`);
+
+    // 3. Recover: Bob re-initialises by sending to Alice (fresh init envelope).
+    await bob.send(alice.identity.address, 'recover-init #1');
+    await new Promise((r) => setTimeout(r, SETTLE_MS));
+    expect(aliceGotRecover).toBe(true);
+
+    // 4. Alice sends again — must now flow over the re-established session.
+    await alice.send(bob.identity.address, 'after-recovery #1');
+    await new Promise((r) => setTimeout(r, SETTLE_MS));
+
+    console.log(
+      `[dm-reset-recover] before=${bobGotBefore} recover=${aliceGotRecover} after=${bobGotAfter} bobErrors=${bob.errors.length}`
+    );
+
+    alice.stop();
+    bob.stop();
+
+    // The conversation recovered: post-reset traffic flows both ways again.
+    expect(bobGotAfter).toBe(true);
+  },
+  120_000
+);

--- a/src/dev/tests/harness/dm-volume.scenario.test.ts
+++ b/src/dev/tests/harness/dm-volume.scenario.test.ts
@@ -1,0 +1,92 @@
+// SLICE 4 — measure whether volume ages a DM session. The open question (§1 of
+// the resurfaced-DM bug): the skipped_keys_map grew 2 → 20 → 23 → 37 across a day
+// and the failure rate rose with it, but nobody has reproduced the aging
+// deliberately — and cause/effect are circular on captured evidence (failures
+// also create skipped keys).
+//
+// This drives CONCURRENT bidirectional load (both bots sending at once → frames
+// arrive out-of-order across DH steps → skipped keys accumulate) and samples the
+// skipped-keys count over the run. If it grows and failures appear, aging is
+// reproduced on the bench. If volume alone does nothing, that is itself the
+// answer: the trigger is time or cross-platform, not volume.
+//
+//   yarn harness dm-volume            # HARNESS_MESSAGES (default 60)
+import { test, expect } from 'vitest';
+import { createBot, type HarnessBot } from './bot';
+import { totalSkipped } from './inspect';
+import { RunLog } from './log';
+
+const MESSAGES = Number(process.env.HARNESS_MESSAGES ?? 60);
+const SAMPLE_EVERY = Number(process.env.HARNESS_SAMPLE_EVERY ?? 10);
+const GAP_MS = Number(process.env.HARNESS_GAP_MS ?? 60);
+const SETTLE_MS = Number(process.env.HARNESS_SETTLE_MS ?? 10000);
+
+test(
+  'dm-volume: skipped-keys growth under concurrent bidirectional load',
+  async () => {
+    const startedAt = Date.now();
+    const log = new RunLog('dm-volume', startedAt);
+
+    // Account names configurable so the same scenario can compare a fresh pair
+    // (clean history) against a reused pair (accumulated queued frames).
+    const [alice, bob] = await Promise.all([
+      createBot(process.env.HARNESS_A_NAME ?? 'vol-alice'),
+      createBot(process.env.HARNESS_B_NAME ?? 'vol-bob'),
+    ]);
+
+    let aRecv = 0;
+    let bRecv = 0;
+    alice.onDecrypted = (m) => { if (m.content?.type === 'post') aRecv += 1; };
+    bob.onDecrypted = (m) => { if (m.content?.type === 'post') bRecv += 1; };
+
+    await Promise.all([alice.start(), bob.start()]);
+
+    // Establish sessions both ways before the load.
+    await alice.send(bob.identity.address, 'A→B init');
+    await new Promise((r) => setTimeout(r, 2500));
+    await bob.send(alice.identity.address, 'B→A init');
+    await new Promise((r) => setTimeout(r, 2500));
+
+    const sample = async (label: string) => {
+      const aSkip = await totalSkipped(alice.messageDB);
+      const bSkip = await totalSkipped(bob.messageDB);
+      const row = {
+        label,
+        aSkip,
+        bSkip,
+        aErr: alice.errors.length,
+        bErr: bob.errors.length,
+      };
+      log.add(Date.now(), 'harness', 'sample', row);
+      console.log(
+        `[dm-volume] ${label.padEnd(10)} aSkip=${aSkip} bSkip=${bSkip} aErr=${alice.errors.length} bErr=${bob.errors.length}`
+      );
+    };
+    await sample('after-init');
+
+    for (let i = 1; i <= MESSAGES; i++) {
+      // Both directions at once — the out-of-order generator.
+      await Promise.all([
+        alice.send(bob.identity.address, `A→B #${i}`).catch(() => {}),
+        bob.send(alice.identity.address, `B→A #${i}`).catch(() => {}),
+      ]);
+      await new Promise((r) => setTimeout(r, GAP_MS));
+      if (i % SAMPLE_EVERY === 0) await sample(`msg-${i}`);
+    }
+
+    await new Promise((r) => setTimeout(r, SETTLE_MS));
+    await sample('final');
+
+    console.log(
+      `[dm-volume] receives A=${aRecv} B=${bRecv}  failures A=${alice.errors.length} B=${bob.errors.length}`
+    );
+    console.log(`[dm-volume] log: ${log.file}`);
+
+    alice.stop();
+    bob.stop();
+
+    // The run itself is the measurement; assert only that traffic flowed.
+    expect(aRecv + bRecv).toBeGreaterThan(0);
+  },
+  10 * 60 * 1000
+);

--- a/src/dev/tests/harness/env.ts
+++ b/src/dev/tests/harness/env.ts
@@ -1,0 +1,60 @@
+// Harness configuration. Reads src/dev/tests/harness/.env.local at runtime if
+// present (a tiny dotenv parser — no new dependency). Keys are OPTIONAL: with no
+// .env.local the harness generates its own throwaway accounts, which is all
+// slices 1-3 need. Provide BOT_*_PRIVATE_KEY only to drive your existing test
+// users.
+//
+// SAFETY: throwaway accounts only. .env.local is gitignored and must never be
+// committed. This file only ever READS the values into config — it never logs
+// or prints a private key.
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+function parseDotenv(path: string): Record<string, string> {
+  let text: string;
+  try {
+    text = readFileSync(path, 'utf-8');
+  } catch {
+    return {};
+  }
+  const out: Record<string, string> = {};
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq === -1) continue;
+    const key = trimmed.slice(0, eq).trim();
+    let val = trimmed.slice(eq + 1).trim();
+    if (
+      (val.startsWith('"') && val.endsWith('"')) ||
+      (val.startsWith("'") && val.endsWith("'"))
+    ) {
+      val = val.slice(1, -1);
+    }
+    if (key) out[key] = val;
+  }
+  return out;
+}
+
+// process.env wins over the file so CI / one-off overrides work.
+const fromFile = parseDotenv(resolve(HERE, '.env.local'));
+const get = (k: string, fallback = '') =>
+  process.env[k] ?? fromFile[k] ?? fallback;
+
+export const config = {
+  apiUrl: get('QUORUM_API_URL', 'https://api.quorummessenger.com'),
+  wsUrl: get('QUORUM_WS_URL', 'wss://api.quorummessenger.com/ws'),
+  // Optional per-bot account keys (114-char ed448 hex). Empty => generate.
+  botKeys: {
+    A: get('BOT_A_PRIVATE_KEY'),
+    B: get('BOT_B_PRIVATE_KEY'),
+  } as Record<string, string>,
+  // Where persisted device keysets and logs live (both gitignored).
+  stateDir: resolve(HERE, '.state'),
+  logsDir: resolve(HERE, 'logs'),
+};
+
+export type HarnessConfig = typeof config;

--- a/src/dev/tests/harness/identity.ts
+++ b/src/dev/tests/harness/identity.ts
@@ -1,0 +1,165 @@
+// Bot identity: turn an ed448 account key into a full, registered Quorum client
+// identity — the same construction the app performs in RegistrationPersister,
+// minus the passkey/WebAuthn storage layer (which cannot cross into node).
+//
+// Two paths:
+//   - generate: mint a fresh throwaway ed448 account (slices 1-3 default)
+//   - fromHex : load one of your existing test users from its 114-char key
+//
+// Either way the device keyset is PERSISTED to .state/<name>.json and reused, so
+// repeated runs do NOT spawn a new device registration each time (that would
+// feed the device-registration ghost-accumulation problem). Persisted state
+// contains REAL private keys — .state/ is gitignored.
+import { channel, channel_raw } from '@quilibrium/quilibrium-js-sdk-channels';
+import { sha256 } from 'multiformats/hashes/sha2';
+import { base58btc } from 'multiformats/bases/base58';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { QuorumApiClient } from '../../../api/baseTypes';
+import { config } from './env';
+
+export interface BotKeyset {
+  userKeyset: channel.UserKeyset;
+  deviceKeyset: channel.DeviceKeyset;
+}
+
+/**
+ * Persisted shape. For a bot loaded from a .env private key (your real test
+ * users), the userKeyset is OMITTED — we never write a second copy of your
+ * account private key to disk; it is re-derived from the env hex each run. Only
+ * generated throwaway bots persist their full keyset.
+ */
+interface StoredKeyset {
+  userKeyset?: channel.UserKeyset;
+  deviceKeyset: channel.DeviceKeyset;
+}
+
+export interface Bot {
+  name: string;
+  /** base58btc(sha256(user_key.public_key)) — the account address. */
+  address: string;
+  /** This device's inbox address; where DMs to this device land. */
+  inboxAddress: string;
+  keyset: BotKeyset;
+}
+
+/** js_generate_ed448 returns {private_key, public_key} with no type — add it. */
+function withEd448Type(rawJson: string): channel.Ed448Keypair {
+  const kp = JSON.parse(rawJson) as { private_key: number[]; public_key: number[] };
+  return { type: 'ed448', private_key: kp.private_key, public_key: kp.public_key };
+}
+
+/** Account address = base58btc(sha256(user_key.public_key)), per ConstructUserRegistration. */
+async function deriveAddress(userKeyset: channel.UserKeyset): Promise<string> {
+  const digest = await sha256.digest(
+    Buffer.from(new Uint8Array(userKeyset.user_key.public_key))
+  );
+  return base58btc.baseEncode(digest.bytes);
+}
+
+function statePath(name: string): string {
+  return resolve(config.stateDir, `${name}.json`);
+}
+
+function loadState(name: string): StoredKeyset | undefined {
+  const path = statePath(name);
+  if (!existsSync(path)) return undefined;
+  return JSON.parse(readFileSync(path, 'utf-8')) as StoredKeyset;
+}
+
+function saveState(name: string, stored: StoredKeyset): void {
+  mkdirSync(config.stateDir, { recursive: true });
+  writeFileSync(statePath(name), JSON.stringify(stored, null, 2), 'utf-8');
+}
+
+/**
+ * Build a UserKeyset from a bare 114-char ed448 private key hex. Public-key
+ * derivation mirrors the SDK's own key-import path (usePasskeyFlow): feed the
+ * private key as base64, read the public key back as base64.
+ */
+function userKeysetFromHex(privateKeyHex: string): channel.UserKeyset {
+  const keyHex = privateKeyHex.trim().toLowerCase();
+  if (keyHex.length !== 114) {
+    throw new Error(
+      `Expected a 114-char ed448 private key hex, got ${keyHex.length} chars`
+    );
+  }
+  const pubB64 = channel_raw.js_get_pubkey_ed448(
+    Buffer.from(keyHex, 'hex').toString('base64')
+  );
+  return channel.NewUserKeyset({
+    type: 'ed448',
+    private_key: [...new Uint8Array(Buffer.from(keyHex, 'hex'))],
+    public_key: [...new Uint8Array(Buffer.from(pubB64, 'base64'))],
+  });
+}
+
+/**
+ * Load a bot's identity from persisted state, or create + register it.
+ *
+ * @param name  stable label; picks the .state/<name>.json file and reuses the device
+ * @param opts.privateKeyHex  optional — load an existing account instead of generating
+ */
+export async function loadOrCreateBot(
+  name: string,
+  apiClient: QuorumApiClient,
+  opts: { privateKeyHex?: string } = {}
+): Promise<Bot> {
+  const saved = loadState(name);
+  if (saved) {
+    // Env-key bots persist device-only; re-derive the account keyset from the
+    // env hex each run so the account private key is never copied to .state/.
+    const userKeyset = opts.privateKeyHex
+      ? userKeysetFromHex(opts.privateKeyHex)
+      : saved.userKeyset;
+    if (!userKeyset) {
+      throw new Error(
+        `state/${name}.json has no userKeyset and no privateKeyHex was given — ` +
+          `set BOT_?_PRIVATE_KEY in .env.local or delete the state file`
+      );
+    }
+    const address = await deriveAddress(userKeyset);
+    return {
+      name,
+      address,
+      inboxAddress: saved.deviceKeyset.inbox_keyset.inbox_address,
+      keyset: { userKeyset, deviceKeyset: saved.deviceKeyset },
+    };
+  }
+
+  // Mint the account key (or load the provided one) and a fresh device.
+  // js_generate_ed448 returns {private_key, public_key} with no `type`; the app
+  // supplies it explicitly (RegistrationPersister), so do the same.
+  const userKeyset = opts.privateKeyHex
+    ? userKeysetFromHex(opts.privateKeyHex)
+    : channel.NewUserKeyset(withEd448Type(channel_raw.js_generate_ed448()));
+  const deviceKeyset = await channel.NewDeviceKeyset();
+  const address = await deriveAddress(userKeyset);
+
+  // Merge our new device with any devices already registered on this account
+  // (relevant when loading an existing test user), then publish the registration.
+  let existingDevices: channel.DeviceRegistration[] = [];
+  try {
+    const existing = (await apiClient.getUser(address))?.data;
+    existingDevices = existing?.device_registrations ?? [];
+  } catch {
+    /* first registration for this account */
+  }
+  const registration = await channel.ConstructUserRegistration(
+    userKeyset,
+    existingDevices,
+    [deviceKeyset]
+  );
+  await apiClient.postUser(address, registration);
+
+  // Persist device-only for env-key bots (never a second copy of your account
+  // private key); full keyset for generated throwaways (which have no other home).
+  saveState(name, opts.privateKeyHex ? { deviceKeyset } : { userKeyset, deviceKeyset });
+
+  return {
+    name,
+    address,
+    inboxAddress: deviceKeyset.inbox_keyset.inbox_address,
+    keyset: { userKeyset, deviceKeyset },
+  };
+}

--- a/src/dev/tests/harness/inspect.ts
+++ b/src/dev/tests/harness/inspect.ts
@@ -1,0 +1,67 @@
+// Read the live ratchet state out of a bot's MessageDB and summarise the numbers
+// the DM investigation cares about — above all the accumulated skipped-keys count
+// (§1: "grew 2 → 20 → 23 → 37 across the day, failure rate rising with it").
+//
+// EncryptionState.state is a JSON string of { ratchet_state: "<json string>", ... },
+// so ratchet_state is double-encoded — same shape dr-ablate parses.
+import type { MessageDB } from '../../../db/messages';
+
+export interface RatchetStat {
+  conv: string;
+  inbox: string;
+  /** current_sending_chain_length — resets to 0 on every DH step, read with root. */
+  sLen: number;
+  rLen: number;
+  /** previous_sending_chain_length. */
+  pS: number;
+  /** total keys across all skipped_keys_map buckets. */
+  skipped: number;
+  /** number of buckets (distinct header keys holding skipped keys). */
+  buckets: number;
+}
+
+/** Count keys across the nested skipped_keys_map ({ headerKey: { idx: key } }). */
+function countSkipped(map: Record<string, Record<string, unknown>> | undefined): {
+  keys: number;
+  buckets: number;
+} {
+  const m = map ?? {};
+  const buckets = Object.keys(m).length;
+  const keys = Object.values(m).reduce(
+    (a, bucket) => a + Object.keys(bucket ?? {}).length,
+    0
+  );
+  return { keys, buckets };
+}
+
+export async function ratchetStats(db: MessageDB): Promise<RatchetStat[]> {
+  const rows = await db.getAllEncryptionStates();
+  const out: RatchetStat[] = [];
+  for (const row of rows) {
+    let rs: Record<string, unknown>;
+    try {
+      rs = JSON.parse(JSON.parse(row.state).ratchet_state);
+    } catch {
+      continue;
+    }
+    const { keys, buckets } = countSkipped(
+      rs.skipped_keys_map as Record<string, Record<string, unknown>> | undefined
+    );
+    out.push({
+      conv: row.conversationId.slice(0, 12),
+      inbox: row.inboxId.slice(0, 10),
+      sLen: Number(rs.current_sending_chain_length ?? 0),
+      rLen: Number(rs.current_receiving_chain_length ?? 0),
+      pS: Number(rs.previous_sending_chain_length ?? 0),
+      skipped: keys,
+      buckets,
+    });
+  }
+  return out;
+}
+
+/** Total skipped keys across all of a bot's sessions — the headline aging metric. */
+export async function totalSkipped(db: MessageDB): Promise<number> {
+  const stats = await ratchetStats(db);
+  return stats.reduce((a, s) => a + s.skipped, 0);
+}

--- a/src/dev/tests/harness/integration-check.scenario.test.ts
+++ b/src/dev/tests/harness/integration-check.scenario.test.ts
@@ -1,0 +1,18 @@
+// Integration sanity check (no network) — the harness's load-bearing seams:
+// MessageDB opens on fake-indexeddb, and the full MessageService import graph
+// loads under the jsdom+lingui pipeline. Fast, CI-safe; hits no relay.
+import { test, expect } from 'vitest';
+import { makeMessageDB } from './storage';
+import { MessageService } from '../../../services/MessageService';
+
+test('probe: MessageDB opens on fake-indexeddb', async () => {
+  const db = await makeMessageDB();
+  const states = await db.getAllEncryptionStates();
+  expect(Array.isArray(states)).toBe(true);
+  console.log(`[probe] MessageDB opened; ${states.length} encryption states`);
+});
+
+test('probe: MessageService import graph loads under node', () => {
+  expect(typeof MessageService).toBe('function');
+  console.log('[probe] MessageService imported OK');
+});

--- a/src/dev/tests/harness/log.ts
+++ b/src/dev/tests/harness/log.ts
@@ -1,0 +1,42 @@
+// Structured, both-sides, one-clock run log. Writes newline-delimited JSON to
+// logs/<timestamp>-<scenario>.jsonl. This is the artifact the manual rig could
+// never produce cleanly: a single ordered transcript of both participants, with
+// no console-save skew and no 5k-char truncation.
+//
+// ⚠️ Entries can embed real message content and (in later slices) key material.
+// logs/ is gitignored; keep logs local.
+import { mkdirSync, writeFileSync, appendFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { config } from './env';
+
+export interface LogEntry {
+  t: number; // ms since run start (one clock for all bots)
+  bot: string; // which bot emitted this
+  kind: string; // 'send' | 'recv' | 'note' | ...
+  [k: string]: unknown;
+}
+
+export class RunLog {
+  private readonly path: string;
+  private readonly start: number;
+  readonly entries: LogEntry[] = [];
+
+  constructor(scenario: string, startEpochMs: number) {
+    this.start = startEpochMs;
+    mkdirSync(config.logsDir, { recursive: true });
+    const stamp = new Date(startEpochMs).toISOString().replace(/[:.]/g, '-');
+    this.path = resolve(config.logsDir, `${stamp}-${scenario}.jsonl`);
+    writeFileSync(this.path, '', 'utf-8');
+  }
+
+  /** Append one entry. `nowMs` is passed in (scripts avoid Date.now internally). */
+  add(nowMs: number, bot: string, kind: string, fields: Record<string, unknown> = {}): void {
+    const entry: LogEntry = { t: nowMs - this.start, bot, kind, ...fields };
+    this.entries.push(entry);
+    appendFileSync(this.path, JSON.stringify(entry) + '\n', 'utf-8');
+  }
+
+  get file(): string {
+    return this.path;
+  }
+}

--- a/src/dev/tests/harness/ping.scenario.test.ts
+++ b/src/dev/tests/harness/ping.scenario.test.ts
@@ -1,0 +1,49 @@
+// SLICE 1 — the smallest proof the stack is real: a bot mints (or loads) a
+// throwaway account, registers it on the relay, opens the live WebSocket, and
+// subscribes to its own inbox.
+//
+// Observable outcome: the console prints the bot's address + inbox address and
+// "connected & listening". A real registration now exists on the relay; re-runs
+// reuse the persisted device (no new registration).
+//
+//   yarn harness ping
+//
+// NOTE: this performs a REAL registration against config.apiUrl (production by
+// default). Throwaway accounts only.
+import { test, expect } from 'vitest';
+import { loadOrCreateBot } from './identity';
+import { makeApiClient, WsTransport } from './transport';
+import { config } from './env';
+
+test('ping: a bot registers, connects, and subscribes to its inbox', async () => {
+  const api = makeApiClient();
+
+  const bot = await loadOrCreateBot('ping-bot', api);
+  console.log(`[ping] account address : ${bot.address}`);
+  console.log(`[ping] inbox address   : ${bot.inboxAddress}`);
+  expect(bot.address.length).toBeGreaterThan(0);
+  expect(bot.inboxAddress.length).toBeGreaterThan(0);
+
+  // Prove the registration is really on the relay.
+  const registered = (await api.getUser(bot.address))?.data;
+  expect(registered?.device_registrations?.length ?? 0).toBeGreaterThan(0);
+  console.log(
+    `[ping] relay confirms ${registered?.device_registrations?.length} device(s) registered`
+  );
+
+  const ws = new WsTransport(config.wsUrl);
+  let received = 0;
+  ws.onMessage(() => {
+    received += 1;
+  });
+  await ws.connect();
+  ws.listen([bot.inboxAddress]);
+  console.log(`[ping] connected & listening on ${config.wsUrl}`);
+  expect(ws.connected).toBe(true);
+
+  // Hold the socket briefly so a manual browser-sent DM (slice 2) could land.
+  await new Promise((r) => setTimeout(r, 2000));
+  console.log(`[ping] frames received while listening: ${received}`);
+
+  ws.close();
+});

--- a/src/dev/tests/harness/setup.harness.ts
+++ b/src/dev/tests/harness/setup.harness.ts
@@ -1,0 +1,36 @@
+// Harness setup — shims + wasm init. NO mocks (that is the unit-test setup.ts,
+// which mocks WebSocket/crypto and is exactly what the harness must avoid).
+//
+// Order matters: the shim must apply before the SDK bundle evaluates, so it is a
+// separate side-effect module imported first.
+import './shim';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { i18n } from '@lingui/core';
+import { channel_raw } from '@quilibrium/quilibrium-js-sdk-channels';
+
+// The service layer calls lingui `t` macros; without an active locale they throw
+// ("Attempted to call a translation function without setting a locale"). The
+// harness doesn't need real translations — an empty 'en' catalog makes `t`
+// return the source string.
+i18n.load('en', {});
+i18n.activate('en');
+
+// NOTE on WebSocket: the harness environment is jsdom (needed for the DOM the
+// shared UI barrel touches at import). jsdom's built-in WebSocket does not
+// connect to a real relay, and node's undici WebSocket hangs under jsdom, so the
+// transport imports the `ws` package explicitly rather than using a global.
+
+// The published npm package ships no .wasm; the app resolves it from the sibling
+// SDK source repo via viteStaticCopy (web/vite.config.ts). Mirror that convention.
+// Override with SDK_WASM if the sibling repo lives elsewhere.
+const wasmPath =
+  process.env.SDK_WASM ??
+  resolve(
+    process.cwd(),
+    '../quilibrium-js-sdk-channels/src/wasm/channelwasm_bg.wasm'
+  );
+
+// Initialise the PACKAGE's wasm binding. channel_raw and the high-level `channel`
+// API are one bundle sharing a single `wasm` var, so this inits both.
+channel_raw.initSync(readFileSync(wasmPath));

--- a/src/dev/tests/harness/shim.ts
+++ b/src/dev/tests/harness/shim.ts
@@ -1,0 +1,26 @@
+// Browser-surface shim. Side-effect only. MUST be imported before the SDK, whose
+// browser bundle assigns `window.Buffer` at module-eval time, and before the
+// app's config, which reads `window.location`. Kept in its own file so it is
+// evaluated ahead of any SDK import (ESM evaluates imported modules in order).
+//
+// This is NOT jsdom and NOT a mock — just the minimum browser globals so a
+// browser bundle can load under a real node environment (which keeps node's real
+// WebSocket + webcrypto, both of which the harness needs).
+import { Buffer as NodeBuffer } from 'node:buffer';
+
+const g = globalThis as unknown as {
+  window?: unknown;
+  Buffer?: unknown;
+  crypto?: unknown;
+};
+
+if (!g.window) g.window = g;
+const w = g.window as { location?: unknown; Buffer?: unknown; crypto?: unknown };
+// Concrete origin so config.quorum's getConfig() never throws. Its value is
+// unused — the harness passes explicit prod URLs to the API client and transport.
+if (!w.location) w.location = { origin: 'http://localhost' };
+if (!g.Buffer) g.Buffer = NodeBuffer;
+if (!w.Buffer) w.Buffer = NodeBuffer;
+// Node 22 provides globalThis.crypto (webcrypto); mirror onto window for the
+// SDK's window.crypto.subtle paths.
+if (g.crypto && !w.crypto) w.crypto = g.crypto;

--- a/src/dev/tests/harness/smoke.scenario.test.ts
+++ b/src/dev/tests/harness/smoke.scenario.test.ts
@@ -1,0 +1,50 @@
+// Offline sanity check — verifies the crypto/identity pipeline loads and runs
+// under the node vitest config with ZERO network effect (wasm init, key
+// generation, registration construction, address derivation, pubkey round-trip).
+// Safe to run in CI; hits no relay.
+import { test, expect } from 'vitest';
+import { channel, channel_raw } from '@quilibrium/quilibrium-js-sdk-channels';
+import { sha256 } from 'multiformats/hashes/sha2';
+import { base58btc } from 'multiformats/bases/base58';
+
+test('smoke: SDK wasm + identity construction works headlessly (no network)', async () => {
+  // wasm inited in setup → generate a fresh ed448 account key. The generator
+  // returns {private_key, public_key} with no `type`; the app adds it.
+  const kp = JSON.parse(channel_raw.js_generate_ed448()) as {
+    private_key: number[];
+    public_key: number[];
+  };
+  expect(kp.public_key.length).toBeGreaterThan(0);
+  const userKey: channel.Ed448Keypair = {
+    type: 'ed448',
+    private_key: kp.private_key,
+    public_key: kp.public_key,
+  };
+
+  const userKeyset = channel.NewUserKeyset(userKey);
+  const deviceKeyset = await channel.NewDeviceKeyset();
+  expect(deviceKeyset.inbox_keyset.inbox_address.length).toBeGreaterThan(0);
+
+  const registration = await channel.ConstructUserRegistration(userKeyset, [], [
+    deviceKeyset,
+  ]);
+  expect(registration.device_registrations.length).toBe(1);
+  expect(registration.signature.length).toBeGreaterThan(0);
+
+  // Address derivation matches ConstructUserRegistration's user_address.
+  const digest = await sha256.digest(
+    Buffer.from(new Uint8Array(userKeyset.user_key.public_key))
+  );
+  const address = base58btc.baseEncode(digest.bytes);
+  expect(address).toBe(registration.user_address);
+
+  // Public-key-from-private derivation (the from-hex path) round-trips.
+  const privHex = Buffer.from(new Uint8Array(userKey.private_key)).toString('hex');
+  const pubB64 = channel_raw.js_get_pubkey_ed448(
+    Buffer.from(privHex, 'hex').toString('base64')
+  );
+  const derivedPub = [...new Uint8Array(Buffer.from(pubB64, 'base64'))];
+  expect(derivedPub).toEqual(userKey.public_key);
+
+  console.log(`[smoke] ok — address ${address}, inbox ${deviceKeyset.inbox_keyset.inbox_address}`);
+});

--- a/src/dev/tests/harness/storage.ts
+++ b/src/dev/tests/harness/storage.ts
@@ -1,0 +1,12 @@
+// Storage: the real MessageDB backed by fake-indexeddb. fake-indexeddb/auto
+// installs indexedDB + IDBKeyRange as globals, which MessageDB.init() opens
+// exactly as it does in the browser. Node 22 provides structuredClone, which
+// fake-indexeddb needs.
+import 'fake-indexeddb/auto';
+import { MessageDB } from '../../../db/messages';
+
+export async function makeMessageDB(): Promise<MessageDB> {
+  const db = new MessageDB();
+  await db.init();
+  return db;
+}

--- a/src/dev/tests/harness/transport.ts
+++ b/src/dev/tests/harness/transport.ts
@@ -1,0 +1,97 @@
+// The transport half of a headless client: the same two channels the browser
+// app uses, minus React.
+//
+//   - REST  via QuorumApiClient (register, fetch/post/delete inbox) — already
+//     node-safe: baseTypes uses globalThis.fetch, which Node 22 provides.
+//   - WebSocket for the live inbox stream. The subscribe protocol is one frame:
+//     {type:'listen', inbox_addresses:[...]} — see MessageDB.tsx setResubscribe.
+//     Inbound frames are the same EncryptedMessage JSON the browig app parses.
+//
+// This mirrors WebsocketProvider.tsx (connect, resubscribe on open, 1s
+// reconnect) but exposes it as a plain object a scenario can await, instead of a
+// React context.
+import WebSocket from 'ws';
+import { QuorumApiClient } from '../../../api/baseTypes';
+import { config } from './env';
+
+/** The inbound frame shape (matches db/messages EncryptedMessage). */
+export interface InboundFrame {
+  inboxAddress: string;
+  [k: string]: unknown;
+}
+
+export type InboundHandler = (frame: InboundFrame) => void | Promise<void>;
+
+export function makeApiClient(): QuorumApiClient {
+  return new QuorumApiClient({ baseUrl: config.apiUrl, wsUrl: config.wsUrl });
+}
+
+export class WsTransport {
+  private ws: WebSocket | undefined;
+  private handler: InboundHandler | undefined;
+  private subscriptions: string[] = [];
+  private closed = false;
+  connected = false;
+
+  constructor(private readonly wsUrl: string = config.wsUrl) {}
+
+  onMessage(handler: InboundHandler): void {
+    this.handler = handler;
+  }
+
+  /** Open the socket; resolves on the first `open`. Re-subscribes automatically. */
+  connect(): Promise<void> {
+    return new Promise((resolvePromise, reject) => {
+      const open = () => {
+        const ws = new WebSocket(this.wsUrl);
+        this.ws = ws;
+
+        ws.on('open', () => {
+          this.connected = true;
+          if (this.subscriptions.length) this.sendListen(this.subscriptions);
+          resolvePromise();
+        });
+
+        ws.on('message', (data: WebSocket.RawData) => {
+          if (!this.handler) return;
+          try {
+            const frame = JSON.parse(data.toString()) as InboundFrame;
+            void this.handler(frame);
+          } catch {
+            /* ignore non-JSON control frames */
+          }
+        });
+
+        ws.on('close', () => {
+          this.connected = false;
+          if (!this.closed) setTimeout(open, 1000);
+        });
+
+        ws.on('error', (err: Error) => {
+          if (!this.connected) reject(new Error(`WS connect failed: ${err.message}`));
+        });
+      };
+      open();
+    });
+  }
+
+  /** Subscribe to inbox addresses. Remembered and re-sent on reconnect. */
+  listen(inboxAddresses: string[]): void {
+    this.subscriptions = Array.from(new Set([...this.subscriptions, ...inboxAddresses]));
+    if (this.connected) this.sendListen(this.subscriptions);
+  }
+
+  private sendListen(inboxAddresses: string[]): void {
+    this.ws?.send(JSON.stringify({ type: 'listen', inbox_addresses: inboxAddresses }));
+  }
+
+  /** Raw send — used later to push outbound sealed frames. */
+  send(raw: string): void {
+    this.ws?.send(raw);
+  }
+
+  close(): void {
+    this.closed = true;
+    this.ws?.close();
+  }
+}

--- a/src/dev/tests/harness/xpdump-format.scenario.test.ts
+++ b/src/dev/tests/harness/xpdump-format.scenario.test.ts
@@ -1,0 +1,63 @@
+// Offline check: the [XPDUMP] lines the harness emits are readable by the
+// existing dr-ablate / dr-replay parsers, so those tools run on harness output
+// unchanged. Uses a synthetic state/frame — no network, no real failure needed;
+// this asserts the FORMAT, not a decrypt.
+import { test, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { makeMessageDB } from './storage';
+import { XpdumpLog } from './xpdump';
+
+test('xpdump-format: emitted lines parse with the dr-ablate reader', async () => {
+  const db = await makeMessageDB();
+  const inbox = 'QmInboxAddressForTest0000000000000000000000000';
+
+  // Realistically-shaped state: EncryptionState.state is JSON with ratchet_state
+  // as a nested JSON string, exactly as MessageService persists it.
+  const ratchetState = JSON.stringify({
+    skipped_keys_map: {},
+    current_sending_chain_length: 3,
+    current_receiving_chain_length: 2,
+    previous_sending_chain_length: 0,
+  });
+  await db.saveEncryptionState(
+    {
+      state: JSON.stringify({ ratchet_state: ratchetState, receiving_inbox: {}, tag: 't' }),
+      timestamp: 111,
+      inboxId: inbox,
+      conversationId: 'QmConv/QmConv',
+    },
+    true
+  );
+
+  const xp = new XpdumpLog('xpdump-format-test', 1000);
+  const frame = {
+    inboxAddress: inbox,
+    encryptedContent: JSON.stringify({ ephemeral_public_key: 'deadbeef', envelope: '{}' }),
+    timestamp: 222,
+  };
+  const ok = await xp.capture(db, frame, 2000);
+  expect(ok).toBe(true);
+
+  // Re-parse with dr-ablate's exact regex + reassembly.
+  const text = readFileSync(xp.file, 'utf-8');
+  const parts = new Map<string, { total: number; chunks: Map<number, string> }>();
+  for (const line of text.split('\n')) {
+    const m = line.match(/\[XPDUMP\]\s+(\d+)\/(\d+)\/(\d+)\s(.*)$/);
+    if (!m) continue;
+    const [, no, idx, total, chunk] = m;
+    if (!parts.has(no)) parts.set(no, { total: +total, chunks: new Map() });
+    parts.get(no)!.chunks.set(+idx, chunk);
+  }
+  expect(parts.size).toBe(1);
+
+  const { total, chunks } = [...parts.values()][0];
+  const joined = Array.from({ length: total }, (_, i) => chunks.get(i + 1)).join('');
+  const record = JSON.parse(joined);
+  const row = JSON.parse(record.state);
+  const rs = JSON.parse(row.ratchet_state);
+  const sealed = JSON.parse(record.frame);
+
+  expect(rs.current_sending_chain_length).toBe(3);
+  expect(sealed.ephemeral_public_key).toBe('deadbeef');
+  console.log('[xpdump-format] dr-ablate reader parsed the emitted record OK');
+});

--- a/src/dev/tests/harness/xpdump.ts
+++ b/src/dev/tests/harness/xpdump.ts
@@ -1,0 +1,72 @@
+// On a decrypt failure, dump the exact (ratchet state, sealed frame) pair in the
+// SAME `[XPDUMP]` format the diag branch emits, so the existing offline analyzers
+// run on harness output UNCHANGED:
+//
+//   node .agents/tools/dm-debug/dr-ablate.mjs   <harness-xpdump-log>
+//   node .agents/tools/dm-debug/dr-replay.mjs   <harness-xpdump-log>
+//
+// The harness has full in-process access, so unlike the browser it writes these
+// from the outside — no probe logging inside MessageService, no key material in
+// service code, and (because DevTools truncation doesn't apply here) one line per
+// dump instead of chunked. dr-ablate reassembles `n/idx/total`, so a single
+// `n/1/1` line is a complete record.
+//
+// ⚠️ These lines contain REAL ratchet key material. logs/ is gitignored; keep local.
+import { mkdirSync, writeFileSync, appendFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { MessageDB } from '../../../db/messages';
+import { config } from './env';
+
+function fnv1a(v: unknown): string {
+  const s = String(v);
+  let h = 0x811c9dc5;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return (h >>> 0).toString(16).padStart(8, '0');
+}
+
+export class XpdumpLog {
+  private readonly path: string;
+  private n = 0;
+
+  constructor(scenario: string, startEpochMs: number) {
+    mkdirSync(config.logsDir, { recursive: true });
+    const stamp = new Date(startEpochMs).toISOString().replace(/[:.]/g, '-');
+    this.path = resolve(config.logsDir, `${stamp}-${scenario}.xpdump.log`);
+    writeFileSync(this.path, '', 'utf-8');
+  }
+
+  /**
+   * Capture the failing frame. `frame` is the inbound EncryptedMessage; its
+   * `encryptedContent` is the sealed message dr-ablate reads as `d.frame`. The
+   * matching ratchet state row is the encryption_states entry on the frame's
+   * inbox.
+   */
+  async capture(
+    db: MessageDB,
+    frame: { inboxAddress?: string; encryptedContent?: string; timestamp?: number },
+    nowMs: number
+  ): Promise<boolean> {
+    const rows = await db.getAllEncryptionStates();
+    const row = rows.find((r) => r.inboxId === frame.inboxAddress);
+    if (!row || !frame.encryptedContent) return false;
+
+    this.n += 1;
+    const record = {
+      n: this.n,
+      ts: frame.timestamp ?? nowMs,
+      envFp: fnv1a(frame.encryptedContent),
+      stFp: fnv1a(row.state),
+      state: row.state, // JSON string: { ratchet_state, receiving_inbox, ... }
+      frame: frame.encryptedContent, // JSON string: { ephemeral_public_key, envelope }
+    };
+    appendFileSync(this.path, `[XPDUMP] ${this.n}/1/1 ${JSON.stringify(record)}\n`, 'utf-8');
+    return true;
+  }
+
+  get file(): string {
+    return this.path;
+  }
+}

--- a/vitest.harness.config.ts
+++ b/vitest.harness.config.ts
@@ -1,0 +1,69 @@
+// Vitest config for the headless DM harness (src/dev/tests/harness/).
+//
+// This is DELIBERATELY separate from vitest.config.ts. The unit-test setup
+// (src/dev/tests/setup.ts) MOCKS WebSocket and crypto — the exact opposite of
+// what the harness needs. Here we want the REAL socket, REAL webcrypto, a node
+// environment, fake-indexeddb for storage, and multi-hour timeouts so a volume
+// run can execute unattended.
+//
+// It reuses the Vite transform pipeline (via defineConfig) so that when a later
+// slice imports the real src/services/MessageService.ts, the lingui macro and
+// the .web.ts / .native.ts extension resolution both work — plain `node` cannot
+// do that, which is why the existing .agents/tools/dm-debug/*.mjs scripts only
+// ever import the SDK, never a service.
+//
+// Run:  yarn harness            (all scenarios)
+//       yarn harness ping       (files matching "ping")
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+import { resolve } from 'path';
+
+export default defineConfig({
+  // Same transform pipeline as vitest.config.ts: the React plugin carries the
+  // lingui macro babel plugin, which MessageService (and the shared barrel) need
+  // to compile their `@lingui/*/macro` imports.
+  plugins: [
+    react({
+      babel: {
+        plugins: ['@lingui/babel-plugin-lingui-macro'],
+      },
+    }),
+  ],
+  test: {
+    // jsdom for the browser DOM surface (window/document/addEventListener) that
+    // the quorum-shared barrel touches at import time (react-tooltip etc.). We do
+    // NOT load the unit-test setup that mocks WebSocket/crypto, so node's REAL
+    // global WebSocket and webcrypto survive — jsdom provides neither, so it
+    // can't shadow them. Confirmed: the ping scenario's live WS still connects.
+    environment: 'jsdom',
+    environmentOptions: { jsdom: { url: 'http://localhost' } },
+    globals: true,
+    // Shim-only setup (window/Buffer) — NOT the unit-test setup, which mocks
+    // WebSocket and crypto. The harness needs those real.
+    setupFiles: ['src/dev/tests/harness/setup.harness.ts'],
+    include: ['src/dev/tests/harness/**/*.scenario.test.ts'],
+    exclude: ['node_modules', 'dist'],
+    // A volume/aging run can take a long time; never time it out by default.
+    testTimeout: 60 * 60 * 1000, // 1 hour
+    hookTimeout: 5 * 60 * 1000,
+    // Scenarios hit a shared live relay and share throwaway accounts — run them
+    // one at a time so two scenarios can't stomp each other's session state.
+    fileParallelism: false,
+    server: {
+      deps: {
+        // The SDK ships an ESM bundle with the wasm inlined; inline it so the
+        // wasm auto-initialises on import (same as the browser app).
+        inline: ['@quilibrium/quilibrium-js-sdk-channels'],
+      },
+    },
+  },
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, 'src'),
+      crypto: resolve(__dirname, 'node_modules/crypto-browserify/index.js'),
+    },
+    // Prefer .web.ts so crypto.ts / platform.ts resolve to their web variants,
+    // never the .native ones (React Native).
+    extensions: ['.web.ts', '.web.js', '.ts', '.js', '.tsx', '.jsx'],
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2576,6 +2576,13 @@
   resolved "https://registry.yarnpkg.com/@types/verror/-/verror-1.10.11.tgz#d3d6b418978c8aa202d41e5bb3483227b6ecc1bb"
   integrity sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg==
 
+"@types/ws@^8.18.1":
+  version "8.18.1"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.18.1.tgz#48464e4bf2ddfd17db13d845467f6070ffea4aa9"
+  integrity sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/yargs-parser@*":
   version "21.0.3"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.3.tgz#815e30b786d2e8f0dcd85fd5bcf5e1a04d008f15"
@@ -11082,6 +11089,11 @@ ws@^7, ws@^7.5.10:
   version "7.5.10"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.10.tgz#58b5c20dc281633f6c19113f39b349bd8bd558d9"
   integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
+
+ws@^8:
+  version "8.21.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.1.tgz#045650cd4b1207809e7547146223c3814a9af586"
+  integrity sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==
 
 ws@^8.12.1:
   version "8.20.0"


### PR DESCRIPTION
## What

A headless test harness that drives the **real** DM client in Node — the real `MessageService` + `MessageDB` (on `fake-indexeddb`) + a `ws` WebSocket transport + the SDK wasm crypto core — so DM protocol work no longer needs the two-browser manual loop. One process drives both sides on one clock, at any volume, unattended.

It is **not** a reimplementation: inbound frames go through the real `handleNewMessage`, outbound through the real `submitMessage` → action queue → socket. Lives in `src/dev/tests/harness/`, runs under a dedicated `vitest.harness.config.ts` (`yarn harness <scenario>`).

## Scenarios

| command | what it does |
|---|---|
| `yarn harness smoke` / `integration-check` / `xpdump-format` | offline sanity (no relay) |
| `yarn harness ping` | a bot registers on the relay, connects, subscribes |
| `yarn harness dm-receive` | decrypts a DM you send from a browser |
| `yarn harness dm-basic` | two bots exchange numbered DMs, no browser |
| `yarn harness dm-volume` | concurrent bidirectional load; samples skipped-keys growth |
| `yarn harness dm-reset-recover` | wipe a session mid-conversation, verify it re-inits and recovers |

On any decrypt failure a bot writes an `[XPDUMP]` log that the existing `dr-ablate` / `dr-replay` tools read **unchanged**.

## Notable finding

Under a controlled bench experiment, **volume alone does not age a DM session** (fresh accounts, concurrent load, 60–82 msgs each way: 0 skipped keys, 0 failures). An initial "reproduced the bug" reading was falsified by a fresh-account control — the failures were stale queued frames from account reuse. This is folded into the DM investigation entry point (`.agents/bugs/2026-07-26-dm-desktop-to-desktop-resurfaced.md`).

## Safety

- Test/throwaway accounts only. `.env.local`, `.state/`, `logs/` are gitignored (real key material / ratchet state).
- Env-key bots persist **device-only** — your account private key is never copied to `.state/`.
- Talks to production by default (same footprint as a browser); override via `QUORUM_API_URL` / `QUORUM_WS_URL`.

## Not in scope

UI, mobile, and fixing the delivery bug. Reproduce/measure only. A spaces-harness spec (for the "messages not landing in spaces" issue) is included as a task doc for a follow-up.

Full plan and env gotchas: `.agents/tasks/2026-07-27-headless-dm-harness.md`.