### PR TITLE
harness: reproduce the DM decrypt failure on demand, and fix two defects that made the bench lie

### DIFF
--- a/.agents/tasks/.done/2026-07-27-headless-dm-harness.md
+++ b/.agents/tasks/.done/2026-07-27-headless-dm-harness.md
@@ -266,6 +266,62 @@ spaces build around that specific issue before implementing. Needs triple-ratche
 session establishment + SpaceService/SyncService + channel send; user A's space
 ownership is why the canonical pair matters here.
 
+### Follow-up session 2026-07-27 (later) — reproduction + mitigation, and two bench defects
+
+The harness delivered what it was built for: the production DM failure is now
+reproducible on demand, and a client-side mitigation is measured. Details live in
+`.agents/bugs/2026-07-26-dm-desktop-to-desktop-resurfaced.md` §1 (findings AI/AJ/AK)
+and §5-B1. What belongs here is the harness work itself:
+
+**New capability**
+- `transport.ts` — controlled reordering: `holdInbound()` / `releaseInbound(order)` /
+  `deliverWithheld()` / `deliver(frame)`, plus `sent` / `arrived` records and
+  `ciphertextFp()` so a frame can be joined across the two sides. Withholding is
+  enforced **by fingerprint**, because an un-acked frame is re-pushed on every
+  `listen` — a version that only skipped the first copy was silently defeated by
+  relay redelivery, and no bucket formed.
+- `dm-reorder.scenario.test.ts` — builds the stale bucket, then delivers the
+  sender's next chain. 3 withheld frames → exactly 3 failures, at exactly the
+  colliding indices; the withheld frames then decrypt with 0 failures.
+- `dm-loss.scenario.test.ts` — #183 item 2, per direction, joined by ciphertext
+  fingerprint, with a long redelivery tail window (a short run cannot tell loss
+  from latency) and frames addressed elsewhere excluded from the denominator.
+- `dm-stale-bucket.scenario.test.ts` — the cycle at scale with the mitigation OFF
+  then ON, fresh accounts per arm.
+
+**Two defects that invalidated earlier harness numbers** (both fixed; both were
+caught by controls, not by inspection)
+1. **All bots shared one IndexedDB.** `MessageDB` hardcodes `DB_NAME='quorum_db'`
+   and every bot uses the one global `fake-indexeddb`, so two bots were a single
+   client with two `MessageService` instances writing the same rows. Each then
+   subscribed to the other's session inboxes and received its own outbound
+   ciphertext — 41-48% of all arrivals, every one an unavoidable AEAD failure.
+   Fixed by a per-bot `DB_NAME` in `storage.ts`.
+   *The control that mattered:* the app's `setResubscribe` uses the identical rule,
+   so this looked like a real app defect. `dr-self-echo.mjs` found **0 self-echo in
+   2709 distinct captured browser arrivals** — harness artifact, not app behaviour.
+2. **The harness could not see decrypt failures.** They never leave
+   `handleNewMessage` (caught, frame retained, `handled` returned). So slice 4's
+   "0 failures" was measured by an observer blind to failures. `bot.ts` now tees the
+   failure log line and classifies **novel vs replay** — a frame already decrypted
+   once is refused by design and must not be counted. Use `bot.novelErrors()`.
+   Also: `refreshSubscriptions` no longer fires per frame (a `listen` re-pushes the
+   relay queue, which turned 3 expected failures into 437); it fires only when the
+   inbox set changes, as the app does.
+
+Slice 4's conclusion ("volume alone does not age a session") **still holds** and is
+now genuinely evidenced: on the fixed bench a fresh pair shows 0 skipped keys,
+0 novel failures and 0 self-echo.
+
+**`importSession.ts` is no longer on the critical path.** It existed to study a
+degraded ratchet by lifting one out of a browser. The degraded state can now be
+*built* from a pristine pair in seconds, so the operator export is optional.
+
+Also fixed: `vitest.config.ts` excluded `src/dev/tests/harness/**`. The scenarios
+were being collected by the default config, which mocks WebSocket/crypto and never
+inits the wasm, so 8 files failed `vitest run` for that reason alone. Suite is
+554/554 green.
+
 ## Progress log
 
 - 2026-07-27: branch `feat/headless-dm-harness` created; plan written.

--- a/.agents/tools/dm-debug/README.md
+++ b/.agents/tools/dm-debug/README.md
@@ -35,11 +35,16 @@ repo; set `SDK_DIR=` if yours is elsewhere.
 | `dr-replay.mjs` | Reassembles `[XPDUMP]` chunks from a log and re-runs the real failing decrypt. Reports whether the seal opened, whether the frame was init-wrapped, and whether the ratchet failed. Use to confirm a failure is genuine and reproducible rather than an app-level race. |
 | `dr-ablate.mjs` | **Finds what CAUSES a failure.** Re-runs the same decrypt while changing ONE property of the ratchet state at a time, so a load-bearing property announces itself by making the frame decrypt. |
 | `dr-advanced-start-fork.mjs` | Needs no log at all. Builds pristine sessions from one X3DH pair and drives a case matrix to reproduce the upstream crate's advanced-start fork in seconds. This is the runnable evidence behind item 1 of [quorum-mobile#183](https://github.com/QuilibriumNetwork/quorum-mobile/issues/183). |
-| `dr-position-table.mjs` | Needs no log. Builds **fresh** sessions and scores first-attempt failure by chain position across six delivery regimes. Result: 1920 frames, zero failures — which corroborates finding AC rather than contradicting anything, because a fresh session has no poisoning skipped-keys bucket. ⛔ Not evidence the crate is clean. Its real value is unrealised: it is the natural home for the synthetic session-ageing test named in archive §2i. |
+| `dr-position-table.mjs` | Needs no log. Builds **fresh** sessions and scores first-attempt failure by chain position across six delivery regimes. Result: 1920 frames, zero failures — which corroborates finding AC rather than contradicting anything, because a fresh session has no poisoning skipped-keys bucket. ⛔ Not evidence the crate is clean. |
+| `dr-prune-safety.mjs` | **Explains the mechanism and validates the mitigation.** Per captured failure it reports what the frame *is* — its index in its own sending chain, whether it drove a DH step, whether that index collides with the stale bucket — and whether recovery is genuine or a re-accepted duplicate. Its synthetic half needs **no log** (`--synthetic-only`): it builds the poisoning condition from a pristine X3DH pair, so one state holds both the frame a retry would recover and the frames a prune would destroy. That is how the "does pruning break a success?" question got answered — the captured corpus cannot answer it, because `[XPDUMP]` only ever fires on failure. |
+| `dr-self-echo.mjs` | Does a client receive its OWN outbound frames? Joins `[DM-send wire]` against `[DM-recv wire]` within one client's log. **0 of 2709 distinct captured browser arrivals** — the control that proved the headless harness's 41-48% self-echo was a bench artifact (all bots shared one IndexedDB) and not the cause of the measured ~40% failure rate. |
 
 ```
-node .agents/tools/dm-debug/dr-replay.mjs <saved-console.log>
-node .agents/tools/dm-debug/dr-ablate.mjs <saved-console.log> [...more logs]
+node .agents/tools/dm-debug/dr-replay.mjs       <saved-console.log>
+node .agents/tools/dm-debug/dr-ablate.mjs       <saved-console.log> [...more logs]
+node .agents/tools/dm-debug/dr-prune-safety.mjs <saved-console.log> [...more logs]
+node .agents/tools/dm-debug/dr-prune-safety.mjs --synthetic-only    # no log needed
+node .agents/tools/dm-debug/dr-self-echo.mjs    <saved-console.log> [...more logs]
 ```
 
 **`dr-ablate` is the cheapest tool in this folder and it arrived last.** It found

--- a/.agents/tools/dm-debug/dr-prune-safety.mjs
+++ b/.agents/tools/dm-debug/dr-prune-safety.mjs
@@ -1,0 +1,411 @@
+// ============================================================================
+// DR PRUNE-SAFETY — is option B1 (prune the poisoning bucket and retry) safe?
+//
+// Finding AE established that 63 of 65 captured failures decrypt when ONE bucket
+// is deleted: skipped_keys_map[current_receiving_header_key]. §5 option B1 proposes
+// doing that in the receive path on decrypt failure. Before any app code, §5-B1
+// names three blocking questions. This answers them from the captured corpus:
+//
+//   Q1 does pruning ever break a frame that would otherwise SUCCEED?
+//   Q2 what is LOST by discarding those keys?
+//   Q3 do the 2-of-65 that never recover behave differently?
+//
+// ⚠ Q1 CANNOT be answered from the logs alone, and it is important to say why:
+// the [XPDUMP] probe fires ONLY inside the two decrypt-failure catch blocks (both
+// on diag/dm-frame-join and in the harness's xpdump.ts). So the corpus contains
+// zero captured successes by construction. Asking "run the variant across all
+// captured successes" has no data to run on. Q1 is answered instead by the
+// SYNTHETIC section below, which builds the poisoning condition from a pristine
+// X3DH pair against the real crate and can therefore hold both a failure and the
+// successes that share its state.
+//
+// What this adds over dr-ablate: dr-ablate proves a property is load-bearing.
+// This asks what the recovered PLAINTEXT is, whether the frame was already
+// delivered by another route, and what the prune costs — i.e. whether recovery is
+// real or is re-accepting a duplicate.
+//
+// usage: node dr-prune-safety.mjs <log> [...more logs]
+//        node dr-prune-safety.mjs --synthetic-only
+// ============================================================================
+import { readFileSync } from 'node:fs';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const SDK_DIR =
+  process.env.SDK_DIR ??
+  resolve(dirname(fileURLToPath(import.meta.url)), '../../../../quilibrium-js-sdk-channels');
+const ch = await import(pathToFileURL(resolve(SDK_DIR, 'src/channel/channelwasm.js')).href);
+ch.initSync(readFileSync(resolve(SDK_DIR, 'src/wasm/channelwasm_bg.wasm')));
+
+const bytes = (b) => [...new Uint8Array(b)];
+const b64 = (s) => Buffer.from(s, 'base64');
+const sk = (v) => (typeof v === 'string' ? bytes(b64(v)) : v);
+
+// ---------------------------------------------------------------- primitives
+function tryDecrypt(ratchetStateJson, envelope) {
+  try {
+    const out = JSON.parse(
+      ch.js_double_ratchet_decrypt(JSON.stringify({ ratchet_state: ratchetStateJson, envelope }))
+    );
+    const msg = Buffer.from(new Uint8Array(out.message)).toString('utf-8');
+    if (msg.startsWith('Decryption failed') || msg.includes('aead')) {
+      return { ok: false, why: 'AEAD' };
+    }
+    return { ok: true, msg, state: out.ratchet_state };
+  } catch (e) {
+    return { ok: false, why: 'THREW:' + String(e).slice(0, 50) };
+  }
+}
+
+/** Delete only skipped_keys_map[current_receiving_header_key]. This is B1. */
+function pruneCurrentBucket(rs) {
+  const m = { ...(rs.skipped_keys_map ?? {}) };
+  const key = rs.current_receiving_header_key;
+  const removed = m[key];
+  delete m[key];
+  return { state: { ...rs, skipped_keys_map: m }, removed, key };
+}
+
+const bucketOf = (rs) => (rs.skipped_keys_map ?? {})[rs.current_receiving_header_key];
+const countKeys = (rs) =>
+  Object.values(rs.skipped_keys_map ?? {}).reduce((a, v) => a + Object.keys(v ?? {}).length, 0);
+
+// ---------------------------------------------------------------- log corpus
+function dumpsFrom(logPath) {
+  const parts = new Map();
+  for (const line of readFileSync(logPath, 'utf-8').split('\n')) {
+    const m = line.match(/\[XPDUMP\]\s+(\d+)\/(\d+)\/(\d+)\s(.*)$/);
+    if (!m) continue;
+    const [, no, idx, total, text] = m;
+    if (!parts.has(no)) parts.set(no, { total: +total, chunks: new Map() });
+    parts.get(no).chunks.set(+idx, text);
+  }
+  const out = [];
+  for (const [no, { total, chunks }] of parts) {
+    if (chunks.size !== total) continue;
+    const joined = Array.from({ length: total }, (_, i) => chunks.get(i + 1)).join('');
+    try { out.push({ no, ...JSON.parse(joined) }); } catch { /* truncated */ }
+  }
+  return out;
+}
+
+/** Unseal exactly as the live receive path does, so the ratchet sees real input. */
+function unseal(row, sealed) {
+  const raw = JSON.parse(ch.js_decrypt_inbox_message(JSON.stringify({
+    inbox_private_key: row.receiving_inbox.inbox_encryption_key.private_key,
+    ephemeral_public_key: [...new Uint8Array(Buffer.from(sealed.ephemeral_public_key, 'hex'))],
+    ciphertext: JSON.parse(sealed.envelope),
+  })));
+  let envelope = Buffer.from(new Uint8Array(raw)).toString('utf-8');
+  try {
+    const maybeInit = JSON.parse(envelope);
+    if (maybeInit.user_address) envelope = maybeInit.message;
+  } catch { /* plain DR envelope */ }
+  return envelope;
+}
+
+function runCorpus(logPaths) {
+  const seen = new Set();          // de-dup by envelope fingerprint (§5 discipline)
+  const rows = [];
+  for (const logPath of logPaths) {
+    for (const d of dumpsFrom(logPath)) {
+      let row, sealed, rs;
+      try {
+        row = JSON.parse(d.state);
+        sealed = JSON.parse(d.frame);
+        rs = JSON.parse(row.ratchet_state);
+      } catch { continue; }
+      let envelope;
+      try { envelope = unseal(row, sealed); } catch { continue; }
+
+      const fp = String(d.envFp ?? '');
+      if (fp && seen.has(fp)) continue;
+      if (fp) seen.add(fp);
+
+      const base = tryDecrypt(row.ratchet_state, envelope);
+      const { state: prunedRs, removed } = pruneCurrentBucket(rs);
+      const pruned = tryDecrypt(JSON.stringify(prunedRs), envelope);
+
+      // The output state identifies the frame: rLen advances to (frame index + 1),
+      // and a changed root_key means the frame arrived under the NEXT receiving
+      // header key, i.e. it drove a DH step.
+      let after = null;
+      if (pruned.ok) {
+        try {
+          const o = JSON.parse(pruned.state);
+          after = {
+            rLen: o.current_receiving_chain_length,
+            dhStep: String(o.root_key) !== String(rs.root_key),
+            keys: countKeys(o),
+            curBucket: bucketOf(o) ? Object.keys(bucketOf(o)).map(Number).sort((a, b) => a - b) : null,
+          };
+        } catch { /* ignore */ }
+      }
+
+      rows.push({
+        after,
+        log: logPath.replace(/\\/g, '/').split('/').pop(),
+        no: d.no,
+        fp,
+        rLen: rs.current_receiving_chain_length,
+        pR: rs.previous_receiving_chain_length,
+        sLen: rs.current_sending_chain_length,
+        pS: rs.previous_sending_chain_length,
+        buckets: Object.keys(rs.skipped_keys_map ?? {}).length,
+        keys: countKeys(rs),
+        curBucket: removed ? Object.keys(removed).map(Number).sort((a, b) => a - b) : null,
+        base,
+        pruned,
+      });
+    }
+  }
+  return rows;
+}
+
+function reportCorpus(rows) {
+  console.log('='.repeat(96));
+  console.log('CAPTURED CORPUS — every [XPDUMP] failure on disk, de-duplicated by envelope fingerprint');
+  console.log('='.repeat(96));
+  if (!rows.length) { console.log('no parseable dumps'); return; }
+
+  console.log('\n  #  rLen  pR  bkts keys  CUR-bucket indices     base  pruned  frame-idx  DH  keys-after');
+  console.log('  ' + '-'.repeat(92));
+  for (const r of rows) {
+    const cur = r.curBucket ? `[${r.curBucket.join(',')}]` : '(none)';
+    const idx = r.after ? String(r.after.rLen - 1) : '?';
+    const dh = r.after ? (r.after.dhStep ? 'yes' : 'no ') : '?  ';
+    const ka = r.after ? `${r.keys}->${r.after.keys}` : '';
+    console.log(
+      `  ${String(r.no).padStart(2)} ${String(r.rLen).padStart(5)} ${String(r.pR).padStart(3)} ` +
+      `${String(r.buckets).padStart(4)} ${String(r.keys).padStart(4)}  ${cur.padEnd(21)} ` +
+      `${(r.base.ok ? 'OK' : r.base.why).padEnd(5)} ${(r.pruned.ok ? 'OK' : r.pruned.why).padEnd(7)} ` +
+      `${idx.padStart(9)}  ${dh} ${ka}`
+    );
+  }
+
+  const idxs = rows.filter((r) => r.after).map((r) => ({
+    idx: r.after.rLen - 1, rLen: r.rLen, inBucket: r.curBucket?.includes(r.after.rLen - 1) ?? false,
+    dh: r.after.dhStep,
+  }));
+  if (idxs.length) {
+    const inB = idxs.filter((x) => x.inBucket).length;
+    const dh = idxs.filter((x) => x.dh).length;
+    const both = idxs.filter((x) => x.inBucket && x.dh).length;
+    console.log(`\n  WHAT THE FAILING FRAME IS (read off the state the recovery produced).`);
+    console.log(`  NOTE: frame-idx is the index within the frame's OWN sending chain, so it is`);
+    console.log(`  NOT comparable to the pre-decrypt rLen (a different chain). The load-bearing`);
+    console.log(`  comparison is against the stale bucket's index set.`);
+    console.log(`     drove a DH step (new sending chain)       ${dh}/${idxs.length}`);
+    console.log(`     index collides with the CUR-bucket index  ${inB}/${idxs.length}`);
+    console.log(`     BOTH (the signature)                     ${both}/${idxs.length}`);
+  }
+
+  const withCur = rows.filter((r) => r.curBucket);
+  const noCur = rows.filter((r) => !r.curBucket);
+  const recovered = rows.filter((r) => !r.base.ok && r.pruned.ok);
+  const broken = rows.filter((r) => r.base.ok && !r.pruned.ok);
+  const baseOk = rows.filter((r) => r.base.ok);
+
+  console.log('\n  ' + '-'.repeat(92));
+  console.log(`  dumps (de-duplicated)              ${rows.length}`);
+  console.log(`  have a CURRENT-header bucket       ${withCur.length}`);
+  console.log(`  have NO current-header bucket      ${noCur.length}   (prune is a no-op for these)`);
+  console.log(`  baseline already decrypts          ${baseOk.length}   <- captured "successes", if any`);
+  console.log(`  prune RECOVERS (fail -> OK)        ${recovered.length}`);
+  console.log(`  prune BREAKS  (OK -> fail)         ${broken.length}`);
+
+  // Q3: characterise the non-recovering failures.
+  const stuck = rows.filter((r) => !r.base.ok && !r.pruned.ok);
+  if (stuck.length) {
+    console.log(`\n  Q3 — the failures prune does NOT recover (${stuck.length}):`);
+    for (const r of stuck) {
+      console.log(`     #${r.no} ${r.log.slice(0, 30).padEnd(32)} rLen=${r.rLen} buckets=${r.buckets} keys=${r.keys} ` +
+        `CUR=${r.curBucket ? '[' + r.curBucket.join(',') + ']' : 'none'}`);
+    }
+  }
+
+  // Is recovery real, or is it re-accepting a duplicate? A plaintext recovered
+  // more than once across dumps is a redelivery, not a rescued message.
+  const byMsg = new Map();
+  for (const r of recovered) {
+    const k = r.pruned.msg;
+    byMsg.set(k, (byMsg.get(k) ?? 0) + 1);
+  }
+  const dupes = [...byMsg.entries()].filter(([, n]) => n > 1);
+  console.log(`\n  distinct recovered plaintexts      ${byMsg.size} of ${recovered.length} recoveries`);
+  if (dupes.length) {
+    console.log('  plaintexts recovered MORE THAN ONCE (same message, several dumps):');
+    for (const [m, n] of dupes) console.log(`     ${n}x  ${m.replace(/\s+/g, ' ').slice(0, 60)}`);
+  }
+
+  // Q2: what the prune throws away, quantified.
+  if (withCur.length) {
+    const sizes = withCur.map((r) => r.curBucket.length);
+    const tot = sizes.reduce((a, b) => a + b, 0);
+    console.log(`\n  Q2 — keys discarded per prune: min ${Math.min(...sizes)} max ${Math.max(...sizes)} ` +
+      `mean ${(tot / sizes.length).toFixed(1)} (of ${(withCur.reduce((a, r) => a + r.keys, 0) / withCur.length).toFixed(0)} avg keys held)`);
+    const belowRlen = withCur.filter((r) => r.curBucket.every((i) => i < r.rLen)).length;
+    console.log(`     buckets whose every index is BELOW rLen: ${belowRlen}/${withCur.length}` +
+      ' (those keys are unrecoverable once discarded — the chain cannot derive backwards)');
+  }
+}
+
+// ---------------------------------------------------------------- synthetic
+// The corpus cannot answer Q1 (no captured successes exist). Build the condition
+// from scratch instead: a pristine pair, controlled delivery order, so the SAME
+// state holds both the frame B1 would retry and the frames whose keys the prune
+// would destroy.
+function newPair() {
+  const aIdent = JSON.parse(ch.js_generate_x448());
+  const aEph = JSON.parse(ch.js_generate_x448());
+  const bIdent = JSON.parse(ch.js_generate_x448());
+  const bPre = JSON.parse(ch.js_generate_x448());
+  const A = sk(JSON.parse(ch.js_sender_x3dh(JSON.stringify({
+    sending_identity_private_key: aIdent.private_key,
+    sending_ephemeral_private_key: aEph.private_key,
+    receiving_identity_key: bIdent.public_key,
+    receiving_signed_pre_key: bPre.public_key, session_key_length: 96,
+  }))));
+  const B = sk(JSON.parse(ch.js_receiver_x3dh(JSON.stringify({
+    sending_identity_private_key: bIdent.private_key,
+    sending_signed_private_key: bPre.private_key,
+    receiving_identity_key: aIdent.public_key,
+    receiving_ephemeral_key: aEph.public_key, session_key_length: 96,
+  }))));
+  return {
+    alice: ch.js_new_double_ratchet(JSON.stringify({
+      session_key: A.slice(0, 32), sending_header_key: A.slice(32, 64),
+      next_receiving_header_key: A.slice(64, 96), is_sender: true,
+      sending_ephemeral_private_key: aEph.private_key, receiving_ephemeral_key: bPre.public_key,
+    })),
+    bob: ch.js_new_double_ratchet(JSON.stringify({
+      session_key: B.slice(0, 32), sending_header_key: B.slice(32, 64),
+      next_receiving_header_key: B.slice(64, 96), is_sender: false,
+      sending_ephemeral_private_key: bPre.private_key, receiving_ephemeral_key: aEph.public_key,
+    })),
+  };
+}
+const enc = (state, text) => {
+  const r = JSON.parse(ch.js_double_ratchet_encrypt(JSON.stringify({
+    ratchet_state: state, message: bytes(Buffer.from(text, 'utf-8')),
+  })));
+  return [r.ratchet_state, r.envelope];
+};
+const dec = (state, env) => {
+  const r = tryDecrypt(state, env);
+  return [r.ok ? r.state : state, r.ok, r.ok ? r.msg : r.why];
+};
+
+/**
+ * Build the exact condition the corpus shows, from a pristine pair:
+ *
+ *   - `skipUpTo` frames of chain 1 are withheld and a later one delivered first,
+ *     so message keys for indices 0..skipUpTo-1 are filed under the header key
+ *     that has just become B's `current_receiving_header_key`.
+ *   - A then opens a NEW sending chain (chain 2). Its frames drive a DH step on B.
+ *
+ * Returns B's state at that moment plus both chains' frames, so a single state
+ * holds the frames B1 would retry AND the frames whose keys the prune destroys.
+ */
+function buildPoisonedState(skipUpTo = 3) {
+  let { alice, bob } = newPair();
+  let e, eb;
+  const c1 = [];
+  for (let i = 0; i < skipUpTo + 2; i++) { [alice, e] = enc(alice, `c1-#${i}`); c1.push(e); }
+  [bob] = dec(bob, c1[skipUpTo]);                       // out-of-order -> bucket forms
+  [bob, eb] = enc(bob, 'b-reply'); [alice] = dec(alice, eb);
+  const c2 = [];
+  for (let i = 0; i < 6; i++) { [alice, e] = enc(alice, `c2-#${i}`); c2.push(e); }
+  return { bob, c1, c2, skipUpTo };
+}
+
+function synthetic() {
+  console.log('\n' + '='.repeat(96));
+  console.log('SYNTHETIC — the mechanism, reproduced on demand, and Q1 answered where the');
+  console.log('            corpus cannot (it holds no successes: [XPDUMP] fires only on failure)');
+  console.log('='.repeat(96));
+
+  const { bob, c1, c2, skipUpTo } = buildPoisonedState(3);
+  const rs = JSON.parse(bob);
+  const stale = bucketOf(rs);
+  const staleIdx = stale ? Object.keys(stale).map(Number).sort((a, b) => a - b) : [];
+  const { state: prunedRs, removed, key: staleKey } = pruneCurrentBucket(rs);
+  const prunedJson = JSON.stringify(prunedRs);
+
+  console.log(`\n  condition built with nothing but out-of-order delivery:`);
+  console.log(`    bucket under B's CURRENT receiving header key = [${staleIdx.join(',')}]`);
+  console.log(`    A has since opened a NEW sending chain, so its frames drive a DH step.`);
+
+  console.log('\n  MECHANISM — deliver each NEW-chain frame against that one state:');
+  console.log('    new-chain idx | in stale bucket | baseline | pruned');
+  const failing = [];
+  for (let i = 0; i < 6; i++) {
+    const b = tryDecrypt(bob, c2[i]);
+    const p = tryDecrypt(prunedJson, c2[i]);
+    if (!b.ok) failing.push(i);
+    console.log(`    ${String(i).padStart(13)} | ${(staleIdx.includes(i) ? 'YES' : 'no').padStart(15)} | ` +
+      `${(b.ok ? 'OK' : 'FAIL').padStart(8)} | ${(p.ok ? 'OK' : 'FAIL').padStart(6)}` +
+      `${!b.ok && p.ok ? '   <<< AE signature' : ''}`);
+  }
+  const exact = failing.join(',') === staleIdx.filter((i) => i < 6).join(',');
+  console.log(`\n    failing indices [${failing.join(',')}] vs stale bucket [${staleIdx.join(',')}]  ` +
+    `-> ${exact ? 'EXACT MATCH' : 'DIFFERENT'}`);
+  console.log('    => the crate matches a skipped key BY INDEX in the bucket filed under the');
+  console.log('       old current header key, without checking that bucket belongs to this');
+  console.log('       frame\'s chain. A new-chain frame at a colliding index gets an OLD-chain');
+  console.log('       key and fails AEAD. Non-colliding indices decrypt normally.');
+
+  console.log('\n  Q1 — does the prune break frames that would otherwise SUCCEED?');
+  let broken = 0;
+  for (let i = 0; i < skipUpTo; i++) {
+    const b = tryDecrypt(bob, c1[i]);
+    const p = tryDecrypt(prunedJson, c1[i]);
+    if (b.ok && !p.ok) broken++;
+    console.log(`    delayed chain-1 frame #${i} (key IS in the bucket)`.padEnd(50) + ' ' +
+      `baseline:${b.ok ? 'OK  ' : 'FAIL'}  pruned:${p.ok ? 'OK' : 'FAIL'}` +
+      `${b.ok && !p.ok ? '   <<< PRUNE DESTROYED IT' : ''}`);
+  }
+  console.log(`\n    => YES. The prune destroys ${broken}/${skipUpTo} frames that decrypt without it.`);
+  console.log('       Naive B1 (prune, decrypt, persist) converts recoverable latency into');
+  console.log('       PERMANENT loss of exactly the out-of-order frames the bucket exists for.');
+
+  console.log('\n  B1′ — prune for the RETRY ONLY, then re-file the bucket under its OWN header');
+  console.log('        key in the state that gets persisted:');
+  const retried = tryDecrypt(prunedJson, c2[0]);
+  if (!retried.ok) { console.log('    retry did not decrypt — B1′ untestable in this run'); return; }
+  const out = JSON.parse(retried.state);
+  const merged = JSON.stringify({
+    ...out,
+    skipped_keys_map: { ...(out.skipped_keys_map ?? {}), [staleKey]: removed },
+  });
+  console.log(`    retry recovered: ${retried.msg}`);
+  console.log(`    after the DH step the stale bucket's header key is no longer CURRENT ` +
+    `(${String(JSON.parse(merged).current_receiving_header_key) === String(staleKey) ? 'still current — CHECK' : 'confirmed'})`);
+
+  let alive = 0;
+  for (let i = 0; i < skipUpTo; i++) {
+    const r = tryDecrypt(merged, c1[i]);
+    if (r.ok) alive++;
+    console.log(`    delayed chain-1 frame #${i} vs the re-merged state`.padEnd(50) + ' ' +
+      `${r.ok ? 'OK  ' + r.msg : 'FAIL  ' + r.why}`);
+  }
+  let clean = 0;
+  for (let i = 1; i < 4; i++) {
+    const r = tryDecrypt(merged, c2[i]);
+    if (r.ok) clean++;
+  }
+  console.log(`\n    => ${alive}/${skipUpTo} delayed frames survive, and ${clean}/3 further new-chain`);
+  console.log(`       frames decrypt. ${alive === skipUpTo ? 'B1′ recovers the failure AND destroys nothing.' : 'B1′ is NOT sufficient.'}`);
+
+  console.log('\n  CONTROL — is the bucket\'s mere PRESENCE enough to cause a failure?');
+  const ctl = tryDecrypt(bob, c2[5]);
+  console.log(`    a new-chain frame at a NON-colliding index: ${ctl.ok ? 'DECRYPTS' : 'FAILS'}`);
+  console.log(`    => presence alone is ${ctl.ok ? 'NOT sufficient; the index must collide' : 'sufficient'}.`);
+}
+
+// ---------------------------------------------------------------- main
+const args = process.argv.slice(2);
+const logs = args.filter((a) => !a.startsWith('--'));
+if (logs.length) reportCorpus(runCorpus(logs));
+else console.log('(no logs given — synthetic section only)');
+synthetic();

--- a/.agents/tools/dm-debug/dr-self-echo.mjs
+++ b/.agents/tools/dm-debug/dr-self-echo.mjs
@@ -1,0 +1,87 @@
+// ============================================================================
+// DR SELF-ECHO — does a client receive its OWN outbound DM frames?
+//
+// The headless harness measured that it does, and that the app's subscription
+// rule is the reason: MessageDB.tsx `setResubscribe` listens on
+// `getAllEncryptionStates().map(c => c.inboxId)` + the device inbox, and at least
+// one of those rows carries an inboxId the client also SENDS to. The relay then
+// hands the client back its own ciphertext, which can never decrypt — a
+// guaranteed AEAD failure with no bug in the crate involved.
+//
+// Harness measurement (fresh throwaway pair, prod relay, 2026-07-27):
+//   41% and 48% of all arrivals at the two bots were the bot's OWN ciphertext.
+//
+// This checks the same thing in the CAPTURED BROWSER logs, where it matters for
+// the headline number: §1 reports "~40% of frames fail AEAD". If a large share of
+// a client's arrivals are its own frames, that percentage is measuring the
+// subscription defect as much as the crate bug.
+//
+// A fingerprint appearing in BOTH `[DM-send wire]` and `[DM-recv wire]` on the
+// SAME client's log is self-echo: this client sent that exact frame and then
+// received it back.
+//
+// usage: node dr-self-echo.mjs <log> [...more logs]
+// ============================================================================
+import { readFileSync } from 'node:fs';
+
+const SEND = /\[DM-send wire\]\s+fp=(\w+)\s+to=(\S+)/;
+const RECV = /\[DM-recv wire\]\s+fp=(\w+)\s+inbox=(\S+)/;
+
+let anyData = false;
+const totals = { sent: 0, recv: 0, echo: 0 };
+
+for (const path of process.argv.slice(2)) {
+  const sent = new Map();   // fp -> target inbox
+  const recv = new Map();   // fp -> arrival inbox
+  let sendLines = 0;
+  let recvLines = 0;
+
+  for (const line of readFileSync(path, 'utf-8').split('\n')) {
+    const s = line.match(SEND);
+    if (s) { sendLines++; if (!sent.has(s[1])) sent.set(s[1], s[2]); continue; }
+    const r = line.match(RECV);
+    if (r) { recvLines++; if (!recv.has(r[1])) recv.set(r[1], r[2]); }
+  }
+  if (!sendLines && !recvLines) continue;
+  anyData = true;
+
+  const echo = [...recv.keys()].filter((fp) => sent.has(fp));
+  const name = path.replace(/\\/g, '/').split('/').pop();
+  const pct = recv.size ? ((echo.length / recv.size) * 100).toFixed(1) : '0.0';
+
+  console.log(`\n${name}`);
+  console.log(`  distinct frames SENT      ${sent.size}   (${sendLines} raw lines)`);
+  console.log(`  distinct frames RECEIVED  ${recv.size}   (${recvLines} raw lines)`);
+  console.log(`  received its OWN frames   ${echo.length}  = ${pct}% of arrivals` +
+    (echo.length ? '   <<<<<< SELF-ECHO' : ''));
+
+  if (echo.length) {
+    // Where do they land, and is that the inbox they were addressed to?
+    const byInbox = new Map();
+    for (const fp of echo) {
+      const key = `${recv.get(fp)}  <- addressed to ${sent.get(fp)}`;
+      byInbox.set(key, (byInbox.get(key) ?? 0) + 1);
+    }
+    for (const [k, n] of [...byInbox.entries()].sort((a, b) => b[1] - a[1]).slice(0, 6)) {
+      console.log(`     ${String(n).padStart(4)}x  arrived on ${k}`);
+    }
+  }
+
+  totals.sent += sent.size;
+  totals.recv += recv.size;
+  totals.echo += echo.length;
+}
+
+if (!anyData) {
+  console.log('No [DM-send wire] / [DM-recv wire] probes found.');
+  console.log('These come from the diag/dm-frame-join build only (bug doc §6).');
+  process.exit(0);
+}
+
+console.log('\n' + '='.repeat(72));
+console.log(`ACROSS ALL LOGS: ${totals.echo} of ${totals.recv} distinct arrivals were the ` +
+  `client's own frames (${totals.recv ? ((totals.echo / totals.recv) * 100).toFixed(1) : '0'}%)`);
+console.log('='.repeat(72));
+console.log('Every self-echoed frame is an unavoidable AEAD failure: it is sealed to');
+console.log('the PEER\'s session and this client has no key for it. Any failure rate');
+console.log('computed over all arrivals therefore counts these as crate failures.');

--- a/src/dev/tests/harness/README.md
+++ b/src/dev/tests/harness/README.md
@@ -114,6 +114,8 @@ Log analyzers stay in `.agents/tools/dm-debug/` (`dr-ablate`, `dr-replay`,
 | `yarn harness dm-basic` | two bots exchange numbered DMs, no browser (HARNESS_ROUNDS) |
 | `yarn harness dm-volume` | concurrent bidirectional load; samples skipped-keys growth |
 | `yarn harness dm-reset-recover` | wipe a session mid-conversation, verify it re-inits and recovers |
+| `yarn harness dm-reorder` | **reproduces the production DM failure on demand.** Withholds the head of a sending chain so a stale skipped-keys bucket forms, then delivers the sender's next chain: the frames at colliding indices fail AEAD, and only those |
+| `yarn harness dm-loss` | send-vs-arrive frame loss per direction, joined by ciphertext fingerprint (issue #183 item 2) |
 
 On any decrypt failure a bot writes `logs/<ts>-<bot>.xpdump.log` in `[XPDUMP]`
 format, so the existing offline analyzers run on it unchanged:
@@ -123,12 +125,48 @@ node .agents/tools/dm-debug/dr-ablate.mjs   logs/<ts>-<bot>.xpdump.log
 node .agents/tools/dm-debug/dr-replay.mjs   logs/<ts>-<bot>.xpdump.log
 ```
 
+## Three things that will mislead you if you don't know them
+
+Each of these silently produced a wrong measurement before it was found. All are
+fixed; the notes are here so a change doesn't reintroduce them.
+
+1. **Every bot needs its OWN database.** `MessageDB` hardcodes
+   `DB_NAME = 'quorum_db'` and all bots share one global `fake-indexeddb`, so
+   without a per-bot name two bots become ONE client with two `MessageService`
+   instances writing the same rows — and each subscribes to the other's session
+   inboxes, so 41-48% of arrivals were the bot's own outbound ciphertext (all
+   guaranteed AEAD failures). See `storage.ts`.
+2. **Decrypt failures do not propagate.** The receive path catches
+   `DmDecryptError`, retains the frame for redelivery and returns `handled` — that
+   retention is what makes recovery work. So `try/catch` around
+   `handleNewMessage` sees nothing. `bot.ts` tees the failure log line instead, and
+   splits failures into **novel** vs **replay**: a frame the bot already decrypted
+   is refused by design. **Quote `bot.novelErrors()`, never `bot.errors`.**
+3. **Do not re-subscribe per frame.** A `listen` makes the relay re-push everything
+   still queued, so re-subscribing after every frame turns one undecryptable frame
+   into an unbounded redelivery loop (3 expected failures became 437). The app
+   subscribes on connect; `refreshSubscriptions` now only fires when the inbox set
+   actually changes.
+
+Also: `transport.holdInbound()` / `releaseInbound()` / `deliverWithheld()` give
+controlled reordering, and withholding is enforced **by fingerprint** — an un-acked
+frame is redelivered on every `listen`, so a version that merely skipped the first
+copy was defeated by the relay.
+
 ## Status
 
 - Slice 1 (identity + transport + register) — DONE, verified on prod.
 - Slice 2 (receive a real browser DM, decrypt headlessly) — DONE, verified on prod.
 - Slice 3 (two bots talk, no browser) — DONE, verified live. Replaces the two-browser loop.
 - Slice 4 (volume + XPDUMP capture) — DONE. Finding: volume alone does not age a
-  session. Remaining: importSession.ts (lift a real aged session from a browser).
+  session (re-confirmed after the fixes above; the original run could not see
+  failures at all).
+- **Reproduction + mitigation (2026-07-27) — DONE.** `dm-reorder` reproduces the
+  production failure mode on demand, and `dm-stale-bucket` measures the client-side
+  mitigation at 32→0 failures with no cost to delayed frames. So the open
+  `importSession.ts` step (lift a real aged session out of a browser) is **no longer
+  on the critical path** — the failure can be built from scratch instead.
 
-See `.agents/tasks/2026-07-27-headless-dm-harness.md` for the full slice plan.
+See `.agents/tasks/2026-07-27-headless-dm-harness.md` for the full slice plan, and
+`.agents/bugs/2026-07-26-dm-desktop-to-desktop-resurfaced.md` §1 for the findings.
+*Last updated: 2026-07-27*

--- a/src/dev/tests/harness/bot.ts
+++ b/src/dev/tests/harness/bot.ts
@@ -9,7 +9,7 @@
 // seam every DM path funnels through), so a scenario observes exactly what the
 // real code produced — no reimplemented routing or crypto.
 import { QueryClient } from '@tanstack/react-query';
-import type { Message, UserRegistration } from '@quilibrium/quorum-shared';
+import { logger, type Message, type UserRegistration } from '@quilibrium/quorum-shared';
 import { MessageService } from '../../../services/MessageService';
 import type { MessageServiceDependencies } from '../../../services/MessageService';
 import { ActionQueueService } from '../../../services/ActionQueueService';
@@ -30,8 +30,18 @@ export interface HarnessBot {
   messageDB: MessageDB;
   /** Every message the real code persisted, in arrival order. */
   captured: Message[];
-  /** handleNewMessage failures (e.g. DmDecryptError), for aging measurement. */
-  errors: { t: number; message: string; frame: unknown }[];
+  /**
+   * Receive-path decrypt failures.
+   *
+   * `replay` distinguishes the two kinds, and the distinction is load-bearing: a
+   * frame this bot ALREADY decrypted once is refused by the ratchet on a second
+   * delivery, which is the protocol working, not a defect. Un-acked frames are
+   * redelivered on every `listen`, so replays dominate a raw failure count — the
+   * same 2-5x overstatement the manual rig kept hitting. Quote `novel` failures.
+   */
+  errors: { t: number; message: string; frame: unknown; replay: boolean }[];
+  /** Failures on a frame never successfully decrypted before. */
+  novelErrors(): { t: number; message: string; frame: unknown; replay: boolean }[];
   /** Fires as each message is persisted (received OR locally saved on send). */
   onDecrypted?: (m: Message) => void;
   /** Fires on a receive-path failure, with the frame that failed. */
@@ -52,7 +62,8 @@ export async function createBot(
 ): Promise<HarnessBot> {
   const apiClient = makeApiClient();
   const identity = await loadOrCreateBot(name, apiClient, opts);
-  const messageDB = await makeMessageDB();
+  // Per-bot database — see storage.ts. Sharing one made two bots into one client.
+  const messageDB = await makeMessageDB(name);
   const transport = new WsTransport();
   const queryClient = new QueryClient();
 
@@ -65,9 +76,20 @@ export async function createBot(
   // Listen on the device inbox + every current session inbox — mirrors the app's
   // setResubscribe, so frames on newly-created session inboxes (e.g. after a
   // reset/re-init) actually arrive.
+  //
+  // Only re-sent when the inbox SET actually changes. A `listen` makes the relay
+  // re-push everything still queued, so re-sending it after every frame turns one
+  // undecryptable frame into an unbounded redelivery loop: a reorder run that
+  // should have produced ~3 failures produced 437. The app subscribes on connect,
+  // not per frame.
+  let subscribed = '';
   const refreshSubscriptions = async () => {
     const states = await messageDB.getAllEncryptionStates();
-    transport.listen([identity.inboxAddress, ...states.map((s) => s.inboxId)]);
+    const addresses = [identity.inboxAddress, ...states.map((s) => s.inboxId)];
+    const key = [...new Set(addresses)].sort().join(',');
+    if (key === subscribed) return;
+    subscribed = key;
+    transport.listen(addresses);
   };
 
   // Action queue: the send path routes through it once a session is established.
@@ -92,6 +114,7 @@ export async function createBot(
     messageDB,
     captured: [],
     errors: [],
+    novelErrors: () => bot.errors.filter((e) => !e.replay),
     send: async (toAddress: string, text: string) => {
       const self = (await apiClient.getUser(identity.address))?.data as UserRegistration;
       const counterparty = (await apiClient.getUser(toAddress))?.data as UserRegistration;
@@ -155,7 +178,37 @@ export async function createBot(
       return (origSave as (...a: unknown[]) => Promise<void>)(message, ...rest);
     };
 
+  // Frames this bot has decrypted at least once, by ciphertext fingerprint.
+  const decryptedOk = new Set<string>();
+
+  const record = async (message: string, frame: unknown, replay: boolean) => {
+    bot.errors.push({ t: Date.now(), message, frame, replay });
+    // Only dump NOVEL failures: a replay's state has legitimately moved past the
+    // frame, so feeding it to dr-ablate would fill the corpus with expected
+    // refusals and dilute the real signal.
+    if (!replay) {
+      if (!xpdump) xpdump = new XpdumpLog(name, Date.now());
+      try {
+        await xpdump.capture(messageDB, frame as Record<string, unknown>, Date.now());
+      } catch { /* capture is best-effort */ }
+    }
+    bot.onError?.(message, frame);
+  };
+
   transport.onMessage(async (frame) => {
+    // A DM decrypt failure does NOT propagate: the receive path catches it,
+    // retains the frame for redelivery and returns `handled` (that retention is
+    // what makes recovery possible). So the only external signal is the log line
+    // the service writes — teed here, and attributed to this frame because
+    // inbound dispatch is serialized. Without this, `errors` stayed empty and the
+    // XPDUMP emitter never fired even while the service logged AEAD failures.
+    let loggedFailure: string | undefined;
+    const origError = logger.error;
+    logger.error = ((...args: unknown[]) => {
+      const first = String(args[0] ?? '');
+      if (first.includes('DM decrypt failed')) loggedFailure = first;
+      return (origError as (...a: unknown[]) => unknown)(...args);
+    }) as typeof logger.error;
     try {
       await messageService.handleNewMessage(
         identity.address,
@@ -164,15 +217,16 @@ export async function createBot(
         queryClient
       );
     } catch (err) {
-      const message = (err as Error)?.message ?? String(err);
-      bot.errors.push({ t: Date.now(), message, frame });
-      // Auto-capture the failing (state, frame) pair in dr-ablate format.
-      if (!xpdump) xpdump = new XpdumpLog(name, Date.now());
-      try {
-        await xpdump.capture(messageDB, frame as Record<string, unknown>, Date.now());
-      } catch { /* capture is best-effort */ }
-      bot.onError?.(message, frame);
+      loggedFailure ??= (err as Error)?.message ?? String(err);
+    } finally {
+      logger.error = origError;
     }
+    // Capture BEFORE re-subscribing: refreshSubscriptions can pull further frames
+    // that advance the ratchet, and the dump must hold the state the frame failed
+    // against.
+    const fp = WsTransport.ciphertextFp(frame) ?? WsTransport.fingerprint(frame);
+    if (loggedFailure) await record(loggedFailure, frame, decryptedOk.has(fp));
+    else decryptedOk.add(fp);
     // Processing a frame may have created a new session inbox — keep subscriptions current.
     await refreshSubscriptions();
   });

--- a/src/dev/tests/harness/dm-loss.scenario.test.ts
+++ b/src/dev/tests/harness/dm-loss.scenario.test.ts
@@ -1,0 +1,178 @@
+// THREAD 3 — measure desktop↔desktop transport loss, per direction.
+//
+// Issue #183 item 2 says the node write path "drops a fraction of frames handed to
+// an open socket, 32% one direction phone↔phone". That has never been measured
+// desktop↔desktop. This does it the only way that is sound:
+//
+//   sent      = frames the real send path handed to the socket (transport.sent)
+//   arrived   = frames the peer's socket actually produced (transport.arrived)
+//   matched   = the intersection, joined by CIPHERTEXT fingerprint
+//
+// Both sides are de-duplicated by fingerprint before any count is quoted: an
+// un-acked frame is redelivered on every `listen`, and raw counters have
+// overstated volume by 2-5x three separate times in this investigation.
+//
+// ⚠️ Two things this CANNOT establish, stated up front:
+//   - "loss" here means "had not arrived by the end of the run". Redelivery has
+//     been observed taking longer than a whole capture round, so a short run
+//     overstates loss. HARNESS_LOSS_SETTLE_MS is the tail window; make it long.
+//   - a frame addressed to an inbox this pair does not subscribe to (multi-device
+//     fan-out to the accounts' OTHER devices) can never arrive here and is not
+//     loss. Only frames addressed to the peer's subscribed inboxes are counted.
+//
+//   yarn harness dm-loss
+//   HARNESS_LOSS_ROUNDS=200 HARNESS_LOSS_SETTLE_MS=600000 yarn harness dm-loss
+import { test, expect } from 'vitest';
+import { createBot, type HarnessBot } from './bot';
+import { WsTransport } from './transport';
+import { RunLog } from './log';
+
+const ROUNDS = Number(process.env.HARNESS_LOSS_ROUNDS ?? 40);
+const GAP_MS = Number(process.env.HARNESS_LOSS_GAP_MS ?? 700);
+const SETTLE_MS = Number(process.env.HARNESS_LOSS_SETTLE_MS ?? 120_000);
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/** Inbox addresses a bot is actually listening on — the only place a frame CAN land. */
+async function subscribedInboxes(bot: HarnessBot): Promise<Set<string>> {
+  const states = await bot.messageDB.getAllEncryptionStates();
+  return new Set([bot.identity.inboxAddress, ...states.map((s) => s.inboxId)]);
+}
+
+function direction(from: HarnessBot, to: HarnessBot, toInboxes: Set<string>) {
+  // Frames this sender addressed to an inbox the receiver is subscribed to.
+  const sent = new Map<string, number>();
+  for (const s of from.transport.sent) {
+    if (!s.fp) continue;
+    if (s.target && !toInboxes.has(s.target)) continue; // fan-out elsewhere, not loss
+    if (!sent.has(s.fp)) sent.set(s.fp, s.t);
+  }
+  const arrived = new Set<string>();
+  for (const f of to.transport.arrived) {
+    const fp = WsTransport.ciphertextFp(f);
+    if (fp) arrived.add(fp);
+  }
+  const missing = [...sent.keys()].filter((fp) => !arrived.has(fp));
+  return {
+    sent: sent.size,
+    arrived: [...sent.keys()].filter((fp) => arrived.has(fp)).length,
+    missing: missing.length,
+    lossPct: sent.size ? (missing.length / sent.size) * 100 : 0,
+    // Frames the receiver got that the sender never recorded sending to it:
+    // redeliveries of older frames, or frames from the account's other devices.
+    unmatchedArrivals: [...arrived].filter((fp) => !sent.has(fp)).length,
+  };
+}
+
+test(
+  'dm-loss: send-vs-arrive frame loss rate, both directions',
+  async () => {
+    const startedAt = Date.now();
+    const log = new RunLog('dm-loss', startedAt);
+    const say = (msg: string, fields: Record<string, unknown> = {}) => {
+      console.log(`[dm-loss] ${msg}`);
+      log.add(Date.now(), 'harness', 'note', { msg, ...fields });
+    };
+
+    // Fresh accounts: reused ones carry queued frames that arrive without having
+    // been sent in this run, which would corrupt both sides of the join.
+    const stamp = String(startedAt).slice(-6);
+    const [alice, bob] = await Promise.all([
+      createBot(`loss-a-${stamp}`),
+      createBot(`loss-b-${stamp}`),
+    ]);
+    await Promise.all([alice.start(), bob.start()]);
+    say(`alice=${alice.identity.address.slice(0, 12)} bob=${bob.identity.address.slice(0, 12)}`);
+
+    let aPosts = 0;
+    let bPosts = 0;
+    alice.onDecrypted = (m) => { if (m.content?.type === 'post') aPosts += 1; };
+    bob.onDecrypted = (m) => { if (m.content?.type === 'post') bPosts += 1; };
+
+    await alice.send(bob.identity.address, 'loss-setup A->B');
+    await sleep(4000);
+    await bob.send(alice.identity.address, 'loss-setup B->A');
+    await sleep(4000);
+
+    for (let i = 1; i <= ROUNDS; i++) {
+      await Promise.all([
+        alice.send(bob.identity.address, `A->B #${i}`).catch(() => {}),
+        bob.send(alice.identity.address, `B->A #${i}`).catch(() => {}),
+      ]);
+      await sleep(GAP_MS);
+      if (i % 10 === 0) {
+        say(`round ${i}/${ROUNDS}  aSent=${alice.transport.sent.length} bSent=${bob.transport.sent.length} ` +
+          `aArrived=${alice.transport.arrived.length} bArrived=${bob.transport.arrived.length}`);
+      }
+    }
+
+    // The tail window matters more than the send loop: recovery by redelivery is
+    // slow, and anything counted before it completes is latency read as loss.
+    say(`send loop done; settling ${Math.round(SETTLE_MS / 1000)}s for redelivery`);
+    const settleStep = Math.max(15_000, Math.floor(SETTLE_MS / 8));
+    for (let waited = 0; waited < SETTLE_MS; waited += settleStep) {
+      await sleep(Math.min(settleStep, SETTLE_MS - waited));
+      const inboxes = await subscribedInboxes(bob);
+      const d = direction(alice, bob, inboxes);
+      say(`  +${Math.round((waited + settleStep) / 1000)}s  A->B still missing ${d.missing}/${d.sent}`);
+    }
+
+    // Does a bot receive its OWN outbound frames? It subscribes to every
+    // encryption-state inbox, and if any of those is the inbox it SENDS to, the
+    // relay hands its own ciphertext back — which can never decrypt and would
+    // manufacture failures that have nothing to do with the bug under study.
+    const selfEcho = async (b: HarnessBot, label: string) => {
+      const mine = new Set(b.transport.sent.map((s) => s.fp).filter(Boolean) as string[]);
+      const echoed = b.transport.arrived.filter((f) => {
+        const fp = WsTransport.ciphertextFp(f);
+        return fp && mine.has(fp);
+      });
+      const own = await subscribedInboxes(b);
+      const targets = new Set(b.transport.sent.map((s) => s.target).filter(Boolean) as string[]);
+      const onInbox = new Map<string, number>();
+      for (const f of echoed) {
+        const a = String(f.inboxAddress ?? '?');
+        onInbox.set(a, (onInbox.get(a) ?? 0) + 1);
+      }
+      const detail = [...onInbox.entries()].map(([a, n]) =>
+        `${a.slice(0, 10)}x${n}${own.has(a) ? ' [subscribed]' : ''}${targets.has(a) ? ' [own send target]' : ''}`
+      ).join(' ');
+      say(`self-echo ${label}: ${echoed.length} of ${b.transport.arrived.length} arrivals are ` +
+        `this bot's OWN ciphertext  ${detail}`, { bot: label, echoed: echoed.length });
+      return echoed.length;
+    };
+    await selfEcho(alice, 'alice');
+    await selfEcho(bob, 'bob');
+
+    const bobInboxes = await subscribedInboxes(bob);
+    const aliceInboxes = await subscribedInboxes(alice);
+    const ab = direction(alice, bob, bobInboxes);
+    const ba = direction(bob, alice, aliceInboxes);
+
+    say('');
+    say('==== RESULT (de-duplicated by ciphertext fingerprint) ====');
+    for (const [label, d] of [['A->B', ab], ['B->A', ba]] as const) {
+      say(`${label}  sent=${d.sent}  arrived=${d.arrived}  missing=${d.missing}  ` +
+        `loss=${d.lossPct.toFixed(1)}%  unmatched-arrivals=${d.unmatchedArrivals}`,
+        { direction: label, ...d });
+    }
+    say(`posts decrypted: alice=${aPosts} bob=${bPosts}`);
+    say(`decrypt failures — NOVEL (the only ones worth quoting): ` +
+      `alice=${alice.novelErrors().length} bob=${bob.novelErrors().length}   ` +
+      `replays (expected refusals): alice=${alice.errors.length - alice.novelErrors().length} ` +
+      `bob=${bob.errors.length - bob.novelErrors().length}`,
+      { aNovel: alice.novelErrors().length, bNovel: bob.novelErrors().length });
+    say(`raw counters (NOT to be quoted): aSent=${alice.transport.sent.length} ` +
+      `bArrived=${bob.transport.arrived.length} bSent=${bob.transport.sent.length} ` +
+      `aArrived=${alice.transport.arrived.length}`);
+    console.log(`[dm-loss] log: ${log.file}`);
+
+    alice.stop();
+    bob.stop();
+
+    // The run IS the measurement; assert only that the join had data on both sides.
+    expect(ab.sent).toBeGreaterThan(0);
+    expect(ba.sent).toBeGreaterThan(0);
+  },
+  4 * 60 * 60 * 1000
+);

--- a/src/dev/tests/harness/dm-reorder.scenario.test.ts
+++ b/src/dev/tests/harness/dm-reorder.scenario.test.ts
@@ -1,0 +1,128 @@
+// THREAD 2 — reproduce the poisoning DELIBERATELY, through the real client.
+//
+// Volume does not do it (slice 4: fresh accounts, concurrent load, zero skipped
+// keys, zero failures) because the relay delivers in order, so nothing is ever
+// skipped and no skipped-keys bucket ever forms. The offline mechanism work
+// (`.agents/tools/dm-debug/dr-prune-safety.mjs`) says exactly what is needed:
+//
+//   1. a LATER frame of a sending chain must be processed before earlier ones,
+//      which files the earlier indices as skipped keys under the header key that
+//      has just become the receiver's CURRENT receiving header key;
+//   2. the sender must then open a NEW sending chain (it does so as soon as it
+//      receives a reply);
+//   3. frames of that new chain whose index COLLIDES with an index in the stale
+//      bucket are handed an old-chain message key and fail AEAD.
+//
+// Non-colliding indices decrypt fine, which is why the failure looks like it
+// depends on "position in the chain".
+//
+//   yarn harness dm-reorder
+import { test, expect } from 'vitest';
+import { createBot } from './bot';
+import { ratchetStats } from './inspect';
+import { RunLog } from './log';
+
+const SETTLE_MS = Number(process.env.HARNESS_SETTLE_MS ?? 3000);
+/** How many of the first chain's frames to withhold (= the stale bucket's size). */
+const WITHHOLD = Number(process.env.HARNESS_WITHHOLD ?? 3);
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+test(
+  'dm-reorder: out-of-order delivery forms a stale bucket, then the next chain fails on demand',
+  async () => {
+    const startedAt = Date.now();
+    const log = new RunLog('dm-reorder', startedAt);
+    const say = (msg: string, fields: Record<string, unknown> = {}) => {
+      console.log(`[dm-reorder] ${msg}`);
+      log.add(Date.now(), 'harness', 'note', { msg, ...fields });
+    };
+
+    // Fresh throwaway accounts. Reused accounts carry queued frames that produce
+    // failures for an unrelated reason (stale redelivery) — the confound that
+    // falsified the previous "harness reproduced the bug" read.
+    const stamp = String(startedAt).slice(-6);
+    const [alice, bob] = await Promise.all([
+      createBot(`ro-a-${stamp}`),
+      createBot(`ro-b-${stamp}`),
+    ]);
+    await Promise.all([alice.start(), bob.start()]);
+
+    const bobRecv: string[] = [];
+    bob.onDecrypted = (m) => {
+      if (m.content?.type === 'post') bobRecv.push(String((m.content as { body?: string }).body ?? ''));
+    };
+
+    // --- phase 1: establish both directions -------------------------------
+    await alice.send(bob.identity.address, 'setup A->B');
+    await sleep(SETTLE_MS);
+    await bob.send(alice.identity.address, 'setup B->A');
+    await sleep(SETTLE_MS);
+    say(`sessions established; bob decrypted ${bobRecv.length} post(s), ${bob.errors.length} error(s)`);
+
+    const before = await ratchetStats(bob.messageDB);
+    say(`bob skipped-keys before: ${before.map((s) => `${s.inbox}=${s.skipped}`).join(' ') || 'none'}`);
+
+    // --- phase 2: withhold the head of a chain, deliver a later frame first --
+    bob.transport.holdInbound();
+    for (let i = 0; i <= WITHHOLD; i++) {
+      await alice.send(bob.identity.address, `chain1-#${i}`);
+      await sleep(400);
+    }
+    await sleep(SETTLE_MS);
+    say(`bob is holding ${bob.transport.heldCount} inbound frame(s)`);
+
+    // Release ONLY the last one. The earlier indices become skipped keys filed
+    // under the header key that thereby becomes bob's current receiving key.
+    // The rest stay withheld by fingerprint, so relay redeliveries don't undo it.
+    const { delivered, withheld } = await bob.transport.releaseInbound((held) => {
+      const last = held[held.length - 1];
+      return last ? [last] : [];
+    });
+    await sleep(SETTLE_MS);
+    say(`released ${delivered}, withholding ${withheld} across redeliveries`);
+
+    const poisoned = await ratchetStats(bob.messageDB);
+    const skipped = poisoned.reduce((a, s) => a + s.skipped, 0);
+    say(`after out-of-order delivery: bob skipped-keys=${skipped} ` +
+      `(${poisoned.map((s) => `${s.inbox}=${s.skipped}/${s.buckets}b`).join(' ')})`,
+      { skipped });
+
+    // --- phase 3: make alice open a NEW sending chain ----------------------
+    // Alice rotates her sending chain as soon as she processes a frame from bob.
+    await bob.send(alice.identity.address, 'B->A rotate');
+    await sleep(SETTLE_MS);
+
+    const errBefore = bob.errors.length;
+    for (let i = 0; i < WITHHOLD + 2; i++) {
+      await alice.send(bob.identity.address, `chain2-#${i}`);
+      await sleep(600);
+    }
+    await sleep(SETTLE_MS * 2);
+    const newFailures = bob.errors.length - errBefore;
+
+    say(`NEW-CHAIN DELIVERY: ${newFailures} decrypt failure(s) on bob ` +
+      `(sent ${WITHHOLD + 2} frames; predicted ~${WITHHOLD} to collide)`,
+      { newFailures, predicted: WITHHOLD });
+
+    // --- phase 4: the withheld frames, delivered late ----------------------
+    // These are the frames whose keys live in the stale bucket. They must still
+    // decrypt — that is the recovery path any mitigation must not break.
+    const errBeforeLate = bob.errors.length;
+    const late = await bob.transport.deliverWithheld();
+    await sleep(SETTLE_MS);
+    say(`late delivery of ${late} withheld frame(s): ${bob.errors.length - errBeforeLate} failure(s)`);
+
+    say(`bob decrypted posts: ${bobRecv.length} -> ${JSON.stringify(bobRecv.slice(-8))}`);
+    say(`bob total errors: ${bob.errors.length}`);
+    console.log(`[dm-reorder] log: ${log.file}`);
+
+    alice.stop();
+    bob.stop();
+
+    // The measurement is the run. Assert only that the mechanism's precondition
+    // was actually built — without a stale bucket the scenario proves nothing.
+    expect(skipped).toBeGreaterThan(0);
+  },
+  20 * 60 * 1000
+);

--- a/src/dev/tests/harness/storage.ts
+++ b/src/dev/tests/harness/storage.ts
@@ -2,11 +2,27 @@
 // installs indexedDB + IDBKeyRange as globals, which MessageDB.init() opens
 // exactly as it does in the browser. Node 22 provides structuredClone, which
 // fake-indexeddb needs.
+//
+// ⚠️ EACH BOT NEEDS ITS OWN DATABASE. MessageDB hardcodes `DB_NAME = 'quorum_db'`,
+// and every bot in this process shares the one global fake-indexeddb — so without
+// a per-bot name, two bots open the SAME database and become one client with two
+// MessageService instances writing the same rows. Measured consequences of the
+// shared-DB version (2026-07-27): each bot subscribed to the other's session
+// inboxes (because `refreshSubscriptions` reads every encryption_states row), so
+// 41-48% of all arrivals were the bot's OWN outbound ciphertext, each an
+// unavoidable AEAD failure. Real browsers showed 0% self-echo across 2709
+// captured arrivals, confirming it was this and not app behaviour.
+//
+// DB_NAME is `private readonly` to TypeScript only; at runtime it is an ordinary
+// instance field, so it can be renamed after construction and before init().
 import 'fake-indexeddb/auto';
 import { MessageDB } from '../../../db/messages';
 
-export async function makeMessageDB(): Promise<MessageDB> {
+export async function makeMessageDB(namespace?: string): Promise<MessageDB> {
   const db = new MessageDB();
+  if (namespace) {
+    (db as unknown as { DB_NAME: string }).DB_NAME = `quorum_db_${namespace}`;
+  }
   await db.init();
   return db;
 }

--- a/src/dev/tests/harness/transport.ts
+++ b/src/dev/tests/harness/transport.ts
@@ -22,6 +22,24 @@ export interface InboundFrame {
 
 export type InboundHandler = (frame: InboundFrame) => void | Promise<void>;
 
+function fnv1a(s: string): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return (h >>> 0).toString(16).padStart(8, '0');
+}
+
+/** One outbound frame handed to the socket. */
+export interface SentFrame {
+  t: number;
+  /** Ciphertext fingerprint — matches the peer's `arrived` entry for this frame. */
+  fp: string | undefined;
+  /** Target inbox address the frame was addressed to, when the frame carries one. */
+  target: string | undefined;
+}
+
 export function makeApiClient(): QuorumApiClient {
   return new QuorumApiClient({ baseUrl: config.apiUrl, wsUrl: config.wsUrl });
 }
@@ -33,10 +51,126 @@ export class WsTransport {
   private closed = false;
   connected = false;
 
+  // ---- controlled reordering ------------------------------------------------
+  // The relay delivers in order, so nothing is ever skipped and no skipped-keys
+  // bucket ever forms — which is why the volume scenario measured zero of them.
+  // A bucket needs a LATER frame of a sending chain to be processed before an
+  // EARLIER one. This buffer makes that happen on demand.
+  //
+  // ⚠️ Withholding has to be enforced by FINGERPRINT, not just by not-dispatching
+  // once: an un-acked frame stays on the relay inbox and is pushed again on every
+  // `listen`, and the receive path re-subscribes after each frame. A first version
+  // of this that only buffered the initial copy was silently defeated — the relay
+  // redelivered the withheld frames in order and no bucket formed.
+  private holding = false;
+  private held: InboundFrame[] = [];
+  private suppressed = new Map<string, InboundFrame>();
+  /** Every frame this transport has ever received, in arrival order. */
+  readonly arrived: InboundFrame[] = [];
+  /** Every frame this transport has ever handed to the socket. */
+  readonly sent: SentFrame[] = [];
+  /** Inbound dispatch is serialized — see dispatch(). */
+  private chain: Promise<void> = Promise.resolve();
+
   constructor(private readonly wsUrl: string = config.wsUrl) {}
 
   onMessage(handler: InboundHandler): void {
     this.handler = handler;
+  }
+
+  /** Stable id for a frame, so redelivered copies are recognised. */
+  static fingerprint(frame: InboundFrame): string {
+    return fnv1a(String((frame as { encryptedContent?: string }).encryptedContent ?? ''));
+  }
+
+  /**
+   * Identify a frame by its CIPHERTEXT, so the same frame can be matched on the
+   * sending side (a raw outbound JSON string) and on the receiving side (where the
+   * relay has rewrapped it as `{inboxAddress, encryptedContent, timestamp}`).
+   * This is what makes a send-vs-arrive loss count possible.
+   */
+  static ciphertextFp(rawOrFrame: string | InboundFrame): string | undefined {
+    let obj: Record<string, unknown> | undefined;
+    try {
+      const s =
+        typeof rawOrFrame === 'string'
+          ? rawOrFrame
+          : String((rawOrFrame as { encryptedContent?: string }).encryptedContent ?? '');
+      obj = JSON.parse(s) as Record<string, unknown>;
+    } catch {
+      return undefined;
+    }
+    // Outbound frames may wrap the sealed message; unwrap one level if needed.
+    const sealed =
+      obj && typeof obj.envelope === 'string'
+        ? obj
+        : (obj?.message as Record<string, unknown> | undefined);
+    const env = sealed && typeof sealed.envelope === 'string' ? sealed.envelope : undefined;
+    return env ? fnv1a(env) : undefined;
+  }
+
+  /** Start buffering inbound frames instead of dispatching them. */
+  holdInbound(): void {
+    this.holding = true;
+  }
+
+  /** How many distinct frames are currently buffered. */
+  get heldCount(): number {
+    return this.held.length;
+  }
+
+  /** How many frames are being withheld across redeliveries. */
+  get suppressedCount(): number {
+    return this.suppressed.size;
+  }
+
+  /**
+   * Stop buffering and dispatch the frames `order` selects, in its order.
+   * `(held) => [held.at(-1)]` delivers only the last, which is what files the
+   * earlier indices as skipped keys.
+   *
+   * Frames `order` omits stay WITHHELD by fingerprint: further copies pushed by
+   * the relay are dropped too, until `deliverWithheld()` lets them through.
+   */
+  async releaseInbound(
+    order: (held: InboundFrame[]) => InboundFrame[] = (h) => h
+  ): Promise<{ delivered: number; withheld: number }> {
+    const batch = this.held;
+    this.held = [];
+    this.holding = false;
+    const chosen = order([...batch]).filter(Boolean);
+    const chosenFps = new Set(chosen.map((f) => WsTransport.fingerprint(f)));
+    for (const frame of batch) {
+      const fp = WsTransport.fingerprint(frame);
+      if (!chosenFps.has(fp)) this.suppressed.set(fp, frame);
+    }
+    for (const frame of chosen) await this.dispatch(frame);
+    return { delivered: chosen.length, withheld: this.suppressed.size };
+  }
+
+  /** Let the withheld frames through — a delayed redelivery. */
+  async deliverWithheld(): Promise<number> {
+    const frames = [...this.suppressed.values()];
+    this.suppressed.clear();
+    for (const frame of frames) await this.dispatch(frame);
+    return frames.length;
+  }
+
+  /** Hand a frame to the receive path directly. */
+  async deliver(frame: InboundFrame): Promise<void> {
+    await this.dispatch(frame);
+  }
+
+  // Serialized: the browser's receive path is entered once per socket message and
+  // guards the ratchet with a mutex, but a harness that fires handleNewMessage
+  // concurrently would also make per-frame attribution of a failure ambiguous.
+  private dispatch(frame: InboundFrame): Promise<void> {
+    if (!this.handler) return Promise.resolve();
+    this.chain = this.chain.then(() => this.handler!(frame)).then(
+      () => undefined,
+      () => undefined
+    );
+    return this.chain;
   }
 
   /** Open the socket; resolves on the first `open`. Re-subscribes automatically. */
@@ -53,13 +187,23 @@ export class WsTransport {
         });
 
         ws.on('message', (data: WebSocket.RawData) => {
-          if (!this.handler) return;
+          let frame: InboundFrame;
           try {
-            const frame = JSON.parse(data.toString()) as InboundFrame;
-            void this.handler(frame);
+            frame = JSON.parse(data.toString()) as InboundFrame;
           } catch {
-            /* ignore non-JSON control frames */
+            return; /* non-JSON control frame */
           }
+          this.arrived.push(frame);
+          const fp = WsTransport.fingerprint(frame);
+          // Already withheld: drop this redelivered copy too.
+          if (this.suppressed.has(fp)) return;
+          if (this.holding) {
+            if (!this.held.some((f) => WsTransport.fingerprint(f) === fp)) {
+              this.held.push(frame);
+            }
+            return;
+          }
+          void this.dispatch(frame);
         });
 
         ws.on('close', () => {
@@ -85,8 +229,14 @@ export class WsTransport {
     this.ws?.send(JSON.stringify({ type: 'listen', inbox_addresses: inboxAddresses }));
   }
 
-  /** Raw send — used later to push outbound sealed frames. */
+  /** Raw send — pushes an outbound sealed frame, and records it for loss counting. */
   send(raw: string): void {
+    let target: string | undefined;
+    try {
+      const o = JSON.parse(raw) as { inbox_address?: string; message?: { inbox_address?: string } };
+      target = o.inbox_address ?? o.message?.inbox_address;
+    } catch { /* not JSON — still counted */ }
+    this.sent.push({ t: Date.now(), fp: WsTransport.ciphertextFp(raw), target });
     this.ws?.send(raw);
   }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,7 +17,12 @@ export default defineConfig({
     globals: true,
     css: false,
     include: ['src/dev/tests/**/*.{test,spec}.{js,ts,jsx,tsx}'],
-    exclude: ['node_modules', 'dist'],
+    // The headless harness scenarios belong to vitest.harness.config.ts and CANNOT
+    // run here: this config's setup.ts mocks WebSocket and crypto, and the wasm core
+    // is never initialised, so every scenario fails on `js_generate_ed448` or on a
+    // missing lingui locale. They were failing this suite (8 files) purely for that
+    // reason. Run them with `yarn harness`.
+    exclude: ['node_modules', 'dist', 'src/dev/tests/harness/**'],
     server: {
       deps: {
         inline: [


### PR DESCRIPTION
Splits cleanly from the mitigation (that is the follow-up PR, stacked on this one). Nothing here changes app behaviour: the only non-test source change is a Vitest config exclusion.

## Reproduction on demand

The relay delivers in order, so nothing is ever skipped and no skipped-keys bucket ever forms — which is why the volume scenario measured zero of them and why "aged session" looked like a precondition.

Adding controlled reordering to the harness transport (`holdInbound` / `releaseInbound` / `deliverWithheld`) makes the production failure deterministic:

1. withhold the head of a sending chain and deliver a later frame first, so the earlier indices are filed under the receiver's **current** receiving header key;
2. let the sender open its **next** chain;
3. the frames whose index collides with that stale bucket fail AEAD — and only those.

```
yarn harness dm-reorder
  → 3 withheld frames produce exactly 3 failures, at exactly the colliding indices
  → the withheld frames then still decrypt (0 failures)
```

Withholding is enforced **by fingerprint**. An un-acked frame is re-pushed on every `listen`, so a first version that merely skipped the initial copy was silently defeated by relay redelivery and no bucket ever formed.

## Two bench defects, both caught by controls rather than inspection

**1. Every bot shared one IndexedDB.** `MessageDB` hardcodes `DB_NAME = 'quorum_db'` and all bots use the one global `fake-indexeddb`, so two bots were a single client with two `MessageService` instances writing the same rows. Each then subscribed to the other's session inboxes and received its own outbound ciphertext — **41-48% of all arrivals**, every one an unavoidable AEAD failure.

This looked like a real app defect, because `setResubscribe` uses the identical subscription rule. The control that settled it: `dr-self-echo.mjs` finds **0 self-echo across 2709 distinct captured browser arrivals**. Bench-only. Fixed with a per-bot database name.

**2. Decrypt failures were invisible to the harness.** They never leave `handleNewMessage` — caught, frame retained for redelivery, `handled` returned (that retention is what makes recovery work). So the earlier "0 failures" result came from an observer that could not see failures. Now the failure log line is teed, and failures are split into **novel** vs **replay**: a frame already decrypted once is refused by design, and replays dominate a raw count.

Also: `refreshSubscriptions` no longer fires per frame. A `listen` re-pushes the relay queue, which turned 3 expected failures into **437**.

> The earlier conclusion "volume alone does not age a session" still holds — it just wasn't evidenced when it was written. On the fixed bench a fresh pair shows 0 skipped keys, 0 novel failures, 0 self-echo.

## Transport loss, measured desktop↔desktop for the first time

`dm-loss` joins send-vs-arrive by ciphertext fingerprint, with a long redelivery tail because a short run cannot tell loss from latency. 300 rounds each way plus a 20-minute tail:

| | A→B | B→A |
|---|---|---|
| frames addressed to an inbox the peer subscribes to | 301 | 301 |
| arrived | **301** | **301** |
| missing | **0** | **0** |

This does not refute issue #183 item 2 (32% one direction phone↔phone) — different platform and path — but it removes transport loss as an explanation for the d↔d symptom.

## Also

- New offline tools: `dr-prune-safety.mjs` (what a failing frame actually *is*, and whether a mitigation would break a frame that otherwise succeeds — answered synthetically, because `[XPDUMP]` only fires on failure so the corpus holds no successes) and `dr-self-echo.mjs`.
- `vitest.config.ts` excludes the harness tree. Those scenarios were being collected by the default config, which mocks WebSocket/crypto and never inits the wasm, so 8 files failed `vitest run` for that reason alone.

## Verification

`tsc` clean, **540/540** tests pass, `dm-basic` and `dm-reset-recover` still pass.