### PR TITLE
dm: recover frames the upstream skipped-key lookup rejects, without discarding the keys

### DIFF
--- a/.agents/bugs/2026-07-26-dm-desktop-to-desktop-resurfaced.md
+++ b/.agents/bugs/2026-07-26-dm-desktop-to-desktop-resurfaced.md
@@ -507,6 +507,23 @@ Measured (`yarn harness dm-stale-bucket`, 8 cycles per arm, fresh accounts both)
 | AEAD failures on new-chain frames | **32** of 56 | **0** of 56 |
 | failures on the DELAYED frames | 0 | **0** ← the regression that matters |
 
+**And measured against REAL degraded production state**, not just bench-built
+sessions. Each `[XPDUMP]` record holds the complete `EncryptionState` row *and* the
+frame that failed against it, so the shipped helper can be run against the field
+corpus directly — no export, no device
+(`DM_LOG_DIR=<logs> yarn harness replay-captured`):
+
+| | |
+|---|---|
+| distinct captured failures (54 logs, de-duplicated) | 159 |
+| recovered by the **shipped** code | **139 (87%)** |
+| recoveries that preserved the bucket's keys | **139/139** |
+| not recovered | 20 (near-empty maps; 2 have no current-header bucket) |
+
+That figure matches `dr-prune-safety.mjs` exactly, which is the point of running
+both: the analyzer open-codes the mutation, so a divergence between it and
+`dmStaleBucketRetry.ts` would otherwise go unnoticed.
+
 Implementation: [`src/utils/dmStaleBucketRetry.ts`](../../src/utils/dmStaleBucketRetry.ts)
 (pure, 14 unit tests) wired into **both** decrypt branches of
 `handleNewMessage`. Two things a future editor must not undo:
@@ -521,9 +538,17 @@ There is a kill switch (`staleBucketRetry.enabled`) because this is a workaround
 for a defect in a dependency we have no source for. It is inert on a healthy
 session: no bucket under the current key means one JSON parse and no retry.
 
-**Still to do before merge:** exercise it against mobile↔desktop traffic, and
-decide whether the `logger.warn` on each recovery is wanted in production or should
-be sampled.
+**Still to do before merge:**
+- Decide whether the `logger.warn` on each recovery is wanted in production or
+  should be sampled.
+- Confirm it in a browser. Everything above is protocol + service layer; nothing
+  has run the UI.
+- ⚠️ **Mobile↔desktop is worth doing but is NOT a correctness gate**, and an earlier
+  version of this section wrongly implied it was. The retry is purely
+  receiver-side: it keys off the receiver's own ratchet state and never inspects
+  the frame's origin, so a mobile-sent frame cannot reach a different branch.
+  What cross-platform traffic would measure is **how often buckets form in real
+  use** — the §5-D trigger question — not whether the mitigation is sound.
 
 **B2. Trigger redelivery on decrypt failure instead of waiting for it.**
 

--- a/.agents/bugs/2026-07-26-dm-desktop-to-desktop-resurfaced.md
+++ b/.agents/bugs/2026-07-26-dm-desktop-to-desktop-resurfaced.md
@@ -1,7 +1,7 @@
 ---
 type: bug
 title: "DM delivery broken again on desktop↔desktop (the 2026-07-02 master report is NOT closed)"
-status: ROOT CAUSE FOUND 2026-07-27, upstream in the channel crate (finding AE). When a session's `skipped_keys_map` holds a bucket under the receiver's CURRENT receiving header key, the crate's decrypt takes that bucket and fails on a frame it could otherwise derive the key for. 63 of 65 captured failures across 6 rounds decrypt when ONLY that bucket is deleted and nothing else changes. It builds up with use, every failure adds another key, and a reset clears it — which is why a conversation degrades over days and works again after a reset. ⚠️ The older framing ("failure is a deterministic function of chain position, 0-2 fail, 3+ never") is a SYMPTOM description and was RETIRED by finding AD — a fresh session shows those same positions behaving normally; position is where the failure lands, not what causes it. Failures are TRANSIENT — the same bytes decrypt on redelivery — so this is LATENCY WITH A LONG TAIL, not demonstrated message loss. TEN app-level mechanisms have been proposed and killed (§3). Three client defects were found and are MERGED to main (§7). Evidence is filed upstream at quorum-mobile#183. A fresh agent's next action is in §5 — it is NOT more local capturing, and §5 now lists a client-side mitigation that only became possible once AE was known.
+status: MECHANISM FULLY CHARACTERISED AND A CLIENT-SIDE MITIGATION IS VALIDATED (2026-07-27, finding AI — refines AE). The crate matches a skipped message key BY INDEX in the bucket filed under the receiver's pre-DH-step `current_receiving_header_key`, without checking that bucket belongs to the incoming frame's chain. A frame that opens a NEW sending chain and lands on an index present in that stale bucket is handed an OLD-chain key and fails AEAD; non-colliding indices decrypt normally. All three conditions hold in 139 of 139 recovered captured failures, the failing index set equals the stale bucket's index set exactly (5/5 synthetic configurations), and it is now REPRODUCIBLE ON DEMAND both against the bare crate and through the real client (`yarn harness dm-reorder`). ⚠️ AE's implied "the bucket's presence causes the failure" is NOT sufficient — controls show an in-order frame and non-colliding frames decrypt fine on a poisoned state. This also answers the lookup-vs-contents question §4 left open: it is the LOOKUP; the bucket's keys are valid and decrypt their own frames correctly. ⚠️⚠️ §5-B1 AS ORIGINALLY WRITTEN MUST NOT SHIP: pruning and persisting destroys the delayed frames whose keys live in that bucket (3/3 measured), converting recoverable latency into permanent loss. The safe form (B1′ — prune for the RETRY ONLY, re-file the bucket into the persisted state) is implemented on branch `feat/dm-stale-bucket-retry` and measured at 32→0 failures over 56 new-chain frames with ZERO cost to delayed frames. TEN app-level mechanisms remain dead (§3); three client defects are MERGED (§7). Evidence is filed upstream at quorum-mobile#183. Failures are TRANSIENT, so this is LATENCY WITH A LONG TAIL, not demonstrated loss.
 created: 2026-07-26
 severity: medium — user-visible lag and apparent loss; no permanent loss demonstrated since the init-envelope fix (see §1)
 repo: quorum-desktop (cross-repo — mobile shares the accounts and the upstream causes)
@@ -23,9 +23,15 @@ related:
 
 > **START HERE if you are a fresh agent.** In order:
 >
-> 1. **The client-side work is finished and merged.** Do not start by hunting for
->    a bug in this repo — ten app-level mechanisms have already been proposed and
->    killed (§3), and the three real defects found along the way are shipped (§7).
+> 0. **2026-07-27: the mechanism is fully characterised, reproducible on demand, and
+>    a client-side mitigation is built and measured.** Run `yarn harness dm-reorder`
+>    to watch the production failure happen in ~35 seconds. The live work item is
+>    **reviewing and merging branch `feat/dm-stale-bucket-retry`** (§5-B1), not
+>    running another experiment. Findings AI/AJ/AK/AL in §1.
+> 1. **The client-side work up to that point is finished and merged.** Do not start
+>    by hunting for a bug in this repo — ten app-level mechanisms have already been
+>    proposed and killed (§3), and the three real defects found along the way are
+>    shipped (§7).
 > 2. **Read §3 before forming a theory.** Every one of those ten was argued
 >    confidently and then disproved by the next measurement. In every single case
 >    the measurement was sound and the interpretation ran ahead of it; one was
@@ -56,37 +62,134 @@ related:
 | Why it usually looks fine | the frame is **redelivered** and decrypts on a later attempt. Recovery can take longer than a whole capture round, so short captures cannot tell loss from latency (finding AB) |
 | Direction | varies by round; both directions fail. Early rounds looked one-directional, later ones did not |
 | Earlier, worse state | 0 of 10 delivered both directions, permanent, until a manual reset |
-| **ROOT CAUSE** | ⚠️ **FOUND — finding AE.** When `skipped_keys_map` holds a bucket under the receiver's **current receiving header key**, the crate's decrypt takes that bucket and fails instead of deriving the key normally. **63 of 65 captured failures across 6 rounds decrypt when that ONE bucket is deleted** and nothing else changes. In a typical case the bucket held 3 keys of 62 — removing the other 59 changes nothing. Minimal repro in the archive; upstream, not fixable here |
+| **ROOT CAUSE** | ⚠️ **FOUND — finding AE, mechanism completed by finding AI.** The crate matches a skipped message key **by index** in the bucket filed under the receiver's *pre-DH-step* `current_receiving_header_key`, without checking that bucket belongs to the incoming frame's chain. A frame opening a NEW sending chain, at an index present in that stale bucket, gets an OLD-chain key and fails AEAD. **139 of 159 captured failures** (the whole corpus on disk, de-duplicated — larger than the 65 first recorded) decrypt when that ONE bucket is removed, and **139/139 of them show all three conditions**. Upstream, not fixable here — but see §5-B1′, which removes the symptom |
+| **Reproducible on demand** | ✅ **YES, since 2026-07-27** — no devices, no aged session, no waiting. Out-of-order delivery within a chain forms the stale bucket; the sender's next chain then fails at exactly the colliding indices. `node .agents/tools/dm-debug/dr-prune-safety.mjs` (crate level, deterministic) and `yarn harness dm-reorder` (through the real client). See finding AI |
 | ~~mechanism~~ (superseded, kept for the reasoning) | ⚠️ **REVISED — see finding AD.** On an AGED session, failure is near-total at chain positions 0-2 and absent from 3+. On a FRESH session the same positions are clean. **Chain position is where the failure lands, not what causes it.** The leading correlate is the accumulated skipped-keys map, which grew 2 → 20 → 23 → 37 across the day as the failure rate rose — but that is a hypothesis, not a conclusion (failures also *create* skipped keys, so cause and effect are circular on current evidence) |
 | Recovery | **transient** — nearly all failed frames decrypt on a later redelivery. All recovery counts in the archive are LOWER BOUNDS, because captures were saved at ~2 minutes |
 | Why the typing indicator is inverted | `typing-start` is the first frame after reading the peer's message, i.e. always **position 0**, the 100%-failure slot; the peer sees the *redelivered* copy a turn later |
 
-The original reproduction pattern — works after a reset, use the same accounts on
-mobile for days, return to desktop broken — **has still never been reproduced
-deliberately** and remains the single most valuable thing to capture.
+The original *field* pattern — works after a reset, use the same accounts on mobile
+for days, return to desktop broken — has still never been reproduced by following
+those steps. **But the failure mode itself no longer needs it:** the mechanism is
+reproducible on demand in seconds (finding AI), so nothing further is blocked on
+capturing an aged session. What the field pattern would still add is *how the
+bucket comes to exist in normal use*, which remains unmeasured (§5-D).
 
-**The one-line summary:** a stale entry in the ratchet's skipped-keys map, under
-the key the receiver is currently using, makes the crate fail frames it could
-decrypt. It builds up with use, every failure adds another, and a reset clears it
-— which is why the conversation degrades over days and works again after a reset.
+**The one-line summary:** the ratchet keeps the message keys of frames it had to
+skip, filed under the sending chain they belong to — and when the sender starts a
+new chain, the crate matches those saved keys **by position number alone**, without
+checking they belong to this chain. So the first frames of every new chain get
+handed a key from the old one and fail. It accumulates with use, every failure adds
+another saved key, and a reset clears the lot — which is why a conversation degrades
+over days and works again after a reset.
 
 > **Bench refinement (headless harness, 2026-07-27):** "builds up with use" is NOT
 > message-count alone. A run of the REAL client headless in Node (both sides, fresh
 > accounts, 60–82 concurrent msgs each way) accumulated **zero** skipped keys and
-> **zero** failures — a controlled confirmation that a fresh session does not fail,
-> narrowing the accumulation trigger to time / cross-platform / reset, NOT volume.
-> A first run *did* fail, but a fresh-account control falsified it as stale queued
-> frames from account reuse (the redelivery mode), not load. See §5 "headless
-> harness" and [the harness task](../tasks/2026-07-27-headless-dm-harness.md).
+> **zero** failures, narrowing the accumulation trigger to time / cross-platform /
+> reset, NOT volume. A first run *did* fail, but a fresh-account control falsified
+> it as stale queued frames from account reuse, not load.
+> ⚠️ **This conclusion still holds but the original measurement did not support it
+> — see finding AJ.** The harness could not see decrypt failures at all when that
+> run was made (the receive path catches `DmDecryptError` and returns `handled`, so
+> nothing propagated), and every bot shared one IndexedDB. Both are fixed; on the
+> fixed bench a fresh pair still shows 0 skipped keys and 0 novel failures, so the
+> claim is now genuinely evidenced.
+
+> ### Bench findings, 2026-07-27 (offline ablation + headless harness)
+>
+> **AI — the mechanism, completing AE.** Three conditions are jointly necessary:
+> (a) a bucket exists under the receiver's `current_receiving_header_key`; (b) the
+> incoming frame opens a NEW sending chain, so the receiver takes a DH step;
+> (c) the frame's index *within that new chain* collides with an index present in
+> the stale bucket. The crate then applies an old-chain message key and fails AEAD.
+> - **139/139** recovered captured failures satisfy all three (whole corpus on
+>   disk, de-duplicated by envelope fingerprint: 159 dumps, 139 recover, 20 do not).
+> - The failing index set **equals** the stale bucket's index set, exactly, across
+>   5/5 synthetic configurations (bucket `[0]`…`[0,1,2,3,4]`).
+> - **Controls that could have falsified it and did not:** the bucket's mere
+>   presence is *not* sufficient (an in-order frame and non-colliding new-chain
+>   frames both decrypt on a poisoned state); and skipped keys from a previous
+>   chain are filed correctly under the *old* header key, so cross-DH-step
+>   withholding alone poisons nothing.
+> - **This settles §4's open lookup-vs-contents question: it is the LOOKUP.** The
+>   bucket's contents are valid — those keys decrypt their own frames correctly
+>   (measured, 3/3). They are simply being applied to the wrong chain.
+> - **It mechanically explains the retired position table.** The indices that get
+>   skipped in practice are the low ones, so the stale bucket holds 0,1,2… and
+>   every subsequent DH chain fails at exactly its first positions and is clean
+>   from there. Position was never causal; it is where the collision lands.
+>
+> **AJ — two harness defects that invalidated earlier bench numbers.** Both found
+> by controls, both fixed:
+> 1. **Every bot shared one database.** `MessageDB` hardcodes `DB_NAME='quorum_db'`
+>    and all bots use one global `fake-indexeddb`, so two bots were one client with
+>    two `MessageService` instances writing the same rows. Each then subscribed to
+>    the other's session inboxes (`refreshSubscriptions` reads every
+>    `encryption_states` row), so **41–48% of all arrivals were the bot's OWN
+>    outbound ciphertext** — each an unavoidable AEAD failure.
+>    ⚠️ It was tempting to conclude the same inflates the browser rounds, since the
+>    app's `setResubscribe` uses the identical rule. **A control killed that:**
+>    `dr-self-echo.mjs` finds **0 self-echo in 2709 distinct captured browser
+>    arrivals**, so the ~40% figure in this table is NOT explained by it. Harness
+>    artifact only. Fixed with a per-bot database name.
+> 2. **The harness could not see decrypt failures.** They never propagate out of
+>    `handleNewMessage`. Fixed by teeing the failure log line, and failures are now
+>    split into **novel** vs **replay** — a frame the bot already decrypted once is
+>    refused by design, and replays dominate a raw count. Only novel failures mean
+>    anything. (Also: re-subscribing after every frame made the relay re-push its
+>    queue in a loop, turning 3 expected failures into 437; the harness now
+>    re-subscribes only when the inbox set changes, as the app does.)
+>
+> **AK — the B1 mitigation, measured.** Naive B1 (prune the bucket, decrypt,
+> persist) **must not ship**: it destroys 3/3 of the delayed frames whose keys live
+> in that bucket, which are exactly the frames redelivery recovers today. **B1′**
+> (prune for the retry only, re-file the bucket into the persisted state) recovers
+> **32→0** failures over 56 new-chain frames per arm with **zero** delayed-frame
+> failures in either arm. See §5-B1.
+>
+> **AL — desktop↔desktop transport loss is 0%, first measurement (#183 item 2).**
+> The upstream lead is "the node write path drops a fraction of frames handed to an
+> open socket, 32% one direction phone↔phone"; d↔d had never been measured.
+> `yarn harness dm-loss`, fresh accounts, 300 rounds each way, 12 min of sending
+> plus a **20-minute** redelivery tail:
+>
+> | | A→B | B→A |
+> |---|---|---|
+> | frames addressed to an inbox the peer subscribes to | 301 | 301 |
+> | arrived (joined by ciphertext fingerprint) | **301** | **301** |
+> | missing | **0** | **0** |
+>
+> Zero novel decrypt failures on either side. Read it precisely:
+> - **It does not refute item 2.** Different platform and network path; this says
+>   nothing about phone↔phone.
+> - Each app-level message produced **2** outbound frames per side (602 raw), only
+>   301 of them addressed to an inbox this peer subscribes to. The rest are
+>   multi-device fan-out to addresses outside this pair and are excluded from the
+>   denominator — if they were *supposed* to land here, that exclusion would hide
+>   the loss. Worth confirming separately.
+> - Arrival counts are asymmetric (313 vs 371) purely because bob received more
+>   redeliveries (70 replays vs 12). The de-duplicated join is unaffected, and this
+>   is exactly why raw counters must never be quoted.
 
 ---
 
 ## §2. What is established (evidence: [captures archive](2026-07-26-dm-desktop-to-desktop-captures.md))
 
-- **THE ROOT CAUSE: a poisoning bucket in the skipped-keys map.** A bucket under
-  the receiver's *current* receiving header key makes the crate fail frames it
-  could decrypt. 63/65 captured failures, 6 rounds, both clients, decrypt when
-  only that bucket is removed. Upstream, in the crate. *(AE, §4 lead 0)*
+- **THE ROOT CAUSE: a stale skipped-keys bucket, matched by index against the
+  wrong chain.** A bucket under the receiver's *current* receiving header key makes
+  the crate fail frames it could decrypt — specifically the frames that open the
+  sender's NEXT chain at an index that bucket happens to hold. 139/159 captured
+  failures (whole corpus, de-duplicated) decrypt when only that bucket is removed,
+  and 139/139 of those show the full signature. Upstream, in the crate.
+  *(AE + AI, §4 lead 0)*
+- **The failure is reproducible on demand, from a pristine session.** Out-of-order
+  delivery within one chain forms the bucket; the sender's next chain then fails at
+  exactly the colliding indices — 5/5 synthetic configurations, and through the real
+  client (`yarn harness dm-reorder`). No aged session, no devices, no waiting. *(AI)*
+- **The bucket's presence alone is NOT sufficient**, and the index collision is what
+  discriminates: on a poisoned state, an in-order frame and any new-chain frame at a
+  non-colliding index both decrypt normally. *(AI — control)*
 - **A FRESH session does not exhibit the failure.** Post-reset, positions 0-2
   went from 12/12 failing to 2/15, and one client logged 0 failures against 60
   the round before. Independently corroborated synthetically: 1920 frames on
@@ -188,10 +291,15 @@ experiment, and structurally by reading the SDK (finding AG: in
 the `sent_accept` branch and is identical on both sides of it, so init-wrapping
 cannot alter the inner ciphertext).
 
-**Still open, and both upstream:** whether the *lookup* consults a bucket it
-shouldn't, or the bucket *contents* were written wrong earlier. Ablation cannot
-separate them; reading the crate would, and there is no Rust source in the SDK
-repo (only `channelwasm_bg.wasm`).
+**~~Still open, and both upstream:~~ RESOLVED 2026-07-27 — it is the LOOKUP.**
+The question was whether the lookup consults a bucket it shouldn't or the bucket
+*contents* were written wrong earlier. Ablation cannot separate them, but
+*inspection* can, and it did not need the crate source: the bucket's keys decrypt
+their own frames correctly (3/3 measured), so the contents are valid — they are
+being matched **by index** against a frame from a different chain. See finding AI
+and `dr-prune-safety.mjs`. This is the sharpest thing we can hand upstream: not
+"skipped-key handling misbehaves" but "the skipped-key lookup does not verify that
+the bucket's header key belongs to the frame's chain".
 → **Filed upstream** as **item 1a** of [#183](https://github.com/QuilibriumNetwork/quorum-mobile/issues/183), the
 issue's lead item. The body was rewritten 2026-07-27 to put it first, correct the
 desktop↔desktop attribution previously given to the fork, and absorb the standalone
@@ -225,7 +333,11 @@ folded into it, so the body is the whole story. Its shape:
     is now stated as UNQUANTIFIED — the d↔d failure once cited for it is
     attributed to 1a, and no production failure is cleanly 1b-shaped.
 - **item 2** — the node write path dropping frames handed to an open socket,
-  32% one direction phone↔phone.
+  32% one direction phone↔phone. **Now measured desktop↔desktop for the first
+  time: 0% loss, both directions, 301 frames each way with a 20-minute redelivery
+  tail** (finding AL, `yarn harness dm-loss`). That does not refute item 2 — it
+  bounds it to platforms/paths other than d↔d, and it removes transport loss as an
+  explanation for the d↔d symptom.
 
 Neither is fixable here. **If you produce new d↔d evidence, add it there — the
 lead dev reads that issue, not this file.**
@@ -244,13 +356,26 @@ Given this bug's history, prompt is the safer first step. Do not build without i
 source for. The app is exhausted as an explanation, the three real client defects
 are merged, and the evidence is filed upstream.
 
-⚠️ **But "cannot fix the cause" is not "cannot fix the symptom", and finding AE
-changed what is possible here.** An earlier version of this section said
-"everything this repo can do has been done"; that predated AE. **Option B below is
-now a candidate for removing the user-visible symptom without any upstream fix,
-and it can be validated offline for free before any app code is written.**
+⚠️ **But "cannot fix the cause" is not "cannot fix the symptom."** An earlier
+version of this section said "everything this repo can do has been done"; that
+predated AE.
 
-### FIRST: three tools that answer questions without a capture round
+> **STATE OF PLAY, 2026-07-27 (read this before picking anything below).**
+> The mechanism is fully characterised (AI), reproducible on demand in seconds with
+> no devices, and **a client-side mitigation is implemented and measured**: branch
+> `feat/dm-stale-bucket-retry`, 32→0 failures with no cost to delayed frames
+> (§5-B1). Transport loss is measured at 0% d↔d (AL).
+>
+> **The highest-value next action is to get that branch reviewed and merged**, not
+> to run another experiment. After that, the open questions are narrow: what supplies
+> the out-of-order delivery that forms the bucket in the field (§5-D), and whether
+> the mitigation behaves on mobile↔desktop traffic.
+>
+> ⚠️ And note what AJ says about this bench: two harness defects silently produced
+> wrong numbers before controls caught them. Treat any new harness measurement as
+> suspect until a control could have falsified it.
+
+### FIRST: the offline tools that answer questions without a capture round
 
 Ten hypotheses in this investigation were killed the slow way — book a round, ask
 the operator for attention, wait, read logs. The tool that finally found the root
@@ -262,6 +387,8 @@ cause needed **none of that** and arrived last. Do not repeat that ordering.
 | `dr-replay.mjs` | is this failure genuine and reproducible, or an app-level race | a saved log |
 | `dr-advanced-start-fork.mjs` | reproduces the upstream crate's advanced-start fork from a pristine X3DH pair | **nothing** — no log, no devices |
 | `dr-position-table.mjs` | drives **fresh** sessions through six delivery regimes and scores failure by chain position. 1920 frames, zero failures — corroborates AC, and is ⛔ **not** evidence the crate is clean (a fresh session has no poisoning bucket). Its unrealised value is the session-ageing test below | **nothing** |
+| `dr-prune-safety.mjs` | **the mechanism and the mitigation.** Reports, per captured failure, what the frame actually *is* (its index in its own chain, whether it drove a DH step, whether that index collides with the stale bucket) and whether recovery is real or a re-accepted duplicate. Its synthetic half **builds the poisoning condition from a pristine X3DH pair** and answers the questions the failure-only corpus cannot — above all "does the prune break a frame that would otherwise succeed" | a log (optional; `--synthetic-only` needs **nothing**) |
+| `dr-self-echo.mjs` | does a client receive its OWN outbound frames? Joins `[DM-send wire]` against `[DM-recv wire]` in one client's log. **0 of 2709 captured browser arrivals** — which is how the harness's 41-48% self-echo was identified as a bench artifact and not the cause of the ~40% failure rate | a log |
 
 ```
 node .agents/tools/dm-debug/dr-ablate.mjs <log> [...more logs]
@@ -303,12 +430,22 @@ straight to `dr-ablate.mjs`.
 ~5 min); regression-test a fix once one lands; measure the transport claim
 (item 2) by counting send-vs-arrive over hours.
 
-**Cannot (yet):** it is the desktop protocol + service layer, **not the UI and
-not mobile**, and it has **not reproduced the AGED-session failure** — volume does
-not age a session (§1 refinement). The open next step is `importSession.ts`: lift a
-real degraded `EncryptionState` row out of a browser (plain JSON in IndexedDB;
-`dr-replay` already loads these) and keep it alive on the bench. Full plan +
-env gotchas: [headless DM harness task](../tasks/2026-07-27-headless-dm-harness.md).
+**It DOES now reproduce the production failure** (finding AI): `yarn harness
+dm-reorder` withholds the head of a sending chain to form the stale bucket, then the
+sender's next chain fails at exactly the colliding indices. `yarn harness
+dm-stale-bucket` runs that cycle at scale with the mitigation off and on. So
+`importSession.ts` (lift a degraded row out of a browser) is **no longer needed** —
+the degraded state can be built from scratch.
+
+**Cannot:** it is the desktop protocol + service layer, **not the UI and not
+mobile**. Volume alone still does not age a session (§1 refinement).
+
+⚠️ **Read AJ before trusting a harness number.** Two defects in this bench produced
+confidently wrong measurements (a shared IndexedDB across bots, and an observer
+blind to decrypt failures). Both are fixed and documented in
+`src/dev/tests/harness/README.md`, but the lesson is the general one: give every
+harness claim a control that could falsify it. Full plan + env gotchas:
+[headless DM harness task](../tasks/2026-07-27-headless-dm-harness.md).
 
 ### If you are here because the user reports DM lag or a missing message
 
@@ -329,38 +466,64 @@ attempt essentially always, so the trigger is systematic rather than incidental.
 captures contain live ratchet state, they live only on the operator's machine, and
 they are not going in a public issue.
 
-### B. Mitigation we control — now TWO options, and B1 is new
+### B. Mitigation we control — B1′ is BUILT AND MEASURED, B2 is now redundant
 
-**B1. Prune the poisoning bucket and retry.** *(possible only since finding AE;
-UNVALIDATED, proposed 2026-07-27)*
+**B1. ~~Prune the poisoning bucket and retry.~~ VALIDATED, BUT ONLY IN THE B1′
+FORM — implemented on branch `feat/dm-stale-bucket-retry`, 2026-07-27.**
 
-AE proves that deleting **one** bucket makes 63 of 65 real captured failures
-decrypt immediately. The ratchet state is plain JSON that JavaScript can read and
-modify — `dr-ablate.mjs` already does exactly this mutation
-(`{ ...rs, skipped_keys_map: m }` after deleting `m[current_receiving_header_key]`),
-and the app already parses the same state on every send (`orderSessionsForSend`
-does `JSON.parse(r.state)`). So on decrypt failure the receive path could retry
-once with that single bucket removed.
+> ⚠️ **B1 as originally written above is DESTRUCTIVE. Do not ship it.** The three
+> blocking questions are now answered, and the answer to (2) is bad: those keys are
+> the ONLY way to read genuinely out-of-order frames, and a receiving chain cannot
+> be run backwards to re-derive them. **Pruning and persisting destroyed 3 of 3
+> delayed frames that decrypt without it** — and those are precisely the frames
+> redelivery recovers today. Naive B1 would have traded recoverable latency for
+> permanent loss and looked like a fix while doing it.
 
-If it holds, **the user-visible symptom goes away while the crate bug stays
-unfixed.** That is a materially better outcome than option B2, which only makes
-recovery faster.
+**The three questions, answered:**
 
-**Validate it offline first — this is free and requires no app code.** `dr-ablate`
-already runs against every captured failure on disk. What must be checked before
-building anything:
+1. *Does pruning break a frame that would otherwise succeed?* **Yes** — the frames
+   whose keys are in the bucket. Note the original plan ("run the variant across
+   all captured successes") **cannot be executed**: `[XPDUMP]` fires only inside the
+   two decrypt-failure catch blocks, so the corpus contains **zero** captured
+   successes by construction. It was answered synthetically instead, where one
+   state holds both the retried frame and the bucket's own frames.
+2. *What is lost?* Everything in the bucket, irrecoverably — see above.
+3. *Do the non-recovering failures differ?* Yes. On the full corpus 20 of 159 do
+   not recover; they sit on near-empty maps (`rLen=3, buckets=1, keys=1`) and 2
+   have no current-header bucket at all. Consistent with genuine replays, as
+   guessed.
 
-1. Does pruning only that bucket ever break a frame that would otherwise succeed?
-   (Run the variant across all captured *successes*, not just failures.)
-2. What is lost by discarding those keys — could a genuinely out-of-order message
-   that needed them become permanently undecryptable? In the representative case
-   the bucket held 3 keys of 62, and pruning would happen only on failure, but
-   that is an argument, not evidence.
-3. Do the 2 of 65 that never recover behave differently? (They sit on near-empty
-   maps and are most likely genuine replays.)
+**B1′ — the form that is safe, and what makes it safe.** Use the pruned state as a
+*decrypt input only*, then re-file the bucket under its own header key in whatever
+state gets persisted. The retried frame drove a DH step, so by the time the state
+is saved that header key is **no longer current** and cannot poison again, while
+the delayed frames it serves still decrypt.
 
-**Do not ship this without 1 and 2 answered.** It is a workaround for someone
-else's bug and it deliberately discards key material.
+Measured (`yarn harness dm-stale-bucket`, 8 cycles per arm, fresh accounts both):
+
+| | retry OFF | retry ON |
+|---|---|---|
+| stale bucket formed | 8/8 cycles | 8/8 cycles |
+| AEAD failures on new-chain frames | **32** of 56 | **0** of 56 |
+| failures on the DELAYED frames | 0 | **0** ← the regression that matters |
+
+Implementation: [`src/utils/dmStaleBucketRetry.ts`](../../src/utils/dmStaleBucketRetry.ts)
+(pure, 14 unit tests) wired into **both** decrypt branches of
+`handleNewMessage`. Two things a future editor must not undo:
+
+- **The retry has to wrap the decrypt AND `parseDecryptedMessage`.** A DM decrypt
+  failure does *not* reject — the crate returns a result whose `message` carries
+  `Decryption failed: aead::Error`, and `parseDecryptedMessage` is what throws.
+  A first version wrapped only the decrypt call and silently never fired.
+- **The re-file step is not optional.** Removing it is exactly naive B1.
+
+There is a kill switch (`staleBucketRetry.enabled`) because this is a workaround
+for a defect in a dependency we have no source for. It is inert on a healthy
+session: no bucket under the current key means one JSON parse and no retry.
+
+**Still to do before merge:** exercise it against mobile↔desktop traffic, and
+decide whether the `logger.warn` on each recovery is wanted in production or should
+be sampled.
 
 **B2. Trigger redelivery on decrypt failure instead of waiting for it.**
 
@@ -372,8 +535,13 @@ inverted typing indicator would shrink *without* the upstream fix.
 Unbuilt and unscoped. It is mitigation, not a cure, and it must not weaken the
 retention that makes recovery possible in the first place. Start from
 `UndecryptableFrameTracker` (`src/utils/frameRetry.ts`) and the skip-and-keep path
-in the receive handler. **B1 subsumes most of B2's value if B1 validates — try B1
-first, it is cheaper to test.**
+in the receive handler.
+
+> **B1′ has landed, so B2 is now mostly redundant** — B1′ recovers the frame on the
+> first delivery, so there is no wait to shorten for the failures it covers. B2 would
+> only help the residue B1′ does not recover (20 of 159 in the corpus, which look like
+> genuine replays and would not benefit either). **Do not build B2 without first
+> measuring what fraction of failures survive B1′ in real traffic.**
 
 ### C. The one fix never exercised live
 
@@ -384,33 +552,45 @@ minutes, reopen on a diag build, and check that `STALE init envelope IGNORED` do
 **not** fire and the message arrives. Fifteen minutes with the client closed, so
 it costs no attention.
 
-### D. Still never reproduced deliberately
+### D. ~~Still never reproduced deliberately~~ — REPRODUCED 2026-07-27, and what is left
 
-The original report — works after a reset, use the same accounts on mobile for
-days, return to desktop broken. Nobody has reproduced it on purpose. It remains
-the single most valuable capture available, and no round so far has attempted it.
+**The failure mode is reproduced deliberately**, in seconds, with no devices:
+`yarn harness dm-reorder` (real client) and `dr-prune-safety.mjs` (bare crate).
+Finding AI. Anything that needed "a genuinely broken session to look at" can stop
+waiting.
 
-### E. Separate the confounds behind the feedback-loop hypothesis
+**What that does NOT answer, and is now the only open question here:** *how the
+stale bucket comes to exist in ordinary use.* Forming it requires a later frame of a
+sending chain to be processed before an earlier one, and the relay delivers in
+order — so on the bench it takes deliberate withholding. In the field something
+supplies that reordering: frame loss followed by redelivery, a reconnect, or
+cross-platform behaviour. Volume alone does not (§1 bench refinement).
 
-§2i's story — "map grows → more failures → map grows" — is a **hypothesis, not a
-conclusion.** `skipped` is confounded with session age, DH epoch count and total
-traffic, and because failures *create* skipped keys, cause and effect are circular
-on captured evidence. §2i names the test: *age a session deliberately and see
-whether failure rate tracks `skipped` independently of elapsed time.*
+That is what the original field pattern would still buy — not the failure, but its
+*trigger*. It is also the one question that bears on whether the mitigation in
+option B1 is enough on its own, or whether the reordering source is itself worth
+fixing. Cheap next probe: instrument how often a real client processes a chain's
+frames out of order, which needs one counter and no capture round.
 
-Captured evidence cannot do this. A **synthetic** harness can, because it controls
-both independently: grow the map without ageing the session, age the session
-without growing the map. `dr-position-table.mjs` is the natural home. It would
-also answer whether the poisoning bucket ever arises **naturally**, or only in
-states that reached it by some other route — which bears directly on the
-lookup-vs-contents question §2j says ablation cannot settle. **No device time.**
+### E. ~~Separate the confounds behind the feedback-loop hypothesis~~ — LARGELY ANSWERED
 
-> **Better vehicle, in progress:** [2026-07-27-headless-dm-harness.md](../tasks/2026-07-27-headless-dm-harness.md)
-> (branch `feat/headless-dm-harness`) re-hosts the REAL `MessageService` in Node
-> over the same wasm core with `fake-indexeddb`. That can age a session through
-> the actual app paths at machine speed, which is strictly better than ageing a
-> synthetic two-party ratchet. Prefer it once slice 1 lands; use
-> `dr-position-table.mjs` only if you need an answer before then.
+§2i's story was "map grows → more failures → map grows", flagged as a hypothesis
+because `skipped` is confounded with session age, DH epoch count and traffic, and
+failures also *create* skipped keys.
+
+**What AI settles.** Ageing is not required at all: the failure needs one stale
+bucket and one index collision, and a session two messages old will do. So the
+"grow the map without ageing the session / age it without growing the map" experiment
+is no longer the pivotal test — the causal arrow is established directly, by building
+the state and observing that the failing index set equals the bucket's index set.
+
+**The feedback loop is real but secondary.** Each failure does leave a skipped key,
+which enlarges the bucket and widens the range of colliding indices. That explains
+gradual degradation. It is not what starts it.
+
+**What is still open is narrower and is now stated in §5-D:** what supplies the
+out-of-order delivery that creates the first bucket in the field. That is a question
+about the transport and the client's processing order, not about the ratchet.
 
 ### Structural facts to carry into ANY code change here
 

--- a/src/dev/tests/harness/README.md
+++ b/src/dev/tests/harness/README.md
@@ -116,6 +116,7 @@ Log analyzers stay in `.agents/tools/dm-debug/` (`dr-ablate`, `dr-replay`,
 | `yarn harness dm-reset-recover` | wipe a session mid-conversation, verify it re-inits and recovers |
 | `yarn harness dm-reorder` | **reproduces the production DM failure on demand.** Withholds the head of a sending chain so a stale skipped-keys bucket forms, then delivers the sender's next chain: the frames at colliding indices fail AEAD, and only those |
 | `yarn harness dm-loss` | send-vs-arrive frame loss per direction, joined by ciphertext fingerprint (issue #183 item 2) |
+| `yarn harness dm-stale-bucket` | the reorder cycle at scale, with the client-side mitigation OFF then ON, on fresh accounts per arm |
 
 On any decrypt failure a bot writes `logs/<ts>-<bot>.xpdump.log` in `[XPDUMP]`
 format, so the existing offline analyzers run on it unchanged:

--- a/src/dev/tests/harness/README.md
+++ b/src/dev/tests/harness/README.md
@@ -117,6 +117,7 @@ Log analyzers stay in `.agents/tools/dm-debug/` (`dr-ablate`, `dr-replay`,
 | `yarn harness dm-reorder` | **reproduces the production DM failure on demand.** Withholds the head of a sending chain so a stale skipped-keys bucket forms, then delivers the sender's next chain: the frames at colliding indices fail AEAD, and only those |
 | `yarn harness dm-loss` | send-vs-arrive frame loss per direction, joined by ciphertext fingerprint (issue #183 item 2) |
 | `yarn harness dm-stale-bucket` | the reorder cycle at scale, with the client-side mitigation OFF then ON, on fresh accounts per arm |
+| `yarn harness replay-captured` | runs the shipped stale-bucket retry against REAL degraded production state from saved rig logs. Needs `DM_LOG_DIR=<dir>`; skips without it |
 
 On any decrypt failure a bot writes `logs/<ts>-<bot>.xpdump.log` in `[XPDUMP]`
 format, so the existing offline analyzers run on it unchanged:

--- a/src/dev/tests/harness/dm-stale-bucket.scenario.test.ts
+++ b/src/dev/tests/harness/dm-stale-bucket.scenario.test.ts
@@ -1,0 +1,180 @@
+// 1b/1c AT SCALE — the same poisoning cycle repeated many times, measured with the
+// stale-bucket retry OFF and then ON, in one process, on one pair of fresh accounts.
+//
+// The captured corpus holds only failures ([XPDUMP] fires in the decrypt-failure
+// catch blocks), so it cannot answer "does the mitigation ever break a frame that
+// would otherwise succeed". This can: every cycle produces BOTH kinds of frame
+// against the same session —
+//
+//   colliding frames  — new-chain frames at an index present in the stale bucket.
+//                       These are the failures the mitigation must recover.
+//   clean frames      — new-chain frames at non-colliding indices. These succeed
+//                       either way; if the mitigation breaks one, it shows here.
+//   delayed frames    — the withheld frames whose keys live IN the stale bucket.
+//                       These are what a naive prune destroys (measured 3/3), so
+//                       they are the regression test for the re-file step.
+//
+//   yarn harness dm-stale-bucket
+//   HARNESS_CYCLES=12 HARNESS_WITHHOLD=4 yarn harness dm-stale-bucket
+import { test, expect } from 'vitest';
+import { createBot, type HarnessBot } from './bot';
+import { staleBucketRetry } from '../../../utils/dmStaleBucketRetry';
+import { ratchetStats } from './inspect';
+import { RunLog } from './log';
+
+const CYCLES = Number(process.env.HARNESS_CYCLES ?? 8);
+const WITHHOLD = Number(process.env.HARNESS_WITHHOLD ?? 3);
+const CLEAN = Number(process.env.HARNESS_CLEAN ?? 3);
+const STEP_MS = Number(process.env.HARNESS_STEP_MS ?? 350);
+const SETTLE_MS = Number(process.env.HARNESS_SETTLE_MS ?? 2500);
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+interface Tally {
+  cycles: number;
+  poisonedBuckets: number;
+  newChainFailures: number;
+  delayedFailures: number;
+  postsDelivered: number;
+}
+
+/**
+ * One poisoning cycle:
+ *   1. withhold the head of a sending chain, deliver a later frame first
+ *      -> the withheld indices are filed under the receiver's CURRENT
+ *         receiving header key
+ *   2. make the sender open a NEW chain, deliver WITHHOLD+CLEAN frames of it
+ *      -> the first WITHHOLD indices collide with the stale bucket
+ *   3. release the withheld frames -> they must still decrypt
+ */
+async function cycle(
+  sender: HarnessBot,
+  receiver: HarnessBot,
+  n: number,
+  tally: Tally,
+  say: (m: string) => void
+): Promise<void> {
+  receiver.transport.holdInbound();
+  for (let i = 0; i <= WITHHOLD; i++) {
+    await sender.send(receiver.identity.address, `c${n}-head-${i}`);
+    await sleep(STEP_MS);
+  }
+  await sleep(SETTLE_MS);
+  await receiver.transport.releaseInbound((held) => {
+    const last = held[held.length - 1];
+    return last ? [last] : [];
+  });
+  await sleep(SETTLE_MS);
+
+  const stats = await ratchetStats(receiver.messageDB);
+  const poisoned = stats.filter((s) => s.skipped > 0).length > 0;
+  if (poisoned) tally.poisonedBuckets += 1;
+
+  // The receiver replies, so the sender rotates its sending chain.
+  await receiver.send(sender.identity.address, `c${n}-rotate`);
+  await sleep(SETTLE_MS);
+
+  const before = receiver.errors.length;
+  const postsBefore = tally.postsDelivered;
+  for (let i = 0; i < WITHHOLD + CLEAN; i++) {
+    await sender.send(receiver.identity.address, `c${n}-new-${i}`);
+    await sleep(STEP_MS);
+  }
+  await sleep(SETTLE_MS);
+  const newChainFailures = receiver.errors.length - before;
+  tally.newChainFailures += newChainFailures;
+
+  const beforeLate = receiver.errors.length;
+  const late = await receiver.transport.deliverWithheld();
+  await sleep(SETTLE_MS);
+  const delayedFailures = receiver.errors.length - beforeLate;
+  tally.delayedFailures += delayedFailures;
+  tally.cycles += 1;
+
+  say(
+    `cycle ${n}: bucket=${poisoned ? 'formed' : 'NONE'} ` +
+    `new-chain failures=${newChainFailures}/${WITHHOLD + CLEAN} ` +
+    `late(${late}) failures=${delayedFailures} ` +
+    `posts+${tally.postsDelivered - postsBefore}`
+  );
+}
+
+test(
+  'dm-stale-bucket: poisoning cycle at scale, retry OFF vs ON',
+  async () => {
+    const startedAt = Date.now();
+    const log = new RunLog('dm-stale-bucket', startedAt);
+    const say = (msg: string, fields: Record<string, unknown> = {}) => {
+      console.log(`[stale-bucket] ${msg}`);
+      log.add(Date.now(), 'harness', 'note', { msg, ...fields });
+    };
+
+    const results: Record<string, Tally> = {};
+
+    for (const arm of ['OFF', 'ON'] as const) {
+      staleBucketRetry.enabled = arm === 'ON';
+      // A fresh pair per arm: a session carried over would bring the previous
+      // arm's accumulated buckets with it and the two arms would not be comparable.
+      const stamp = `${String(startedAt).slice(-5)}${arm.toLowerCase()}`;
+      const [sender, receiver] = await Promise.all([
+        createBot(`sb-s-${stamp}`),
+        createBot(`sb-r-${stamp}`),
+      ]);
+      await Promise.all([sender.start(), receiver.start()]);
+
+      const tally: Tally = {
+        cycles: 0, poisonedBuckets: 0, newChainFailures: 0,
+        delayedFailures: 0, postsDelivered: 0,
+      };
+      receiver.onDecrypted = (m) => {
+        if (m.content?.type === 'post') tally.postsDelivered += 1;
+      };
+
+      say(`==== arm: retry ${arm} ====`);
+      await sender.send(receiver.identity.address, 'init');
+      await sleep(SETTLE_MS);
+      await receiver.send(sender.identity.address, 'init-back');
+      await sleep(SETTLE_MS);
+
+      for (let n = 1; n <= CYCLES; n++) {
+        await cycle(sender, receiver, n, tally, (m) => say(m));
+      }
+
+      const framesPerCycle = WITHHOLD + CLEAN;
+      say(
+        `arm ${arm}: cycles=${tally.cycles} buckets-formed=${tally.poisonedBuckets} ` +
+        `new-chain frames=${tally.cycles * framesPerCycle} failures=${tally.newChainFailures} ` +
+        `delayed-frame failures=${tally.delayedFailures} ` +
+        `novel=${receiver.novelErrors().length} replay=${receiver.errors.length - receiver.novelErrors().length}`,
+        { arm, ...tally, novel: receiver.novelErrors().length }
+      );
+      results[arm] = tally;
+
+      sender.stop();
+      receiver.stop();
+      await sleep(1000);
+    }
+
+    staleBucketRetry.enabled = true;
+
+    const framesPerCycle = WITHHOLD + CLEAN;
+    const off = results.OFF;
+    const on = results.ON;
+    say('');
+    say('================ RESULT ================');
+    say(`new-chain frames per arm            ${off.cycles * framesPerCycle} (OFF) / ${on.cycles * framesPerCycle} (ON)`);
+    say(`AEAD failures on new-chain frames   ${off.newChainFailures} (OFF) -> ${on.newChainFailures} (ON)`);
+    say(`failures on the DELAYED frames      ${off.delayedFailures} (OFF) -> ${on.delayedFailures} (ON)`);
+    say(`  ^ any increase here means the mitigation destroyed a recoverable frame`);
+    say(`posts delivered                     ${off.postsDelivered} (OFF) -> ${on.postsDelivered} (ON)`);
+    console.log(`[stale-bucket] log: ${log.file}`);
+
+    // The precondition must actually have been built, or the arms compare nothing.
+    expect(off.poisonedBuckets).toBeGreaterThan(0);
+    expect(on.poisonedBuckets).toBeGreaterThan(0);
+    // The mitigation must recover failures WITHOUT costing delayed frames.
+    expect(on.newChainFailures).toBeLessThan(off.newChainFailures);
+    expect(on.delayedFailures).toBeLessThanOrEqual(off.delayedFailures);
+  },
+  90 * 60 * 1000
+);

--- a/src/dev/tests/harness/replay-captured.scenario.test.ts
+++ b/src/dev/tests/harness/replay-captured.scenario.test.ts
@@ -1,0 +1,175 @@
+// Drive the REAL mitigation code against REAL degraded production state.
+//
+// Every other test of the stale-bucket retry uses a session this bench built. This
+// one uses genuinely aged sessions from the field: each `[XPDUMP]` record captured
+// during a manual rig round contains the complete `EncryptionState` row AND the
+// sealed frame that failed against it, so the exact production decrypt can be
+// re-run here — against `src/utils/dmStaleBucketRetry.ts` itself, not a
+// reimplementation of it. `dr-prune-safety.mjs` does the same mutation, but it
+// open-codes it; if the shipped helper and that script ever disagreed, only this
+// test would notice.
+//
+// It needs no export and no device: the logs already on disk are the aged sessions.
+//
+//   DM_LOG_DIR="D:/path/to/logs/OLD" yarn harness replay-captured
+//
+// ⚠️ Those logs hold REAL ratchet key material. They live outside the repo, the
+// path comes from the environment, and nothing here writes state back. With
+// DM_LOG_DIR unset the test skips rather than failing, so CI stays green.
+import { test, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { channel_raw } from '@quilibrium/quilibrium-js-sdk-channels';
+import { findStaleBucket, restoreStaleBucket } from '../../../utils/dmStaleBucketRetry';
+import { RunLog } from './log';
+
+const LOG_DIR = process.env.DM_LOG_DIR;
+
+interface Dump {
+  no: string;
+  envFp?: string;
+  state: string;
+  frame: string;
+}
+
+/** Reassemble the chunked `[XPDUMP] n/idx/total {json}` records in a console log. */
+function dumpsFrom(path: string): Dump[] {
+  const parts = new Map<string, { total: number; chunks: Map<number, string> }>();
+  for (const line of readFileSync(path, 'utf-8').split('\n')) {
+    const m = line.match(/\[XPDUMP\]\s+(\d+)\/(\d+)\/(\d+)\s(.*)$/);
+    if (!m) continue;
+    const [, no, idx, total, text] = m;
+    if (!parts.has(no)) parts.set(no, { total: Number(total), chunks: new Map() });
+    parts.get(no)!.chunks.set(Number(idx), text);
+  }
+  const out: Dump[] = [];
+  for (const [no, { total, chunks }] of parts) {
+    if (chunks.size !== total) continue;
+    const joined = Array.from({ length: total }, (_, i) => chunks.get(i + 1)).join('');
+    try { out.push({ no, ...JSON.parse(joined) }); } catch { /* truncated */ }
+  }
+  return out;
+}
+
+/** Unseal the outer layer exactly as the live receive path does. */
+function unseal(row: Record<string, any>, sealed: Record<string, any>): string {
+  const raw = JSON.parse(channel_raw.js_decrypt_inbox_message(JSON.stringify({
+    inbox_private_key: row.receiving_inbox.inbox_encryption_key.private_key,
+    ephemeral_public_key: [...new Uint8Array(Buffer.from(sealed.ephemeral_public_key, 'hex'))],
+    ciphertext: JSON.parse(sealed.envelope),
+  })));
+  let envelope = Buffer.from(new Uint8Array(raw as number[])).toString('utf-8');
+  try {
+    const maybeInit = JSON.parse(envelope);
+    if (maybeInit.user_address) envelope = maybeInit.message;
+  } catch { /* plain DR envelope */ }
+  return envelope;
+}
+
+/** The ratchet decrypt. Mirrors how the app detects failure: via the message text. */
+function decrypt(ratchetState: string, envelope: string):
+  { ok: true; msg: string; state: string } | { ok: false } {
+  try {
+    const out = JSON.parse(channel_raw.js_double_ratchet_decrypt(
+      JSON.stringify({ ratchet_state: ratchetState, envelope })
+    ));
+    const msg = Buffer.from(new Uint8Array(out.message)).toString('utf-8');
+    if (msg.startsWith('Decryption failed') || msg.includes('aead')) return { ok: false };
+    return { ok: true, msg, state: out.ratchet_state };
+  } catch {
+    return { ok: false };
+  }
+}
+
+const maybe = LOG_DIR ? test : test.skip;
+
+maybe(
+  'replay-captured: the shipped stale-bucket retry recovers real production failures',
+  () => {
+    const dir = LOG_DIR!;
+    const files = readdirSync(dir).filter((f) => f.endsWith('.log'));
+    const seen = new Set<string>();
+
+    let total = 0;
+    let baselineDecrypted = 0;
+    let hadStaleBucket = 0;
+    let recovered = 0;
+    let unrecovered = 0;
+    let bucketPreserved = 0;
+
+    for (const file of files) {
+      for (const d of dumpsFrom(resolve(dir, file))) {
+        let row: Record<string, any>;
+        let sealed: Record<string, any>;
+        try {
+          row = JSON.parse(d.state);
+          sealed = JSON.parse(d.frame);
+          JSON.parse(row.ratchet_state);
+        } catch { continue; }
+
+        let envelope: string;
+        try { envelope = unseal(row, sealed); } catch { continue; }
+
+        // De-duplicate by envelope fingerprint before counting anything: a failed
+        // frame is redelivered and re-captured, and raw counts have overstated
+        // volume 2-5x throughout this investigation.
+        const fp = String(d.envFp ?? '');
+        if (fp && seen.has(fp)) continue;
+        if (fp) seen.add(fp);
+        total += 1;
+
+        // 1. The first attempt, exactly as it happened in production.
+        const first = decrypt(row.ratchet_state, envelope);
+        if (first.ok) { baselineDecrypted += 1; continue; }
+
+        // 2. What the shipped code does on failure.
+        const stale = findStaleBucket(d.state);
+        if (!stale) { unrecovered += 1; continue; }
+        hadStaleBucket += 1;
+
+        const retry = decrypt(stale.prunedRow.ratchet_state, envelope);
+        if (!retry.ok) { unrecovered += 1; continue; }
+        recovered += 1;
+
+        // 3. The invariant that makes the mitigation non-destructive: the bucket
+        //    must be back in the state that would be persisted, and its keys intact.
+        const persisted = restoreStaleBucket(retry.state, stale.headerKey, stale.bucket);
+        const back = JSON.parse(persisted).skipped_keys_map?.[stale.headerKey] ?? {};
+        const allKeysPresent = Object.keys(stale.bucket).every(
+          (k) => back[k] === (stale.bucket as Record<string, unknown>)[k]
+        );
+        expect(allKeysPresent).toBe(true);
+        bucketPreserved += 1;
+      }
+    }
+
+    const pct = total ? ((recovered / total) * 100).toFixed(0) : '0';
+    const summary = [
+      `${files.length} logs, ${total} distinct captured failures`,
+      `  already decrypted on replay : ${baselineDecrypted}`,
+      `  had a stale bucket          : ${hadStaleBucket}`,
+      `  RECOVERED by the shipped fix: ${recovered}  (${pct}%)`,
+      `  not recovered               : ${unrecovered}`,
+      `  bucket preserved after retry: ${bucketPreserved}/${recovered}`,
+    ];
+    // console.log is swallowed by the harness reporter, so the numbers go to the
+    // run log — which is where a bench result belongs anyway.
+    const log = new RunLog('replay-captured', Date.now());
+    for (const line of summary) log.add(Date.now(), 'harness', 'note', { msg: line });
+    log.add(Date.now(), 'harness', 'result', {
+      total, baselineDecrypted, hadStaleBucket, recovered, unrecovered, bucketPreserved,
+    });
+    console.log(summary.map((s) => `[replay-captured] ${s}`).join('\n'));
+    console.log(`[replay-captured] log: ${log.file}`);
+
+    // The corpus must actually have been read — an empty run must not read as a pass.
+    expect(total).toBeGreaterThan(50);
+    // Every recovery must have preserved the discarded keys. This is the property
+    // that separates the shipped fix from the naive prune that loses messages.
+    expect(bucketPreserved).toBe(recovered);
+    // Recovery rate measured at 139/159 (87%) on 2026-07-27. Guard against a
+    // regression that silently stops the retry firing.
+    expect(recovered / total).toBeGreaterThan(0.8);
+  },
+  10 * 60 * 1000
+);

--- a/src/dev/tests/utils/dmStaleBucketRetry.unit.test.ts
+++ b/src/dev/tests/utils/dmStaleBucketRetry.unit.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  findStaleBucket,
+  restoreStaleBucket,
+  staleBucketRetry,
+} from '../../../utils/dmStaleBucketRetry';
+
+const CUR = 'currentHeaderKeyBase64';
+const NEXT = 'nextHeaderKeyBase64';
+const OLD = 'oldHeaderKeyBase64';
+
+/** An EncryptionState.state row — `ratchet_state` is a nested JSON string. */
+function row(skipped: Record<string, Record<string, string>>, current = CUR): string {
+  return JSON.stringify({
+    ratchet_state: JSON.stringify({
+      current_receiving_header_key: current,
+      next_receiving_header_key: NEXT,
+      current_receiving_chain_length: 7,
+      root_key: 'rootKey',
+      skipped_keys_map: skipped,
+    }),
+    receiving_inbox: { inbox_encryption_key: { private_key: [1, 2, 3] } },
+    sending_inbox: { inbox_public_key: 'pub' },
+    tag: { tag: 'x' },
+  });
+}
+
+afterEach(() => {
+  staleBucketRetry.enabled = true;
+});
+
+describe('findStaleBucket', () => {
+  it('finds a bucket filed under the CURRENT receiving header key', () => {
+    const found = findStaleBucket(row({ [CUR]: { 0: 'k0', 1: 'k1' } }));
+    expect(found?.headerKey).toBe(CUR);
+    expect(Object.keys(found?.bucket ?? {})).toEqual(['0', '1']);
+  });
+
+  it('removes ONLY that bucket, leaving every other one intact', () => {
+    const found = findStaleBucket(
+      row({ [CUR]: { 0: 'k0' }, [OLD]: { 3: 'k3' }, [NEXT]: { 5: 'k5' } })
+    );
+    const rs = JSON.parse(found!.prunedRow.ratchet_state);
+    expect(Object.keys(rs.skipped_keys_map).sort()).toEqual([NEXT, OLD].sort());
+    expect(rs.skipped_keys_map[OLD]).toEqual({ 3: 'k3' });
+  });
+
+  it('preserves the rest of the row and the rest of the ratchet state', () => {
+    const found = findStaleBucket(row({ [CUR]: { 0: 'k0' } }));
+    expect(found!.prunedRow.tag).toEqual({ tag: 'x' });
+    const rs = JSON.parse(found!.prunedRow.ratchet_state);
+    expect(rs.root_key).toBe('rootKey');
+    expect(rs.current_receiving_chain_length).toBe(7);
+    expect(rs.current_receiving_header_key).toBe(CUR);
+  });
+
+  // The mitigation must be inert on a healthy session: no bucket under the current
+  // key means the upstream lookup cannot mis-fire, so there is nothing to retry.
+  it('returns null when no bucket sits under the current key', () => {
+    expect(findStaleBucket(row({ [OLD]: { 1: 'k1' }, [NEXT]: { 2: 'k2' } }))).toBeNull();
+  });
+
+  it('returns null for an empty skipped-keys map', () => {
+    expect(findStaleBucket(row({}))).toBeNull();
+  });
+
+  it('returns null for an empty bucket under the current key', () => {
+    expect(findStaleBucket(row({ [CUR]: {} }))).toBeNull();
+  });
+
+  it('returns null when there is no current receiving header key', () => {
+    const noCurrent = JSON.stringify({
+      ratchet_state: JSON.stringify({ skipped_keys_map: { [OLD]: { 1: 'k' } } }),
+    });
+    expect(findStaleBucket(noCurrent)).toBeNull();
+  });
+
+  it('returns null (never throws) on unparseable input', () => {
+    expect(findStaleBucket('not json')).toBeNull();
+    expect(findStaleBucket('{}')).toBeNull();
+    expect(findStaleBucket(JSON.stringify({ ratchet_state: 'not json' }))).toBeNull();
+  });
+
+  it('is disabled by the kill switch', () => {
+    staleBucketRetry.enabled = false;
+    expect(findStaleBucket(row({ [CUR]: { 0: 'k0' } }))).toBeNull();
+  });
+});
+
+describe('restoreStaleBucket', () => {
+  // This is the step that keeps the mitigation non-destructive: those message keys
+  // are the only way to read genuinely delayed frames and cannot be re-derived.
+  it('re-files the bucket under its own header key', () => {
+    const after = JSON.stringify({ skipped_keys_map: {}, root_key: 'newRoot' });
+    const merged = JSON.parse(restoreStaleBucket(after, CUR, { 0: 'k0', 1: 'k1' }));
+    expect(merged.skipped_keys_map[CUR]).toEqual({ 0: 'k0', 1: 'k1' });
+    expect(merged.root_key).toBe('newRoot');
+  });
+
+  it('keeps buckets the crate wrote during the successful decrypt', () => {
+    const after = JSON.stringify({ skipped_keys_map: { [OLD]: { 9: 'k9' } } });
+    const merged = JSON.parse(restoreStaleBucket(after, CUR, { 0: 'k0' }));
+    expect(merged.skipped_keys_map[OLD]).toEqual({ 9: 'k9' });
+    expect(merged.skipped_keys_map[CUR]).toEqual({ 0: 'k0' });
+  });
+
+  // The crate's own entry is newer and authoritative; a restore must not clobber it.
+  it('does not overwrite an index the crate just wrote under the same key', () => {
+    const after = JSON.stringify({ skipped_keys_map: { [CUR]: { 0: 'fresh' } } });
+    const merged = JSON.parse(restoreStaleBucket(after, CUR, { 0: 'stale', 1: 'k1' }));
+    expect(merged.skipped_keys_map[CUR]).toEqual({ 0: 'fresh', 1: 'k1' });
+  });
+
+  it('returns the input unchanged rather than rewriting a state it cannot parse', () => {
+    expect(restoreStaleBucket('not json', CUR, { 0: 'k0' })).toBe('not json');
+  });
+});
+
+describe('round trip', () => {
+  it('prune then restore reproduces the original skipped-keys map', () => {
+    const original = { [CUR]: { 0: 'k0', 2: 'k2' }, [OLD]: { 4: 'k4' } };
+    const found = findStaleBucket(row(original))!;
+    const restored = JSON.parse(
+      restoreStaleBucket(found.prunedRow.ratchet_state, found.headerKey, found.bucket)
+    );
+    expect(restored.skipped_keys_map).toEqual(original);
+  });
+});

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -81,6 +81,7 @@ import { TypingService, type TypingMessage } from '@quilibrium/quorum-shared';
 import { ENABLE_DM_ACTION_QUEUE } from '../config/features';
 import { dmRatchetMutex } from '../utils/keyedMutex';
 import { isStaleInitEnvelope } from '../utils/initEnvelopeGuard';
+import { findStaleBucket, restoreStaleBucket } from '../utils/dmStaleBucketRetry';
 import { orderSessionsForSend } from '../utils/sessionSelection';
 import { UndecryptableFrameTracker, frameKey } from '../utils/frameRetry';
 import { ThreadService } from './ThreadService';
@@ -3856,13 +3857,35 @@ export class MessageService {
           message.encryptedContent
         );
         if (freshKeys.sending_inbox.inbox_public_key === '') {
+          let restore: { headerKey: string; bucket: Record<string, unknown> } | null = null;
           try {
-            const result =
-              await secureChannel.ConfirmDoubleRatchetSenderSession(
-                JSON.parse(fresh.state),
+            // Wraps decrypt AND parse: the crate reports an AEAD failure in the
+            // returned message, not by rejecting, so parseDecryptedMessage is the
+            // call that throws (see the InboxDecrypt branch).
+            const decryptAndParse = async (row: unknown) => {
+              const r = await secureChannel.ConfirmDoubleRatchetSenderSession(
+                row as Parameters<typeof secureChannel.ConfirmDoubleRatchetSenderSession>[0],
                 JSON.parse(message.encryptedContent)
               );
-            const content = parseDecryptedMessage(result.message, 'Confirm');
+              return { result: r, content: parseDecryptedMessage(r.message, 'Confirm') };
+            };
+
+            let attempt: Awaited<ReturnType<typeof decryptAndParse>>;
+            try {
+              attempt = await decryptAndParse(JSON.parse(fresh.state));
+            } catch (firstError) {
+              // Upstream skipped-key lookup defect — see utils/dmStaleBucketRetry.ts.
+              const stale = findStaleBucket(fresh.state);
+              if (!stale) throw firstError;
+              attempt = await decryptAndParse(stale.prunedRow);
+              restore = { headerKey: stale.headerKey, bucket: stale.bucket };
+              logger.warn(
+                '[MessageService] DM frame recovered by pruning the stale skipped-keys bucket for the retry (upstream #183 item 1a)',
+                { branch: 'Confirm', prunedKeys: Object.keys(stale.bucket).length }
+              );
+            }
+            const result = attempt.result;
+            const content = attempt.content;
             if (content?.content?.type === 'delete-conversation') {
               logger.warn(
                 '[MessageService] ⚠️ RESET SIGNAL received (delete-conversation, Confirm branch) — wiping encryption states',
@@ -3883,7 +3906,11 @@ export class MessageService {
             await this.messageDB.saveEncryptionState(
               {
                 state: JSON.stringify({
-                  ratchet_state: result.ratchet_state,
+                  // Re-file a bucket pruned for the retry — see the InboxDecrypt
+                  // branch and utils/dmStaleBucketRetry.ts for why this is required.
+                  ratchet_state: restore
+                    ? restoreStaleBucket(result.ratchet_state, restore.headerKey, restore.bucket)
+                    : result.ratchet_state,
                   receiving_inbox: result.receiving_inbox,
                   sending_inbox: result.sending_inbox,
                   tag: result.tag,
@@ -3923,11 +3950,38 @@ export class MessageService {
             return { outcome: 'handled' as const };
           }
         } else {
+          // Retry bookkeeping for the stale-bucket mitigation: set only when the
+          // first decrypt failed and a pruned retry succeeded, so the bucket can
+          // be re-filed into the state that gets persisted.
+          let restore: { headerKey: string; bucket: Record<string, unknown> } | null = null;
           try {
-            const result = await secureChannel.DoubleRatchetInboxDecrypt(
-              JSON.parse(fresh.state),
-              JSON.parse(message.encryptedContent)
-            );
+            // A DM decrypt failure does NOT reject: the crate returns a result
+            // whose `message` carries "Decryption failed: aead::Error", and
+            // parseDecryptedMessage is what throws. So the stale-bucket retry has
+            // to wrap BOTH calls — wrapping only the decrypt never fires.
+            const decryptAndParse = async (row: unknown) => {
+              const r = await secureChannel.DoubleRatchetInboxDecrypt(
+                row as Parameters<typeof secureChannel.DoubleRatchetInboxDecrypt>[0],
+                JSON.parse(message.encryptedContent)
+              );
+              return { result: r, content: parseDecryptedMessage(r.message, 'InboxDecrypt') };
+            };
+
+            let attempt: Awaited<ReturnType<typeof decryptAndParse>>;
+            try {
+              attempt = await decryptAndParse(JSON.parse(fresh.state));
+            } catch (firstError) {
+              // Upstream skipped-key lookup defect — see utils/dmStaleBucketRetry.ts.
+              const stale = findStaleBucket(fresh.state);
+              if (!stale) throw firstError;
+              attempt = await decryptAndParse(stale.prunedRow);
+              restore = { headerKey: stale.headerKey, bucket: stale.bucket };
+              logger.warn(
+                '[MessageService] DM frame recovered by pruning the stale skipped-keys bucket for the retry (upstream #183 item 1a)',
+                { branch: 'InboxDecrypt', prunedKeys: Object.keys(stale.bucket).length }
+              );
+            }
+            const result = attempt.result;
             const maybeInit = result as {
               receiving_inbox: secureChannel.InboxKeyset;
               user_profile: secureChannel.UserProfile;
@@ -3938,22 +3992,29 @@ export class MessageService {
             };
 
             let advancedState: string;
+            // If the retry pruned a bucket to get here, put it back: those keys
+            // are the ONLY way to read genuinely delayed frames, and persisting
+            // the pruned state destroys them permanently (measured 3/3).
+            const keep = (ratchetState: string) =>
+              restore
+                ? restoreStaleBucket(ratchetState, restore.headerKey, restore.bucket)
+                : ratchetState;
             if (maybeInit.user_profile) {
               advancedState = JSON.stringify({
-                ratchet_state: maybeInit.ratchet_state,
+                ratchet_state: keep(maybeInit.ratchet_state),
                 receiving_inbox: maybeInit.receiving_inbox,
                 sending_inbox: maybeInit.sending_inbox,
                 tag: maybeInit.tag,
               });
             } else {
               advancedState = JSON.stringify({
-                ratchet_state: result.ratchet_state,
+                ratchet_state: keep(result.ratchet_state),
                 receiving_inbox: freshKeys.receiving_inbox,
                 sending_inbox: freshKeys.sending_inbox,
                 tag: freshKeys.tag,
               });
             }
-            const content = parseDecryptedMessage(result.message, 'InboxDecrypt');
+            const content = attempt.content;
             if (content?.content?.type === 'delete-conversation') {
               logger.warn(
                 '[MessageService] ⚠️ RESET SIGNAL received (delete-conversation, InboxDecrypt branch) — wiping encryption states',

--- a/src/utils/dmStaleBucketRetry.ts
+++ b/src/utils/dmStaleBucketRetry.ts
@@ -1,0 +1,126 @@
+/**
+ * Mitigation for the upstream skipped-key lookup defect (quorum-mobile#183 item
+ * 1a; bug doc `.agents/bugs/2026-07-26-dm-desktop-to-desktop-resurfaced.md` §5-B1).
+ *
+ * THE UPSTREAM DEFECT, as measured. A receiver files the message keys of frames
+ * it had to skip into `skipped_keys_map`, keyed by the header key of the sending
+ * chain they belong to. When the sender later opens a NEW sending chain, the
+ * receiver takes a DH step — and the crate then matches a skipped key BY INDEX in
+ * the bucket filed under the *pre-step* `current_receiving_header_key`, without
+ * checking that the bucket belongs to the incoming frame's chain. A new-chain
+ * frame whose index COLLIDES with an index in that stale bucket is handed an
+ * old-chain message key and fails AEAD. Non-colliding indices decrypt normally,
+ * which is why the failure looks like it depends on position in the chain.
+ *
+ * Evidence: 139 of 159 captured production failures show exactly this signature
+ * (frame drove a DH step, index present in the stale bucket) and every one of
+ * them decrypts when that one bucket is removed. Reproduced on demand both against
+ * the bare crate and through the real client
+ * (`yarn harness dm-reorder`: 3 withheld frames -> 3 failures, at exactly the
+ * 3 colliding indices).
+ *
+ * WHAT THIS DOES. On a decrypt failure, retry ONCE against a copy of the ratchet
+ * state with that single bucket removed, so the crate falls through to normal
+ * derivation.
+ *
+ * ⚠️ WHY THE BUCKET IS PUT BACK, AND WHY THAT IS NOT OPTIONAL. Those keys are the
+ * only way to read genuinely out-of-order frames — they cannot be re-derived, as
+ * a receiving chain cannot run backwards. Measured: pruning and persisting the
+ * pruned state destroys 3 of 3 delayed frames that decrypt without it, converting
+ * recoverable latency into permanent loss. So the pruned state is used ONLY as a
+ * decrypt input, and the bucket is re-filed under its own header key in whatever
+ * state gets persisted. After the DH step that header key is no longer current, so
+ * it cannot poison again, and the delayed frames it serves still decrypt
+ * (measured 3/3).
+ */
+
+/**
+ * Kill switch. This is a workaround for a defect in a dependency we have no source
+ * for, so it must be possible to turn off without a rebuild — and the bench needs
+ * to measure the same scenario with it on and off in one process.
+ */
+export const staleBucketRetry = { enabled: true };
+
+/** The skipped-keys map: header key -> message index -> message key. */
+type SkippedKeysMap = Record<string, Record<string, unknown>>;
+
+interface RatchetState {
+  current_receiving_header_key?: string;
+  skipped_keys_map?: SkippedKeysMap;
+  [k: string]: unknown;
+}
+
+/** The row stored in `EncryptionState.state` — `ratchet_state` is a JSON string. */
+interface StateRow {
+  ratchet_state: string;
+  [k: string]: unknown;
+}
+
+export interface StaleBucket {
+  /** The header key the bucket is filed under. */
+  headerKey: string;
+  /** The bucket itself, so it can be re-filed after a successful retry. */
+  bucket: Record<string, unknown>;
+  /** The row with ONLY that bucket removed — the retry's decrypt input. */
+  prunedRow: StateRow;
+}
+
+function parseRow(stateJson: string): { row: StateRow; rs: RatchetState } | null {
+  try {
+    const row = JSON.parse(stateJson) as StateRow;
+    if (typeof row?.ratchet_state !== 'string') return null;
+    return { row, rs: JSON.parse(row.ratchet_state) as RatchetState };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Is this state carrying a bucket under its CURRENT receiving header key — the
+ * only configuration in which the upstream lookup can mis-fire? Returns the
+ * pruned row to retry with, or null when there is nothing to try (the common
+ * case: a healthy session has no such bucket, so this costs one JSON parse).
+ */
+export function findStaleBucket(stateJson: string): StaleBucket | null {
+  if (!staleBucketRetry.enabled) return null;
+  const parsed = parseRow(stateJson);
+  if (!parsed) return null;
+  const { row, rs } = parsed;
+  const headerKey = rs.current_receiving_header_key;
+  if (!headerKey) return null;
+  const map = rs.skipped_keys_map;
+  const bucket = map?.[headerKey];
+  if (!bucket || Object.keys(bucket).length === 0) return null;
+
+  const prunedMap: SkippedKeysMap = { ...map };
+  delete prunedMap[headerKey];
+  return {
+    headerKey,
+    bucket,
+    prunedRow: {
+      ...row,
+      ratchet_state: JSON.stringify({ ...rs, skipped_keys_map: prunedMap }),
+    },
+  };
+}
+
+/**
+ * Re-file a bucket that was pruned for a retry, into the ratchet state the
+ * successful retry produced. Never overwrites a bucket the crate itself wrote
+ * under the same header key — the crate's own entry is authoritative and newer.
+ */
+export function restoreStaleBucket(
+  ratchetStateJson: string,
+  headerKey: string,
+  bucket: Record<string, unknown>
+): string {
+  try {
+    const rs = JSON.parse(ratchetStateJson) as RatchetState;
+    const map: SkippedKeysMap = { ...(rs.skipped_keys_map ?? {}) };
+    map[headerKey] = { ...bucket, ...(map[headerKey] ?? {}) };
+    return JSON.stringify({ ...rs, skipped_keys_map: map });
+  } catch {
+    // A state we cannot parse is a state we must not rewrite.
+    return ratchetStateJson;
+  }
+}


### PR DESCRIPTION
Stacked on #264 (the harness work), which supplies the reproduction this is measured against. Merge #264 first.

## The upstream defect

`quorum-mobile#183` item 1a. The ratchet keeps the message keys of frames it had to skip, filed under the sending chain they belong to. When the sender opens a **new** chain the receiver takes a DH step — and the crate then matches a skipped key **by index** in the bucket filed under the *pre-step* `current_receiving_header_key`, without checking that bucket belongs to this frame's chain.

A new-chain frame at a colliding index is handed an old-chain key and fails AEAD. Non-colliding indices decrypt normally, which is why the failure looked like it depended on position in the chain.

Evidence:
- **139 of 159** captured production failures (whole corpus on disk, de-duplicated by envelope fingerprint) show the full signature and recover when that one bucket is removed.
- The failing index set **equals** the stale bucket's index set, exactly, across 5/5 synthetic configurations.
- Reproducible on demand: `yarn harness dm-reorder`.

This also settles the lookup-vs-contents question the investigation had left open: it is the **lookup**. The bucket's keys are valid and decrypt their own frames correctly — they are being applied to the wrong chain.

## The fix

On decrypt failure, retry once against a **copy** of the state with that single bucket removed, then re-file the bucket under its own header key in the state that gets persisted. After the DH step that header key is no longer current, so it cannot poison again, while the delayed frames it serves still decrypt.

**The re-file step is not optional.** Pruning and persisting destroys the delayed frames whose keys live in that bucket — measured 3/3 — and those are exactly the frames redelivery recovers today. Without it, this would trade recoverable latency for permanent loss while looking like a fix. The bug doc originally proposed the destructive form.

**The retry has to wrap the decrypt *and* `parseDecryptedMessage`.** A DM decrypt failure does not reject: the crate returns a result whose `message` carries `Decryption failed: aead::Error`, and the parse is what throws. A first version wrapped only the decrypt call and silently never fired.

## Regression surface

- `findStaleBucket` is called **only inside the catch**, so the success path is unchanged and costs nothing.
- A failure with no bucket under the current key **rethrows the original error** — existing behaviour is preserved exactly for every failure this does not target (replays, genuinely undecryptable frames).
- A failing retry degrades to the same retain-frame / keep-session handler as before.
- The decrypt is authenticated, so a recovered frame cannot carry forged content.
- The pruned state is never persisted; `restoreStaleBucket` lets crate-written entries win over restored ones.
- There is a kill switch, because this is a workaround for a defect in a dependency we have no source for.

## Measured

Bench, `yarn harness dm-stale-bucket` (8 cycles per arm, fresh accounts per arm):

| | retry OFF | retry ON |
|---|---|---|
| stale bucket formed | 8/8 cycles | 8/8 cycles |
| AEAD failures on new-chain frames | **32** of 56 | **0** of 56 |
| failures on the DELAYED frames | 0 | **0** ← the regression that matters |

Against **real degraded production state** — each `[XPDUMP]` record holds the complete `EncryptionState` row *and* the frame that failed against it, so the field corpus drives the shipped helper directly (`DM_LOG_DIR=<logs> yarn harness replay-captured`):

| | |
|---|---|
| distinct captured failures (54 logs) | 159 |
| recovered by the **shipped** code | **139 (87%)** |
| recoveries that preserved the bucket's keys | **139/139** |
| not recovered | 20 (near-empty maps; 2 have no current-header bucket) |

That matches `dr-prune-safety.mjs` exactly, which is why both exist: the analyzer open-codes the same mutation, so a divergence would otherwise go unnoticed.

`tsc` clean, **554/554** tests pass, 14 new unit tests.

## Known limits

- **Not run in a browser.** Everything above is protocol + service layer; nothing has rendered UI.
- Mobile↔desktop is worth doing but is **not** a correctness gate: the retry is purely receiver-side and never inspects the frame's origin, so a mobile-sent frame cannot reach a different branch. Cross-platform traffic measures how often buckets *form*, which is the separate trigger question.
- It emits a `logger.warn` per recovery — keep, sample, or drop is a product call.
- It fixes the symptom, not the cause. The cause is upstream and unfixable here.