### PR TITLE
dm: apply named read acks, so a lost delivery ack can still reach the second tick

### DIFF
--- a/src/components/context/MessageDB.tsx
+++ b/src/components/context/MessageDB.tsx
@@ -1154,20 +1154,32 @@ const MessageDBProvider: FC<MessageDBContextProps> = ({ children }) => {
           });
         }
       },
-      onReadFlush: (address: string, highWaterMark: { messageId: string; timestamp: number }) => {
+      onReadFlush: (
+        address: string,
+        payload: { messageId: string; timestamp: number; messageIds: string[] }
+      ) => {
         // Queue standalone read ack via Action Queue
         actionQueueService.enqueue(
           'send-read-ack',
           {
             address,
-            upToMessageId: highWaterMark.messageId,
-            upToTimestamp: highWaterMark.timestamp,
+            upToMessageId: payload.messageId,
+            upToTimestamp: payload.timestamp,
+            // Naming what was read lets the peer settle ✓✓ for messages whose
+            // delivery ack was lost. The mark still rides along and still heals
+            // a dropped read ack, so both failure modes stay covered.
+            messageIds: payload.messageIds,
             selfUserAddress: selfAddress,
           },
           `read-ack:${address}` // dedup key: one pending read ack per address
         );
       },
-      onReadAckProcessed: (upToMessageId: string, upToTimestamp: number, conversationAddress: string) => {
+      onReadAckProcessed: (
+        upToMessageId: string,
+        upToTimestamp: number,
+        conversationAddress: string,
+        messageIds?: string[]
+      ) => {
         const now = Date.now();
 
         // A peer sending an unbounded timestamp would otherwise mark our entire
@@ -1175,13 +1187,18 @@ const MessageDBProvider: FC<MessageDBContextProps> = ({ children }) => {
         if (!isReadAckTimestampValid(upToTimestamp, now)) return;
 
         // Remember how far they have read, so delivery acks still in flight can
-        // finish the upgrade when they land (see onAckProcessed).
+        // finish the upgrade when they land (see onAckProcessed). Kept even now
+        // that acks name messages: naming dies with a dropped ack, the watermark
+        // is restated by every later one and so repairs it.
         readWatermarksRef.current.set(
           conversationAddress,
           advanceReadWatermark(readWatermarksRef.current.get(conversationAddress) ?? 0, upToTimestamp)
         );
 
-        const ctx = { upToMessageId, upToTimestamp, now };
+        // Named ids are self-proving, so they settle ✓✓ even when the delivery
+        // ack was lost. Absent for peers on older builds.
+        const readMessageIds = messageIds?.length ? new Set(messageIds) : undefined;
+        const ctx = { upToMessageId, upToTimestamp, now, readMessageIds };
 
         // Update React Query cache — scope to this conversation only (not all conversations)
         const conversationKey = buildMessagesKeyPrefix({ spaceId: conversationAddress, channelId: conversationAddress });
@@ -1210,7 +1227,15 @@ const MessageDBProvider: FC<MessageDBContextProps> = ({ children }) => {
 
         // Persist to IndexedDB — DM spaceId and channelId are both the address
         messageDB
-          .updateMessagesReadAt(conversationAddress, conversationAddress, selfAddress, upToMessageId, upToTimestamp, now)
+          .updateMessagesReadAt(
+            conversationAddress,
+            conversationAddress,
+            selfAddress,
+            upToMessageId,
+            upToTimestamp,
+            now,
+            readMessageIds
+          )
           .catch(() => {
             // Best effort — React Query cache is already updated
           });

--- a/src/db/messages.ts
+++ b/src/db/messages.ts
@@ -491,7 +491,13 @@ export class MessageDB {
    *
    * Only messages with a genuine deliveredAt are marked — a read ack must never
    * invent a delivery, or messages lost in transport get ✓✓ they never earned.
-   * The HWM message itself is exempt: reading it proves it arrived.
+   * Messages the peer NAMED are exempt: reading one proves it arrived, so a
+   * named message settles even if its delivery ack was lost. `readMessageIds`
+   * is absent for peers on older builds, leaving only the HWM self-proving.
+   *
+   * The cursor range is bounded by upToTimestamp, which covers every named id:
+   * the mark is the newest read in the window, and ids are collected with the
+   * same createdDate the range is keyed on.
    */
   async updateMessagesReadAt(
     spaceId: string,
@@ -499,7 +505,8 @@ export class MessageDB {
     ownAddress: string,
     upToMessageId: string,
     upToTimestamp: number,
-    readAt: number
+    readAt: number,
+    readMessageIds?: ReadonlySet<string>
   ): Promise<void> {
     await this.init();
     return new Promise((resolve, reject) => {
@@ -511,7 +518,7 @@ export class MessageDB {
         [spaceId, channelId, upToTimestamp]
       );
       const request = index.openCursor(range);
-      const ctx = { upToMessageId, upToTimestamp, now: readAt };
+      const ctx = { upToMessageId, upToTimestamp, now: readAt, readMessageIds };
 
       request.onsuccess = () => {
         const cursor = request.result;

--- a/src/dev/tests/db/receiptReconciliation.test.ts
+++ b/src/dev/tests/db/receiptReconciliation.test.ts
@@ -122,6 +122,92 @@ describe('MessageDB - DM receipt reconciliation', () => {
     });
   });
 
+  describe('read acks that name what was read', () => {
+    const namedReadAck = (
+      upToMessageId: string,
+      upToTimestamp: number,
+      ids: string[],
+      at = 9_000
+    ) => db.updateMessagesReadAt(PEER, PEER, ME, upToMessageId, upToTimestamp, at, new Set(ids));
+
+    it('recovers a message whose delivery ack was lost, because reading proves arrival', async () => {
+      // No deliveredAt: its delivery ack never made it back. Before naming, the
+      // only escape was being the high-water mark itself.
+      await saveDm({ messageId: 'm1', createdDate: 400 });
+      await saveDm({ messageId: 'hwm', createdDate: 500, deliveredAt: 800 });
+
+      await namedReadAck('hwm', 500, ['m1', 'hwm']);
+
+      const m1 = await db.getMessageById('m1');
+      expect(m1?.readAt).toBe(9_000);
+      expect(m1?.deliveredAt).toBe(9_000);
+    });
+
+    it('still refuses a message the peer did NOT name — the delivery gate holds', async () => {
+      await saveDm({ messageId: 'lost', createdDate: 400 });
+      await saveDm({ messageId: 'read-one', createdDate: 450 });
+
+      await namedReadAck('hwm', 500, ['read-one']);
+
+      const lost = await db.getMessageById('lost');
+      expect(lost?.readAt).toBeUndefined();
+      expect(lost?.deliveredAt).toBeUndefined();
+    });
+
+    it('does not overwrite a real delivery time on a named message', async () => {
+      await saveDm({ messageId: 'm1', createdDate: 400, deliveredAt: 800 });
+
+      await namedReadAck('hwm', 500, ['m1']);
+
+      const m1 = await db.getMessageById('m1');
+      expect(m1?.readAt).toBe(9_000);
+      expect(m1?.deliveredAt).toBe(800);
+    });
+
+    it('leaves the peer\'s own messages alone even when named', async () => {
+      await saveDm({ messageId: 'theirs', createdDate: 400, senderId: PEER });
+
+      await namedReadAck('hwm', 500, ['theirs']);
+
+      const theirs = await db.getMessageById('theirs');
+      expect(theirs?.readAt).toBeUndefined();
+      expect(theirs?.deliveredAt).toBeUndefined();
+    });
+
+    it('repairs the reported-bug conversation when the reader names what it read', async () => {
+      // Same ten messages, #4 and #7 lost — but now the reader names them, so
+      // both recover instead of sitting blank until a delivery ack that never comes.
+      for (let n = 1; n <= 10; n++) {
+        const lost = n === 4 || n === 7;
+        await saveDm({
+          messageId: `m${n}`,
+          createdDate: n * 100,
+          deliveredAt: lost ? undefined : 800,
+        });
+      }
+
+      await namedReadAck('m10', 1000, Array.from({ length: 10 }, (_, i) => `m${i + 1}`));
+
+      const results = await Promise.all(
+        Array.from({ length: 10 }, (_, i) => db.getMessageById(`m${i + 1}`))
+      );
+
+      expect(results.every((m) => m?.readAt === 9_000)).toBe(true);
+      expect(results[3]?.deliveredAt).toBe(9_000); // m4 recovered
+      expect(results[6]?.deliveredAt).toBe(9_000); // m7 recovered
+    });
+
+    it('behaves exactly as before when the peer names nothing (older build)', async () => {
+      await saveDm({ messageId: 'lost', createdDate: 400 });
+      await saveDm({ messageId: 'ok', createdDate: 450, deliveredAt: 800 });
+
+      await readAck('hwm', 500);
+
+      expect((await db.getMessageById('lost'))?.readAt).toBeUndefined();
+      expect((await db.getMessageById('ok'))?.readAt).toBe(9_000);
+    });
+  });
+
   describe('delivery acks', () => {
     it('stamps deliveredAt when no read ack has arrived', async () => {
       await saveDm({ messageId: 'm1', createdDate: 400 });

--- a/src/services/ActionQueueHandlers.ts
+++ b/src/services/ActionQueueHandlers.ts
@@ -1107,7 +1107,13 @@ export class ActionQueueHandlers {
    * - address: string (DM conversation address)
    * - upToMessageId: string (high-water mark message ID)
    * - upToTimestamp: number (high-water mark timestamp)
+   * - messageIds: string[] (ids read since the last flush; may be absent)
    * - selfUserAddress: string (user's address for identity in envelope)
+   *
+   * If a newer read flush replaces this task before it sends (queue dedup on
+   * `read-ack:${address}`), the superseding ack carries a mark at least as high,
+   * so read state still lands; only the naming for the replaced window is lost
+   * and those messages fall back to needing their own delivery ack.
    */
   private sendReadAck: TaskHandler = {
     execute: async (context) => {
@@ -1120,6 +1126,7 @@ export class ActionQueueHandlers {
       const address = context.address as string;
       const upToMessageId = context.upToMessageId as string;
       const upToTimestamp = context.upToTimestamp as number;
+      const messageIds = context.messageIds as string[] | undefined;
       const selfUserAddress = context.selfUserAddress as string;
 
       if (!upToMessageId) {
@@ -1131,6 +1138,7 @@ export class ActionQueueHandlers {
         type: 'read-ack' as const,
         upToMessageId,
         upToTimestamp,
+        ...(messageIds?.length ? { messageIds } : {}),
       };
 
       try {

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -599,7 +599,14 @@ export class MessageService {
         const upToMessageId = raw.upToMessageId;
         const upToTimestamp = raw.upToTimestamp;
         if (upToMessageId && upToTimestamp) {
-          this.receiptService.onReadAckReceived(upToMessageId, upToTimestamp, senderAddress);
+          // messageIds is absent from peers on older builds — the mark alone
+          // still applies, exactly as before.
+          this.receiptService.onReadAckReceived(
+            upToMessageId,
+            upToTimestamp,
+            senderAddress,
+            raw.messageIds
+          );
         }
       }
       return true; // Signal: intercept this message
@@ -646,7 +653,12 @@ export class MessageService {
     // 2b. Extract piggybacked readAckUpTo, process, then strip
     const readAckUpTo = raw.readAckUpTo;
     if (readAckUpTo && this.receiptService && readReceiptsEnabled) {
-      this.receiptService.onReadAckReceived(readAckUpTo.messageId, readAckUpTo.timestamp, senderAddress);
+      this.receiptService.onReadAckReceived(
+        readAckUpTo.messageId,
+        readAckUpTo.timestamp,
+        senderAddress,
+        readAckUpTo.messageIds
+      );
     }
     delete raw.readAckUpTo;
 


### PR DESCRIPTION
Desktop side of QuilibriumNetwork/quorum-shared#67. **Merge that one first** — desktop resolves shared via `link:../quorum-shared`, so this won't compile against a clean shared checkout until it lands.

## What this fixes

Send a message, it arrives, but its delivery confirmation is lost on the way back. That message used to sit on one tick forever with no way to recover. Now when the other person reads it, their read ack names it explicitly, and naming is proof of arrival — so it reaches ✓✓. Previously only the single newest message could do that.

## Wiring

**Sending** — the read flush carries the ids into the action queue and onto the wire (`ActionQueueHandlers.sendReadAck`), and the piggyback path carries them on the envelope (`attachPiggybackedAcks`).

**Receiving** — both the standalone `read-ack` intercept and the piggybacked `readAckUpTo` pass ids through to reconciliation (`MessageService`), and the IndexedDB walk applies them (`updateMessagesReadAt`).

The existing cursor range already covers every named id: ids are collected with the same `createdDate` the range is keyed on, and the mark is the newest read in the window.

## The watermark is intentionally not removed

It looks redundant once acks name messages and every test still passes without it, but it is the only thing that repairs a **read ack** lost in transport. Naming cannot do that — it dies with the ack that carried it.

## Compatibility

Optional throughout. A peer on an older build ignores the field and gets exactly today's behaviour; an older peer sending no ids leaves us on the mark-only path. Both directions covered by tests.

## Tests

560 pass. Receipt storage suite 18, up from 12 — the six new ones cover recovery of a lost delivery ack, that an **unnamed** undelivered message is still refused, that a real delivery time is never overwritten, and the old-peer fallback.

Typecheck clean, build succeeds.

## Not included

Mobile is untouched and unaffected (pins `2.1.0-37`). Mobile piggybacking and mobile's 2b wiring remain open follow-ups.

No two-device run yet — all evidence here is unit tests.