### PR TITLE
Harness: measure multi-device DM delivery, and time the ratchet lock

### DIFF
--- a/.agents/bugs/2026-07-28-dm-receive-holds-ratchet-lock-across-http.md
+++ b/.agents/bugs/2026-07-28-dm-receive-holds-ratchet-lock-across-http.md
@@ -1,9 +1,9 @@
 ---
 type: bug
 title: "Desktop DM receive holds the per-conversation ratchet lock across relay HTTP, so one slow ack stalls the whole conversation"
-status: OPEN — MECHANISM IDENTIFIED BY CODE READING, NOT YET CONFIRMED BY MEASUREMENT. The receive path awaits `deleteInboxMessages` / `ackProcessedFrame` (POST `/inbox/delete`, 22s mutate timeout) INSIDE `dmRatchetMutex.runExclusive(conversationId, …)`, so a single slow ack blocks every message on that conversation, in BOTH directions, for up to 22s. A 4-device bench run showed one device persisting 52/100 messages while all 101 frames arrived and nothing failed to decrypt — consistent with this, but that run may have been taken against a degrading relay (see §4) and the confirming evidence (§5) has not been collected. Mobile does NOT have this shape and its pattern is the proposed fix (§6).
+status: OPEN — MECHANISM IDENTIFIED BY CODE READING, NOT YET CONFIRMED BY MEASUREMENT. The receive path awaits `deleteInboxMessages` / `ackProcessedFrame` (POST `/inbox/delete`, 22s mutate timeout, retried ×3) INSIDE `dmRatchetMutex.runExclusive(conversationId, …)`, so a single slow ack blocks every message on that conversation, in BOTH directions, for up to ~69s (see §1). A 4-device bench run showed one device persisting 52/100 messages while all 101 frames arrived and nothing failed to decrypt — consistent with this, but that run may have been taken against a degrading relay (see §4) and the confirming evidence (§5) has not been collected. Mobile does NOT have this shape and its pattern is the proposed fix (§6).
 created: 2026-07-28
-severity: medium — user-visible "messages not arriving" on desktop; likely LATENCY not permanent loss (§3), degrades with device count
+severity: medium — user-visible "messages not arriving" on desktop; likely LATENCY not permanent loss (§3), degrades with device count. ⚠️ NOT revisited after the 2026-07-28 review tripled the stall bound from 22s to ~69s: a conversation frozen for over a minute is closer to "broken" than "slow" from a user's seat, so re-rate this if §5 confirms the mechanism.
 repo: quorum-desktop (mobile verified NOT affected — §6)
 area: DM receive path / ratchet serialization / transport
 related:
@@ -29,18 +29,33 @@ src/services/MessageService.ts:3858
   const dm = await dmRatchetMutex.runExclusive(conversationId, async () => {
 ```
 
-Inside that lock it **awaits HTTP calls to the relay**:
+Inside that lock it **awaits HTTP calls to the relay** — three shapes, all the
+same POST `/inbox/delete`:
 
-- `await this.deleteInboxMessages(…, this.apiClient)` — POST `/inbox/delete`
+- `await this.deleteInboxMessages(…, this.apiClient)` — in the
+  delete-conversation branches (`MessageService.ts:3911`, `4040`). This one
+  **rethrows** on failure (`MessageDB.tsx:343-350`).
 - `await this.ackProcessedFrame(freshKeys.receiving_inbox, message.timestamp)`
-  (`MessageService.ts:350-356`), which is the same POST wrapped in a try/catch
+  on decrypt success (`MessageService.ts:3938`, `4058`; body at `350-356`) —
+  same POST wrapped in a try/catch.
+- `await this.retainOrDropUndecryptableFrame(…)` on decrypt **failure**
+  (`MessageService.ts:3957`, `4074`): when the frame's retry budget is
+  exhausted it awaits the same POST (`MessageService.ts:331`), and like the
+  first shape it rethrows.
 
-The mutate timeout is **22 seconds** (`defaultMutateTimeout`,
-`src/api/baseTypes.ts:862`). There is no separate, shorter timeout for this call.
+The mutate timeout is **22 seconds per attempt** (`defaultMutateTimeout`,
+`src/api/baseTypes.ts:862`), and the client **retries mutations twice** on
+timeout/5xx with 1s/2s backoff (`fetchWithRetry`, `baseTypes.ts:150-196`; only
+4xx is not retried). So a fully timing-out delete holds the lock for up to
+**22+1+22+2+22 ≈ 69s**, not 22s. In the app, `timeoutRetryDecayFactor: 0.3`
+(`QuorumApiContext.tsx:33`) shrinks repeat-call timeouts (floor 6.6s), so the
+in-app worst case is ~23-49s; the harness client sets no decay factor
+(`harness/transport.ts:44`), so bench stalls run the full ~69s.
 
 **Consequence:** one slow inbox-delete blocks *every* message on that
-`conversationId` for up to 22s. Both directions of a DM share one conversationId
-(`<partner>/<partner>`), so both stall together.
+`conversationId` for tens of seconds — up to ~69s. Both directions of a DM
+share one conversationId (`<partner>/<partner>` — `MessageService.ts:686`
+receive, `:968` send), so both stall together.
 
 `KeyedMutex`'s own documentation warns about exactly this
 (`quorum-shared/src/utils/keyedMutex.ts`):
@@ -74,7 +89,7 @@ src/services/MessageService.ts:350-356
 ```
 
 So the code already accepts "this may fail, the frame will be redelivered". Waiting
-22 seconds for something whose failure is a no-op buys nothing.
+up to a minute for something whose failure is a no-op buys nothing.
 
 ## §3. ⚠️ What this predicts — LATENCY, not loss. ATTACK THIS FIRST.
 
@@ -91,7 +106,8 @@ whether they later arrived.**
 ## §4. The measurement that suggested it, and why it is not yet proof
 
 `yarn harness dm-multidevice` with `HARNESS_MD_DEVICES=4`, 100 rounds, fresh
-generated account (run log `logs/2026-07-28T13-45-03-227Z-dm-multidevice.jsonl`):
+generated account (run log
+`src/dev/tests/harness/logs/2026-07-28T13-45-03-227Z-dm-multidevice.jsonl`):
 
 ```
 all 8 frame legs:   101/101 arrived, 0.0% loss
@@ -120,7 +136,10 @@ be treated as a clean product measurement.
    - contiguous tail ⇒ the device stopped processing at a moment ⇒ **backlog, this bug**
    - scattered gaps ⇒ per-message drops ⇒ **a different bug; this one does not explain it**
 3. Optionally, time the lock: log how long `runExclusive` holds `conversationId` on
-   the receive path. A visible cluster near 22s would be conclusive.
+   the receive path. In the harness, conclusive holds cluster at the retry
+   multiples ~22s / ~45s / ~68s (no timeout decay there); in the app the decay
+   factor (§1) also produces 6.6-15.4s holds. Do not test only for "≈22s" — a
+   retried ack misses that window.
 
 ## §6. ✅ Mobile is NOT affected — and its pattern is the fix
 
@@ -144,7 +163,18 @@ and leaves the coupling between relay latency and message processing in place.
 
 - The delete must still fire **after** the encryption state is persisted, or a
   crash between the two loses a frame the relay would otherwise redeliver.
+  (Verified ordering today: save at `MessageService.ts:3918`/`4047` precedes
+  ack at `3938`/`4058` — preserve it.)
 - Do not move the *state save* out of the lock. Only the ack.
+- The fix must cover **all three shapes in §1**, not just `ackProcessedFrame` —
+  the give-up path inside `retainOrDropUndecryptableFrame`
+  (`MessageService.ts:331`) and the delete-conversation branches (`3911`,
+  `4040`) hold the lock the same way.
+- Those two shapes **rethrow** on failure today (the ack swallows). Making them
+  fire-and-forget silences an error the inbound loop currently catches and
+  logs — acceptable (redelivery covers it, and `MessageDB.tsx:345` already
+  logs loudly before rethrowing), but it is a behavior change; keep the
+  `.catch` logging.
 - Check the other `runExclusive` sites for the same shape before assuming this is
   the only one: `MessageService.ts:983, 3012, 3195, 3477, 3858, 6610` and
   `ActionQueueHandlers.ts:672`. 983 and 672 are known-good (they wrap as
@@ -166,3 +196,11 @@ platform carrying this defect, and `dm-loss` counts frames, so it was blind to i
 
 ---
 *Last updated: 2026-07-28*
+
+## Review Log
+**2026-07-28 - claude-fable-5**: Verified every code claim against desktop and mobile sources; corrected the stall bound, added a third locked HTTP shape, fixed the run-log path, widened the confirmation criterion.
+- Stall bound was understated ~3x: fetchWithRetry (baseTypes.ts:150-196) retries mutations twice on timeout/5xx with 1s/2s backoff, so a timing-out /inbox/delete holds the lock up to ~69s in the harness (no decay factor, transport.ts:44) and ~23-49s in the app (decay 0.3, QuorumApiContext.tsx:33) — sec1 rewritten
+- Third HTTP shape inside the lock was unlisted: retainOrDropUndecryptableFrame (3957/4074) awaits the same POST at MessageService.ts:331 when the retry budget is exhausted, and rethrows unlike ackProcessedFrame — added to sec1 and the sec6 care list
+- sec5.3 lock-timing criterion (cluster near 22s) could false-negative a retried ack — now anchored to ~22/45/68s retry multiples plus decayed 6.6-15.4s values
+- Run-log path corrected to src/dev/tests/harness/logs/
+- Everything else verified accurate: runExclusive site list complete (983/3012/3195/3477/3858/6610 + AQH 672), keyedMutex doc quote faithful, persist-before-ack ordering holds (3918/4047 before 3938/4058), mobile-unaffected claims all confirmed in quorum-mobile (lock only in services/crypto, deleteProcessedEnvelope fire-and-forget at WebSocketContext.tsx:188-201), DM conversationId <partner>/<partner> confirmed, gap report exists in dm-multidevice.scenario.test.ts:91-95

--- a/.agents/bugs/2026-07-28-dm-receive-holds-ratchet-lock-across-http.md
+++ b/.agents/bugs/2026-07-28-dm-receive-holds-ratchet-lock-across-http.md
@@ -1,0 +1,168 @@
+---
+type: bug
+title: "Desktop DM receive holds the per-conversation ratchet lock across relay HTTP, so one slow ack stalls the whole conversation"
+status: OPEN — MECHANISM IDENTIFIED BY CODE READING, NOT YET CONFIRMED BY MEASUREMENT. The receive path awaits `deleteInboxMessages` / `ackProcessedFrame` (POST `/inbox/delete`, 22s mutate timeout) INSIDE `dmRatchetMutex.runExclusive(conversationId, …)`, so a single slow ack blocks every message on that conversation, in BOTH directions, for up to 22s. A 4-device bench run showed one device persisting 52/100 messages while all 101 frames arrived and nothing failed to decrypt — consistent with this, but that run may have been taken against a degrading relay (see §4) and the confirming evidence (§5) has not been collected. Mobile does NOT have this shape and its pattern is the proposed fix (§6).
+created: 2026-07-28
+severity: medium — user-visible "messages not arriving" on desktop; likely LATENCY not permanent loss (§3), degrades with device count
+repo: quorum-desktop (mobile verified NOT affected — §6)
+area: DM receive path / ratchet serialization / transport
+related:
+  - ".agents/tasks/2026-07-28-harness-multidevice-and-coverage.md (owner task — the bench work that surfaced this)"
+  - ".agents/docs/transport-measurements.md (§ multi-device rows — the 52/100 measurement)"
+  - ".agents/docs/transport-reliability-index.md (§3.2 — the finding in context; map for the whole investigation)"
+---
+
+# Desktop DM receive holds the ratchet lock across relay HTTP
+
+> **For a fresh reviewer:** everything below §1 is read from code and can be
+> verified without running anything. §3 and §4 are the parts I am *not* sure of,
+> and they are flagged. Please attack §3 first — if it is wrong, the severity and
+> the fix both change.
+
+## §1. The defect
+
+`MessageService.handleNewMessage` runs its receive critical section inside the
+per-conversation ratchet mutex:
+
+```
+src/services/MessageService.ts:3858
+  const dm = await dmRatchetMutex.runExclusive(conversationId, async () => {
+```
+
+Inside that lock it **awaits HTTP calls to the relay**:
+
+- `await this.deleteInboxMessages(…, this.apiClient)` — POST `/inbox/delete`
+- `await this.ackProcessedFrame(freshKeys.receiving_inbox, message.timestamp)`
+  (`MessageService.ts:350-356`), which is the same POST wrapped in a try/catch
+
+The mutate timeout is **22 seconds** (`defaultMutateTimeout`,
+`src/api/baseTypes.ts:862`). There is no separate, shorter timeout for this call.
+
+**Consequence:** one slow inbox-delete blocks *every* message on that
+`conversationId` for up to 22s. Both directions of a DM share one conversationId
+(`<partner>/<partner>`), so both stall together.
+
+`KeyedMutex`'s own documentation warns about exactly this
+(`quorum-shared/src/utils/keyedMutex.ts`):
+
+> *"Do NOT hold the lock across transport delivery: if the delivery queue's
+> callbacks also take this lock, waiting for delivery inside the lock is a
+> circular wait. Note that an async callback returning a promise gets
+> auto-flattened — returning a delivery promise from `fn` silently extends the
+> critical section until delivery."*
+
+The **send** paths follow that guidance, returning the delivery promise wrapped as
+`{ sent }` so it is not awaited inside the lock
+(`MessageService.ts:983`, `ActionQueueHandlers.ts:672`). The **receive** path does
+not.
+
+## §2. Why the ack does not need to be inside the lock
+
+The lock exists to serialize *ratchet state* — read state, advance, save — because
+concurrent operations fork it. The inbox delete is not part of that: by the time it
+runs, the encryption state has already been persisted, and the delete's only job is
+to stop the relay redelivering a frame we have finished with.
+
+Its failure is already treated as harmless. `ackProcessedFrame` catches and only
+warns:
+
+```
+src/services/MessageService.ts:350-356
+  catch (err) {
+    logger.warn('[MessageService] failed to ack a processed DM frame (will be redelivered)', err);
+  }
+```
+
+So the code already accepts "this may fail, the frame will be redelivered". Waiting
+22 seconds for something whose failure is a no-op buys nothing.
+
+## §3. ⚠️ What this predicts — LATENCY, not loss. ATTACK THIS FIRST.
+
+If this is the mechanism, messages are **not dropped**. They are queued behind the
+lock and processed late; a longer tail should recover them.
+
+That distinction matters enormously, and this investigation has repeatedly
+mistaken one for the other — see the master report's *"failures are TRANSIENT, so
+this is LATENCY WITH A LONG TAIL, not demonstrated loss."*
+
+**Do not accept "messages went missing" as evidence for this bug without checking
+whether they later arrived.**
+
+## §4. The measurement that suggested it, and why it is not yet proof
+
+`yarn harness dm-multidevice` with `HARNESS_MD_DEVICES=4`, 100 rounds, fresh
+generated account (run log `logs/2026-07-28T13-45-03-227Z-dm-multidevice.jsonl`):
+
+```
+all 8 frame legs:   101/101 arrived, 0.0% loss
+decrypt failures:   0 everywhere
+A.dev1 persisted:   52/100 messages   (BOTH directions, same count)
+A.dev2, A.dev3:     100/100
+```
+
+Fits the mechanism on every axis: both directions equal (one lock), no error
+raised (the ack swallows its own), all frames arrived (the socket is upstream of
+this), worse with device count (4 devices ⇒ ~4× the delete traffic ⇒ more chance of
+a slow call), and clean at 2 devices.
+
+⚠️ **But it is one run, one device of three extras, and the relay may have been
+degrading during it.** That run finished at 15:51; `api.quorummessenger.com` was
+returning 502 on every path by 15:53 and stayed down for over an hour. A degrading
+relay is precisely the condition that makes this mechanism bite, so the run cannot
+be treated as a clean product measurement.
+
+## §5. What would confirm it
+
+1. **Re-run against a healthy relay:**
+   `HARNESS_MD_DEVICES=4 HARNESS_MD_ROUNDS=100 yarn harness dm-multidevice`
+2. **Read the gap report** the scenario now prints. It says whether the missing
+   numbers are a **CONTIGUOUS TAIL** or **SCATTERED**:
+   - contiguous tail ⇒ the device stopped processing at a moment ⇒ **backlog, this bug**
+   - scattered gaps ⇒ per-message drops ⇒ **a different bug; this one does not explain it**
+3. Optionally, time the lock: log how long `runExclusive` holds `conversationId` on
+   the receive path. A visible cluster near 22s would be conclusive.
+
+## §6. ✅ Mobile is NOT affected — and its pattern is the fix
+
+Verified by reading (2026-07-28, read-only):
+
+| | desktop | mobile |
+|---|---|---|
+| ratchet lock placement | wraps the whole receive critical section (`MessageService.ts:3858`) | only inside `services/crypto/encryption-service.ts` (crypto layer) |
+| lock wraps network I/O? | **yes** | **no** — that file has no network calls and imports no API client |
+| inbox ack | `await`ed inside the lock | `deleteProcessedEnvelope` returns **`void`**; dispatched `.catch(() => {})`, never awaited |
+| lock in the receive handler | yes | none — `runExclusive` appears nowhere in `context/` |
+
+**Proposed fix: adopt mobile's shape.** Dispatch the inbox delete without awaiting
+it, ignore its failure. Desktop's own `ackProcessedFrame` already swallows the
+error, so this changes *when* the call happens, not what happens when it fails.
+
+**Do not** simply shorten the timeout. That reduces the stall without removing it,
+and leaves the coupling between relay latency and message processing in place.
+
+### Care required
+
+- The delete must still fire **after** the encryption state is persisted, or a
+  crash between the two loses a frame the relay would otherwise redeliver.
+- Do not move the *state save* out of the lock. Only the ack.
+- Check the other `runExclusive` sites for the same shape before assuming this is
+  the only one: `MessageService.ts:983, 3012, 3195, 3477, 3858, 6610` and
+  `ActionQueueHandlers.ts:672`. 983 and 672 are known-good (they wrap as
+  `{ sent }`); the rest have not been audited for network calls inside the lock.
+
+## §7. Scope — what this does NOT explain
+
+**It does not explain the mobile↔mobile field loss** (issue
+[quorum-mobile#183](https://github.com/QuilibriumNetwork/quorum-mobile/issues/183)
+item 2, round 29: 8 of 25 frames lost one direction, 0 of 18 the reverse, both
+phones instrumented). Mobile does not have this defect (§6), and that loss is at
+the *frame* layer — frames never arrived — whereas this bug is entirely downstream
+of arrival. **Do not let this finding absorb #183 item 2.**
+
+It **is** consistent with the operator's live observation during a canonical
+`dm-loss` run: two of their **desktop** clients received ~10 of 200 and 0 of 200
+messages while the bench's peer channel measured 201/201, 0% loss. Desktop is the
+platform carrying this defect, and `dm-loss` counts frames, so it was blind to it.
+
+---
+*Last updated: 2026-07-28*

--- a/.agents/bugs/2026-07-28-dm-receive-holds-ratchet-lock-across-http.md
+++ b/.agents/bugs/2026-07-28-dm-receive-holds-ratchet-lock-across-http.md
@@ -135,11 +135,37 @@ be treated as a clean product measurement.
    numbers are a **CONTIGUOUS TAIL** or **SCATTERED**:
    - contiguous tail ⇒ the device stopped processing at a moment ⇒ **backlog, this bug**
    - scattered gaps ⇒ per-message drops ⇒ **a different bug; this one does not explain it**
-3. Optionally, time the lock: log how long `runExclusive` holds `conversationId` on
-   the receive path. In the harness, conclusive holds cluster at the retry
-   multiples ~22s / ~45s / ~68s (no timeout decay there); in the app the decay
-   factor (§1) also produces 6.6-15.4s holds. Do not test only for "≈22s" — a
-   retried ack misses that window.
+3. **Read the lock-hold histogram — this is the DIRECT test and it is already
+   built.** `src/dev/tests/harness/lock-probe.ts` wraps the `dmRatchetMutex`
+   singleton from outside (no product change, the code under measurement is the
+   code that ships) and `dm-multidevice` prints a summary at the end of every run:
+
+   ```
+   ==== RATCHET LOCK HOLD TIMES (bug 2026-07-28, §5.3) ====
+   lock holds: n=… p50=… p90=… p99=… max=…
+     <100ms  (crypto only)              …
+     15-30s  ⚠ 1 timed-out attempt      …
+     30-55s  ⚠ 2 attempts               …
+     >55s    ⚠ 3 attempts (full retry)  …
+   ```
+
+   - holds in single-digit ms ⇒ the lock is doing crypto only; **the mechanism is
+     not firing on this run**
+   - holds clustering at the retry multiples ~22s / ~45s / ~69s (harness, no decay)
+     or 6.6-15.4s (in-app, decay 0.3) ⇒ **confirmed**
+
+   ⚠️ Do **not** test only for "≈22s". Mutations retry twice, so a stalled ack
+   lands near 45s or 69s and never near 22s — the criterion this section
+   originally carried would have produced a false negative.
+
+   This works **even on a run where nothing goes missing**, which makes it
+   stronger evidence than the gap shape in step 2: it measures the mechanism
+   rather than inferring it from consequences.
+
+   The probe has its own offline self-test (`yarn harness lock-probe`, no relay
+   needed) proving it records hold time, queue time, and throwing critical
+   sections — run it first if a result looks surprising, so an instrument fault is
+   ruled out before a product conclusion is drawn.
 
 ## §6. ✅ Mobile is NOT affected — and its pattern is the fix
 

--- a/.agents/docs/transport-measurements.md
+++ b/.agents/docs/transport-measurements.md
@@ -113,6 +113,31 @@ are nulls about a narrower channel than they appear to describe.
 > §3.1 matrix collapsed them into a single row; finding that is what prompted this
 > file.
 
+### Multi-device (`dm-multidevice`) — the channel the rows above are blind to
+
+| when | run | configuration | class | result | what it changed | source |
+|---|---|---|---|---|---|---|
+| 07-28 | `dm-multidevice` | **one account with TWO devices** + peer, all harness bots, Node, fresh account | arrival | 5 rounds — all four legs 0%, 5/5 messages on every device | proved the shape; too small to speak to the 200-message observation | run log |
+| 07-28 | `dm-multidevice` | same, **100 rounds** | arrival + decrypt | **101/101 frames on all four legs, 0%. 100/100 messages on every device** — including the self-sync copy and the peer's 2nd device. 1 novel decrypt failure (phone), healed | **multi-device fan-out is NOT broken by itself on desktop.** Does NOT reproduce the ~10/200 observation | run log `2026-07-28T13-18-18` |
+
+⚠️ **Provenance note, recorded because it nearly went unnoticed:** this result came
+from an invocation that appeared to have been cancelled — the process kept running
+and completed. A *subsequent* background run of the same scenario failed at
+collection (`Vitest failed to find the current suite`, 9.7s) because it started
+while the first was still finishing, and produced nothing. Two vitest runs of the
+harness must not overlap.
+
+**What still separates this bench from the operator's observation**, in decreasing
+order of how cheaply it can be closed:
+
+1. **device count** — 2 here, 5+ on the canonical accounts. The one-key-many-bots
+   trick extends to 4 devices with no change to any real account
+2. **account age** — fresh here, heavily used there
+3. **the receiving client** — the observed devices were the real desktop app *in a
+   browser*; here they are harness bots in Node. Same client code, different
+   runtime, different storage, no UI layer. The harness cannot close this one by
+   construction
+
 ### Mobile harness (`quorum-mobile`, `yarn harness:dm`)
 
 | when | run | configuration | class | result | what it changed | source |

--- a/.agents/docs/transport-measurements.md
+++ b/.agents/docs/transport-measurements.md
@@ -84,6 +84,30 @@ Full detail: `quorum-mobile/.agents/bugs/2026-07-24-dm-desktop-frames-undecrypta
 > other devices, which can never arrive at the peer bot and are not loss. The other
 > ~3400 are **unobserved, not observed-good**.
 
+### ⭐ The fan-out channel during that same run — operator observation
+
+| when | run | configuration | class | result | what it changed | source |
+|---|---|---|---|---|---|---|
+| 07-28 | `dm-loss` run 2, **same run as the row above** | the canonical accounts' OTHER devices — two desktop clients the operator had open and online | arrival | **~10 of 200 messages landed on one desktop, 0 of 200 on the other** | the fan-out channel behaved nothing like the peer channel *in the same run, at the same moment* | operator, observed live during the run; confirmed 2026-07-28 as desktop run 2 |
+
+**This is the most consequential row in the file, and it reframes the one above
+it.** In one run, on one pair of accounts, the peer channel was perfect (201/201
+each way) while the self-sync fan-out to the same accounts' other devices was
+close to total loss. The bench reported 0% and was *structurally blind* to the
+channel that was failing — the ~3400 frames it excluded by design.
+
+⚠️ **Qualifier, deliberately recorded:** this was observed in two desktop UIs, not
+instrumented. A message could in principle arrive and be persisted without
+rendering in a conversation that is not open. That is exactly why the next
+scenario counts what `saveMessage` receives per device rather than what a UI shows
+— see `tasks/2026-07-28-harness-multidevice-and-coverage.md`. Until that runs, treat
+the figure as a strong signal, not a measurement.
+
+**Consequence for every earlier row in this file:** *every* bench run to date used
+one device per account. The self-sync copy and the peer's second device have never
+been exercised by any bench, on either platform. The nulls above are real, and they
+are nulls about a narrower channel than they appear to describe.
+
 > ⚠️ The 07-27 run (301/direction) and the 07-28 run 1 (201/direction) are
 > **different runs**, not two reports of one. An earlier version of the index's
 > §3.1 matrix collapsed them into a single row; finding that is what prompted this

--- a/.agents/docs/transport-measurements.md
+++ b/.agents/docs/transport-measurements.md
@@ -35,16 +35,26 @@ add a newer row and a note. Every row must cite the doc that reported it, so any
 number here can be traced back rather than taken on trust.
 
 **Record the CLASS of the result.** The single most expensive confusion in this
-investigation has been conflating two different failures:
+investigation has been conflating failures that live at different layers:
 
-| class | meaning |
-|---|---|
-| **arrival** | did the frame reach the peer at all? A miss here is transport loss |
-| **decrypt** | it arrived — did it open? A miss here is a crypto/session failure, and is usually transient |
+| class | question | a miss here means |
+|---|---|---|
+| **arrival** | did the frame reach the peer's socket at all? | transport loss |
+| **decrypt** | it arrived — did it open? | a crypto/session failure, usually transient |
+| **persistence** | it opened — did the app keep it? | the message is gone with no error anywhere |
 
 A frame that arrives and fails AEAD is **not** lost. Reporting it as loss is how
 "desktop↔desktop loses 100% of messages" got written down when what actually
 happened was that every frame arrived and none decrypted.
+
+> ⭐ **The third class was added 2026-07-28, and its absence is why this went
+> unfound for weeks.** Every scenario before `dm-multidevice` measured arrival, and
+> `dm-loss` measures *only* arrival by construction. A message that arrives,
+> decrypts cleanly, and is then dropped before `saveMessage` is invisible to every
+> one of them — they would all report that run as flawless, and on the canonical
+> accounts `dm-loss` did exactly that while the operator watched messages fail to
+> appear. **If a scenario does not count what the app persisted, it cannot see this
+> class at all.** Say which classes a run measured, not just its numbers.
 
 ---
 

--- a/.agents/docs/transport-measurements.md
+++ b/.agents/docs/transport-measurements.md
@@ -120,6 +120,38 @@ are nulls about a narrower channel than they appear to describe.
 | 07-28 | `dm-multidevice` | **one account with TWO devices** + peer, all harness bots, Node, fresh account | arrival | 5 rounds — all four legs 0%, 5/5 messages on every device | proved the shape; too small to speak to the 200-message observation | run log |
 | 07-28 | `dm-multidevice` | same, **100 rounds** | arrival + decrypt | **101/101 frames on all four legs, 0%. 100/100 messages on every device** — including the self-sync copy and the peer's 2nd device. 1 novel decrypt failure (phone), healed | **multi-device fan-out is NOT broken by itself on desktop.** Does NOT reproduce the ~10/200 observation | run log `2026-07-28T13-18-18` |
 
+### ⭐⭐ 4 devices — the operator's symptom reproduces on the bench
+
+| when | run | configuration | class | result | what it changed | source |
+|---|---|---|---|---|---|---|
+| 07-28 | `dm-multidevice` | **one account with FOUR devices** + peer, all harness bots, Node, fresh account, 100 rounds | arrival **and** persistence | **every one of the 8 frame legs: 101/101, 0% loss. Zero decrypt failures anywhere.** But `dev1` persisted only **52/100** messages — in BOTH directions, the same count — while `dev2` and `dev3` persisted 100/100 | **first bench reproduction of the operator's symptom.** Loss between arrival and persistence, with no error of any kind | run log `2026-07-28T13-45-03` |
+
+**Why this is the important row in the file.** The frames all arrived. Nothing
+failed to decrypt. `dm-loss` counts frames, so it would have reported this run as
+flawless — which is exactly what it did report on the canonical accounts while the
+operator watched messages fail to appear. The gap is **between the socket and
+`saveMessage`**, and no existing scenario looks there.
+
+It also rules something out: at 2 devices, 100 rounds, everything was clean. The
+failure needs more than one extra device, which fits the operator's 5+ device
+accounts and explains why every earlier bench (one device each) was green.
+
+**The identical 52 in both directions is the informative detail.** A per-message
+drop would not hit two independent streams equally; a device that stopped
+processing at one moment would. That points at a receive-pipeline stall rather than
+per-message loss — but the count alone cannot distinguish "stopped at #52" from
+"dropped every other one", and those are different bugs. The scenario now reports
+WHICH message numbers are missing so the shape is unambiguous.
+
+⚠️ **Not yet confirmed, and these are the ways it could still be the bench's fault:**
+
+- one run, one device out of three extras — not yet reproduced
+- all five bots share ONE Node process, so a starvation or event-loop effect
+  peculiar to the harness cannot be excluded. That `dev2` and `dev3` were perfect in
+  the same process argues against it, but does not settle it
+- the persistence seam is a tee on `saveMessage`; a fault in the tee itself would
+  look identical from outside
+
 ⚠️ **Provenance note, recorded because it nearly went unnoticed:** this result came
 from an invocation that appeared to have been cancelled — the process kept running
 and completed. A *subsequent* background run of the same scenario failed at

--- a/.agents/docs/transport-reliability-index.md
+++ b/.agents/docs/transport-reliability-index.md
@@ -223,6 +223,7 @@ Paths are repo-qualified — see §0.
 
 | path | what it is |
 |---|---|
+| `quorum-desktop/.agents/bugs/2026-07-28-dm-receive-holds-ratchet-lock-across-http.md` | ⭐ **desktop receive awaits relay HTTP inside the per-conversation ratchet lock** (22s mutate timeout), so one slow ack stalls the conversation in both directions. Found by reading; confirmation owed. Mobile verified unaffected, and its pattern is the proposed fix |
 | `quorum-mobile/.agents/bugs/.solved/2026-07-24-dm-session-confirm-row-mismatch-x3dh-every-send.md` | authoritative SDK reading: confirm wrote to a row the send path never read. **Solved** (#177) |
 | `quorum-mobile/.agents/bugs/2026-06-13-desktop-to-mobile-messages-fail-decryption-invalid-signature.md` | earlier cross-platform decrypt/signature failure. Needs a full retest |
 | `quorum-mobile/.agents/bugs/2026-07-19-multidevice-inbox-key-breaks-verified-signer-auth.md` | multi-device inbox keys broke every verified-signer authorization |
@@ -394,7 +395,7 @@ Ranked. Each item names the doc that owns it — go there for detail.
 
 | # | item | owner doc | repo |
 |---|---|---|---|
-| 0 | ⭐ **Confirm the multi-device persistence loss (§3.2), then read the receive path for what discards a message after a successful decrypt.** Ranked above the node write-loss because it is client-side, reproducible on the bench, and needs nobody else | `tasks/2026-07-28-harness-multidevice-and-coverage.md` | desktop (then mobile) |
+| 0 | ⭐ **Desktop receive holds the ratchet lock across relay HTTP** — one slow ack stalls a whole conversation, both directions, up to 22s. Mechanism identified by reading; needs one clean bench run to tell backlog from loss. Mobile is NOT affected and its pattern is the fix | `bugs/2026-07-28-dm-receive-holds-ratchet-lock-across-http.md` | desktop |
 | 1 | **Node write-loss (#183 item 2)** — blocked on node-side logs / a write ack. Nothing client-side left | [#183](https://github.com/QuilibriumNetwork/quorum-mobile/issues/183) | upstream |
 | 2 | **Layer 2: space `log-append` resend on missing hub ack** — the proven ~1/5 space loss. Mobile-only (desktop has no hub log) | `quorum-mobile/.agents/tasks/2026-07-21-fix-space-append-send-loss-ack-resend.md` | mobile |
 | 3 | **Receipt truthfulness two-device runtime check** — code shipped on all three platforms, verification owed by both clients | `quorum-mobile/.agents/tasks/2026-07-26-receipt-truthfulness-delivery-gated-reads.md` | both |

--- a/.agents/docs/transport-reliability-index.md
+++ b/.agents/docs/transport-reliability-index.md
@@ -50,7 +50,8 @@ also resolves. If you are already in the repo a path names, drop the prefix.
 3. **The app-side layer is now largely fixed** — ~30 client PRs across both repos in July 2026, catalogued in §7.
 4. **Two root causes remain outside the app repos**, both filed upstream as [quorum-mobile#183](https://github.com/QuilibriumNetwork/quorum-mobile/issues/183): a skipped-key lookup bug in the `channel` crate, and a slice of node inbox writes vanishing with no client-visible signal.
 5. The crate bug (#183 item 1a) is **fully characterised, reproducible on demand in seconds, and mitigated client-side** on desktop (PR #265).
-6. The node write-loss (#183 item 2) is measured on mobile senders (up to 32%, strongly directional), and **0% on every headless bench so far** — desktop↔desktop and now mobile↔mobile — which narrows it without localising it (§3.1); it is not fixable from any client, and needs node-side logs.
+6. The node write-loss (#183 item 2) is measured on mobile senders (up to 32%, strongly directional), and **0% on every headless bench** — but every one of those benches measured only whether frames ARRIVED (§3.1); it is not fixable from any client, and needs node-side logs.
+6b. **A separate failure lives past arrival**: with four devices on one account, every frame arrived and decrypted while one device persisted only half the messages, no error raised (§3.2). Unconfirmed, and it may be the larger share of what users actually experience as "messages not arriving".
 7. Remaining client-side work is send-side durability on mobile spaces, receipt truthfulness runtime verification, and hygiene items (ghost devices, junk state rows).
 
 ---
@@ -92,11 +93,20 @@ protocol-level **write ack** is feasible (it would close the last loss class).
 
 ## §3.1. What the benches actually cover — read before quoting a 0% result
 
-Three separate 0%-loss results now exist. **None of them contradicts the field
-loss, and it would be a serious error to read them as "the transport is fixed."**
-Each bench differs from the field configuration in more than one variable, so what
-they collectively establish is narrower than it looks: *both clients' send/receive
-logic is clean when run in Node, on fresh accounts, over the WASM crypto build.*
+> ⭐ **UPDATED 2026-07-28: the benches stopped being all-green.** `dm-multidevice`
+> reproduced the operator's symptom — see §3.2. Everything below still holds, but
+> the reason the earlier nulls were narrow turns out to be more specific than
+> "several variables differ": **they were all measuring the wrong layer.**
+
+Four separate 0%-**arrival**-loss results exist. **None of them contradicts the
+field loss, and it would be a serious error to read them as "the transport is
+fixed."** Each bench differs from the field configuration in more than one
+variable, so what they collectively establish is narrower than it looks: *both
+clients' send/receive logic delivers frames cleanly when run in Node, on fresh
+accounts, over the WASM crypto build.*
+
+Note the word **arrival**. That is the only class any of these rows measured, and
+§3.2 is a failure in a different one.
 
 **→ Every run and every number lives in [`docs/transport-measurements.md`](transport-measurements.md).**
 That file is the append-only log; this section is only the summary that matters
@@ -126,13 +136,72 @@ Consequently the live suspects for D remain undistinguished:
 3. real-account state: aged sessions, ghost devices, multi-device fan-out
 4. device network conditions
 
-**The two cheapest experiments that would actually discriminate**, neither yet run:
+**The cheapest experiment that would discriminate**, still not run:
+**mobile↔desktop on one bench** (§6 item 8) — the field's reported worst case, and
+the only cell no bench covers at all.
 
-- **mobile bench on the canonical multi-device accounts.** Changes exactly ONE
-  variable from row C (account shape) and directly tests suspect 3. Note it will
-  register an additional device on those accounts, as the desktop bench already did.
-- **mobile↔desktop on one bench** (§6 item 8). The field's reported worst case, and
-  the only cell no bench covers at all.
+*(A previous version of this section also proposed running the mobile bench on the
+canonical accounts. That is now superseded and should NOT be done: it would
+permanently add devices to shared accounts and fan out to ghost inboxes we cannot
+observe. §3.2's approach — one generated account, several bots — gives real
+multi-device with none of that cost.)*
+
+---
+
+## §3.2. ⭐ The multi-device finding — a failure class no bench was measuring
+
+**2026-07-28, `dm-multidevice`, four devices on one generated account, 100 rounds:**
+
+```
+all 8 frame legs:   101/101 arrived,  0.0% loss
+decrypt failures:   0 everywhere
+A.dev1 persisted:   52/100 messages  (BOTH directions, same count)
+A.dev2, A.dev3:     100/100
+```
+
+Every frame arrived. Nothing failed to decrypt. One device kept **half** the
+messages, with no error raised anywhere.
+
+**This is why weeks of green benches meant less than they appeared to.** `dm-loss`
+counts frames, so it would have reported this run as flawless — which is precisely
+what it did on the canonical accounts while the operator watched messages fail to
+land on a second desktop. The failure is **between the socket and `saveMessage`**,
+a layer no scenario looked at until this one. The measurement log now carries a
+third result class, `persistence`, for exactly this.
+
+**It needs more than one extra device.** At 2 devices, 100 rounds, everything was
+clean. That fits the operator's 5+ device accounts and explains why every earlier
+bench — all of them one device per account — was green.
+
+**The identical 52 in both directions is the informative detail.** A per-message
+drop would not hit two independent streams equally; a device that stopped
+processing at one moment would. That points at a receive-pipeline stall rather than
+per-message loss. The scenario now reports WHICH message numbers are absent, since
+"stopped at #52" and "dropped every other one" are different bugs.
+
+⚠️ **Not yet confirmed.** One run, one device of three extras. The confirmation run
+is blocked on a production outage (`api.quorummessenger.com` returning 502 from
+Cloudflare on every path including root, from ~15:53 on 07-28; other hostnames
+healthy, so an origin failure, not us). All five bots also share one Node process,
+so a harness-specific starvation effect is not excluded — though `dev2` and `dev3`
+being perfect in that same process argues against it.
+
+**If it confirms, the next step is not another measurement.** It is reading the
+receive path for what can discard a message after a successful decrypt, with the
+missing-number shape pointing at where.
+
+### A second, untested path to the same symptom
+
+Worth recording as a **hypothesis, not a finding**: the DM send path fetches both
+registrations to build its device fan-out, and a failed fetch is caught and falls
+back rather than failing loudly. A sender that cannot read the peer's registration
+builds a **shorter device list** — which would look exactly like "the message
+reached some devices and not others", and would be invisible to any frame-level
+count because every frame it did send arrives. Today's 502 outage shows those
+fetches do fail in production. This does **not** explain the 52/100 run (the relay
+was healthy and all frames arrived), but it is a plausible second route to the same
+field symptom, and how each client handles a registration-fetch failure mid-conversation
+has never been examined.
 
 ---
 
@@ -230,7 +299,17 @@ yarn harness dm-reorder        # reproduces the production failure in ~35s
 yarn harness dm-stale-bucket   # the same cycle at scale, mitigation off vs on
 yarn harness dm-loss           # send-vs-arrive accounting (the #183 item 2 measurement)
 yarn harness dm-reset-recover  # recovery after a session reset
+yarn harness dm-multidevice    # N devices on ONE account — the §3.2 finding
 ```
+
+`dm-multidevice` takes `HARNESS_MD_DEVICES=N` (default 2; the finding needs 4).
+It generates its own throwaway account and hands the same key to N bots, so it
+gives real multi-device **without touching the canonical accounts** — which must
+not be used for this, as every run would permanently add a device to them.
+
+⚠️ **It is the only scenario that measures the `persistence` class.** The others
+count frames, and a message that arrives, decrypts, and is then dropped is
+invisible to them.
 
 `dm-loss` also takes `HARNESS_LOSS_CANONICAL=1` to run on the canonical aged
 multi-device accounts instead of fresh throwaways (row B of §3.1).
@@ -315,6 +394,7 @@ Ranked. Each item names the doc that owns it — go there for detail.
 
 | # | item | owner doc | repo |
 |---|---|---|---|
+| 0 | ⭐ **Confirm the multi-device persistence loss (§3.2), then read the receive path for what discards a message after a successful decrypt.** Ranked above the node write-loss because it is client-side, reproducible on the bench, and needs nobody else | `tasks/2026-07-28-harness-multidevice-and-coverage.md` | desktop (then mobile) |
 | 1 | **Node write-loss (#183 item 2)** — blocked on node-side logs / a write ack. Nothing client-side left | [#183](https://github.com/QuilibriumNetwork/quorum-mobile/issues/183) | upstream |
 | 2 | **Layer 2: space `log-append` resend on missing hub ack** — the proven ~1/5 space loss. Mobile-only (desktop has no hub log) | `quorum-mobile/.agents/tasks/2026-07-21-fix-space-append-send-loss-ack-resend.md` | mobile |
 | 3 | **Receipt truthfulness two-device runtime check** — code shipped on all three platforms, verification owed by both clients | `quorum-mobile/.agents/tasks/2026-07-26-receipt-truthfulness-delivery-gated-reads.md` | both |

--- a/.agents/tasks/2026-07-28-harness-multidevice-and-coverage.md
+++ b/.agents/tasks/2026-07-28-harness-multidevice-and-coverage.md
@@ -1,0 +1,188 @@
+---
+type: task
+title: "Harness coverage: multi-device DM delivery, then the cells no bench reaches"
+status: IN PROGRESS — scenario 1 (dm-multidevice) being built
+created: 2026-07-28
+updated: 2026-07-28
+area: headless harness / DM delivery / multi-device fan-out
+repos: quorum-desktop (primary) + quorum-mobile
+related: docs/transport-measurements.md, docs/transport-reliability-index.md, quorum-mobile#183
+---
+
+# Harness coverage — multi-device first, then the unreached cells
+
+## ⚠️ Why this exists: the benches were blind, and we now know to what
+
+Four bench runs reported 0% loss. All four are real. All four used **one device per
+account**, and `dm-loss` joins send-vs-arrive **only** for frames addressed to an
+inbox the peer bot subscribes to — everything fanned out to the accounts' other
+devices is excluded by design, as "unobserved, not observed-good".
+
+During desktop `dm-loss` run 2, on the canonical accounts, the operator had two
+desktop clients open and online. The bench reported **201/201 each way, 0% loss**.
+Those same two desktops received **~10 of 200 messages, and 0 of 200**.
+
+Same run. Same accounts. Same minutes. The channel the bench measured was perfect;
+the channel it structurally could not see was close to total loss.
+
+That is why the manual testing kept showing dropped messages while the bench went
+green. **The two were never measuring the same thing.** Nothing about the earlier
+nulls was wrong; they were nulls about a narrower channel than they appeared to
+describe, and the write-up now says so (`docs/transport-measurements.md`).
+
+**Untested channels, on both platforms, to date:**
+
+1. the **self-sync copy** — a sender's own other devices
+2. the **peer's second device**
+
+Both are on the normal DM send path: desktop fans out to
+`self.device_registrations.concat(counterparty.device_registrations)`
+(`src/services/MessageService.ts:3016-3021`).
+
+## Goal
+
+Make the harness able to exercise the delivery paths the product actually uses, so
+debugging continues on the bench instead of on devices. Multi-device first, because
+a live observation already implicates it.
+
+---
+
+## Scenario 1 — `dm-multidevice` (quorum-desktop) ⬅ BUILD FIRST
+
+Two bots share ONE account (two devices), a third bot is the peer. Assert
+**per-device** arrival.
+
+### ⛔ Do NOT use the canonical test accounts
+
+They already carry 5+ device registrations, and `loadOrCreateBot` mints a NEW
+device per bot *name* and merges it into the registration
+(`src/dev/tests/harness/identity.ts:141-153`). Running this on canonical accounts
+would permanently add devices to shared accounts, fan out to ghost inboxes we
+cannot observe, and confound the exact variable being isolated.
+
+Generate a throwaway account in-scenario and hand the SAME key to two bots:
+
+```ts
+const kp = JSON.parse(channel_raw.js_generate_ed448());
+const KEY_A = Buffer.from(kp.private_key).toString('hex');   // ed448: 57 bytes = 114 hex chars
+const aPhone  = await createBot(`md-a-phone-${stamp}`,  { privateKeyHex: KEY_A });
+const aLaptop = await createBot(`md-a-laptop-${stamp}`, { privateKeyHex: KEY_A });
+const bob     = await createBot(`md-b-${stamp}`);
+```
+
+`createBot` takes the **account** from `privateKeyHex` and the **device** from
+`name` (`identity.ts:133-137`).
+
+### Create them SEQUENTIALLY, never `Promise.all`
+
+Registration is a read-modify-write: each bot fetches the current device list, then
+posts a merged registration (`identity.ts:141-153`). Concurrent creation drops one
+device. This is not a style preference — it silently produces a one-device account
+and the whole scenario then measures nothing.
+
+### STEP 1 — prove the premise before measuring anything
+
+Fetch account A's registration and assert **both** bots' `inboxAddress` are present.
+Assert **membership, not a count** — a count passes for the wrong reasons. On a
+fresh account it happens to be exactly 2, which is why a count would look right even
+if the wrong devices were registered.
+
+If either is missing: **stop and report.** The premise is wrong and every downstream
+number would be meaningless.
+
+### STEP 2 — assert PER-DEVICE arrival
+
+Send N messages A→B. Each message must land on:
+
+- both of B's devices, **and**
+- A's own second device (the self-sync copy)
+
+**Aggregate counting is exactly how Finding AA looked green** — it recorded that a
+second device "made no measurable difference" without ever asking what that second
+device received. Extend `dm-loss`'s send-vs-arrive accounting with a per-target-inbox
+dimension rather than writing new counting; the existing fingerprint join is the part
+that has already been debugged.
+
+### Count persistence, not rendering
+
+The 10-of-200 observation came from watching two UIs. A message can arrive and be
+persisted without rendering in a conversation that is not open. Count what
+`saveMessage` receives per device — that is the whole reason to do this on the bench
+rather than by hand, and it means a green result here does not contradict what was
+seen live; it *distinguishes* delivery from display.
+
+### Bench-lie risks — both directions
+
+- The sender's device list must be fetched **after** the second device registers, or
+  a red result is a harness artifact rather than a product defect (cf. PR #264, where
+  two bench defects made the bench lie).
+- **The same applies to B→A.** Bob must fetch A's registration after *both* of A's
+  devices exist, or his replies legitimately reach only one and that is our bug, not
+  the product's.
+
+### A named hypothesis this scenario tests
+
+Both clients carry **self-echo guards**, and mobile's discards a channel-less
+self-echo outright. If a guard is over-broad, "0 of 200 on the second device" is
+exactly the shape it would produce.
+
+⚠️ `dr-self-echo.mjs` (0 of 2709) is **not** reassurance here. It asked whether a
+client receives its *own* frames back on the *same* device. Whether a *second device
+of the same account* accepts a sync copy is a different question, and unasked.
+
+### Hygiene
+
+Timestamped bot names mean `.state/` gains a file per run. Correct for
+throwaway-per-run accounts (no accumulation on any account that matters), but the
+scenario should clean up its own state files or the directory grows without bound.
+
+---
+
+## Scenario 2 — mobile↔desktop on one bench
+
+The field's reported worst case, and the only configuration **no** bench covers.
+Specced as slice 4 of `tasks/2026-07-27-cross-platform-dm-harness.md`. Cheap now
+that both bots exist.
+
+## Scenario 3 — multi-device on the MOBILE harness
+
+The same two-bots-one-account trick, using mobile's `loadOrCreateIdentity`, which
+already accepts a `privateKeyHex`. Blocked only by scenario 1 proving the shape.
+
+⚠️ On mobile each bot needs its **own process** (module singletons; see
+`quorum-mobile/dev/harness/bot.ts`), so two devices of one account means two
+processes plus the peer — three in total. `run-two-bots.mjs` generalises to N roles.
+
+---
+
+## Coverage: what the bench can and cannot reach
+
+| path | covered? | by |
+|---|---|---|
+| desktop↔desktop DM, 1 device each | ✅ | `dm-loss`, `dm-basic` |
+| mobile↔mobile DM, 1 device each | ✅ | `harness:dm` |
+| decrypt failure / stale bucket | ✅ | `dm-reorder`, `dm-stale-bucket`, `dr-*` |
+| session reset + recovery | ✅ | `dm-reset-recover` |
+| **self-sync copy to own 2nd device** | ❌ | scenario 1 |
+| **peer's 2nd device** | ❌ | scenario 1 |
+| **mobile↔desktop** | ❌ | scenario 2 |
+| mobile multi-device | ❌ | scenario 3 |
+| RN native WebSocket | ❌ **by construction** | needs a device; the bench exists to remove it |
+| uniffi bridge | ❌ **by construction** | WASM only in Node |
+| native batch decrypt | ❌ **by construction** | native-only, no WASM equivalent |
+| SQLCipher at rest | ❌ **by construction** | shim drops `PRAGMA key` |
+| spaces / hub log | ❌ | `tasks/2026-07-27-headless-space-harness.md` (unstarted) |
+
+The four "by construction" rows are why a green bench never means the product is
+healthy — it means the layers the bench covers are healthy.
+
+---
+
+## After every run
+
+Append a row to `docs/transport-measurements.md`: date, what ran, configuration
+(**including device count per account**), result, and what it changed. Record the
+class, `arrival` or `decrypt`.
+
+---
+*Last updated: 2026-07-28*

--- a/.agents/tasks/2026-07-28-harness-multidevice-and-coverage.md
+++ b/.agents/tasks/2026-07-28-harness-multidevice-and-coverage.md
@@ -155,6 +155,78 @@ processes plus the peer — three in total. `run-two-bots.mjs` generalises to N 
 
 ---
 
+## ⭐ Offline analysis (2026-07-28) — a mechanism that fits the 52/100, and it may be latency
+
+Found by reading, while the relay was down. **Not confirmed**, and it changes what
+the 4-device result probably means.
+
+### The receive path holds the ratchet lock across network I/O
+
+`MessageService.handleNewMessage` runs its critical section inside
+`dmRatchetMutex.runExclusive(conversationId, …)` (`MessageService.ts:3858`), and
+inside that lock it awaits **HTTP calls to the relay**:
+
+- `this.deleteInboxMessages(…, this.apiClient)` — POST `/inbox/delete`
+- `this.ackProcessedFrame(…)` — which is the same POST, wrapped
+
+`defaultMutateTimeout` is **22 seconds** (`src/api/baseTypes.ts:862`).
+
+So a single slow inbox-delete blocks **every** message on that conversation for up
+to 22s. At the bench's 700ms send gap that is ~31 messages backed up per stall;
+two or three stalls across a 100-message run accounts for the ~48 that were
+missing.
+
+`KeyedMutex`'s own documentation warns about precisely this shape:
+
+> *"Do NOT hold the lock across transport delivery… an async callback returning a
+> promise gets auto-flattened — returning a delivery promise from `fn` silently
+> extends the critical section until delivery."*
+
+The SEND paths follow that guidance (they wrap the delivery promise as `{ sent }`,
+`MessageService.ts:983`, `ActionQueueHandlers.ts:672`). The RECEIVE path does not —
+it awaits HTTP directly inside the lock.
+
+### Why this fits every feature of the result
+
+| observation | explained by |
+|---|---|
+| both directions stopped at the same count | one lock, one `conversationId` — A↔B share it |
+| no error raised anywhere | `ackProcessedFrame` catches and only `logger.warn`s |
+| all frames arrived (101/101) | the socket is unaffected; this is downstream of it |
+| clean at 2 devices, broken at 4 | 4 devices ⇒ ~4× the delete traffic ⇒ more chances of a slow call |
+| one device of four | whichever device's calls happened to be slow |
+
+### ⚠️ It predicts LATENCY, not loss — and that changes the finding
+
+If this is the mechanism, the missing messages were **not dropped**; they were
+still queued behind the lock when the run's settle window closed. They would land
+with a longer tail. This investigation has mistaken exactly this for loss before —
+see the master's "failures are TRANSIENT, so this is LATENCY WITH A LONG TAIL, not
+demonstrated loss".
+
+**The distinguishing evidence is already instrumented:** the gap report says
+whether the missing numbers are a CONTIGUOUS TAIL (backlog) or SCATTERED (real
+drops). That one line decides between two very different bugs.
+
+### ⚠️ And the run may have been degraded
+
+The 4-device run finished at 15:51. `api.quorummessenger.com` was returning 502 on
+every path by 15:53. The relay was plausibly already degrading *during* the run,
+which is exactly the condition that makes this mechanism bite. **Re-run against a
+healthy relay before treating 52/100 as a product measurement.**
+
+### Why it is still worth fixing either way
+
+Even as pure latency, this says user-visible delivery degrades **non-linearly**
+when the relay is slow, and gets worse with every device on the account. A 22s
+stall on one HTTP call should not stop a conversation's message processing. The
+acknowledgement is best-effort by design (its failure is caught and ignored), so
+there is no reason for it to be awaited inside the ratchet critical section at all.
+
+**Candidate fix, not yet attempted:** move the inbox-delete/ack outside the lock —
+the state is already persisted by then, and the ack's own failure path is already
+"it will be redelivered". Check the mobile receive path for the same shape.
+
 ## Coverage: what the bench can and cannot reach
 
 | path | covered? | by |

--- a/.agents/tasks/2026-07-28-harness-multidevice-and-coverage.md
+++ b/.agents/tasks/2026-07-28-harness-multidevice-and-coverage.md
@@ -225,7 +225,32 @@ there is no reason for it to be awaited inside the ratchet critical section at a
 
 **Candidate fix, not yet attempted:** move the inbox-delete/ack outside the lock —
 the state is already persisted by then, and the ack's own failure path is already
-"it will be redelivered". Check the mobile receive path for the same shape.
+"it will be redelivered".
+
+### ✅ Checked mobile (read-only, 2026-07-28): it does NOT have this shape
+
+Mobile is structurally immune, for three independent reasons:
+
+| | desktop | mobile |
+|---|---|---|
+| where the ratchet lock sits | around the whole receive critical section (`MessageService.ts:3858`) | inside `services/crypto/encryption-service.ts` only — the crypto layer |
+| does the lock wrap network I/O? | **yes** — awaits `deleteInboxMessages` / `ackProcessedFrame` | **no** — `encryption-service.ts` performs no network I/O and does not import an API client |
+| how the inbox ack is issued | `await`ed inside the lock, 22s mutate timeout | `deleteProcessedEnvelope` returns **`void`**; dispatched `.catch(() => {})`, never awaited |
+| lock in the receive handler | yes | none — `runExclusive` appears nowhere in `context/` |
+
+**Two consequences.**
+
+1. **This mechanism is desktop-only, so it cannot explain the mobile↔mobile field
+   loss (round 29).** That stays #183 item 2. Do not let this finding absorb it.
+2. **It does fit what the operator observed**, because those two clients were
+   *desktops*: ~10 of 200 on one, 0 of 200 on the other, during a run in which the
+   peer channel was perfect. Desktop is exactly the platform with the defect.
+
+**Mobile's pattern IS the fix.** Desktop should dispatch the delete and not await
+it, catching and ignoring failure — which is what mobile already does, and what
+desktop's own `ackProcessedFrame` already implies by swallowing its error. That
+makes the fix "adopt the sibling platform's existing shape" rather than a new
+design, which is about as low-risk as a change to this path can be.
 
 ## Coverage: what the bench can and cannot reach
 

--- a/src/dev/tests/harness/dm-loss.scenario.test.ts
+++ b/src/dev/tests/harness/dm-loss.scenario.test.ts
@@ -20,12 +20,20 @@
 //     fan-out to the accounts' OTHER devices) can never arrive here and is not
 //     loss. Only frames addressed to the peer's subscribed inboxes are counted.
 //
+// ⚠️ THAT SECOND CAVEAT TURNED OUT TO MATTER ENORMOUSLY. During run 2 on the
+// canonical accounts this scenario reported 201/201 each way, 0% loss — while the
+// operator watched those same accounts' OTHER devices receive ~10 of 200 messages
+// on one desktop and 0 of 200 on the other, in the same run. This bench was
+// structurally blind to the channel that was failing. `dm-multidevice` is the
+// scenario that measures it; run it before quoting a 0% result from here.
+//
 //   yarn harness dm-loss
 //   HARNESS_LOSS_ROUNDS=200 HARNESS_LOSS_SETTLE_MS=600000 yarn harness dm-loss
 import { test, expect } from 'vitest';
 import { createBot, type HarnessBot } from './bot';
 import { createCanonicalPair, hasCanonicalKeys } from './canonical';
 import { WsTransport } from './transport';
+import { direction, subscribedInboxes } from './loss';
 import { RunLog } from './log';
 
 const ROUNDS = Number(process.env.HARNESS_LOSS_ROUNDS ?? 40);
@@ -33,37 +41,6 @@ const GAP_MS = Number(process.env.HARNESS_LOSS_GAP_MS ?? 700);
 const SETTLE_MS = Number(process.env.HARNESS_LOSS_SETTLE_MS ?? 120_000);
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
-
-/** Inbox addresses a bot is actually listening on — the only place a frame CAN land. */
-async function subscribedInboxes(bot: HarnessBot): Promise<Set<string>> {
-  const states = await bot.messageDB.getAllEncryptionStates();
-  return new Set([bot.identity.inboxAddress, ...states.map((s) => s.inboxId)]);
-}
-
-function direction(from: HarnessBot, to: HarnessBot, toInboxes: Set<string>) {
-  // Frames this sender addressed to an inbox the receiver is subscribed to.
-  const sent = new Map<string, number>();
-  for (const s of from.transport.sent) {
-    if (!s.fp) continue;
-    if (s.target && !toInboxes.has(s.target)) continue; // fan-out elsewhere, not loss
-    if (!sent.has(s.fp)) sent.set(s.fp, s.t);
-  }
-  const arrived = new Set<string>();
-  for (const f of to.transport.arrived) {
-    const fp = WsTransport.ciphertextFp(f);
-    if (fp) arrived.add(fp);
-  }
-  const missing = [...sent.keys()].filter((fp) => !arrived.has(fp));
-  return {
-    sent: sent.size,
-    arrived: [...sent.keys()].filter((fp) => arrived.has(fp)).length,
-    missing: missing.length,
-    lossPct: sent.size ? (missing.length / sent.size) * 100 : 0,
-    // Frames the receiver got that the sender never recorded sending to it:
-    // redeliveries of older frames, or frames from the account's other devices.
-    unmatchedArrivals: [...arrived].filter((fp) => !sent.has(fp)).length,
-  };
-}
 
 test(
   'dm-loss: send-vs-arrive frame loss rate, both directions',

--- a/src/dev/tests/harness/dm-multidevice.scenario.test.ts
+++ b/src/dev/tests/harness/dm-multidevice.scenario.test.ts
@@ -29,9 +29,12 @@
 // devices to shared accounts and fan out to ghost inboxes we cannot observe —
 // confounding the exact variable being isolated. Instead the account is generated
 // here and thrown away.
+import { existsSync, rmSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { test, expect } from 'vitest';
 import { channel_raw } from '@quilibrium/quilibrium-js-sdk-channels';
 import { createBot, type HarnessBot } from './bot';
+import { config } from './env';
 import { direction, subscribedInboxes } from './loss';
 import { makeApiClient } from './transport';
 import { RunLog } from './log';
@@ -39,6 +42,17 @@ import { RunLog } from './log';
 const ROUNDS = Number(process.env.HARNESS_MD_ROUNDS ?? 20);
 const GAP_MS = Number(process.env.HARNESS_MD_GAP_MS ?? 900);
 const SETTLE_MS = Number(process.env.HARNESS_MD_SETTLE_MS ?? 120_000);
+/**
+ * Devices on account A. Two proved the shape and measured clean at 100 rounds,
+ * which did NOT reproduce the ~10-of-200 seen on accounts carrying 5+ devices —
+ * so device COUNT is the next variable, and it is the cheap one: raising this
+ * costs nothing on any real account.
+ *
+ * Fan-out is already known to scale hard with device count (~9 frames/message on
+ * 5+ device accounts vs ~1:1 on throwaways), so if a threshold exists this is the
+ * dial that finds it.
+ */
+const DEVICES = Math.max(2, Number(process.env.HARNESS_MD_DEVICES ?? 2));
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
@@ -51,7 +65,7 @@ const postsMatching = (bot: HarnessBot, prefix: string) =>
   );
 
 test(
-  'dm-multidevice: a two-device account, per-device arrival',
+  'dm-multidevice: an N-device account, per-device arrival',
   async () => {
     const startedAt = Date.now();
     const log = new RunLog('dm-multidevice', startedAt);
@@ -74,15 +88,28 @@ test(
     // fetches the current device list then posts a merged registration
     // (identity.ts:141-153). Concurrent creation silently drops one device, and the
     // scenario would then measure a one-device account while claiming otherwise.
-    const aPhone = await createBot(`md-a-phone-${stamp}`, { privateKeyHex: KEY_A });
-    const aLaptop = await createBot(`md-a-laptop-${stamp}`, { privateKeyHex: KEY_A });
-    const bob = await createBot(`md-b-${stamp}`);
+    // This is also why the loop below awaits each createBot in turn.
+    const botNames: string[] = [];
+    const aDevices: HarnessBot[] = [];
+    for (let d = 0; d < DEVICES; d++) {
+      const name = `md-a-dev${d}-${stamp}`;
+      botNames.push(name);
+      aDevices.push(await createBot(name, { privateKeyHex: KEY_A }));
+    }
+    const bobName = `md-b-${stamp}`;
+    botNames.push(bobName);
+    const bob = await createBot(bobName);
+
+    // Device 0 is the sender; every other device of account A should receive a
+    // self-sync copy of what it sends, and a copy of everything bob sends.
+    const sender = aDevices[0];
+    const others = aDevices.slice(1);
 
     say(
-      `account A=${aPhone.identity.address.slice(0, 12)} ` +
-        `phone=${aPhone.identity.inboxAddress.slice(0, 12)} ` +
-        `laptop=${aLaptop.identity.inboxAddress.slice(0, 12)}  ` +
-        `bob=${bob.identity.address.slice(0, 12)}`
+      `account A=${sender.identity.address.slice(0, 12)} with ${DEVICES} device(s): ` +
+        aDevices.map((b, i) => `dev${i}=${b.identity.inboxAddress.slice(0, 10)}`).join(' ') +
+        `  bob=${bob.identity.address.slice(0, 12)}`,
+      { devices: DEVICES }
     );
 
     // ── STEP 1: prove the premise before measuring anything ──────────────────
@@ -92,19 +119,21 @@ test(
     // something else". If this fails, every downstream number is meaningless, so
     // fail here rather than report a red result that is really a setup bug.
     const api = makeApiClient();
-    const regA = (await api.getUser(aPhone.identity.address))?.data;
+    const regA = (await api.getUser(sender.identity.address))?.data;
     const registeredInboxes = (regA?.device_registrations ?? []).map(
       (d) => d.inbox_registration.inbox_address
     );
     say(`account A registration lists ${registeredInboxes.length} device(s)`, {
-      devices: registeredInboxes.length,
+      registered: registeredInboxes.length,
     });
-    expect(aPhone.identity.address).toBe(aLaptop.identity.address); // same ACCOUNT
-    expect(aPhone.identity.inboxAddress).not.toBe(aLaptop.identity.inboxAddress); // different DEVICE
-    expect(registeredInboxes).toContain(aPhone.identity.inboxAddress);
-    expect(registeredInboxes).toContain(aLaptop.identity.inboxAddress);
+    for (const b of aDevices) {
+      expect(b.identity.address).toBe(sender.identity.address); // same ACCOUNT
+      expect(registeredInboxes).toContain(b.identity.inboxAddress); // this DEVICE is registered
+    }
+    // Every device distinct — catches a name collision silently reusing a keyset.
+    expect(new Set(aDevices.map((b) => b.identity.inboxAddress)).size).toBe(DEVICES);
 
-    await Promise.all([aPhone.start(), aLaptop.start(), bob.start()]);
+    await Promise.all([...aDevices.map((b) => b.start()), bob.start()]);
 
     // ── Handshake ────────────────────────────────────────────────────────────
     //
@@ -114,17 +143,17 @@ test(
     // is ours, not the product's (cf. PR #264, where two bench defects made the
     // bench lie). Both devices are registered above before any bot starts, and the
     // handshake below forces each side to fetch registrations afterwards.
-    await aPhone.send(bob.identity.address, 'md-setup phone->bob');
+    await sender.send(bob.identity.address, 'md-setup A.dev0->bob');
     await sleep(5000);
-    await bob.send(aPhone.identity.address, 'md-setup bob->A');
+    await bob.send(sender.identity.address, 'md-setup bob->A');
     await sleep(5000);
 
     // ── STEP 2: send, then count PER DEVICE ──────────────────────────────────
     for (let i = 1; i <= ROUNDS; i++) {
-      await aPhone.send(bob.identity.address, `MD-A->B #${i}`).catch((e) =>
+      await sender.send(bob.identity.address, `MD-A->B #${i}`).catch((e) =>
         say(`send A->B #${i} threw: ${(e as Error).message}`)
       );
-      await bob.send(aPhone.identity.address, `MD-B->A #${i}`).catch((e) =>
+      await bob.send(sender.identity.address, `MD-B->A #${i}`).catch((e) =>
         say(`send B->A #${i} threw: ${(e as Error).message}`)
       );
       await sleep(GAP_MS);
@@ -136,18 +165,25 @@ test(
     // Frame-level, reusing dm-loss's join once PER RECEIVING DEVICE. This is the
     // whole point: the same accounting, applied to each device separately, instead
     // of aggregated per account.
-    const [phoneIn, laptopIn, bobIn] = await Promise.all([
-      subscribedInboxes(aPhone),
-      subscribedInboxes(aLaptop),
-      subscribedInboxes(bob),
-    ]);
+    const inboxesOf = new Map<HarnessBot, Set<string>>();
+    for (const b of [...aDevices, bob]) inboxesOf.set(b, await subscribedInboxes(b));
 
-    const legs = [
-      ['A.phone -> bob        (peer, primary)', direction(aPhone, bob, bobIn)],
-      ['A.phone -> A.laptop   (SELF-SYNC)     ', direction(aPhone, aLaptop, laptopIn)],
-      ['bob     -> A.phone    (peer 1st dev)  ', direction(bob, aPhone, phoneIn)],
-      ['bob     -> A.laptop   (PEER 2nd DEV)  ', direction(bob, aLaptop, laptopIn)],
-    ] as const;
+    const pad = (s: string) => s.padEnd(34);
+    const legs: [string, ReturnType<typeof direction>][] = [
+      [pad('A.dev0 -> bob (peer, primary)'), direction(sender, bob, inboxesOf.get(bob)!)],
+      [pad('bob -> A.dev0 (peer 1st dev)'), direction(bob, sender, inboxesOf.get(sender)!)],
+    ];
+    for (const [i, dev] of others.entries()) {
+      const n = i + 1;
+      legs.push([
+        pad(`A.dev0 -> A.dev${n} (SELF-SYNC)`),
+        direction(sender, dev, inboxesOf.get(dev)!),
+      ]);
+      legs.push([
+        pad(`bob -> A.dev${n} (PEER->EXTRA DEV)`),
+        direction(bob, dev, inboxesOf.get(dev)!),
+      ]);
+    }
 
     say('');
     say('==== FRAME-LEVEL, PER DEVICE (de-duplicated by ciphertext fingerprint) ====');
@@ -168,29 +204,38 @@ test(
     // result here does not contradict what was seen live — it separates delivery
     // from display.
     const bobGot = postsMatching(bob, 'MD-A->B');
-    const phoneGot = postsMatching(aPhone, 'MD-B->A');
-    const laptopGotPeer = postsMatching(aLaptop, 'MD-B->A');
-    const laptopGotSelf = postsMatching(aLaptop, 'MD-A->B');
 
     say('');
     say('==== MESSAGE-LEVEL, PER DEVICE (persisted, not rendered) ====');
-    say(`bob        received A->B : ${bobGot.size}/${ROUNDS}`, { bobGot: bobGot.size });
-    say(`A.phone    received B->A : ${phoneGot.size}/${ROUNDS}`, { phoneGot: phoneGot.size });
-    say(`A.laptop   received B->A : ${laptopGotPeer.size}/${ROUNDS}   <- PEER to 2nd device`, {
-      laptopGotPeer: laptopGotPeer.size,
-    });
-    say(`A.laptop   received A->B : ${laptopGotSelf.size}/${ROUNDS}   <- SELF-SYNC copy`, {
-      laptopGotSelf: laptopGotSelf.size,
-    });
+    say(`bob      received A->B : ${bobGot.size}/${ROUNDS}`, { bobGot: bobGot.size });
+    for (const [i, dev] of aDevices.entries()) {
+      const peer = postsMatching(dev, 'MD-B->A').size;
+      const self = postsMatching(dev, 'MD-A->B').size;
+      say(
+        `A.dev${i}   received B->A : ${peer}/${ROUNDS}` +
+          (i === 0
+            ? '   <- the sending device'
+            : `   |  self-sync A->B : ${self}/${ROUNDS}   <- EXTRA DEVICE`),
+        { device: i, peer, self }
+      );
+    }
     say(
-      `novel decrypt failures: phone=${aPhone.novelErrors().length} ` +
-        `laptop=${aLaptop.novelErrors().length} bob=${bob.novelErrors().length}`
+      'novel decrypt failures: ' +
+        aDevices.map((b, i) => `dev${i}=${b.novelErrors().length}`).join(' ') +
+        ` bob=${bob.novelErrors().length}`
     );
     console.log(`[dm-md] log: ${log.file}`);
 
-    aPhone.stop();
-    aLaptop.stop();
+    for (const b of aDevices) b.stop();
     bob.stop();
+
+    // Each run mints a throwaway account and one state file per bot. Nothing
+    // accumulates on an account that matters, but the directory would grow without
+    // bound, so the scenario removes what it created.
+    for (const name of botNames) {
+      const p = resolve(config.stateDir, `${name}.json`);
+      if (existsSync(p)) rmSync(p, { force: true });
+    }
 
     // The run IS the measurement, so the assertions are deliberately weak: they
     // check the bench had data to join on, not that delivery succeeded. A hard

--- a/src/dev/tests/harness/dm-multidevice.scenario.test.ts
+++ b/src/dev/tests/harness/dm-multidevice.scenario.test.ts
@@ -151,8 +151,26 @@ test(
     // cannot tell "both of our devices registered" from "one of ours plus
     // something else". If this fails, every downstream number is meaningless, so
     // fail here rather than report a red result that is really a setup bug.
+    // The relay intermittently 502s on /users. This read is SETUP, not
+    // measurement, so retry it — a transient server error killing the run after
+    // every bot has already registered wastes the whole setup and, worse, tempts
+    // whoever hits it into loosening the assertion instead. Retrying here is safe
+    // precisely because nothing about delivery is being measured yet.
     const api = makeApiClient();
-    const regA = (await api.getUser(sender.identity.address))?.data;
+    const fetchRegistration = async () => {
+      let lastErr: unknown;
+      for (let attempt = 1; attempt <= 5; attempt++) {
+        try {
+          return (await api.getUser(sender.identity.address))?.data;
+        } catch (err) {
+          lastErr = err;
+          say(`registration read attempt ${attempt}/5 failed: ${(err as Error).message}`);
+          await sleep(2000 * attempt);
+        }
+      }
+      throw lastErr;
+    };
+    const regA = await fetchRegistration();
     const registeredInboxes = (regA?.device_registrations ?? []).map(
       (d) => d.inbox_registration.inbox_address
     );

--- a/src/dev/tests/harness/dm-multidevice.scenario.test.ts
+++ b/src/dev/tests/harness/dm-multidevice.scenario.test.ts
@@ -64,6 +64,39 @@ const postsMatching = (bot: HarnessBot, prefix: string) =>
       .map((m) => m.content?.text as string)
   );
 
+/**
+ * WHICH numbered messages are missing, not just how many.
+ *
+ * The count alone cannot separate two very different bugs, and the first
+ * multi-device run produced exactly the ambiguity: one device persisted 52 of 100
+ * in BOTH directions while every frame arrived and nothing failed to decrypt.
+ *
+ *   a contiguous TAIL missing  ⇒ the device stopped processing at some moment
+ *                                (a receive-pipeline stall)
+ *   SCATTERED gaps             ⇒ per-message drops
+ *   every OTHER one            ⇒ something in dedupe/ordering
+ *
+ * Those need different investigations, so the run has to say which it is.
+ */
+function missingReport(bot: HarnessBot, prefix: string, rounds: number): string {
+  const got = new Set<number>();
+  for (const text of postsMatching(bot, prefix)) {
+    const n = Number(/#(\d+)$/.exec(text)?.[1]);
+    if (Number.isFinite(n)) got.add(n);
+  }
+  const missing: number[] = [];
+  for (let i = 1; i <= rounds; i++) if (!got.has(i)) missing.push(i);
+  if (missing.length === 0) return 'none';
+
+  // Contiguous tail? i.e. everything from some point on is absent.
+  const isTail = missing[missing.length - 1] === rounds && missing.length === rounds - missing[0] + 1;
+  const shape = isTail
+    ? `CONTIGUOUS TAIL from #${missing[0]} — looks like the device STOPPED`
+    : `scattered (${missing.length} gaps, first #${missing[0]}, last #${missing[missing.length - 1]})`;
+  const sample = missing.slice(0, 24).join(',') + (missing.length > 24 ? ',…' : '');
+  return `${shape}  missing=[${sample}]`;
+}
+
 test(
   'dm-multidevice: an N-device account, per-device arrival',
   async () => {
@@ -218,6 +251,9 @@ test(
             : `   |  self-sync A->B : ${self}/${ROUNDS}   <- EXTRA DEVICE`),
         { device: i, peer, self }
       );
+      if (peer < ROUNDS) say(`   dev${i} B->A gaps: ${missingReport(dev, 'MD-B->A', ROUNDS)}`);
+      if (i > 0 && self < ROUNDS)
+        say(`   dev${i} A->B gaps: ${missingReport(dev, 'MD-A->B', ROUNDS)}`);
     }
     say(
       'novel decrypt failures: ' +

--- a/src/dev/tests/harness/dm-multidevice.scenario.test.ts
+++ b/src/dev/tests/harness/dm-multidevice.scenario.test.ts
@@ -1,0 +1,205 @@
+// Multi-device DM delivery — the channel every other scenario is blind to.
+//
+//   yarn harness dm-multidevice
+//
+// ── Why this exists ─────────────────────────────────────────────────────────
+//
+// Every previous scenario is two bots with ONE device each, so two paths on the
+// normal DM send route have never been exercised:
+//
+//   1. the SELF-SYNC copy — a sender's own other devices
+//   2. the PEER's second device
+//
+// Both are real: the send path fans out to
+// `self.device_registrations.concat(counterparty.device_registrations)`
+// (services/MessageService.ts:3016-3021).
+//
+// This is not a theoretical gap. During `dm-loss` run 2 on the canonical accounts
+// the bench reported 201/201 each way, 0% loss — while the operator watched those
+// same accounts' other devices receive ~10 of 200 messages on one desktop and 0 of
+// 200 on the other, in the same run, both online. `dm-loss` excludes fan-out
+// frames from its join by design ("unobserved, not observed-good"), so it was
+// structurally blind to the channel that was failing.
+//
+// ── What this scenario refuses to do ────────────────────────────────────────
+//
+// It does NOT use the canonical accounts. They already carry 5+ device
+// registrations, and createBot mints a NEW device per bot NAME and merges it into
+// the registration (identity.ts:141-153). Running this there would permanently add
+// devices to shared accounts and fan out to ghost inboxes we cannot observe —
+// confounding the exact variable being isolated. Instead the account is generated
+// here and thrown away.
+import { test, expect } from 'vitest';
+import { channel_raw } from '@quilibrium/quilibrium-js-sdk-channels';
+import { createBot, type HarnessBot } from './bot';
+import { direction, subscribedInboxes } from './loss';
+import { makeApiClient } from './transport';
+import { RunLog } from './log';
+
+const ROUNDS = Number(process.env.HARNESS_MD_ROUNDS ?? 20);
+const GAP_MS = Number(process.env.HARNESS_MD_GAP_MS ?? 900);
+const SETTLE_MS = Number(process.env.HARNESS_MD_SETTLE_MS ?? 120_000);
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/** Messages of a given text prefix this bot's real code actually persisted. */
+const postsMatching = (bot: HarnessBot, prefix: string) =>
+  new Set(
+    bot.captured
+      .filter((m) => m.content?.type === 'post' && (m.content.text ?? '').startsWith(prefix))
+      .map((m) => m.content?.text as string)
+  );
+
+test(
+  'dm-multidevice: a two-device account, per-device arrival',
+  async () => {
+    const startedAt = Date.now();
+    const log = new RunLog('dm-multidevice', startedAt);
+    const say = (msg: string, fields: Record<string, unknown> = {}) => {
+      console.log(`[dm-md] ${msg}`);
+      log.add(Date.now(), 'harness', 'note', { msg, ...fields });
+    };
+    const stamp = String(startedAt).slice(-6);
+
+    // One generated account, handed to two bots. createBot takes the ACCOUNT from
+    // privateKeyHex and the DEVICE from name, so this is genuinely one user with
+    // two devices — not two users.
+    const kp = JSON.parse(channel_raw.js_generate_ed448()) as { private_key: number[] };
+    const KEY_A = Buffer.from(kp.private_key).toString('hex');
+    // ed448 private keys are 57 bytes. Measured, not read off a spec sheet — two
+    // earlier guesses at this length in this investigation were both wrong.
+    expect(KEY_A).toHaveLength(114);
+
+    // SEQUENTIAL, never Promise.all. Registration is a read-modify-write: each bot
+    // fetches the current device list then posts a merged registration
+    // (identity.ts:141-153). Concurrent creation silently drops one device, and the
+    // scenario would then measure a one-device account while claiming otherwise.
+    const aPhone = await createBot(`md-a-phone-${stamp}`, { privateKeyHex: KEY_A });
+    const aLaptop = await createBot(`md-a-laptop-${stamp}`, { privateKeyHex: KEY_A });
+    const bob = await createBot(`md-b-${stamp}`);
+
+    say(
+      `account A=${aPhone.identity.address.slice(0, 12)} ` +
+        `phone=${aPhone.identity.inboxAddress.slice(0, 12)} ` +
+        `laptop=${aLaptop.identity.inboxAddress.slice(0, 12)}  ` +
+        `bob=${bob.identity.address.slice(0, 12)}`
+    );
+
+    // ── STEP 1: prove the premise before measuring anything ──────────────────
+    //
+    // Membership, not a count. A count of 2 passes for the wrong reasons — it
+    // cannot tell "both of our devices registered" from "one of ours plus
+    // something else". If this fails, every downstream number is meaningless, so
+    // fail here rather than report a red result that is really a setup bug.
+    const api = makeApiClient();
+    const regA = (await api.getUser(aPhone.identity.address))?.data;
+    const registeredInboxes = (regA?.device_registrations ?? []).map(
+      (d) => d.inbox_registration.inbox_address
+    );
+    say(`account A registration lists ${registeredInboxes.length} device(s)`, {
+      devices: registeredInboxes.length,
+    });
+    expect(aPhone.identity.address).toBe(aLaptop.identity.address); // same ACCOUNT
+    expect(aPhone.identity.inboxAddress).not.toBe(aLaptop.identity.inboxAddress); // different DEVICE
+    expect(registeredInboxes).toContain(aPhone.identity.inboxAddress);
+    expect(registeredInboxes).toContain(aLaptop.identity.inboxAddress);
+
+    await Promise.all([aPhone.start(), aLaptop.start(), bob.start()]);
+
+    // ── Handshake ────────────────────────────────────────────────────────────
+    //
+    // Bench-lie guard, BOTH directions. A sender builds its fan-out from the
+    // registration it fetched; if either side fetched before the second device
+    // existed, that side legitimately reaches only one device and the red result
+    // is ours, not the product's (cf. PR #264, where two bench defects made the
+    // bench lie). Both devices are registered above before any bot starts, and the
+    // handshake below forces each side to fetch registrations afterwards.
+    await aPhone.send(bob.identity.address, 'md-setup phone->bob');
+    await sleep(5000);
+    await bob.send(aPhone.identity.address, 'md-setup bob->A');
+    await sleep(5000);
+
+    // ── STEP 2: send, then count PER DEVICE ──────────────────────────────────
+    for (let i = 1; i <= ROUNDS; i++) {
+      await aPhone.send(bob.identity.address, `MD-A->B #${i}`).catch((e) =>
+        say(`send A->B #${i} threw: ${(e as Error).message}`)
+      );
+      await bob.send(aPhone.identity.address, `MD-B->A #${i}`).catch((e) =>
+        say(`send B->A #${i} threw: ${(e as Error).message}`)
+      );
+      await sleep(GAP_MS);
+    }
+
+    say(`send loop done; settling ${Math.round(SETTLE_MS / 1000)}s for redelivery`);
+    await sleep(SETTLE_MS);
+
+    // Frame-level, reusing dm-loss's join once PER RECEIVING DEVICE. This is the
+    // whole point: the same accounting, applied to each device separately, instead
+    // of aggregated per account.
+    const [phoneIn, laptopIn, bobIn] = await Promise.all([
+      subscribedInboxes(aPhone),
+      subscribedInboxes(aLaptop),
+      subscribedInboxes(bob),
+    ]);
+
+    const legs = [
+      ['A.phone -> bob        (peer, primary)', direction(aPhone, bob, bobIn)],
+      ['A.phone -> A.laptop   (SELF-SYNC)     ', direction(aPhone, aLaptop, laptopIn)],
+      ['bob     -> A.phone    (peer 1st dev)  ', direction(bob, aPhone, phoneIn)],
+      ['bob     -> A.laptop   (PEER 2nd DEV)  ', direction(bob, aLaptop, laptopIn)],
+    ] as const;
+
+    say('');
+    say('==== FRAME-LEVEL, PER DEVICE (de-duplicated by ciphertext fingerprint) ====');
+    for (const [label, d] of legs) {
+      say(
+        `${label}  sent=${d.sent}  arrived=${d.arrived}  missing=${d.missing}  ` +
+          `loss=${d.lossPct.toFixed(1)}%  unmatched=${d.unmatchedArrivals}`,
+        { leg: label.trim(), ...d, missingFps: undefined }
+      );
+    }
+
+    // Message-level. Frames and messages can disagree — a frame can arrive and
+    // fail to decrypt — and the operator's observation was about MESSAGES, so
+    // report both rather than assume they track each other.
+    //
+    // Counts what saveMessage received, NOT what a UI rendered. A message can be
+    // persisted without appearing in a conversation that is not open, so a green
+    // result here does not contradict what was seen live — it separates delivery
+    // from display.
+    const bobGot = postsMatching(bob, 'MD-A->B');
+    const phoneGot = postsMatching(aPhone, 'MD-B->A');
+    const laptopGotPeer = postsMatching(aLaptop, 'MD-B->A');
+    const laptopGotSelf = postsMatching(aLaptop, 'MD-A->B');
+
+    say('');
+    say('==== MESSAGE-LEVEL, PER DEVICE (persisted, not rendered) ====');
+    say(`bob        received A->B : ${bobGot.size}/${ROUNDS}`, { bobGot: bobGot.size });
+    say(`A.phone    received B->A : ${phoneGot.size}/${ROUNDS}`, { phoneGot: phoneGot.size });
+    say(`A.laptop   received B->A : ${laptopGotPeer.size}/${ROUNDS}   <- PEER to 2nd device`, {
+      laptopGotPeer: laptopGotPeer.size,
+    });
+    say(`A.laptop   received A->B : ${laptopGotSelf.size}/${ROUNDS}   <- SELF-SYNC copy`, {
+      laptopGotSelf: laptopGotSelf.size,
+    });
+    say(
+      `novel decrypt failures: phone=${aPhone.novelErrors().length} ` +
+        `laptop=${aLaptop.novelErrors().length} bob=${bob.novelErrors().length}`
+    );
+    console.log(`[dm-md] log: ${log.file}`);
+
+    aPhone.stop();
+    aLaptop.stop();
+    bob.stop();
+
+    // The run IS the measurement, so the assertions are deliberately weak: they
+    // check the bench had data to join on, not that delivery succeeded. A hard
+    // assertion on per-device arrival would turn a genuine product finding into a
+    // red test that gets "fixed" by relaxing it. Read the numbers above.
+    expect(bobGot.size).toBeGreaterThan(0);
+    for (const [label, d] of legs) {
+      if (d.sent === 0) say(`⚠️ NO FRAMES joined for ${label.trim()} — that leg measured nothing`);
+    }
+  },
+  4 * 60 * 60 * 1000
+);

--- a/src/dev/tests/harness/dm-multidevice.scenario.test.ts
+++ b/src/dev/tests/harness/dm-multidevice.scenario.test.ts
@@ -36,6 +36,7 @@ import { channel_raw } from '@quilibrium/quilibrium-js-sdk-channels';
 import { createBot, type HarnessBot } from './bot';
 import { config } from './env';
 import { direction, subscribedInboxes } from './loss';
+import { installLockProbe, summariseLockHolds } from './lock-probe';
 import { makeApiClient } from './transport';
 import { RunLog } from './log';
 
@@ -107,6 +108,13 @@ test(
       log.add(Date.now(), 'harness', 'note', { msg, ...fields });
     };
     const stamp = String(startedAt).slice(-6);
+
+    // BEFORE any bot exists: the mutex is a process-wide singleton, so the wrap
+    // has to be in place before the first critical section runs or the early
+    // holds are missed. Confirms or refutes the ratchet-lock-across-HTTP bug
+    // directly, instead of inferring it from which messages went missing —
+    // and it reports even on a run where nothing is lost.
+    const lockSamples = installLockProbe();
 
     // One generated account, handed to two bots. createBot takes the ACCOUNT from
     // privateKeyHex and the DEVICE from name, so this is genuinely one user with
@@ -278,6 +286,15 @@ test(
         aDevices.map((b, i) => `dev${i}=${b.novelErrors().length}`).join(' ') +
         ` bob=${bob.novelErrors().length}`
     );
+
+    // The direct test of the ratchet-lock-across-HTTP mechanism. Holds clustering
+    // at ~22s / ~45s / ~69s mean the lock is waiting on a timing-out POST; holds
+    // in single-digit ms mean it is doing crypto only and the mechanism is not
+    // firing on this run. ⚠️ Do NOT look only near 22s — mutations retry twice,
+    // so a stalled ack lands near 45s or 69s.
+    say('');
+    say('==== RATCHET LOCK HOLD TIMES (bug 2026-07-28, §5.3) ====');
+    for (const line of summariseLockHolds(lockSamples)) say(line);
     console.log(`[dm-md] log: ${log.file}`);
 
     for (const b of aDevices) b.stop();

--- a/src/dev/tests/harness/lock-probe.scenario.test.ts
+++ b/src/dev/tests/harness/lock-probe.scenario.test.ts
@@ -1,0 +1,75 @@
+// OFFLINE. Proves the lock probe measures what it claims, before a networked run
+// depends on it.
+//
+//   yarn harness lock-probe
+//
+// A probe that silently recorded nothing would report "no samples" after a
+// 7-minute run against production and waste it — and worse, a probe that recorded
+// the WRONG number would be read as evidence. The bug this instrument exists to
+// confirm turns on distinguishing a ~20ms hold from a ~22s one, so the two
+// quantities are checked against known, deliberately-induced delays.
+import { test, expect } from 'vitest';
+import { dmRatchetMutex } from '../../../utils/keyedMutex';
+import { installLockProbe, summariseLockHolds } from './lock-probe';
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+test('lock-probe: records hold time and queue time against known delays', async () => {
+  const samples = installLockProbe();
+  const before = samples.length;
+
+  // Two callers on the SAME key: the second cannot start until the first
+  // finishes, which is the serialization the bug is about.
+  const key = 'probe-conversation/probe-conversation';
+  const first = dmRatchetMutex.runExclusive(key, async () => {
+    await sleep(300);
+    return 'a';
+  });
+  // Started after the first has taken the lock, so it must queue behind it.
+  await sleep(20);
+  const second = dmRatchetMutex.runExclusive(key, async () => {
+    await sleep(50);
+    return 'b';
+  });
+
+  expect(await first).toBe('a');
+  expect(await second).toBe('b');
+
+  const mine = samples.slice(before).filter((s) => s.key === key);
+  expect(mine).toHaveLength(2);
+
+  const [held1, held2] = mine.map((s) => s.heldMs);
+  // Generous bounds: this asserts the probe measures the right ORDER OF
+  // MAGNITUDE, which is all the bug needs. Tight bounds would make it flaky on a
+  // loaded machine for no diagnostic gain.
+  expect(held1).toBeGreaterThanOrEqual(250);
+  expect(held1).toBeLessThan(2_000);
+  expect(held2).toBeGreaterThanOrEqual(40);
+  expect(held2).toBeLessThan(2_000);
+
+  // The second caller queued behind the first — the user-visible consequence.
+  const queued = mine[1].waitedMs;
+  expect(queued).toBeGreaterThanOrEqual(200);
+
+  // A throwing critical section must still be recorded: the delete-conversation
+  // and give-up paths RETHROW (bug §1), and those are the holds most worth seeing.
+  const n = samples.length;
+  await expect(
+    dmRatchetMutex.runExclusive(key, async () => {
+      await sleep(30);
+      throw new Error('probe: deliberate');
+    })
+  ).rejects.toThrow('probe: deliberate');
+  expect(samples.length).toBe(n + 1);
+  expect(samples[samples.length - 1].heldMs).toBeGreaterThanOrEqual(20);
+
+  // Installing twice must not double-count — the mutex is a process-wide
+  // singleton shared by every bot, so a second wrap would inflate every hold.
+  const again = installLockProbe();
+  expect(again).toBe(samples);
+  const m = samples.length;
+  await dmRatchetMutex.runExclusive('other/other', async () => sleep(10));
+  expect(samples.length).toBe(m + 1);
+
+  for (const line of summariseLockHolds(samples)) console.log(`[lock-probe] ${line}`);
+}, 60_000);

--- a/src/dev/tests/harness/lock-probe.ts
+++ b/src/dev/tests/harness/lock-probe.ts
@@ -1,0 +1,123 @@
+// Measures how long the DM ratchet lock is HELD, per conversation.
+//
+// ── Why this exists ─────────────────────────────────────────────────────────
+//
+// `bugs/2026-07-28-dm-receive-holds-ratchet-lock-across-http.md` says the receive
+// path awaits relay HTTP inside `dmRatchetMutex.runExclusive(conversationId, …)`,
+// so one slow `/inbox/delete` stalls every message on that conversation. That was
+// found by READING. This turns it into a direct measurement.
+//
+// Inferring it from message counts is weaker evidence and needs things to actually
+// go missing. A hold-time histogram confirms or refutes the mechanism even on a
+// run where nothing is lost, because the signature is in the TIMING:
+//
+//   holds clustering at ~22s / ~45s / ~69s  ⇒ the lock is waiting on a timing-out
+//                                             POST (1, 2 or 3 attempts — see the
+//                                             bug's §1 retry arithmetic)
+//   holds in the low milliseconds           ⇒ the lock is doing crypto only, and
+//                                             the mechanism is NOT firing here
+//
+// ⚠️ The bug's §5.3 originally said to look for a cluster "near 22s". That is
+// wrong and would produce a FALSE NEGATIVE: mutations retry twice, so a stalled
+// ack lands near 45s or 69s and never near 22s. Read the whole distribution.
+//
+// ── Why a harness-side wrapper, not instrumentation in the product ──────────
+//
+// `dmRatchetMutex` is an exported singleton (`src/utils/keyedMutex.ts:17`), so it
+// can be wrapped from outside exactly the way bot.ts tees `messageDB.saveMessage`.
+// Nothing in `src/services/` changes, so the code under measurement is the code
+// that ships — which is the whole point of measuring it rather than a copy.
+import { dmRatchetMutex } from '../../../utils/keyedMutex';
+
+export interface LockSample {
+  /** conversationId the lock was taken on. */
+  key: string;
+  /** ms spent QUEUED behind other holders — how long this message waited its turn. */
+  waitedMs: number;
+  /** ms the lock was HELD — the number that carries the signature. */
+  heldMs: number;
+  /** ms since probe install, so samples can be lined up against the run. */
+  t: number;
+}
+
+let installed = false;
+const samples: LockSample[] = [];
+let installedAt = 0;
+
+/**
+ * Wrap the shared mutex once per process. Idempotent: the singleton is shared by
+ * every bot in this process, so a second install would double-count every hold.
+ */
+export function installLockProbe(): LockSample[] {
+  if (installed) return samples;
+  installed = true;
+  installedAt = Date.now();
+
+  const original = dmRatchetMutex.runExclusive.bind(dmRatchetMutex);
+  (dmRatchetMutex as unknown as { runExclusive: typeof dmRatchetMutex.runExclusive }).runExclusive =
+    async function <T>(key: string, fn: () => Promise<T>): Promise<T> {
+      const queuedAt = Date.now();
+      return original(key, async () => {
+        const startedAt = Date.now();
+        try {
+          return await fn();
+        } finally {
+          // Recorded in `finally` so a throwing critical section still reports its
+          // hold — the delete-conversation and give-up paths RETHROW (bug §1), and
+          // those are exactly the holds worth seeing.
+          samples.push({
+            key,
+            waitedMs: startedAt - queuedAt,
+            heldMs: Date.now() - startedAt,
+            t: startedAt - installedAt,
+          });
+        }
+      });
+    };
+  return samples;
+}
+
+/** Buckets chosen to match the bug's retry arithmetic, not round numbers. */
+const BUCKETS: [string, (ms: number) => boolean][] = [
+  ['<100ms      (crypto only)', (ms) => ms < 100],
+  ['100ms-1s', (ms) => ms >= 100 && ms < 1_000],
+  ['1-5s', (ms) => ms >= 1_000 && ms < 5_000],
+  ['5-15s       (decayed timeout, in-app)', (ms) => ms >= 5_000 && ms < 15_000],
+  ['15-30s      ⚠ 1 timed-out attempt', (ms) => ms >= 15_000 && ms < 30_000],
+  ['30-55s      ⚠ 2 attempts', (ms) => ms >= 30_000 && ms < 55_000],
+  ['>55s        ⚠ 3 attempts (full retry)', (ms) => ms >= 55_000],
+];
+
+/**
+ * Human-readable summary. Reports the tail explicitly: a mean is useless here
+ * because the whole claim is about rare, very long holds among many short ones.
+ */
+export function summariseLockHolds(all: LockSample[]): string[] {
+  if (all.length === 0) return ['lock probe: no samples (was installLockProbe() called before the bots?)'];
+
+  const held = all.map((s) => s.heldMs).sort((a, b) => a - b);
+  const at = (q: number) => held[Math.min(held.length - 1, Math.floor(held.length * q))];
+  const lines: string[] = [
+    `lock holds: n=${held.length}  p50=${at(0.5)}ms  p90=${at(0.9)}ms  p99=${at(0.99)}ms  max=${held[held.length - 1]}ms`,
+  ];
+  for (const [label, test] of BUCKETS) {
+    const n = held.filter(test).length;
+    if (n > 0) lines.push(`  ${label.padEnd(38)} ${n}`);
+  }
+
+  // The longest holds by conversation: if the mechanism is real these concentrate
+  // on one conversationId rather than spreading evenly.
+  const worst = [...all].sort((a, b) => b.heldMs - a.heldMs).slice(0, 5);
+  for (const s of worst) {
+    if (s.heldMs < 1_000) break;
+    lines.push(`  slowest: ${s.heldMs}ms held on ${s.key.slice(0, 24)} at t+${Math.round(s.t / 1000)}s`);
+  }
+
+  // Queueing is the user-visible consequence — how long a message sat waiting.
+  const waited = all.map((s) => s.waitedMs).sort((a, b) => a - b);
+  lines.push(
+    `queued behind the lock: p50=${waited[Math.floor(waited.length * 0.5)]}ms  ` +
+      `max=${waited[waited.length - 1]}ms`
+  );
+  return lines;
+}

--- a/src/dev/tests/harness/loss.ts
+++ b/src/dev/tests/harness/loss.ts
@@ -1,0 +1,67 @@
+// Send-vs-arrive accounting, shared by every scenario that measures delivery.
+//
+// Extracted from dm-loss so `dm-multidevice` reuses the SAME join rather than
+// growing a second implementation. That matters more than it looks: raw frame
+// counters have overstated volume by 2-5x three separate times in this
+// investigation, and every one of those corrections is baked into the
+// de-duplication below. A parallel counter would have to relearn them.
+//
+// The join is per (sender, receiver) PAIR, which is exactly what makes per-device
+// accounting possible: call it once per receiving device instead of once per
+// account, and each device's arrivals are measured on their own.
+import type { HarnessBot } from './bot';
+import { WsTransport } from './transport';
+
+/**
+ * Inbox addresses a bot is actually listening on — the only place a frame CAN
+ * land for it. A frame addressed anywhere else is fan-out to some other device,
+ * not loss, and counting it as loss is the single easiest way to make this bench
+ * lie.
+ */
+export async function subscribedInboxes(bot: HarnessBot): Promise<Set<string>> {
+  const states = await bot.messageDB.getAllEncryptionStates();
+  return new Set([bot.identity.inboxAddress, ...states.map((s) => s.inboxId)]);
+}
+
+export interface DirectionResult {
+  sent: number;
+  arrived: number;
+  missing: number;
+  lossPct: number;
+  /** Frames the receiver got that this sender never recorded sending to it. */
+  unmatchedArrivals: number;
+  /** Fingerprints that never arrived — for reporting WHICH ones, not just how many. */
+  missingFps: string[];
+}
+
+/**
+ * Frames `from` addressed to an inbox `to` is subscribed to, joined against what
+ * `to`'s socket actually produced. Both sides de-duplicated by ciphertext
+ * fingerprint first: un-acked frames are redelivered on every `listen`.
+ */
+export function direction(
+  from: HarnessBot,
+  to: HarnessBot,
+  toInboxes: Set<string>
+): DirectionResult {
+  const sent = new Map<string, number>();
+  for (const s of from.transport.sent) {
+    if (!s.fp) continue;
+    if (s.target && !toInboxes.has(s.target)) continue; // fan-out elsewhere, not loss
+    if (!sent.has(s.fp)) sent.set(s.fp, s.t);
+  }
+  const arrived = new Set<string>();
+  for (const f of to.transport.arrived) {
+    const fp = WsTransport.ciphertextFp(f);
+    if (fp) arrived.add(fp);
+  }
+  const missingFps = [...sent.keys()].filter((fp) => !arrived.has(fp));
+  return {
+    sent: sent.size,
+    arrived: [...sent.keys()].filter((fp) => arrived.has(fp)).length,
+    missing: missingFps.length,
+    lossPct: sent.size ? (missingFps.length / sent.size) * 100 : 0,
+    unmatchedArrivals: [...arrived].filter((fp) => !sent.has(fp)).length,
+    missingFps,
+  };
+}


### PR DESCRIPTION
Test infrastructure and documentation only. **No product code changes.**

## Why

Every bench until now used **one device per account**, and `dm-loss` joins
send-vs-arrive only for frames the peer bot subscribes to — fan-out to an
account's *other* devices is excluded by design as "unobserved, not
observed-good". So two paths on the normal DM send route had never been measured:
the self-sync copy to a sender's own devices, and the peer's second device.

That gap had a cost. During `dm-loss` run 2 on the canonical accounts the bench
reported 201/201 each way, 0% loss, while the operator watched those same
accounts' other devices receive ~10 of 200 messages on one desktop and 0 of 200 on
the other, in the same run, both online. The bench was structurally blind to the
channel that was failing.

## What's here

**`dm-multidevice` scenario.** Generates one throwaway account and hands the same
key to N bots, so it gives real multi-device without touching the canonical
accounts — those carry 5+ device registrations and `createBot` merges a new device
per bot name, so running there would permanently pollute shared accounts and fan
out to ghost inboxes we cannot observe.

- `HARNESS_MD_DEVICES=N` (default 2; the finding needs 4)
- bots created in an awaited loop — registration is a read-modify-write, and
  concurrent creation silently drops a device
- step 1 asserts device **membership**, not a count, and that every device inbox
  is distinct
- reports both frame-level (per receiving device) and message-level (what
  `saveMessage` actually received, not what a UI rendered)
- reports **which** message numbers are missing and labels the shape, because
  "stopped at #52" and "dropped every other one" are different bugs

**`lock-probe`.** Wraps the exported `dmRatchetMutex` singleton from outside — the
same trick `bot.ts` uses to tee `saveMessage` — so the code under measurement is
the code that ships. Prints a hold-time histogram bucketed by the retry
arithmetic, with p50/p90/p99/max and the slowest holds by conversation. Ships with
an **offline self-test** (`yarn harness lock-probe`, no relay) checking it against
induced delays, a throwing critical section, and double-install.

**`loss.ts`.** Extracts `direction()` / `subscribedInboxes()` from `dm-loss` so
both scenarios share one join. Raw frame counters have overstated volume 2-5x
three separate times in this investigation, and every one of those corrections is
baked into that de-duplication — a parallel counter would have to relearn them.

## What it found

4 devices, 100 rounds: **all 8 frame legs 101/101, 0% loss, zero decrypt failures**
— and one device persisted **52/100** messages, in both directions, the same
count. At 2 devices everything was clean.

Loss between arrival and persistence, with no error raised. `dm-loss` counts
frames, so it would have called that run flawless.

That prompted a third result class in the measurement log — `arrival`, `decrypt`,
and now **`persistence`** — because its absence is why this went unfound for
weeks: a scenario that does not count what the app persisted cannot see this class
at all.

## The bug it surfaced

`.agents/bugs/2026-07-28-dm-receive-holds-ratchet-lock-across-http.md`

The DM receive path awaits relay HTTP (`POST /inbox/delete`, 22s per attempt,
retried twice → ~69s worst case) **inside** `dmRatchetMutex.runExclusive`, so one
slow ack stalls every message on that conversation in both directions.
`KeyedMutex`'s own docstring warns against this; the send paths follow the
guidance, the receive path does not.

Stated as **unconfirmed**, with the caveats intact: it predicts *latency* rather
than loss, and the run that suggested it finished two minutes before the API went
502 for over an hour, so it may have been taken against a degrading relay.

Reviewed adversarially (see the report's Review Log): the reviewer tripled the
stall bound, found a third locked HTTP shape I had missed, and corrected a
confirmation criterion that would have produced a false negative. All claims
independently re-verified before acceptance.

Mobile is verified **not** affected, and its pattern is the proposed fix.

## Deliberately not here

The fix. It touches `MessageService.ts` at three call sites with a behaviour
change around rethrow-vs-swallow, so it wants its own branch, its own review, its
own revert boundary — and a before/after histogram, which needs one clean run
against a healthy relay first.

## Verification

- desktop suite: **37 files / 565 tests** passing
- `yarn harness lock-probe` and `yarn harness integration-check` pass offline
- typecheck clean
