### PR TITLE
Stop awaiting the relay inside the DM receive handler

### DIFF
--- a/.agents/bugs/2026-07-28-dm-receive-holds-ratchet-lock-across-http.md
+++ b/.agents/bugs/2026-07-28-dm-receive-holds-ratchet-lock-across-http.md
@@ -1,7 +1,7 @@
 ---
 type: bug
 title: "Desktop DM receive holds the per-conversation ratchet lock across relay HTTP, so one slow ack stalls the whole conversation"
-status: OPEN — ✅ **MECHANISM CONFIRMED BY MEASUREMENT 2026-07-29** via fault injection (§5-CONFIRMED). Stalling `/inbox/delete` by 30s on 1 call in 20 produced every predicted signature: lock holds in the `30-55s` bucket (max 31260ms), messages queued up to 31173ms, persistence collapsing to `CONTIGUOUS TAIL` gaps on every device with **zero** scattered gaps, while all 8 frame legs still arrived 101/101. The fix (§6) is now justified on evidence and has an acceptance test that can fail. ⚠️ Two clean healthy-relay runs preceded it and proved nothing either way — see §5-RESULT for why, and §5-CONFIRMED's caveats before quoting the magnitude (the harness shares one lock across all four devices, so its blast radius is inflated; and this is almost certainly latency, not permanent loss). The receive path awaits `deleteInboxMessages` / `ackProcessedFrame` (POST `/inbox/delete`, 22s mutate timeout, retried ×3) INSIDE `dmRatchetMutex.runExclusive(conversationId, …)`, so a single slow ack blocks every message on that conversation, in BOTH directions, for up to ~69s (see §1). A 4-device bench run showed one device persisting 52/100 messages while all 101 frames arrived and nothing failed to decrypt — consistent with this, but that run may have been taken against a degrading relay (see §4). ⚠️ **§5 has now been run against a verified-healthy relay and everything was clean: 100/100 on every device, and the lock histogram showed 1065 holds all under 555ms with none in the 15s+ buckets (§5-RESULT).** That does not refute §1, which is a reading of the source — it shows the coupling does not bite when the relay is fast, so a clean-relay run cannot settle this either way. Mobile does NOT have this shape and its pattern is the proposed fix (§6).
+status: ✅ **FIXED AND VALIDATED 2026-07-29** on branch `fix/dm-receive-lock-across-http` — awaiting review/merge, NOT yet deployed. Under 66 injected 30s relay stalls the fixed build kept **100/100 on every device in both directions, zero decrypt failures, no gaps, max lock hold 562ms** (§8). ⚠️ The first fix — freeing the ratchet lock only — passed the unit suite and cut lock holds 48× **while the messages still vanished**; the real constraint turned out to be broader than §1 states: `processInbound` awaits `handleNewMessage` serially per inbox, so *any* awaited relay call in that handler is a head-of-line block. Eight more sites outside the lock had to go too. Mobile never had this and needs nothing. Below is the original analysis, kept as written: **MECHANISM CONFIRMED BY MEASUREMENT 2026-07-29** via fault injection (§5-CONFIRMED). Stalling `/inbox/delete` by 30s on 1 call in 20 produced every predicted signature: lock holds in the `30-55s` bucket (max 31260ms), messages queued up to 31173ms, persistence collapsing to `CONTIGUOUS TAIL` gaps on every device with **zero** scattered gaps, while all 8 frame legs still arrived 101/101. The fix (§6) is now justified on evidence and has an acceptance test that can fail. ⚠️ Two clean healthy-relay runs preceded it and proved nothing either way — see §5-RESULT for why, and §5-CONFIRMED's caveats before quoting the magnitude (the harness shares one lock across all four devices, so its blast radius is inflated; and this is almost certainly latency, not permanent loss). The receive path awaits `deleteInboxMessages` / `ackProcessedFrame` (POST `/inbox/delete`, 22s mutate timeout, retried ×3) INSIDE `dmRatchetMutex.runExclusive(conversationId, …)`, so a single slow ack blocks every message on that conversation, in BOTH directions, for up to ~69s (see §1). A 4-device bench run showed one device persisting 52/100 messages while all 101 frames arrived and nothing failed to decrypt — consistent with this, but that run may have been taken against a degrading relay (see §4). ⚠️ **§5 has now been run against a verified-healthy relay and everything was clean: 100/100 on every device, and the lock histogram showed 1065 holds all under 555ms with none in the 15s+ buckets (§5-RESULT).** That does not refute §1, which is a reading of the source — it shows the coupling does not bite when the relay is fast, so a clean-relay run cannot settle this either way. Mobile does NOT have this shape and its pattern is the proposed fix (§6).
 created: 2026-07-28
 severity: medium — user-visible "messages not arriving" on desktop; likely LATENCY not permanent loss (§3), degrades with device count. ⚠️ NOT revisited after the 2026-07-28 review tripled the stall bound from 22s to ~69s: a conversation frozen for over a minute is closer to "broken" than "slow" from a user's seat, so re-rate this if §5 confirms the mechanism.
 repo: quorum-desktop (mobile verified NOT affected — §6)
@@ -289,33 +289,79 @@ Against §5's own criteria, in order:
   probably the known reorder/stale-bucket class, provoked by frames being
   redelivered while the session advanced. Worth a look, not part of this finding.
 
-### ⏭️ RESUME HERE (2026-07-29) — the fix is written, its validation run was interrupted
+## §8. ✅ FIXED AND VALIDATED (2026-07-29) — and the first attempt failed, which is the point
 
-Branch `fix/dm-receive-lock-across-http`: `6d4b8005f` (injection tooling) +
-`da24521d3` (the fix). Typecheck clean, **565 unit tests pass across 37 files**.
-The after-measurement was still running when the machine had to be shut down, so
-**the fix is UNVALIDATED — do not merge it on the strength of the unit tests.**
+Branch `fix/dm-receive-lock-across-http`. Three runs, identical parameters, only
+the code changing:
 
-Re-run the identical injection and compare against §5-CONFIRMED's table:
+| | **before** | **partial fix** (lock only) | **complete fix** |
+|---|---|---|---|
+| stalls injected | 50 of 1016 | 42 of 856 | **66 of 1327** (harshest) |
+| lock hold max | 31260ms | 655ms | **562ms** |
+| queued behind lock max | 31173ms | 456ms | **394ms** |
+| holds in `30-55s` | 10 | 0 | **0** |
+| dev0 / dev1 / dev2 / dev3 | 97 / 50 / 25 / 23 | 79 / 38 / 30 / 23 | **100 / 100 / 100 / 100** |
+| bob | 85/100 | 93/100 | **100/100** |
+| novel decrypt failures | 246 (bob) | 121 (bob) | **0 everywhere** |
+| gap shape | `CONTIGUOUS TAIL` | `CONTIGUOUS TAIL` | **none — nothing missing** |
 
-```bash
-HARNESS_MD_DEVICES=4 HARNESS_MD_ROUNDS=100 HARNESS_MD_GAP_MS=700 \
-HARNESS_MD_SETTLE_MS=300000 HARNESS_FAULT_DELETE_DELAY_MS=30000 \
-HARNESS_FAULT_DELETE_RATE=0.05 yarn harness dm-multidevice
+The final run absorbed **66 injected 30-second stalls — over half an hour of
+cumulative relay stall — and lost nothing, delayed nothing, and failed to decrypt
+nothing.**
+
+### ⚠️ The first fix passed every test except the one that mattered
+
+The middle column is the important lesson. Freeing the ratchet lock worked
+*perfectly at what it targeted*: hold times fell 48×, and the `30-55s` bucket
+emptied. Typecheck was clean and all 565 unit tests passed. **And the messages
+still vanished in contiguous tails.** Shipping on that evidence would have closed
+this bug while the user-visible symptom survived untouched.
+
+**The model in §1 was too narrow.** The ratchet lock is not the only serialization
+point, and it is not even the important one. `WebsocketProvider.processInbound`
+(`src/components/context/WebsocketProvider.tsx:77`) guards itself with
+`inboundProcessingRef` and then awaits `handleNewMessage` once per message, in a
+`for` loop, per inbox:
+
+```ts
+for (const message of messages) {
+  await handlerRef.current!(message);   // serial, per inbox
+}
 ```
 
-Check the relay is healthy first (`/` → 404, a known user → 200), run it in the
-background (~10 min), and read the JSONL log, not the console. **Expected: zero
-holds in `30-55s`, no `CONTIGUOUS TAIL` anywhere, persistence back near 100/100.**
-If tails remain, the fix is incomplete — report that rather than explaining it away;
-the injection exists precisely so this test can fail.
+So **any** awaited relay call anywhere in `handleNewMessage` stalls every later
+frame for that inbox — lock or no lock. Verified in the app, not inferred from the
+harness: the browser serializes per inbox exactly as the bench does, which is why
+the bench was faithful here rather than exaggerating.
 
-Next after that: **slice 4, mobile↔desktop on one bench** — the field's worst case
-and the only configuration no bench covers. Design settled 2026-07-29 and it
-deviates from the written spec: two processes paired through mobile's existing file
-rendezvous, NOT the specced single-process bundle (mobile's DM core is deliberately
-un-extracted and lives inside `WebSocketProvider`, and slices 1-3 established that
-two bots cannot share a process). quorum-mobile needs no changes.
+`handleNewMessage` spans ~2400 lines (3416-5808) and held **eight more** awaited
+inbox-deletes outside the critical section. All were the same housekeeping shape.
+`b41df6f7f` dispatches those too; the handler now awaits no inbox-delete anywhere.
+
+**Generalised rule for this file, worth more than the fix:** the constraint is not
+"don't hold the lock across HTTP", it is **"don't await the relay inside
+`handleNewMessage` at all."** The inbound queue is serial per inbox, so every
+`await` in there is a head-of-line block on that inbox.
+
+### A secondary confirmation nobody asked for
+
+Novel decrypt failures went **246 → 121 → 0**. Those were never a separate bug:
+frames backing up behind a stall get redelivered while the session advances, which
+is the reorder/stale-bucket class. Removing the stall removed them. That the
+number fell in lockstep with the tails across three runs is independent evidence
+the mechanism was correctly identified.
+
+### Still true, and still not fixed by this
+
+This is **desktop-only** and does not touch the field symptom (§7 stands). Mobile
+never had the defect — its pattern is what this fix copies — so **quorum-mobile
+needs no change, no PR and no deploy.** The next real target is
+**slice 4, mobile↔desktop on one bench**: the field's worst case and the only
+configuration no bench covers. Design settled 2026-07-29 and it deviates from the
+written spec — two processes paired through mobile's existing file rendezvous, NOT
+the specced single-process bundle (mobile's DM core is deliberately un-extracted
+and lives inside `WebSocketProvider`, and slices 1-3 established two bots cannot
+share a process). quorum-mobile needs no changes for that either.
 
 ### The fix now has an acceptance test that can fail
 

--- a/.agents/bugs/2026-07-28-dm-receive-holds-ratchet-lock-across-http.md
+++ b/.agents/bugs/2026-07-28-dm-receive-holds-ratchet-lock-across-http.md
@@ -289,6 +289,34 @@ Against §5's own criteria, in order:
   probably the known reorder/stale-bucket class, provoked by frames being
   redelivered while the session advanced. Worth a look, not part of this finding.
 
+### ⏭️ RESUME HERE (2026-07-29) — the fix is written, its validation run was interrupted
+
+Branch `fix/dm-receive-lock-across-http`: `6d4b8005f` (injection tooling) +
+`da24521d3` (the fix). Typecheck clean, **565 unit tests pass across 37 files**.
+The after-measurement was still running when the machine had to be shut down, so
+**the fix is UNVALIDATED — do not merge it on the strength of the unit tests.**
+
+Re-run the identical injection and compare against §5-CONFIRMED's table:
+
+```bash
+HARNESS_MD_DEVICES=4 HARNESS_MD_ROUNDS=100 HARNESS_MD_GAP_MS=700 \
+HARNESS_MD_SETTLE_MS=300000 HARNESS_FAULT_DELETE_DELAY_MS=30000 \
+HARNESS_FAULT_DELETE_RATE=0.05 yarn harness dm-multidevice
+```
+
+Check the relay is healthy first (`/` → 404, a known user → 200), run it in the
+background (~10 min), and read the JSONL log, not the console. **Expected: zero
+holds in `30-55s`, no `CONTIGUOUS TAIL` anywhere, persistence back near 100/100.**
+If tails remain, the fix is incomplete — report that rather than explaining it away;
+the injection exists precisely so this test can fail.
+
+Next after that: **slice 4, mobile↔desktop on one bench** — the field's worst case
+and the only configuration no bench covers. Design settled 2026-07-29 and it
+deviates from the written spec: two processes paired through mobile's existing file
+rendezvous, NOT the specced single-process bundle (mobile's DM core is deliberately
+un-extracted and lives inside `WebSocketProvider`, and slices 1-3 established that
+two bots cannot share a process). quorum-mobile needs no changes.
+
 ### The fix now has an acceptance test that can fail
 
 Re-run the identical injection after applying §6. Expected: **no holds in

--- a/.agents/docs/transport-measurements.md
+++ b/.agents/docs/transport-measurements.md
@@ -225,6 +225,36 @@ nothing.
 > hold, it does not observe what runs inside it, so this is a hint about where to
 > look next and not evidence the coupling fired.
 
+### ⭐⭐ The 07-29 fix validation — and the partial fix that passed every other test
+
+| when | run | configuration | class | result | what it changed | source |
+|---|---|---|---|---|---|---|
+| 07-29 | `dm-multidevice` + injection | same injection, **lock-only fix applied** | persistence | lock max **655ms** (was 31260ms), queueing **456ms**, zero `30-55s` holds — **but persistence still 79/38/30/23 with `CONTIGUOUS TAIL` everywhere** | ⚠️ **the fix that wasn't.** Freed the lock perfectly and the symptom survived | run log `2026-07-29T06-36-45` |
+| 07-29 | `dm-multidevice` + injection | same injection, **complete fix applied** (all 14 sites) | arrival + decrypt + persistence | **66 of 1327 calls stalled 30s — the harshest fault of any run — and every device persisted 100/100 both directions, bob 100/100, ZERO decrypt failures anywhere, no gaps.** Lock max **562ms** | ✅ **validated.** Over half an hour of cumulative relay stall absorbed with nothing lost or delayed | run log `2026-07-29T08-08-45` |
+
+**The middle row is the one to remember.** Freeing the ratchet lock cut hold times
+48×, emptied the `30-55s` bucket, kept the typecheck clean and passed all 565 unit
+tests — **and the messages still vanished in contiguous tails.** Every signal
+except the one that mattered said "fixed".
+
+The cause: the ratchet lock is not the only serialization point, and not the
+important one. `WebsocketProvider.processInbound` awaits `handleNewMessage`
+serially per inbox, so **any** awaited relay call in that ~2400-line handler is a
+head-of-line block on that inbox — lock or no lock. Eight more awaited
+inbox-deletes lived outside the critical section. Verified against the app's own
+code, not assumed from the bench.
+
+> **The durable rule, worth more than the fix:** not *"don't hold the lock across
+> HTTP"* but **"don't await the relay inside `handleNewMessage` at all."**
+
+Novel decrypt failures fell **246 → 121 → 0** across the three runs, in lockstep
+with the tails. Those were frames backing up behind a stall and being redelivered
+while the session advanced — the known reorder/stale-bucket class, not a separate
+defect. Independent corroboration that the mechanism was correctly identified.
+
+⚠️ Still desktop-only, still does not explain the mobile field loss, and mobile
+needs no change — its pattern is what the fix copies.
+
 ### ⭐⭐ The 07-29 fault-injected run — the lock mechanism, measured
 
 **This is the run that settles the ratchet-lock-across-HTTP question**, and it only

--- a/src/dev/tests/harness/dm-multidevice.scenario.test.ts
+++ b/src/dev/tests/harness/dm-multidevice.scenario.test.ts
@@ -37,7 +37,7 @@ import { createBot, type HarnessBot } from './bot';
 import { config } from './env';
 import { direction, subscribedInboxes } from './loss';
 import { installLockProbe, summariseLockHolds } from './lock-probe';
-import { makeApiClient } from './transport';
+import { deleteFault, makeApiClient } from './transport';
 import { RunLog } from './log';
 
 const ROUNDS = Number(process.env.HARNESS_MD_ROUNDS ?? 20);
@@ -294,6 +294,14 @@ test(
     // so a stalled ack lands near 45s or 69s.
     say('');
     say('==== RATCHET LOCK HOLD TIMES (bug 2026-07-28, §5.3) ====');
+    // Which relay condition this run measured. Without this line a reader cannot
+    // tell a clean baseline from a clean fault-injected run, and those mean
+    // opposite things: the first proves nothing, the second refutes the mechanism.
+    say(deleteFault.summary(), {
+      faultDelayMs: deleteFault.delayMs,
+      faultCalls: deleteFault.calls,
+      faultInjected: deleteFault.injected,
+    });
     for (const line of summariseLockHolds(lockSamples)) say(line);
     console.log(`[dm-md] log: ${log.file}`);
 

--- a/src/dev/tests/harness/transport.ts
+++ b/src/dev/tests/harness/transport.ts
@@ -40,8 +40,65 @@ export interface SentFrame {
   target: string | undefined;
 }
 
+// ── Fault injection: a deliberately slow POST /inbox/delete ─────────────────
+//
+// `bugs/2026-07-28-dm-receive-holds-ratchet-lock-across-http.md` says the receive
+// path holds the per-conversation ratchet lock across this POST, so one slow ack
+// stalls every message on the conversation, both directions.
+//
+// ⚠️ That hypothesis CANNOT be tested on a healthy relay, and the 2026-07-29 run
+// proved it the expensive way: 100/100 on every device, no lock hold above 555ms,
+// which is exactly what the mechanism predicts when the POST is fast. A null there
+// cannot separate "no bug" from "no trigger", so repeating it adds nothing.
+//
+// The trigger has to be SUPPLIED. This makes a fraction of inbox-delete calls slow
+// the way a degrading relay would — and the relay really does degrade: it returned
+// 502 on every path for over an hour on 2026-07-28, which is the condition that
+// makes this bite.
+//
+// Selection is DETERMINISTIC (every Nth call), not random, so a run reproduces and
+// a before/after comparison is like-for-like. The counter is module-level, so the
+// rate is global across every bot in the process rather than per-bot.
+//
+// OFF unless HARNESS_FAULT_DELETE_DELAY_MS is set, so no existing run changes.
+export const deleteFault = {
+  /** ms to stall each selected call. 0 disables injection entirely. */
+  delayMs: Number(process.env.HARNESS_FAULT_DELETE_DELAY_MS ?? 0),
+  /** Fraction of calls to stall, 0..1. 0.1 => every 10th. */
+  rate: Number(process.env.HARNESS_FAULT_DELETE_RATE ?? 0.1),
+  /** How many inbox-delete calls were made. */
+  calls: 0,
+  /** How many of them this injector stalled. */
+  injected: 0,
+  /** One-line summary for the run log. */
+  summary(): string {
+    return this.delayMs > 0
+      ? `delete-fault ON: ${this.injected}/${this.calls} calls stalled by ${this.delayMs}ms (rate ${this.rate})`
+      : 'delete-fault OFF (healthy-relay baseline)';
+  },
+};
+
+type DeleteInbox = QuorumApiClient['deleteInbox'];
+
 export function makeApiClient(): QuorumApiClient {
-  return new QuorumApiClient({ baseUrl: config.apiUrl, wsUrl: config.wsUrl });
+  const client = new QuorumApiClient({ baseUrl: config.apiUrl, wsUrl: config.wsUrl });
+  if (deleteFault.delayMs > 0) {
+    const original = client.deleteInbox.bind(client) as DeleteInbox;
+    const every = Math.max(1, Math.round(1 / Math.min(1, Math.max(0.0001, deleteFault.rate))));
+    (client as unknown as { deleteInbox: DeleteInbox }).deleteInbox = ((
+      ...args: Parameters<DeleteInbox>
+    ) => {
+      deleteFault.calls += 1;
+      if (deleteFault.calls % every !== 0) return original(...args);
+      deleteFault.injected += 1;
+      // Stall BEFORE delegating. The lock is held for this whole time either way,
+      // which is the thing under test; doing it here also keeps the stall exactly
+      // as long as configured instead of at the mercy of the client's own
+      // timeout/retry arithmetic, so the expected histogram bucket is predictable.
+      return new Promise((r) => setTimeout(r, deleteFault.delayMs)).then(() => original(...args));
+    }) as DeleteInbox;
+  }
+  return client;
 }
 
 export class WsTransport {

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -3474,10 +3474,10 @@ export class MessageService {
               ),
             }
           );
-          await this.deleteInboxMessages(
+          this.dispatchInboxDelete(
             keyset.deviceKeyset.inbox_keyset,
             [envelope.timestamp],
-            this.apiClient
+            'malformed init envelope (no user address)'
           );
           return;
         }
@@ -3496,10 +3496,10 @@ export class MessageService {
             }
           );
           await this.deleteEncryptionStates({ conversationId });
-          await this.deleteInboxMessages(
+          this.dispatchInboxDelete(
             keyset.deviceKeyset.inbox_keyset,
             [envelope.timestamp],
-            this.apiClient
+            'delete-conversation reset signal (init-envelope path)'
           );
           return;
         }
@@ -3521,10 +3521,10 @@ export class MessageService {
             }
           );
           await this.deleteConversationLocally(target + '/' + target, queryClient);
-          await this.deleteInboxMessages(
+          this.dispatchInboxDelete(
             keyset.deviceKeyset.inbox_keyset,
             [envelope.timestamp],
-            this.apiClient
+            'delete-conversation-self from own device'
           );
           return;
         }
@@ -3669,10 +3669,10 @@ export class MessageService {
               senderProfile
             );
           }
-          await this.deleteInboxMessages(
+          this.dispatchInboxDelete(
             keyset.deviceKeyset.inbox_keyset,
             [envelope.timestamp],
-            this.apiClient
+            'init path, message added'
           );
           return;
         }
@@ -3738,10 +3738,10 @@ export class MessageService {
             // delivery-ack control message — encryption state saved and the
             // frame fully processed, so delete it (it used to be left behind
             // and redelivered until the stale guard killed it).
-            await this.deleteInboxMessages(
+            this.dispatchInboxDelete(
               keyset.deviceKeyset.inbox_keyset,
               [envelope.timestamp],
-              this.apiClient
+              'init path, intercepted control message'
             );
             return;
           }
@@ -3822,10 +3822,10 @@ export class MessageService {
         } else {
           console.error(t`Failed to decrypt message with any known state`);
         }
-        await this.deleteInboxMessages(
+        this.dispatchInboxDelete(
           keyset.deviceKeyset.inbox_keyset,
           [envelope.timestamp],
-          this.apiClient
+          'init path, frame fully processed'
         );
       } catch (initPathError) {
         if (decryptedContent) {
@@ -3855,10 +3855,10 @@ export class MessageService {
           },
           initPathError
         );
-        await this.deleteInboxMessages(
+        this.dispatchInboxDelete(
           keyset.deviceKeyset.inbox_keyset,
           [message.timestamp],
-          this.apiClient
+          'init envelope failed before decrypt'
         );
         return;
       }
@@ -3878,10 +3878,10 @@ export class MessageService {
           timestamp: message.timestamp,
         }
       );
-      await this.deleteInboxMessages(
+      this.dispatchInboxDelete(
         keyset.deviceKeyset.inbox_keyset,
         [message.timestamp],
-        this.apiClient
+        'DM frame for an unknown inbox'
       );
       return;
     }
@@ -5767,10 +5767,10 @@ export class MessageService {
     }
 
     if (keys.sending_inbox) {
-      await this.deleteInboxMessages(
+      this.dispatchInboxDelete(
         keys.receiving_inbox,
         [message.timestamp],
-        this.apiClient
+        'post-processing cleanup (DM inbox)'
       );
     } else {
       const inbox_key = await this.messageDB.getSpaceKey(
@@ -5786,7 +5786,7 @@ export class MessageService {
         return;
       }
 
-      await this.deleteInboxMessages(
+      this.dispatchInboxDelete(
         {
           inbox_address: inbox_key.address!,
           inbox_encryption_key: {} as never,
@@ -5797,7 +5797,7 @@ export class MessageService {
           },
         },
         [message.timestamp],
-        this.apiClient
+        'post-processing cleanup (space inbox)'
       );
     }
   }

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -309,11 +309,11 @@ export class MessageService {
    * The attempt/TTL budget preserves the original protection against a
    * genuinely poisonous frame lingering forever.
    */
-  private async retainOrDropUndecryptableFrame(
+  private retainOrDropUndecryptableFrame(
     branch: string,
     message: { inboxAddress?: string; encryptedContent: string; timestamp: number },
     receivingInbox: unknown
-  ): Promise<void> {
+  ): void {
     const key = frameKey(message.inboxAddress, message.encryptedContent);
     if (!this.undecryptableFrames.recordFailure(key)) {
       // Keep it: the server redelivers anything not acked-by-delete, so the
@@ -328,7 +328,70 @@ export class MessageService {
         frameTimestamp: message.timestamp,
       }
     );
-    await this.deleteInboxMessages(receivingInbox, [message.timestamp], this.apiClient);
+    this.dispatchInboxDelete(
+      receivingInbox,
+      [message.timestamp],
+      'give-up on an undecryptable frame'
+    );
+  }
+
+  /**
+   * Fire an inbox-delete at the relay WITHOUT holding the caller open on it.
+   *
+   * ── Why this exists ───────────────────────────────────────────────────────
+   *
+   * Every caller of this runs inside `dmRatchetMutex.runExclusive(conversationId,
+   * …)`, and awaiting a relay POST in there holds the per-conversation lock for
+   * the duration of the call. `defaultMutateTimeout` is 22s and mutations retry
+   * twice, so one slow delete froze an entire conversation — both directions,
+   * since a DM's two directions share one conversationId — for up to ~69s.
+   *
+   * That is measured, not theorised: stalling this POST by 30s on 1 call in 20
+   * produced lock holds of 31.2s, messages queued 31.1s behind the lock, and
+   * per-device persistence collapsing into CONTIGUOUS TAIL gaps while every frame
+   * still arrived. See `bugs/2026-07-28-dm-receive-holds-ratchet-lock-across-http.md`
+   * §5-CONFIRMED, reproducible with `HARNESS_FAULT_DELETE_DELAY_MS`.
+   *
+   * ── Why not awaiting is safe ──────────────────────────────────────────────
+   *
+   * The lock exists to serialize RATCHET STATE — read, advance, save. The delete
+   * is not part of that: by the time it runs the encryption state is already
+   * persisted, and the delete's only job is to stop the relay redelivering a
+   * frame we have finished with. Its failure was already a no-op by design (the
+   * frame simply comes back and is skipped again), so waiting up to a minute for
+   * it bought nothing.
+   *
+   * This is the shape mobile already uses (`deleteProcessedEnvelope` returns void
+   * and is dispatched `.catch(() => {})`, never awaited) and the shape desktop's
+   * own SEND paths already use (they wrap the delivery promise as `{ sent }` so it
+   * is not awaited inside the lock). The receive path was the odd one out.
+   *
+   * ⚠️ **Call this only AFTER the encryption state is persisted.** A crash between
+   * the two would otherwise lose a frame the relay would have redelivered. Every
+   * current caller satisfies this because the preceding `saveEncryptionState` /
+   * `deleteEncryptionStates` is still awaited.
+   *
+   * ⚠️ Two of the callers used to RETHROW on failure (the delete-conversation
+   * branches and the give-up path). They no longer can, so the `.catch` below is
+   * the only remaining signal — keep it. Redelivery covers the functional case,
+   * and `MessageDB.deleteInboxMessages` already logs loudly before it rejects.
+   */
+  private dispatchInboxDelete(
+    receivingInbox: unknown,
+    timestamps: number[],
+    context: string
+  ): void {
+    // Deferred through a resolved promise so a SYNCHRONOUS throw from the
+    // dependency lands in the same .catch as a rejection, rather than escaping
+    // into the critical section this exists to keep short.
+    void Promise.resolve()
+      .then(() => this.deleteInboxMessages(receivingInbox, timestamps, this.apiClient))
+      .catch((err) => {
+        logger.warn(
+          `[MessageService] inbox-delete failed (${context}) — the frame will be redelivered`,
+          err
+        );
+      });
   }
 
   /**
@@ -347,12 +410,8 @@ export class MessageService {
    * and skipped again, which is strictly better than losing the message we
    * already decrypted.
    */
-  private async ackProcessedFrame(receivingInbox: unknown, timestamp: number): Promise<void> {
-    try {
-      await this.deleteInboxMessages(receivingInbox, [timestamp], this.apiClient);
-    } catch (err) {
-      logger.warn('[MessageService] failed to ack a processed DM frame (will be redelivered)', err);
-    }
+  private ackProcessedFrame(receivingInbox: unknown, timestamp: number): void {
+    this.dispatchInboxDelete(receivingInbox, [timestamp], 'ack of a processed DM frame');
   }
 
   constructor(dependencies: MessageServiceDependencies) {
@@ -3908,10 +3967,12 @@ export class MessageService {
                 }
               );
               await this.deleteEncryptionStates({ conversationId });
-              await this.deleteInboxMessages(
+              // NOT awaited — dispatched after the state wipe above. This used to
+              // rethrow; it no longer can, so its .catch is the only signal.
+              this.dispatchInboxDelete(
                 freshKeys.receiving_inbox,
                 [message.timestamp],
-                this.apiClient
+                'delete-conversation reset signal (Confirm branch)'
               );
               return { outcome: 'handled' as const };
             }
@@ -3935,7 +3996,9 @@ export class MessageService {
               true
             );
             this.undecryptableFrames.clear(undecryptableKey);
-            await this.ackProcessedFrame(freshKeys.receiving_inbox, message.timestamp);
+            // NOT awaited: dispatched after the state save above, so it cannot
+            // extend this critical section. See dispatchInboxDelete.
+            this.ackProcessedFrame(freshKeys.receiving_inbox, message.timestamp);
             return {
               outcome: 'ok' as const,
               content,
@@ -3954,7 +4017,7 @@ export class MessageService {
             // encrypting to a session the receiver had torn down.
             // (https://signal.org/docs/specifications/doubleratchet/)
             logger.error('[MessageService] DM decrypt failed (ConfirmDoubleRatchetSenderSession) — skipping frame, keeping session', decryptError);
-            await this.retainOrDropUndecryptableFrame(
+            this.retainOrDropUndecryptableFrame(
               'Confirm',
               message,
               freshKeys.receiving_inbox
@@ -4037,10 +4100,12 @@ export class MessageService {
                 }
               );
               await this.deleteEncryptionStates({ conversationId });
-              await this.deleteInboxMessages(
+              // NOT awaited — dispatched after the state wipe above. This used to
+              // rethrow; it no longer can, so its .catch is the only signal.
+              this.dispatchInboxDelete(
                 freshKeys.receiving_inbox,
                 [message.timestamp],
-                this.apiClient
+                'delete-conversation reset signal (InboxDecrypt branch)'
               );
               return { outcome: 'handled' as const };
             }
@@ -4055,7 +4120,9 @@ export class MessageService {
               true
             );
             this.undecryptableFrames.clear(undecryptableKey);
-            await this.ackProcessedFrame(freshKeys.receiving_inbox, message.timestamp);
+            // NOT awaited: dispatched after the state save above, so it cannot
+            // extend this critical section. See dispatchInboxDelete.
+            this.ackProcessedFrame(freshKeys.receiving_inbox, message.timestamp);
             return {
               outcome: 'ok' as const,
               content,
@@ -4071,7 +4138,7 @@ export class MessageService {
             // encrypting to a session the receiver had torn down.
             // (https://signal.org/docs/specifications/doubleratchet/)
             logger.error('[MessageService] DM decrypt failed (DoubleRatchetInboxDecrypt) — skipping frame, keeping session', decryptError);
-            await this.retainOrDropUndecryptableFrame(
+            this.retainOrDropUndecryptableFrame(
               'InboxDecrypt',
               message,
               freshKeys.receiving_inbox


### PR DESCRIPTION
The DM receive path awaited relay HTTP while processing an inbound frame, so a slow `/inbox/delete` stalled everything queued behind it. This confirms that by measurement, fixes it, and proves the fix with the same instrument.

## The defect

`processInbound` (`WebsocketProvider.tsx:77`) guards itself with `inboundProcessingRef` and then awaits `handleNewMessage` **serially per inbox**. So any awaited relay call inside that handler is a head-of-line block on the inbox. `handleNewMessage` had **14** of them.

Six sat inside `dmRatchetMutex.runExclusive`, which made it worse: a DM's two directions share one `conversationId`, so both froze together.

## Why this needed fault injection

It cannot be tested against a healthy relay — a lock held across a fast POST is indistinguishable from one not held at all. Two clean 4-device runs proved exactly nothing. So `HARNESS_FAULT_DELETE_DELAY_MS` stalls a deterministic fraction of inbox-deletes, off unless set.

## Numbers — three runs, identical parameters, only the code changing

| | before | lock-only fix | complete fix |
|---|---|---|---|
| stalls injected | 50 of 1016 | 42 of 856 | **66 of 1327** |
| lock hold max | 31260ms | 655ms | **562ms** |
| queued max | 31173ms | 456ms | **394ms** |
| dev0/1/2/3 persisted | 97/50/25/23 | 79/38/30/23 | **100/100/100/100** |
| peer | 85/100 | 93/100 | **100/100** |
| novel decrypt failures | 246 | 121 | **0** |
| gap shape | CONTIGUOUS TAIL | CONTIGUOUS TAIL | **none** |

Frame arrival was 101/101, 0% loss in all three — this was never transport loss.

## The middle column is the point

Freeing the ratchet lock cut hold times 48x, emptied the warning bucket, typechecked clean and passed all 565 unit tests — **and the messages still vanished.** Every signal except the one that mattered said "fixed". The original model was too narrow; the lock is not the only serialization point and not the important one.

**The durable rule:** not "don't hold the lock across HTTP" but **"don't await the relay inside `handleNewMessage` at all."**

## Safety

- Ordering preserved: the encryption-state save is still awaited *before* each delete is dispatched, so a crash cannot lose a frame the relay would redeliver.
- All 14 are housekeeping issued once the frame is finished with; failure just means redelivery, which the code already relied on.
- Four callers used to rethrow and no longer can, so the `.catch` logging is the remaining signal. `MessageDB.deleteInboxMessages` already logs before rejecting.
- This is the shape mobile already uses and that desktop's own send paths use. Receive was the odd one out.

## Scope

Desktop only. Mobile never had this defect — its pattern is what this copies — so no mobile change is needed. **This does not explain the mobile to desktop or mobile to mobile field loss** (quorum-mobile#183 item 2); that stays open.

565 unit tests pass, 37 files. Typecheck clean.
