### PR TITLE
harness: mobile<->desktop DM delivery on one bench

### DIFF
--- a/.agents/docs/transport-measurements.md
+++ b/.agents/docs/transport-measurements.md
@@ -305,6 +305,42 @@ test that can actually fail (re-run this injection after the fix; expect no
 attention with the field investigation — it can be fixed and closed on its own
 evidence.
 
+### ⭐ Cross-platform (`dm-cross`) — the last empty cell in the 2×2
+
+| when | run | configuration | class | result | what it changed | source |
+|---|---|---|---|---|---|---|
+| 07-29 | `dm-cross` smoke | mobile↔desktop, 5 rounds, **20s settle** | — | 4/8 "delivered" | ⛔ **not a measurement** — settle far too short, and the gaps were at the HEAD not the tail. Recorded only so nobody re-derives it as a finding | run log |
+| 07-29 | `dm-cross` | **mobile↔desktop on one bench**, two processes/two repos, Node `ws`, WASM, fresh throwaways, 1 device each, 40 rounds each way, 180s settle | arrival | **mobile→desktop 40/40, 0.0%. desktop→mobile 39/40, missing only #1.** 79/80 total | ⭐ **the field's reported worst direction is CLEAN on the bench.** Completes the 2×2; no bench configuration now reproduces the field loss | run log `run-1785314457979` |
+
+**The single miss is message #1 in the echo direction, and that shape repeated in
+the smoke run.** Role `b` echoes the instant it receives round 1, which is the
+earliest possible moment in the reverse direction — before that direction's
+session is settled. Missing the **head** is the signature of session
+establishment; per-message transport loss does not preferentially eat message #1
+twice in a row. ⚠️ Recorded as a strong inference, not a demonstrated cause: it
+has not been isolated, and it is worth its own scenario (mobile's own notes
+already flag simultaneous-open as a real and separate mechanism).
+
+**What this closes.** Every cell of the platform matrix is now measured:
+
+| | desktop receiver | mobile receiver |
+|---|---|---|
+| **desktop sender** | 301/301, 201/201, 0% | **40/40, 0%** (this run, echo direction minus #1) |
+| **mobile sender** | **40/40, 0%** (this run) | 80/80, 0% |
+
+**No bench configuration reproduces the field loss** — including, now, the exact
+cross-platform direction the field complains about. Since all four benches share
+Node `ws` + WASM + fresh accounts, that combination is what they collectively
+exonerate, and the remaining suspects for round 29 are unchanged and sharpened:
+RN's native WebSocket write path, the uniffi bridge, aged real-account state, and
+device network conditions. **The client logic is not where this lives.**
+
+⚠️ One unexplained observation, recorded rather than dismissed: mobile persisted
+119 messages for 40 sent + 39 received, with its own outgoing texts appearing
+twice in the sample. Not loss, and it does not affect the join (the receiver's
+set is deduped by number), but it is unaccounted for and someone should find out
+why before quoting mobile's `persisted=` figure for anything.
+
 ### Mobile harness (`quorum-mobile`, `yarn harness:dm`)
 
 | when | run | configuration | class | result | what it changed | source |

--- a/.agents/docs/transport-reliability-index.md
+++ b/.agents/docs/transport-reliability-index.md
@@ -143,9 +143,19 @@ Consequently the live suspects for D remain undistinguished:
 3. real-account state: aged sessions, ghost devices, multi-device fan-out
 4. device network conditions
 
-**The cheapest experiment that would discriminate**, still not run:
-**mobile↔desktop on one bench** (§6 item 8) — the field's reported worst case, and
-the only cell no bench covers at all.
+✅ **That experiment has now been run (2026-07-29, `yarn harness:cross`).**
+mobile↔desktop on one bench, 40 rounds each way, 180s settle: **mobile→desktop
+40/40, 0.0%; desktop→mobile 39/40**, the single miss being message #1 in the echo
+direction (a session-open signature, not per-message loss — it recurred in the
+smoke run). **The field's reported worst direction is clean on the bench**, which
+completes the 2×2 and means *no* bench configuration reproduces the field loss.
+
+All four benches share Node `ws` + WASM + fresh accounts, so that combination is
+what they collectively exonerate — and the suspects above are unchanged but now
+carry the whole weight, because client logic no longer explains anything. **The
+cheapest remaining discriminator is no longer a bench**: it needs RN's native
+socket or an aged real account in the loop, which the harness cannot supply by
+construction.
 
 *(A previous version of this section also proposed running the mobile bench on the
 canonical accounts. That is now superseded and should NOT be done: it would

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "test": "vitest",
     "test:run": "vitest --run",
     "harness": "vitest --run --config vitest.harness.config.ts",
+    "harness:cross": "node src/dev/tests/harness/run-cross.mjs",
     "mobile": "cd mobile && expo start --dev-client",
     "mobile:clear": "cd mobile && expo start --dev-client --clear",
     "mobile:tunnel": "cd mobile && expo start --dev-client --tunnel",

--- a/src/dev/tests/harness/dm-cross.scenario.test.ts
+++ b/src/dev/tests/harness/dm-cross.scenario.test.ts
@@ -1,0 +1,161 @@
+// mobile↔desktop DM delivery — the one configuration no bench has ever covered.
+//
+//   yarn harness:cross
+//
+// ── Why this exists ─────────────────────────────────────────────────────────
+//
+// The field evidence says loss is worse **mobile→desktop and mobile→mobile than
+// desktop→desktop** (`tasks/2026-07-27-cross-platform-dm-harness.md`). Every
+// bench to date measures one platform talking to itself:
+//
+//   desktop↔desktop   301/301, 201/201, 0%      (dm-loss)
+//   mobile↔mobile     80/80, 0%                 (quorum-mobile yarn harness:dm)
+//   mobile↔desktop    NEVER RUN                 <- this file
+//
+// So the cell the field actually complains about is the cell with no data. That
+// is what this closes. It does NOT close quorum-mobile#183 item 2 (node-side
+// write loss) — see §7 of the solved ratchet-lock bug for why those are
+// different layers.
+//
+// ── How the pairing works ───────────────────────────────────────────────────
+//
+// This is HALF of a run. `run-cross.mjs` starts mobile's existing
+// `dm-two-bot` jest scenario as one role and this file as the other, sharing a
+// HARNESS_RUN_ID and a rendezvous directory. quorum-mobile needs NO changes —
+// this side simply speaks its protocol. See rendezvous.ts for why two processes
+// rather than the single-process bundle slice 4 originally specced.
+//
+// ⚠️ Skipped unless HARNESS_ROLE is set, so a plain `yarn harness` (which runs
+// every scenario) does not hang here waiting for a peer that was never started.
+import { test, expect } from 'vitest';
+import { createBot } from './bot';
+import {
+  awaitPeer,
+  label,
+  parseLabel,
+  peerOf,
+  publish,
+  waitUntil,
+  type Hello,
+  type Role,
+} from './rendezvous';
+import { RunLog } from './log';
+
+const ROLE = (process.env.HARNESS_ROLE ?? '') as Role;
+// These MUST match what mobile reads, because both sides derive `endAt` from
+// them independently. run-cross.mjs sets them once and both children inherit.
+const ROUNDS = Number(process.env.HARNESS_ROUNDS ?? 20);
+const SEND_INTERVAL_MS = Number(process.env.HARNESS_SEND_INTERVAL_MS ?? 1500);
+const SETTLE_MS = Number(process.env.HARNESS_SETTLE_MS ?? 20_000);
+
+const paired = ROLE === 'a' || ROLE === 'b';
+
+test.skipIf(!paired)(
+  'dm-cross: desktop exchanges DMs with a mobile bot in another process',
+  async () => {
+    const startedAt = Date.now();
+    const log = new RunLog(`dm-cross-${ROLE}`, startedAt);
+    const say = (msg: string, fields: Record<string, unknown> = {}) => {
+      console.log(`[dm-cross ${ROLE}] ${msg}`);
+      log.add(Date.now(), 'harness', 'note', { msg, ...fields });
+    };
+    const peer = peerOf(ROLE);
+
+    const bot = await createBot(`cross-desktop-${ROLE}-${String(startedAt).slice(-6)}`);
+    await bot.start();
+
+    // Stale frames from an earlier run would be counted as this run's arrivals.
+    const drained = await bot.drainInbox();
+    if (drained > 0) say(`drained ${drained} stale frame(s) before starting`);
+
+    publish(ROLE, 'hello', {
+      address: bot.identity.address,
+      inboxAddress: bot.identity.inboxAddress,
+      readyAt: Date.now(),
+    } satisfies Hello);
+
+    const theirs = await awaitPeer<Hello>(ROLE, 'hello');
+    const mine = { readyAt: Date.now() };
+
+    // Both sides derive the SAME instant from the SAME two numbers, so neither
+    // starts before the other is listening. A bot that began early would post to
+    // an unsubscribed inbox and count it as loss. Mobile computes this
+    // identically — do not change one side alone.
+    const startAt = Math.max(theirs.readyAt, mine.readyAt) + 5_000;
+    const endAt = startAt + ROUNDS * SEND_INTERVAL_MS + SETTLE_MS;
+
+    say(
+      `me=${bot.identity.address.slice(0, 12)} peer(mobile)=${theirs.address.slice(0, 12)} ` +
+        `rounds=${ROUNDS}`,
+      { role: ROLE, rounds: ROUNDS }
+    );
+
+    const sentByMe: number[] = [];
+    const receivedFromPeer = new Set<number>();
+
+    const trySend = async (n: number) => {
+      try {
+        await bot.send(theirs.address, label(ROLE, n));
+        sentByMe.push(n);
+      } catch (err) {
+        // A send that THREW is a different failure from a message that vanished
+        // silently; conflating them would misattribute the loss.
+        say(`send #${n} threw: ${(err as Error).message}`);
+      }
+    };
+
+    bot.onDecrypted = (m) => {
+      const text = m.content?.type === 'post' ? (m.content.text ?? '') : '';
+      const tag = text ? parseLabel(text) : null;
+      // Only the PEER's messages count. This seam also fires for our own
+      // outgoing messages, which would otherwise inflate the count to a perfect
+      // score no matter what the wire did.
+      if (!tag || tag.from !== peer) return;
+      const isNew = !receivedFromPeer.has(tag.n);
+      receivedFromPeer.add(tag.n);
+      // B answers each DISTINCT message once. Replying on a redelivery would
+      // send the same number twice and corrupt the sent list.
+      if (ROLE === 'b' && isNew) void trySend(tag.n);
+    };
+
+    await waitUntil(startAt);
+
+    // ONE initiator, mirroring mobile exactly. Both sides sending from the same
+    // instant looked natural and was wrong: it opens sessions in both directions
+    // at once, and a 25-round run failed all 50 messages on X3DH while every
+    // frame arrived intact. That is a session-establishment race, not transport
+    // loss, and mixing the two makes the number meaningless. So A initiates and
+    // B echoes — both directions still traverse the wire independently.
+    if (ROLE === 'a') {
+      for (let n = 1; n <= ROUNDS; n++) {
+        await trySend(n);
+        await waitUntil(startAt + n * SEND_INTERVAL_MS);
+      }
+    }
+
+    await waitUntil(endAt);
+
+    publish(ROLE, 'result', {
+      role: ROLE,
+      address: bot.identity.address,
+      sent: sentByMe,
+      received: [...receivedFromPeer].sort((x, y) => x - y),
+    });
+
+    say(
+      `sent=${sentByMe.length}/${ROLE === 'a' ? ROUNDS : receivedFromPeer.size} ` +
+        `received=${receivedFromPeer.size}  novel decrypt failures=${bot.novelErrors().length}`,
+      { sent: sentByMe.length, received: receivedFromPeer.size }
+    );
+    console.log(`[dm-cross ${ROLE}] log: ${log.file}`);
+
+    bot.stop();
+
+    // Deliberately weak: run-cross.mjs owns the loss verdict, because neither
+    // side can compute it alone — loss is one side's sends against the other
+    // side's arrivals. Asserting delivery here would turn a genuine product
+    // finding into a red test that gets "fixed" by relaxing it.
+    expect(paired).toBe(true);
+  },
+  60 * 60 * 1000
+);

--- a/src/dev/tests/harness/rendezvous.ts
+++ b/src/dev/tests/harness/rendezvous.ts
@@ -1,0 +1,127 @@
+// File-based pairing with a bot living in ANOTHER REPO's process.
+//
+// ── Why this shape, and not the one slice 4 specced ─────────────────────────
+//
+// `tasks/2026-07-27-cross-platform-dm-harness.md` slice 4 proposed bundling
+// mobile's bot into a Node ESM artifact and running both bots in ONE desktop
+// process. Two things that landed after it was written make that wrong:
+//
+//   1. Slice 2 (extract mobile's DM core) was deliberately NOT done. Mobile's
+//      receive path is ~4000 lines of useCallback INSIDE WebSocketProvider, so
+//      its bot RENDERS the provider via react-test-renderer rather than
+//      extracting it. Bundling would drag React, react-test-renderer,
+//      react-query, mobile's context layer and five native shims into desktop's
+//      jsdom vitest — exactly the failure the slice-4 spec predicted of itself
+//      ("the bundle won't build small (or at all)"). Mobile also has no bundler
+//      installed, so it would mean a new dependency and a lockfile change the
+//      task worked hard to avoid.
+//   2. Slices 1-3 established that two bots CANNOT share a process: lazy
+//      `require()`s run after jest's module isolation closes and resolve against
+//      the shared registry, silently fusing the two devices being compared.
+//      "Bots get one process each" is a finding, not a preference.
+//
+// So the pair is two processes in two repos, coordinated through disk, talking
+// over the real relay — the shape mobile already uses for its own two bots. The
+// cost is the spec's "one clock, one merged log"; both sides already emit
+// timestamped JSONL, so merging is post-processing rather than architecture.
+//
+// ⚠️ This MUST stay wire-compatible with
+// `quorum-mobile/dev/harness/rendezvous.ts`. Mobile runs its existing scenario
+// unchanged, so any drift here breaks the pairing with a timeout rather than a
+// useful error.
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+export type Role = 'a' | 'b';
+
+export const peerOf = (role: Role): Role => (role === 'a' ? 'b' : 'a');
+
+/**
+ * The shared directory, which lives in quorum-mobile because mobile's
+ * orchestrator owns the layout. Defaults to the sibling checkout; override when
+ * the repos are not siblings.
+ *
+ * ⚠️ This deliberately points INTO quorum-mobile rather than keeping a desktop
+ * copy. One directory IS the coordination mechanism — two would pair each bot
+ * with itself and report a clean run that never happened.
+ */
+const ROOT =
+  process.env.HARNESS_RENDEZVOUS_ROOT ??
+  resolve(HERE, '../../../..', '..', 'quorum-mobile/dev/harness/.state/rendezvous');
+
+function runDir(): string {
+  const id = process.env.HARNESS_RUN_ID;
+  if (!id) {
+    throw new Error(
+      '[harness] HARNESS_RUN_ID is not set. dm-cross is started by ' +
+        'src/dev/tests/harness/run-cross.mjs, which sets it and spawns BOTH sides. ' +
+        'Run `yarn harness:cross` rather than invoking this scenario directly — on ' +
+        'its own it has no peer and would wait out its timeout.'
+    );
+  }
+  return resolve(ROOT, id);
+}
+
+const filePath = (role: Role, kind: string) => resolve(runDir(), `${role}.${kind}.json`);
+
+export function publish(role: Role, kind: string, data: unknown): void {
+  mkdirSync(runDir(), { recursive: true });
+  writeFileSync(filePath(role, kind), JSON.stringify(data, null, 2), 'utf8');
+}
+
+export function read<T>(role: Role, kind: string): T | null {
+  const p = filePath(role, kind);
+  if (!existsSync(p)) return null;
+  try {
+    return JSON.parse(readFileSync(p, 'utf8')) as T;
+  } catch {
+    // A torn read costs one poll tick, not a bad pairing — mobile's choice, kept.
+    return null;
+  }
+}
+
+/** Poll until the peer publishes `kind`, or fail with a diagnosable message. */
+export async function awaitPeer<T>(role: Role, kind: string, timeoutMs = 180_000): Promise<T> {
+  const peer = peerOf(role);
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const value = read<T>(peer, kind);
+    if (value) return value;
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  throw new Error(
+    `[harness] role ${role} waited ${timeoutMs}ms for peer ${peer}'s "${kind}" and it never ` +
+      `appeared. The peer runs in the OTHER repo, so its failure is NOT in this ` +
+      `output — read the quorum-mobile jest run. Rendezvous dir: ${runDir()}`
+  );
+}
+
+/** Sleep until an absolute epoch ms, so both sides start their loop together. */
+export async function waitUntil(epochMs: number): Promise<void> {
+  const delta = epochMs - Date.now();
+  if (delta > 0) await new Promise((r) => setTimeout(r, delta));
+}
+
+/** MUST match quorum-mobile/dev/harness/dm-two-bot.scenario.ts. */
+export interface Hello {
+  address: string;
+  inboxAddress: string;
+  readyAt: number;
+}
+
+/**
+ * `A→B #7` / `B→A #7`, byte-identical to mobile's `label()`.
+ *
+ * ⚠️ The arrow is U+2192, NOT '->'. Mobile parses with /^([AB])→[AB] #(\d+)$/,
+ * so an ASCII arrow here would send messages that arrive and decrypt perfectly
+ * and count as zero — the worst possible failure, because it looks like loss.
+ */
+export const label = (from: Role, n: number) => (from === 'a' ? `A→B #${n}` : `B→A #${n}`);
+
+export const parseLabel = (text: string): { from: Role; n: number } | null => {
+  const m = /^([AB])→[AB] #(\d+)$/.exec(text);
+  return m ? { from: m[1] === 'A' ? 'a' : 'b', n: Number(m[2]) } : null;
+};

--- a/src/dev/tests/harness/run-cross.mjs
+++ b/src/dev/tests/harness/run-cross.mjs
@@ -1,0 +1,150 @@
+// Orchestrator for the mobile↔desktop DM measurement.
+//
+//   yarn harness:cross
+//
+// Starts TWO processes in TWO repos — mobile's existing `dm-two-bot` jest
+// scenario as one role, desktop's `dm-cross` vitest scenario as the other —
+// pairs them through a shared run directory, then matches each side's sends
+// against the other's arrivals.
+//
+// The loss verdict lives here rather than in either scenario because neither bot
+// can compute it alone: each knows only what it sent and what it received.
+//
+// ⚠️ quorum-mobile is NOT modified. This drives its existing scenario by env
+// var, exactly as its own `run-two-bots.mjs` does.
+import { spawn } from 'node:child_process';
+import { existsSync, readFileSync, readdirSync, rmSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const DESKTOP_REPO = resolve(HERE, '../../../..');
+const MOBILE_REPO = resolve(DESKTOP_REPO, '..', 'quorum-mobile');
+// Must match BOTH rendezvous.ts files. Mobile owns the layout because its
+// orchestrator defined it first; desktop's rendezvous.ts points here too.
+const RENDEZVOUS_ROOT = resolve(MOBILE_REPO, 'dev/harness/.state/rendezvous');
+
+// Which platform initiates. Role 'a' initiates and 'b' echoes (see either
+// scenario for why one-initiator matters), so this decides whether we measure
+// mobile→desktop first or the reverse. Default puts MOBILE as the initiator,
+// because mobile→desktop is the field's reported bad direction.
+const DESKTOP_ROLE = process.env.HARNESS_DESKTOP_ROLE === 'a' ? 'a' : 'b';
+const MOBILE_ROLE = DESKTOP_ROLE === 'a' ? 'b' : 'a';
+
+if (!existsSync(MOBILE_REPO)) {
+  console.error(
+    `[cross] FAIL — quorum-mobile not found at ${MOBILE_REPO}.\n` +
+      `        The two repos must be siblings, or set HARNESS_MOBILE_REPO.`
+  );
+  process.exit(1);
+}
+
+const runId = `run-${Date.now()}`;
+
+// Pruned here, not in a scenario: a scenario cannot know whether a sibling
+// directory belongs to a live peer or a dead one.
+if (existsSync(RENDEZVOUS_ROOT)) {
+  for (const entry of readdirSync(RENDEZVOUS_ROOT)) {
+    if (entry !== runId) rmSync(resolve(RENDEZVOUS_ROOT, entry), { recursive: true, force: true });
+  }
+}
+
+// Both sides derive `endAt` from these independently, so they MUST be identical
+// on both children. Set once here; the children inherit.
+const shared = {
+  HARNESS_RUN_ID: runId,
+  HARNESS_ROUNDS: process.env.HARNESS_ROUNDS ?? '20',
+  HARNESS_SEND_INTERVAL_MS: process.env.HARNESS_SEND_INTERVAL_MS ?? '1500',
+  HARNESS_SETTLE_MS: process.env.HARNESS_SETTLE_MS ?? '20000',
+  HARNESS_RENDEZVOUS_ROOT: RENDEZVOUS_ROOT,
+};
+
+function start(label, cwd, command, args, role) {
+  const child = spawn(command, args, {
+    cwd,
+    env: { ...process.env, ...shared, HARNESS_ROLE: role },
+    shell: true,
+  });
+  // Both children share a terminal, so tag every line. Without this an
+  // interleaved failure is very hard to attribute to a side — and here the two
+  // sides are different test runners in different repos.
+  const tag = (stream) => {
+    let buffered = '';
+    stream.on('data', (chunk) => {
+      buffered += chunk.toString();
+      const lines = buffered.split('\n');
+      buffered = lines.pop() ?? '';
+      for (const line of lines) console.log(`[${label}] ${line}`);
+    });
+  };
+  tag(child.stdout);
+  tag(child.stderr);
+  return new Promise((res) => child.on('close', (code) => res({ label, role, code })));
+}
+
+console.log(
+  `[cross] run ${runId} — mobile=role ${MOBILE_ROLE}, desktop=role ${DESKTOP_ROLE} ` +
+    `(role 'a' initiates, 'b' echoes)`
+);
+console.log(`[cross] rounds=${shared.HARNESS_ROUNDS} rendezvous=${RENDEZVOUS_ROOT}`);
+
+const outcomes = await Promise.all([
+  start('mobile', MOBILE_REPO, 'npx', ['jest', '--config', 'jest.harness.config.js', 'dm-two-bot'], MOBILE_ROLE),
+  start('desktop', DESKTOP_REPO, 'npx', ['vitest', '--run', '--config', 'vitest.harness.config.ts', 'dm-cross'], DESKTOP_ROLE),
+]);
+
+for (const { label, code } of outcomes) {
+  if (code !== 0) console.log(`[cross] ${label} exited ${code}`);
+}
+
+const readResult = (role) => {
+  const p = resolve(RENDEZVOUS_ROOT, runId, `${role}.result.json`);
+  return existsSync(p) ? JSON.parse(readFileSync(p, 'utf8')) : null;
+};
+
+const a = readResult('a');
+const b = readResult('b');
+
+if (!a || !b) {
+  console.error(
+    `[cross] FAIL — missing results (a=${!!a} b=${!!b}). A side crashed before ` +
+      `publishing; read that side's tagged output above. No loss figure is ` +
+      `reported, because a partial run cannot produce an honest one.`
+  );
+  process.exit(1);
+}
+
+// Delivered = the RECEIVER recorded the number. The receiver's set is deduped,
+// so relay redelivery cannot inflate it.
+function direction(from, to, label) {
+  const sent = from.sent.length;
+  const got = to.received.filter((n) => from.sent.includes(n)).length;
+  const missing = from.sent.filter((n) => !to.received.includes(n));
+  const pct = sent === 0 ? 0 : ((sent - got) / sent) * 100;
+  console.log(
+    `[cross] ${label}: sent=${sent} arrived=${got} loss=${pct.toFixed(1)}%` +
+      (missing.length ? `  missing=[${missing.join(',')}]` : '')
+  );
+  return { sent, missing };
+}
+
+const platformOf = (role) => (role === MOBILE_ROLE ? 'mobile' : 'desktop');
+
+console.log('');
+console.log(`[cross] run ${runId}`);
+const ab = direction(a, b, `${platformOf('a')}→${platformOf('b')}`);
+const ba = direction(b, a, `${platformOf('b')}→${platformOf('a')}`);
+
+const lost = ab.missing.length + ba.missing.length;
+const total = ab.sent + ba.sent;
+console.log(`[cross] total: ${total - lost}/${total} delivered`);
+
+if (total === 0) {
+  console.error('[cross] FAIL — nothing was sent; this measured nothing.');
+  process.exit(1);
+}
+if (lost > 0) {
+  console.error(`[cross] LOSS DETECTED — ${lost}/${total} messages did not arrive.`);
+  process.exit(1);
+}
+console.log('[cross] no loss.');


### PR DESCRIPTION
Adds `yarn harness:cross`, which measures mobile↔desktop DM delivery — the one cell of the platform matrix no bench has ever covered, and one of the two directions the field reports as unreliable.

It starts mobile's existing `dm-two-bot` jest scenario and desktop's new `dm-cross` vitest scenario as two processes in two repos, pairs them through mobile's file rendezvous, exchanges numbered DMs over the production relay, and matches each side's sends against the other's arrivals for one merged verdict.

**quorum-mobile is not modified.** It is driven by env var through its existing scenario, exactly as its own orchestrator does.

## Not the design slice 4 specced, deliberately

The spec called for bundling mobile's bot into desktop and running both in one process. Two things make that unworkable, and both are recorded in `rendezvous.ts` so the next reader isn't confused by the spec saying otherwise:

- Slice 2 (extract mobile's DM core) was never done, on purpose. Mobile's receive path lives inside `WebSocketProvider`, so its bot renders the provider via `react-test-renderer`. Bundling would drag React, react-test-renderer, react-query and five native shims into desktop's jsdom vitest — the failure that spec predicted of itself. Mobile also has no bundler, so it would mean a new dependency and a lockfile change.
- Slices 1-3 established that two bots cannot share a process: lazy `require()`s resolve against the shared registry after jest's module isolation closes, silently fusing the two devices being compared.

Two processes coordinated through disk satisfies that constraint instead of fighting it. The cost is the spec's "one clock, one merged log"; both sides already emit timestamped JSONL, so merging is post-processing.

## First measurement — 40 rounds each way, 180s settle

```
mobile -> desktop   40/40   0.0% loss
desktop -> mobile   39/40   missing only #1
                    79/80 total
```

The field's reported worst direction is clean. The single miss is message #1 in the echo direction, and the same head-not-tail shape recurred in a shorter smoke run — the signature of session establishment rather than per-message loss. Recorded as inference, not demonstrated cause; it deserves its own scenario.

This completes the 2×2, and **no bench configuration now reproduces the field loss**. All four benches share Node `ws` + WASM + fresh accounts, which is exactly what they collectively exonerate. The remaining suspects for quorum-mobile#183 item 2 are unchanged but now carry the whole weight: RN's native WebSocket write path, the uniffi bridge, aged real-account state, device network conditions. The cheapest remaining discriminator is no longer a bench.

## Notes

- The scenario skips unless `HARNESS_ROLE` is set, so a plain `yarn harness` does not hang waiting for a peer that was never started.
- The 5-round smoke numbers are recorded in the measurement log explicitly as **not** a measurement, so nobody re-derives a loss finding from them.
- One unexplained observation is recorded rather than dropped: mobile persisted 119 messages for 40 sent + 39 received. It does not affect the join, but it should be understood before quoting mobile's `persisted=` figure.
