### PR TITLE
harness: measure persistence on aged accounts, and detect stalls the histogram cannot see

### DIFF
--- a/.agents/bugs/2026-07-29-session-replacement-destroys-in-flight-frames.md
+++ b/.agents/bugs/2026-07-29-session-replacement-destroys-in-flight-frames.md
@@ -1,0 +1,140 @@
+---
+type: bug
+title: "A session replacement deletes the old encryption state, and every frame already addressed to the old inbox is then dropped AND deleted from the relay — permanent, silent message loss"
+status: OPEN — MECHANISM CONFIRMED FROM PRODUCTION LOGS AND CODE, NOT YET FIXED. Two safe-looking behaviours combine into unrecoverable data loss: replacing a session **deletes** the previous encryption state rows immediately (`MessageService.ts:3593-3595`), and a frame arriving for an inbox with no state is **deleted from the relay** rather than retained (`MessageService.ts:3868-3885`). Any frame in flight to the old inbox at the moment of replacement is therefore destroyed with no error and no possibility of redelivery. Measured in the operator's own desktop console: **36 session replacements, 366 destroyed frames, ~10 per replacement** — which matches the long-standing "~10 of 200 messages arrived" field observation.
+created: 2026-07-29
+severity: HIGH — silent, permanent loss of user messages. No error surfaces, the sender believes it delivered, and the frame is removed from the relay so redelivery can never recover it. This is the loss class the investigation has been chasing for six months.
+repo: quorum-desktop (mobile NOT yet checked — see §6)
+area: DM receive path / session lifecycle / init envelopes
+related:
+  - ".agents/docs/transport-measurements.md (the bench runs that could not see this)"
+  - ".agents/docs/transport-reliability-index.md"
+  - ".agents/bugs/.solved/2026-07-28-dm-receive-holds-ratchet-lock-across-http.md (a different defect in the same handler)"
+  - "quorum-mobile#183 (upstream; this is CLIENT-side and does NOT explain item 2)"
+---
+
+# Session replacement destroys every frame in flight to the old inbox
+
+## §1. The two behaviours that combine
+
+Neither is obviously wrong alone. Together they guarantee loss.
+
+**(a) Replacing a session deletes the old state immediately.** When an init
+envelope installs a new session, `MessageService.ts:3593-3595`:
+
+```js
+logger.warn('[MessageService] ⚠️ SESSION REPLACED by init envelope', { … });
+for (const e of existing) {
+  await this.messageDB.deleteEncryptionState(e);   // ← the old rows are GONE
+}
+// … then a new state is saved under a NEW receiving inbox:
+await this.messageDB.saveEncryptionState({ …, inboxId: inbox_key.inbox_address, … }, true);
+```
+
+The new session gets a **new receiving inbox address**. The old inbox is now
+unknown to this client.
+
+**(b) A frame for an unknown inbox is deleted from the relay.** The receive path
+looks a frame up by the inbox it arrived on (`const found = states[message.inboxAddress]`,
+`MessageService.ts:3431`), and when there is no state (`:3868`):
+
+```js
+logger.warn('[MessageService] DM frame for unknown inbox — no encryption state, dropping unread', { … });
+this.dispatchInboxDelete(…);   // ← POST /inbox/delete: the frame is destroyed
+return;
+```
+
+## §2. Why that is unrecoverable
+
+The relay is the only copy. Deleting the frame there means it can never be
+redelivered, so the message is **permanently gone**. Nothing surfaces to either
+user: the sender's send succeeded, the receiver logs a warning nobody reads, and
+the message simply never exists.
+
+The peer keeps sending to the old inbox because a session replacement is
+**one-sided** — the replacing side mints a new receiving inbox and the peer is not
+told until it learns otherwise. Every frame sent in that window is destroyed on
+arrival.
+
+## §3. Measured in production, not inferred
+
+From the operator's desktop console during a live bench run (their account is the
+receiver; account A is the harness):
+
+```
+366   DM frame for unknown inbox — no encryption state, dropping unread
+ 36   ⚠️ SESSION REPLACED by init envelope
+```
+
+- **Exactly two distinct inbox addresses** account for all 366 drops, **183 each** —
+  perfectly symmetric, so this is structural, not sampling loss.
+- The ordering is decisive: a burst of **35 replacements**, then 2 drops, then one
+  more replacement, then **364 consecutive drops**. Everything after the last
+  replacement was destroyed.
+- **~10 frames destroyed per replacement**, which is the same magnitude as the
+  operator's long-standing field observation of *"~10 of 200 messages arrived on
+  one desktop, 0 of 200 on the other"*.
+- All replacements name one `conversationId`, and the envelopes are fresh
+  (`envelopeAgeSeconds: -1, 0, 1`) — these are live replacements, not zombies.
+
+## §4. Why every bench missed it
+
+Six months of benches reported 0% loss because of what they measured:
+
+| bench | what it counted | why it was blind |
+|---|---|---|
+| `dm-loss` | frames arriving at the socket | the frame DOES arrive — it is destroyed after arrival |
+| `dm-multidevice` | messages persisted per device | catches the symptom, but only on a device that hits a replacement |
+| all of them | fresh throwaway accounts, one session, no resets | **a session replacement never happens**, so the trigger is absent |
+
+The trigger is *session churn*, and a clean bench with a single stable session has
+none. This is why the operator's real, aged, multi-device accounts fail where every
+generated account is perfect.
+
+⚠️ **Honest confound about the 36 replacements in §3:** repeated harness runs
+against that account almost certainly caused most of them, because each run's bots
+re-establish sessions. **Do not quote "production churns sessions 36 times."** What
+the log establishes is the *mechanism* — that a replacement destroys in-flight
+frames — not the natural rate of replacement. The rate needs measuring separately.
+
+## §5. The fix — attack (a), not (b)
+
+**Retaining the frame is not enough.** If the old state is gone forever, a retained
+frame is redelivered, fails the same lookup, and is deleted when its retry budget
+runs out. The message still dies, just later.
+
+**The real fix is to stop deleting the replaced session state.** The old ratchet
+state can still decrypt frames encrypted to the old session, so keeping it for a
+grace period recovers exactly the frames that are currently destroyed. Sketch:
+
+1. On replacement, **retain** the previous rows (mark superseded, keep the keys)
+   rather than `deleteEncryptionState`.
+2. Keep the old inbox in the subscription list while retained, so the frames are
+   still delivered to us.
+3. Expire retained sessions on a bound (age or count), not immediately.
+4. Independently, make the unknown-inbox branch **retain rather than delete** —
+   defence in depth, and it converts any remaining case from permanent loss into
+   delayed delivery.
+
+This is the same philosophy as the already-shipped `c0635f965 fix: stop deleting
+DM frames that would decrypt moments later` — applied to session *state* instead of
+to frames.
+
+⚠️ Do NOT simply stop replacing sessions. Replacement exists for real reasons
+(resets, re-inits) and suppressing it would resurrect the bugs it was added to fix.
+
+## §6. Not yet checked
+
+- **Mobile.** Whether `quorum-mobile` has the same delete-on-replace and
+  delete-on-unknown-inbox pair is unexamined. It must be checked before any claim
+  about cross-platform scope.
+- **The natural replacement rate** in ordinary use, without a harness hammering the
+  account (see §4's confound).
+- **Why so many init envelopes arrive at all.** Reducing replacement frequency is a
+  separate, possibly larger, question — the loss on each replacement is the bug
+  filed here.
+- This does **not** explain quorum-mobile#183 item 2 (frames never arriving at all).
+  That is upstream of arrival; this is entirely downstream of it.
+
+---
+*Last updated: 2026-07-29*

--- a/.agents/bugs/2026-07-29-session-replacement-strands-in-flight-frames.md
+++ b/.agents/bugs/2026-07-29-session-replacement-strands-in-flight-frames.md
@@ -1,9 +1,9 @@
 ---
 type: bug
 title: "A session replacement deletes the old encryption state, and every frame already addressed to the old inbox is then dropped AND deleted from the relay — permanent, silent message loss"
-status: OPEN — MECHANISM CONFIRMED FROM PRODUCTION LOGS AND CODE, NOT YET FIXED. Two safe-looking behaviours combine into unrecoverable data loss: replacing a session **deletes** the previous encryption state rows immediately (`MessageService.ts:3593-3595`), and a frame arriving for an inbox with no state is **deleted from the relay** rather than retained (`MessageService.ts:3868-3885`). Any frame in flight to the old inbox at the moment of replacement is therefore destroyed with no error and no possibility of redelivery. Measured in the operator's own desktop console: **36 session replacements, 366 destroyed frames, ~10 per replacement** — which matches the long-standing "~10 of 200 messages arrived" field observation.
+status: OPEN — PARTIALLY CONFIRMED, AND THIS FILE'S ORIGINAL CLAIM WAS WRONG IN ONE IMPORTANT WAY. ⚠️ **Corrected 2026-07-29 after independent adversarial review — read §7 before anything else.** What holds: session replacement orphans the receiving inbox (`MessageService.ts:3593-3616`), and **366 distinct messages** (verified distinct by frame timestamp) hit the no-state branch and were never persisted. What is WRONG: the original claim that those frames are *permanently destroyed*. The `!found` branch signs and addresses its delete with the **device** inbox (`keyset.deviceKeyset.inbox_keyset`, `MessageService.ts:3881`) while the frame sits in a **session** inbox, so it asks the relay to delete from the wrong mailbox and the frame is almost certainly untouched. Messages are **not delivered but probably still recoverable server-side**.
 created: 2026-07-29
-severity: HIGH — silent, permanent loss of user messages. No error surfaces, the sender believes it delivered, and the frame is removed from the relay so redelivery can never recover it. This is the loss class the investigation has been chasing for six months.
+severity: MEDIUM-HIGH — user-visible message loss (366 messages not persisted in one capture, silently, with no error to either party), but **downgraded from the original HIGH**: the data is probably not destroyed, only stranded. Re-rate upward if the relay is shown to expire or drop stranded frames.
 repo: quorum-desktop (mobile NOT yet checked — see §6)
 area: DM receive path / session lifecycle / init envelopes
 related:
@@ -135,6 +135,100 @@ to frames.
   filed here.
 - This does **not** explain quorum-mobile#183 item 2 (frames never arriving at all).
   That is upstream of arrival; this is entirely downstream of it.
+
+## §7. ⚠️ CORRECTIONS from independent adversarial review (2026-07-29)
+
+This section supersedes the claims above where they conflict. §1-§6 are left as
+written so the reasoning error is legible rather than quietly erased.
+
+### 7.1 The delete targets the WRONG INBOX — frames are stranded, not destroyed
+
+The single most important correction. At `MessageService.ts:3881` the `!found`
+branch calls:
+
+```js
+this.dispatchInboxDelete(keyset.deviceKeyset.inbox_keyset, [message.timestamp], …);
+```
+
+`deleteInboxMessages` builds its payload from that keyset —
+`inbox_address: inboxKeyset.inbox_address` (`MessageDB.tsx:317-322`) — i.e. the
+**device** inbox. But the frame arrived on `message.inboxAddress`, a **session**
+inbox; the device-inbox case already returned earlier (`:3434`). So the request
+names a mailbox the frame is not in.
+
+**Consequences:**
+
+- **"Permanently destroyed" (§2) is wrong.** The frames are very probably still on
+  the relay. Severity drops accordingly, and the messages may be recoverable once
+  the state problem is fixed.
+- **The code's own comment is false.** *"Keep the delete (leaving the frame would
+  redeliver it forever)"* — the delete does not work, so the frame does redeliver
+  forever. The stated intent is not achieved.
+- Mobile hit this exact bug and fixed it: `deleteProcessedEnvelope`
+  (`quorum-mobile/context/WebSocketContext.tsx:182-201`) explicitly picks the
+  signing key matching the inbox type, with a comment recording that using the
+  wrong one *"fails signature verification server-side and the envelope redelivers
+  forever — observed as an endless storm."*
+
+### 7.2 The 366 count is NOT inflated — checked, not assumed
+
+The reviewer proposed that 366 log lines might be a small set of frames re-logged
+on redelivery, citing this investigation's own rule to de-duplicate by fingerprint
+before reasoning. That rule was skipped when filing, which was a real methodological
+error.
+
+**Checked against the log: 366 lines, 366 distinct frame timestamps, each appearing
+exactly once.** No inflation. The count in §3 stands.
+
+### 7.3 The "~10 of 200" corroboration is NOT discriminating — retracted
+
+§3 leaned on the ratio matching the field observation. That is not evidence for
+*this* mechanism: the already-solved ratchet-lock bug explains the same observation
+(`.solved/2026-07-28-…-ratchet-lock-across-http.md` §7), and it was confirmed by
+fault injection. Reaching for a number that fits and treating the fit as support is
+the reasoning error this investigation has repeated several times. **Do not cite
+the ~10 ratio as support for this bug.**
+
+### 7.4 The §5 fix is broken as written
+
+The replace path selects rows by **tag alone** and unconditionally deletes every
+match (`MessageService.ts:3540-3542`, `:3593-3595`). Retained-but-superseded rows
+would be swept by the *next* replacement — and §3's own evidence is a burst of 35
+replacements. The proposed grace period would be nullified by exactly the churn
+cited to justify it. Any retention scheme must change what `existing` selects, not
+just mark rows.
+
+Also raised, and worth carrying:
+- Retaining superseded ratchet material widens a forward-secrecy window; Divergence 1
+  deliberately argues the opposite tradeoff.
+- No GC is proposed. `bugs/2025-12-09-encryption-state-evals-bloat.md` records ~16MB
+  of orphaned states from a structurally identical omission.
+- Four session-**prune** sites could sweep retained rows; the interaction is unexamined.
+
+### 7.5 Revised fix direction — smaller and better targeted
+
+**Fix the delete's inbox first** (mobile's pattern: address and sign for the inbox
+the frame actually arrived on, or do not attempt a server-side delete at all), and
+retain locally with a bounded skip-list. That is a far smaller change than
+retaining ratchet state across six call sites, and it targets the mechanism that is
+actually broken rather than the one originally hypothesised.
+
+### 7.6 Mobile — confirmed unaffected, with better evidence
+
+Mobile keeps a **persistent per-conversation inbox keypair** distinct from the
+ratchet state (`WebSocketContext.tsx:2735`, `:2901`), so replacement swaps ratchet
+material without minting a new receiving address — the orphaning precondition never
+exists. It also trial-decrypts against every stored state (`:2960-2988`) rather than
+a single keyed lookup, and on total failure calls `recordInboxAttempt` and returns
+**without** any server-side delete (`:2990-3009`). **No mobile change needed.**
+
+### 7.7 Still unproven
+
+- Whether the relay accepts or rejects the mismatched delete (relay source is not in
+  this repo). Settles by logging the response status in `dispatchInboxDelete`.
+- Whether stranded frames actually redeliver, and whether a redelivery storm could
+  starve fresh traffic — mobile documented exactly that consequence.
+- The natural, non-harness-driven session replacement rate (§4's confound, still open).
 
 ---
 *Last updated: 2026-07-29*

--- a/.agents/docs/transport-measurements.md
+++ b/.agents/docs/transport-measurements.md
@@ -305,6 +305,58 @@ test that can actually fail (re-run this injection after the fix; expect no
 attention with the field investigation — it can be fixed and closed on its own
 evidence.
 
+### ⭐⭐⭐ 2026-07-29 — THE SYMPTOM REPRODUCED ON THE BENCH, healthy relay, no injection
+
+| when | run | configuration | class | result | what it changed | source |
+|---|---|---|---|---|---|---|
+| 07-29 | `dm-multidevice` **canonical** | **aged account A** with 2 harness devices (`user-a` + the new `user-a-obs`) + `user-b`, 200 rounds, 700ms gap, **600s settle**, relay healthy, **no fault injected**, lock fix in place | arrival + decrypt + **persistence** | **all 4 frame legs 201/201, 0% loss.** bob 200/200, dev0 200/200 — but **`user-a-obs` persisted 100/200 in BOTH directions**, `CONTIGUOUS TAIL from #101` in both. Decrypt failures dev0=80, dev1=17, bob=46. Lock max 412ms | ⭐ **the operator's ~10-of-200 symptom, on the bench, automated** | run log `2026-07-29T10-07-26` |
+
+**This is the first reproduction that needs no fault injection and no degraded
+relay.** Every frame arrived at the extra device's socket — 201/201 on both its
+legs — and it persisted exactly half of them, stopping dead at message #101 in
+both directions simultaneously and never recovering across a **10-minute** tail.
+
+**Reading the shape:**
+
+- **Both directions stop at the same number.** Sends alternate on a 700ms gap, so
+  `#101` in each direction is the *same instant* — roughly 70s into the send loop.
+  This is one event at one moment, not two independent failures.
+- **It is not latency.** 600s of settle with frames still arriving and nothing
+  further persisted. §3's "a longer tail recovers them" does not hold here.
+- **It is not the ratchet-lock-across-HTTP bug** (that is fixed and shipped), and
+  not relay degradation (relay verified healthy, no injection).
+- **The socket stayed alive.** `transport.arrived` recorded all 201 frames per leg
+  *after* the device stopped persisting. So the failure is downstream of arrival
+  and downstream of the socket, in the receive pipeline itself.
+- **Aged account is the differentiating variable.** The identical shape on a
+  *fresh* 4-device account was clean (100/100 everywhere, same day, same code).
+
+### ⚠️ The lock histogram CANNOT rule out a deadlock — it only sees holds that finished
+
+`installLockProbe` records a sample in a `finally` block (`lock-probe.ts:65-74`).
+**A critical section that never returns never reaches that `finally`, so it is
+never sampled.** `max=412ms` therefore means "the longest hold that *completed*
+was 412ms" — it says nothing about a hold still outstanding when the run ended.
+
+That matters because a permanently-held `dmRatchetMutex` on one `conversationId`
+would produce precisely this signature: both directions of that conversation stop
+at one instant, permanently, while the socket keeps receiving. `KeyedMutex`'s own
+documentation warns about exactly this failure mode — *"waiting for delivery
+inside the lock is a circular wait"*.
+
+**Deadlock is therefore a live hypothesis that our current instrument is blind to,
+and the cheapest next step is to make it visible:** track holds at *acquire* time
+and report any still outstanding at the end of the run, rather than only those
+that released.
+
+⚠️ **Harness-vs-product is NOT yet settled.** All three bots share one Node
+process and the harness serializes inbound dispatch through a single promise chain
+(`transport.ts` `dispatch()`), so one handler invocation that never settles would
+stall that bot's entire queue forever — matching the shape exactly. The browser
+serializes per inbox too (`processInbound`), so the mechanism is plausible in the
+app, but this run cannot distinguish "product deadlock" from "harness-only hang".
+**Do not report this upstream until that is separated.**
+
 ### ⭐ Persistence on AGED accounts (`dm-loss` canonical) — closes one of two blind cells
 
 | when | run | configuration | class | result | what it changed | source |

--- a/.agents/docs/transport-measurements.md
+++ b/.agents/docs/transport-measurements.md
@@ -331,6 +331,44 @@ both directions simultaneously and never recovering across a **10-minute** tail.
 - **Aged account is the differentiating variable.** The identical shape on a
   *fresh* 4-device account was clean (100/100 everywhere, same day, same code).
 
+### ✅ Deadlock RULED OUT, and the reproduction is deterministic
+
+**Second canonical run, 2026-07-29 (log `2026-07-29T10-35-59`), with both new
+detectors armed:**
+
+```
+outstanding critical sections: NONE (no lock was still held at the end)
+no bot has a stuck inbound frame
+```
+
+Neither the ratchet lock nor any handler invocation was outstanding. **The
+deadlock hypothesis below is dead**, and so is the broader "something hung"
+reading. Kept here because the reasoning was sound and the instrument that killed
+it is the useful artifact.
+
+**And the reproduction is exact:**
+
+| | run 1 | run 2 |
+|---|---|---|
+| dev1 persisted | 100/200 both directions | **100/200 both directions** |
+| tail begins | #101 | **#101** |
+| decrypt failures dev0/dev1/bob | 80 / 17 / 46 | 102 / 33 / 25 |
+
+Identical counts twice rules out a race. **The handler RETURNS for messages #101
+onward — they are processed and silently discarded, not stalled.** That is a
+different bug class from everything this investigation has assumed so far, and it
+retires the "backlog, a longer tail recovers them" reading (§3 of the solved lock
+bug) for this failure.
+
+**Two readings of the number, and they predict different things:**
+
+1. **A ceiling** — dev1 persisted exactly 200 messages (100 + 100) and stopped.
+2. **Proportional** — it stopped at exactly the halfway point; and the 07-28
+   fresh-account 4-device run showed **52/100**, also about half.
+
+Discriminated by re-running at 100 rounds: **~50/100 ⇒ proportional (time or
+rate); 100/100 ⇒ a ceiling near 200.**
+
 ### ⚠️ The lock histogram CANNOT rule out a deadlock — it only sees holds that finished
 
 `installLockProbe` records a sample in a `finally` block (`lock-probe.ts:65-74`).

--- a/.agents/docs/transport-measurements.md
+++ b/.agents/docs/transport-measurements.md
@@ -305,6 +305,45 @@ test that can actually fail (re-run this injection after the fix; expect no
 attention with the field investigation — it can be fixed and closed on its own
 evidence.
 
+### ⭐ Persistence on AGED accounts (`dm-loss` canonical) — closes one of two blind cells
+
+| when | run | configuration | class | result | what it changed | source |
+|---|---|---|---|---|---|---|
+| 07-29 | `dm-loss` canonical | **the operator's real aged multi-device accounts**, 200 rounds, 700ms gap, **600s settle**, per-message persistence counted for the first time | arrival **and** persistence | **frames 201/201 each way, 0%. Persisted: bob 200/200, alice 200/200.** 6 novel decrypt failures total, all healed. Fan-out **2412 frames for 201 messages (~12:1)** | **aged session state does NOT break persistence on the peer channel.** Concentrates suspicion on the fan-out channel | run log `2026-07-29T09-44-43` |
+
+**Why this run existed.** `dm-loss` had only ever counted frames, plus a running
+`posts decrypted` tally that could not say *which* message went missing. So on the
+canonical accounts it reported 201/201 / 0% while the operator watched those same
+accounts' other devices receive ~10 of 200 — it was never asking the question.
+Per-message persistence accounting now makes it ask.
+
+**The answer is clean**, and that is informative rather than disappointing: it
+removes "aged session state corrupts persistence" as an explanation. Frames arrive,
+decrypt, and get persisted correctly on aged accounts, over a 10-minute tail.
+
+### ⚠️ The blind cell that REMAINS, and it is the one that matches the observation
+
+This run measured the **peer** channel. The operator's observation was about the
+**fan-out** channel — messages reaching their *other* devices.
+
+| channel | fresh accounts | **aged accounts** |
+|---|---|---|
+| peer — frames | ✅ clean | ✅ clean |
+| peer — **persistence** | ✅ clean | ✅ **clean (this run)** |
+| fan-out — frames | ✅ clean | ✅ clean |
+| fan-out — **persistence** | ✅ clean (4 devices) | ❌ **NEVER MEASURED** |
+
+The amplification is the tell: **2412 frames went out for 201 messages**, and only
+320 landed on inboxes this bench subscribes to. The other ~2100 went to the
+operator's real devices and are unobserved — "unobserved, not observed-good", the
+same structural blindness recorded against run 2.
+
+**Reaching that last cell needs a second harness bot registered as a device on the
+aged account A**, which mints one permanent extra device registration there (stable
+bot name, so it is minted once and reused). That is the cost the trap list warns
+about, it is bounded, and it is the only automated route left to the operator's
+actual symptom. Everything cheaper has now been run.
+
 ### ⭐ Cross-platform (`dm-cross`) — the last empty cell in the 2×2
 
 | when | run | configuration | class | result | what it changed | source |

--- a/src/dev/tests/harness/dm-loss.scenario.test.ts
+++ b/src/dev/tests/harness/dm-loss.scenario.test.ts
@@ -34,6 +34,7 @@ import { createBot, type HarnessBot } from './bot';
 import { createCanonicalPair, hasCanonicalKeys } from './canonical';
 import { WsTransport } from './transport';
 import { direction, subscribedInboxes } from './loss';
+import { missingReport, persistedNumbers } from './persistence';
 import { RunLog } from './log';
 
 const ROUNDS = Number(process.env.HARNESS_LOSS_ROUNDS ?? 40);
@@ -161,6 +162,26 @@ test(
         { direction: label, ...d });
     }
     say(`posts decrypted: alice=${aPosts} bob=${bPosts}`);
+
+    // ── MESSAGE-LEVEL, the question the frame counts above cannot answer ─────
+    //
+    // `posts decrypted` is a running tally, so it cannot say WHICH message went
+    // missing, and on multi-device accounts it also counts self-sync copies. That
+    // is why this scenario reported 201/201 / 0% on the canonical accounts while
+    // the operator watched the same accounts' other devices receive ~10 of 200:
+    // nothing here was ever counting per-message persistence.
+    //
+    // These two lines are the whole point of running this on aged accounts:
+    // "of the N messages the peer sent, how many did this bot's real code
+    // actually persist, and are the absences a stall or scattered drops?"
+    const bGot = persistedNumbers(bob, 'A->B');
+    const aGot = persistedNumbers(alice, 'B->A');
+    say('');
+    say('==== MESSAGE-LEVEL, PERSISTED (not frames, not rendered) ====');
+    say(`bob   persisted A->B : ${bGot.size}/${ROUNDS}`, { bobPersisted: bGot.size });
+    if (bGot.size < ROUNDS) say(`   bob A->B gaps: ${missingReport(bob, 'A->B', ROUNDS)}`);
+    say(`alice persisted B->A : ${aGot.size}/${ROUNDS}`, { alicePersisted: aGot.size });
+    if (aGot.size < ROUNDS) say(`   alice B->A gaps: ${missingReport(alice, 'B->A', ROUNDS)}`);
     say(`decrypt failures — NOVEL (the only ones worth quoting): ` +
       `alice=${alice.novelErrors().length} bob=${bob.novelErrors().length}   ` +
       `replays (expected refusals): alice=${alice.errors.length - alice.novelErrors().length} ` +

--- a/src/dev/tests/harness/dm-multidevice.scenario.test.ts
+++ b/src/dev/tests/harness/dm-multidevice.scenario.test.ts
@@ -44,7 +44,7 @@ import { createBot, type HarnessBot } from './bot';
 import { config } from './env';
 import { hasCanonicalKeys } from './canonical';
 import { direction, subscribedInboxes } from './loss';
-import { installLockProbe, summariseLockHolds } from './lock-probe';
+import { installLockProbe, summariseLockHolds, summariseOutstandingHolds } from './lock-probe';
 import { deleteFault, makeApiClient } from './transport';
 import { missingReport, postsMatching } from './persistence';
 import { RunLog } from './log';
@@ -310,6 +310,34 @@ test(
       faultInjected: deleteFault.injected,
     });
     for (const line of summariseLockHolds(lockSamples)) say(line);
+
+    // ── THE DEADLOCK REPORT ─────────────────────────────────────────────────
+    //
+    // The histogram above CANNOT show a deadlock: its samples are pushed in a
+    // `finally`, so a critical section that never returns is never sampled and
+    // `max=` only ever describes holds that COMPLETED. These two reports are the
+    // ones that can say "something is still stuck", and together they localise it:
+    // outstanding in BOTH ⇒ the ratchet lock; stuck frames only ⇒ a hang elsewhere
+    // in handleNewMessage.
+    say('');
+    say('==== STILL STUCK AT END OF RUN (deadlock detector) ====');
+    for (const line of summariseOutstandingHolds()) say(line);
+    for (const [i, b] of [...aDevices, bob].entries()) {
+      const stuck = b.transport.stuckFrames();
+      const who = i < aDevices.length ? `dev${i}` : 'bob';
+      if (stuck.length === 0) continue;
+      say(
+        `⛔ ${who}: ${stuck.length} inbound frame(s) never finished processing — ` +
+          `this bot's queue is blocked permanently`,
+        { bot: who, stuck: stuck.length }
+      );
+      for (const f of stuck.slice(0, 3)) {
+        say(`   fp=${f.fp} inbox=${f.inbox.slice(0, 16)} stuck ${Math.round(f.stuckMs / 1000)}s`);
+      }
+    }
+    if ([...aDevices, bob].every((b) => b.transport.stuckFrames().length === 0)) {
+      say('no bot has a stuck inbound frame');
+    }
     console.log(`[dm-md] log: ${log.file}`);
 
     for (const b of aDevices) b.stop();

--- a/src/dev/tests/harness/dm-multidevice.scenario.test.ts
+++ b/src/dev/tests/harness/dm-multidevice.scenario.test.ts
@@ -21,20 +21,28 @@
 // frames from its join by design ("unobserved, not observed-good"), so it was
 // structurally blind to the channel that was failing.
 //
-// ── What this scenario refuses to do ────────────────────────────────────────
+// ── Accounts: throwaway by default, canonical only on purpose ───────────────
 //
-// It does NOT use the canonical accounts. They already carry 5+ device
-// registrations, and createBot mints a NEW device per bot NAME and merges it into
-// the registration (identity.ts:141-153). Running this there would permanently add
-// devices to shared accounts and fan out to ghost inboxes we cannot observe —
-// confounding the exact variable being isolated. Instead the account is generated
-// here and thrown away.
+// DEFAULT: a generated account, thrown away. The canonical accounts already carry
+// 5+ device registrations, and createBot mints a NEW device per bot NAME and
+// merges it into the registration (identity.ts:141-153) — so running there
+// permanently adds devices to a real account and fans out to inboxes we cannot
+// observe, confounding the variable being isolated. For measuring device COUNT,
+// which is what this scenario was built for, a generated account is strictly
+// better and free.
+//
+// HARNESS_MD_CANONICAL=1 opts into the real aged accounts, for the one question a
+// generated account cannot answer: does fan-out persistence break on an AGED
+// account? That is the last unmeasured cell and the one the operator's ~10-of-200
+// observation lives in. It costs ONE permanent device registration, held to one by
+// stable bot names — see the block at the top of the test body before using it.
 import { existsSync, rmSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { test, expect } from 'vitest';
 import { channel_raw } from '@quilibrium/quilibrium-js-sdk-channels';
 import { createBot, type HarnessBot } from './bot';
 import { config } from './env';
+import { hasCanonicalKeys } from './canonical';
 import { direction, subscribedInboxes } from './loss';
 import { installLockProbe, summariseLockHolds } from './lock-probe';
 import { deleteFault, makeApiClient } from './transport';
@@ -76,11 +84,44 @@ test(
     // and it reports even on a run where nothing is lost.
     const lockSamples = installLockProbe();
 
-    // One generated account, handed to two bots. createBot takes the ACCOUNT from
+    // ── CANONICAL MODE (HARNESS_MD_CANONICAL=1) ─────────────────────────────
+    //
+    // Runs this scenario against the operator's REAL aged accounts instead of a
+    // generated throwaway, to reach the one cell nothing has measured:
+    // **fan-out persistence on an aged account**. Everything cheaper is already
+    // green — peer-channel persistence is clean on aged accounts (dm-loss
+    // canonical, 200/200 both ways), and fan-out persistence is clean on fresh
+    // accounts at 4 devices.
+    //
+    // ⚠️ COSTS ONE PERMANENT DEVICE REGISTRATION on account A, and there is no
+    // way to take it back: `deregister` does not exist (see
+    // `tasks/2026-07-21-device-registration-ghost-accumulation-cross-platform.md`,
+    // status PLAN — not started). Authorised by the operator 2026-07-29.
+    //
+    // The cost is held to exactly ONE by using STABLE bot names. `createBot` mints
+    // a device per bot NAME and merges it into the registration
+    // (identity.ts:141-153), so a timestamped name would mint a NEW device on
+    // every run — which is precisely what the trap list warns about. Here:
+    //   dev0 = `user-a`      — already registered by earlier dm-loss runs
+    //   dev1 = `user-a-obs`  — the ONE new device, the observer, reused forever
+    //   peer = `user-b`      — already registered
+    // Re-running this scenario therefore adds nothing further.
+    const useCanonical = process.env.HARNESS_MD_CANONICAL === '1';
+    if (useCanonical && !hasCanonicalKeys()) {
+      throw new Error(
+        'HARNESS_MD_CANONICAL=1 but BOT_A_PRIVATE_KEY/BOT_B_PRIVATE_KEY are not set ' +
+          'in src/dev/tests/harness/.env.local'
+      );
+    }
+
+    // One account, handed to several bots. createBot takes the ACCOUNT from
     // privateKeyHex and the DEVICE from name, so this is genuinely one user with
-    // two devices — not two users.
-    const kp = JSON.parse(channel_raw.js_generate_ed448()) as { private_key: number[] };
-    const KEY_A = Buffer.from(kp.private_key).toString('hex');
+    // several devices — not several users.
+    const KEY_A = useCanonical
+      ? config.botKeys.A
+      : Buffer.from(
+          (JSON.parse(channel_raw.js_generate_ed448()) as { private_key: number[] }).private_key
+        ).toString('hex');
     // ed448 private keys are 57 bytes. Measured, not read off a spec sheet — two
     // earlier guesses at this length in this investigation were both wrong.
     expect(KEY_A).toHaveLength(114);
@@ -90,16 +131,22 @@ test(
     // (identity.ts:141-153). Concurrent creation silently drops one device, and the
     // scenario would then measure a one-device account while claiming otherwise.
     // This is also why the loop below awaits each createBot in turn.
+    // Canonical mode is pinned to exactly two A-devices — the already-registered
+    // `user-a` plus ONE new observer — because every extra name here is another
+    // permanent device on a real account. Throwaway mode is unconstrained.
+    const deviceNames = useCanonical
+      ? ['user-a', 'user-a-obs']
+      : Array.from({ length: DEVICES }, (_, d) => `md-a-dev${d}-${stamp}`);
+    const nDevices = deviceNames.length;
     const botNames: string[] = [];
     const aDevices: HarnessBot[] = [];
-    for (let d = 0; d < DEVICES; d++) {
-      const name = `md-a-dev${d}-${stamp}`;
+    for (const name of deviceNames) {
       botNames.push(name);
       aDevices.push(await createBot(name, { privateKeyHex: KEY_A }));
     }
-    const bobName = `md-b-${stamp}`;
+    const bobName = useCanonical ? 'user-b' : `md-b-${stamp}`;
     botNames.push(bobName);
-    const bob = await createBot(bobName);
+    const bob = await createBot(bobName, useCanonical ? { privateKeyHex: config.botKeys.B } : {});
 
     // Device 0 is the sender; every other device of account A should receive a
     // self-sync copy of what it sends, and a copy of everything bob sends.
@@ -107,10 +154,10 @@ test(
     const others = aDevices.slice(1);
 
     say(
-      `account A=${sender.identity.address.slice(0, 12)} with ${DEVICES} device(s): ` +
+      `account A=${sender.identity.address.slice(0, 12)} with ${nDevices} harness device(s): ` +
         aDevices.map((b, i) => `dev${i}=${b.identity.inboxAddress.slice(0, 10)}`).join(' ') +
         `  bob=${bob.identity.address.slice(0, 12)}`,
-      { devices: DEVICES }
+      { devices: nDevices, mode: useCanonical ? 'canonical' : 'throwaway' }
     );
 
     // ── STEP 1: prove the premise before measuring anything ──────────────────
@@ -150,7 +197,7 @@ test(
       expect(registeredInboxes).toContain(b.identity.inboxAddress); // this DEVICE is registered
     }
     // Every device distinct — catches a name collision silently reusing a keyset.
-    expect(new Set(aDevices.map((b) => b.identity.inboxAddress)).size).toBe(DEVICES);
+    expect(new Set(aDevices.map((b) => b.identity.inboxAddress)).size).toBe(nDevices);
 
     await Promise.all([...aDevices.map((b) => b.start()), bob.start()]);
 
@@ -271,9 +318,17 @@ test(
     // Each run mints a throwaway account and one state file per bot. Nothing
     // accumulates on an account that matters, but the directory would grow without
     // bound, so the scenario removes what it created.
-    for (const name of botNames) {
-      const p = resolve(config.stateDir, `${name}.json`);
-      if (existsSync(p)) rmSync(p, { force: true });
+    // ⚠️ NEVER in canonical mode. These .state files hold the DEVICE KEYSETS of
+    // real registrations on a real account. Deleting one does not remove the
+    // device — nothing can, `deregister` is unimplemented — it orphans it into an
+    // unreachable ghost AND makes the next run mint yet another device under the
+    // same name. One deleted file would turn a bounded one-device cost into an
+    // unbounded one.
+    if (!useCanonical) {
+      for (const name of botNames) {
+        const p = resolve(config.stateDir, `${name}.json`);
+        if (existsSync(p)) rmSync(p, { force: true });
+      }
     }
 
     // The run IS the measurement, so the assertions are deliberately weak: they

--- a/src/dev/tests/harness/dm-multidevice.scenario.test.ts
+++ b/src/dev/tests/harness/dm-multidevice.scenario.test.ts
@@ -38,6 +38,7 @@ import { config } from './env';
 import { direction, subscribedInboxes } from './loss';
 import { installLockProbe, summariseLockHolds } from './lock-probe';
 import { deleteFault, makeApiClient } from './transport';
+import { missingReport, postsMatching } from './persistence';
 import { RunLog } from './log';
 
 const ROUNDS = Number(process.env.HARNESS_MD_ROUNDS ?? 20);
@@ -56,47 +57,6 @@ const SETTLE_MS = Number(process.env.HARNESS_MD_SETTLE_MS ?? 120_000);
 const DEVICES = Math.max(2, Number(process.env.HARNESS_MD_DEVICES ?? 2));
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
-
-/** Messages of a given text prefix this bot's real code actually persisted. */
-const postsMatching = (bot: HarnessBot, prefix: string) =>
-  new Set(
-    bot.captured
-      .filter((m) => m.content?.type === 'post' && (m.content.text ?? '').startsWith(prefix))
-      .map((m) => m.content?.text as string)
-  );
-
-/**
- * WHICH numbered messages are missing, not just how many.
- *
- * The count alone cannot separate two very different bugs, and the first
- * multi-device run produced exactly the ambiguity: one device persisted 52 of 100
- * in BOTH directions while every frame arrived and nothing failed to decrypt.
- *
- *   a contiguous TAIL missing  ⇒ the device stopped processing at some moment
- *                                (a receive-pipeline stall)
- *   SCATTERED gaps             ⇒ per-message drops
- *   every OTHER one            ⇒ something in dedupe/ordering
- *
- * Those need different investigations, so the run has to say which it is.
- */
-function missingReport(bot: HarnessBot, prefix: string, rounds: number): string {
-  const got = new Set<number>();
-  for (const text of postsMatching(bot, prefix)) {
-    const n = Number(/#(\d+)$/.exec(text)?.[1]);
-    if (Number.isFinite(n)) got.add(n);
-  }
-  const missing: number[] = [];
-  for (let i = 1; i <= rounds; i++) if (!got.has(i)) missing.push(i);
-  if (missing.length === 0) return 'none';
-
-  // Contiguous tail? i.e. everything from some point on is absent.
-  const isTail = missing[missing.length - 1] === rounds && missing.length === rounds - missing[0] + 1;
-  const shape = isTail
-    ? `CONTIGUOUS TAIL from #${missing[0]} — looks like the device STOPPED`
-    : `scattered (${missing.length} gaps, first #${missing[0]}, last #${missing[missing.length - 1]})`;
-  const sample = missing.slice(0, 24).join(',') + (missing.length > 24 ? ',…' : '');
-  return `${shape}  missing=[${sample}]`;
-}
 
 test(
   'dm-multidevice: an N-device account, per-device arrival',

--- a/src/dev/tests/harness/lock-probe.ts
+++ b/src/dev/tests/harness/lock-probe.ts
@@ -45,6 +45,30 @@ const samples: LockSample[] = [];
 let installedAt = 0;
 
 /**
+ * Critical sections that have STARTED and not yet returned.
+ *
+ * ⚠️ This exists because `samples` structurally cannot show a deadlock. A sample
+ * is pushed in a `finally`, so a critical section that never returns is never
+ * sampled — which means `max=…` only ever reports "the longest hold that
+ * COMPLETED". On 2026-07-29 a run showed `max=412ms` while one device had stopped
+ * persisting entirely; that number was not evidence the lock was healthy, it was
+ * evidence about the holds that finished.
+ *
+ * A permanently-held lock produces a very specific signature: both directions of
+ * one conversation stop at the same instant, forever, while the socket keeps
+ * receiving. `KeyedMutex`'s own docs warn about it as a circular wait. This map is
+ * what turns that hypothesis into a yes/no.
+ */
+interface InFlightHold {
+  key: string;
+  startedAt: number;
+  /** ms since probe install, so it can be lined up against the run timeline. */
+  t: number;
+}
+const inFlight = new Map<number, InFlightHold>();
+let holdSeq = 0;
+
+/**
  * Wrap the shared mutex once per process. Idempotent: the singleton is shared by
  * every bot in this process, so a second install would double-count every hold.
  */
@@ -59,9 +83,15 @@ export function installLockProbe(): LockSample[] {
       const queuedAt = Date.now();
       return original(key, async () => {
         const startedAt = Date.now();
+        // Registered BEFORE the body runs and removed in `finally`, so anything
+        // still here at the end of the run never returned. That is the only way
+        // to see a deadlock — `samples` below cannot, by construction.
+        const holdId = ++holdSeq;
+        inFlight.set(holdId, { key, startedAt, t: startedAt - installedAt });
         try {
           return await fn();
         } finally {
+          inFlight.delete(holdId);
           // Recorded in `finally` so a throwing critical section still reports its
           // hold — the delete-conversation and give-up paths RETHROW (bug §1), and
           // those are exactly the holds worth seeing.
@@ -120,4 +150,42 @@ export function summariseLockHolds(all: LockSample[]): string[] {
       `max=${waited[waited.length - 1]}ms`
   );
   return lines;
+}
+
+/**
+ * Critical sections still outstanding — the DEADLOCK report.
+ *
+ * Call at the very end of a run. Anything listed here entered
+ * `dmRatchetMutex.runExclusive` and never came back, which means every later
+ * message on that `conversationId` is blocked forever. A DM's two directions share
+ * one conversationId, so a single entry here explains BOTH directions of that
+ * conversation stopping at the same instant.
+ *
+ * Empty is the expected result. A non-empty list is the strongest possible
+ * evidence for the stall class this investigation has been chasing, because
+ * unlike a missing-message count it names the lock, the moment, and the fact that
+ * it never released.
+ */
+export function summariseOutstandingHolds(): string[] {
+  if (inFlight.size === 0) {
+    return ['outstanding critical sections: NONE (no lock was still held at the end)'];
+  }
+  const now = Date.now();
+  const lines = [
+    `⛔ OUTSTANDING CRITICAL SECTIONS: ${inFlight.size} — these NEVER returned.`,
+    `   Every later message on these conversationIds is blocked permanently.`,
+  ];
+  for (const { key, startedAt, t } of [...inFlight.values()].sort((a, b) => a.startedAt - b.startedAt)) {
+    lines.push(
+      `   held ${Math.round((now - startedAt) / 1000)}s and counting on ${key.slice(0, 24)} ` +
+        `(acquired at t+${Math.round(t / 1000)}s)`
+    );
+  }
+  return lines;
+}
+
+/** Reset between scenarios in one process — the mutex wrap itself stays installed. */
+export function resetLockProbe(): void {
+  samples.length = 0;
+  inFlight.clear();
 }

--- a/src/dev/tests/harness/persistence.ts
+++ b/src/dev/tests/harness/persistence.ts
@@ -1,0 +1,69 @@
+// Message-level accounting: what the real code actually PERSISTED, by number.
+//
+// ── Why this is separate from frame counting ────────────────────────────────
+//
+// `loss.ts` answers "did the frame reach the peer's socket". That is a different
+// question from "did the app keep the message", and conflating them is the single
+// most expensive mistake this investigation has made. A frame can arrive, decrypt
+// cleanly, and never reach `saveMessage` — invisible to every frame-level count.
+//
+// `dm-loss` reported 201/201 and 0% on the canonical accounts while the operator
+// watched those same accounts' other devices receive ~10 of 200. It was not wrong;
+// it was answering a different question.
+//
+// These helpers live here rather than inside one scenario because BOTH dm-loss and
+// dm-multidevice need them, and a divergent copy of the gap-shape rule would be
+// worse than no rule — two scenarios silently disagreeing about what "contiguous"
+// means is exactly the kind of drift that costs a day.
+import type { HarnessBot } from './bot';
+
+/** Messages of a given text prefix this bot's real code actually persisted. */
+export const postsMatching = (bot: HarnessBot, prefix: string) =>
+  new Set(
+    bot.captured
+      .filter((m) => m.content?.type === 'post' && (m.content.text ?? '').startsWith(prefix))
+      .map((m) => m.content?.text as string)
+  );
+
+/** The numbered messages of `prefix` this bot persisted. */
+export function persistedNumbers(bot: HarnessBot, prefix: string): Set<number> {
+  const got = new Set<number>();
+  for (const text of postsMatching(bot, prefix)) {
+    const n = Number(/#(\d+)$/.exec(text)?.[1]);
+    if (Number.isFinite(n)) got.add(n);
+  }
+  return got;
+}
+
+/**
+ * WHICH numbered messages are missing, not just how many.
+ *
+ * The count alone cannot separate two very different bugs, and the first
+ * multi-device run produced exactly that ambiguity: one device persisted 52 of
+ * 100 in BOTH directions while every frame arrived and nothing failed to decrypt.
+ *
+ *   a contiguous TAIL missing  ⇒ the device stopped processing at some moment
+ *                                (a receive-pipeline stall)
+ *   SCATTERED gaps             ⇒ per-message drops
+ *   every OTHER one            ⇒ something in dedupe/ordering
+ *
+ * Those need different investigations, so the run has to say which it is. The
+ * fault-injected runs of 2026-07-29 confirmed the tail shape means a stall: every
+ * gap was contiguous while a slow `/inbox/delete` head-of-line blocked the inbox,
+ * and all of them vanished once the handler stopped awaiting the relay.
+ */
+export function missingReport(bot: HarnessBot, prefix: string, rounds: number): string {
+  const got = persistedNumbers(bot, prefix);
+  const missing: number[] = [];
+  for (let i = 1; i <= rounds; i++) if (!got.has(i)) missing.push(i);
+  if (missing.length === 0) return 'none';
+
+  // Contiguous tail? i.e. everything from some point on is absent.
+  const isTail =
+    missing[missing.length - 1] === rounds && missing.length === rounds - missing[0] + 1;
+  const shape = isTail
+    ? `CONTIGUOUS TAIL from #${missing[0]} — looks like the device STOPPED`
+    : `scattered (${missing.length} gaps, first #${missing[0]}, last #${missing[missing.length - 1]})`;
+  const sample = missing.slice(0, 24).join(',') + (missing.length > 24 ? ',…' : '');
+  return `${shape}  missing=[${sample}]`;
+}

--- a/src/dev/tests/harness/transport.ts
+++ b/src/dev/tests/harness/transport.ts
@@ -128,6 +128,9 @@ export class WsTransport {
   readonly sent: SentFrame[] = [];
   /** Inbound dispatch is serialized — see dispatch(). */
   private chain: Promise<void> = Promise.resolve();
+  /** Handler invocations started but not yet settled — see stuckFrames(). */
+  private inFlightFrames = new Map<number, { fp: string; inbox: string; at: number }>();
+  private dispatchSeq = 0;
 
   constructor(private readonly wsUrl: string = config.wsUrl) {}
 
@@ -223,11 +226,50 @@ export class WsTransport {
   // concurrently would also make per-frame attribution of a failure ambiguous.
   private dispatch(frame: InboundFrame): Promise<void> {
     if (!this.handler) return Promise.resolve();
-    this.chain = this.chain.then(() => this.handler!(frame)).then(
-      () => undefined,
-      () => undefined
-    );
+    this.chain = this.chain
+      .then(() => {
+        // Registered before the handler runs, removed when it settles. Anything
+        // left in here at the end of a run is a handler invocation that NEVER
+        // returned — and because this chain is serial, it has blocked every frame
+        // behind it permanently.
+        //
+        // This is deliberately broader than the lock probe: it catches a hang
+        // ANYWHERE in handleNewMessage, not only inside runExclusive. Together the
+        // two localise the stall — outstanding in both ⇒ the lock; outstanding
+        // here only ⇒ somewhere else in the handler.
+        const id = ++this.dispatchSeq;
+        this.inFlightFrames.set(id, {
+          fp: WsTransport.fingerprint(frame),
+          inbox: String(frame.inboxAddress ?? '?'),
+          at: Date.now(),
+        });
+        return Promise.resolve(this.handler!(frame)).finally(() =>
+          this.inFlightFrames.delete(id)
+        );
+      })
+      .then(
+        () => undefined,
+        () => undefined
+      );
     return this.chain;
+  }
+
+  /**
+   * Handler invocations that started and never settled.
+   *
+   * Empty is expected. A non-empty result means this bot's inbound queue is
+   * permanently stuck: `dispatch` is serial, so every frame after the stuck one
+   * is blocked forever, which is exactly the "device stopped at message #N and
+   * never recovered" shape — while the socket keeps receiving, because
+   * `arrived` is appended in `ws.on('message')` upstream of this.
+   */
+  stuckFrames(): { fp: string; inbox: string; stuckMs: number }[] {
+    const now = Date.now();
+    return [...this.inFlightFrames.values()].map((f) => ({
+      fp: f.fp,
+      inbox: f.inbox,
+      stuckMs: now - f.at,
+    }));
   }
 
   /** Open the socket; resolves on the first `open`. Re-subscribes automatically. */


### PR DESCRIPTION
Instrumentation for the two questions the bench could not previously ask, plus what it found.

## Instrumentation

- **`dm-loss` counts per-message persistence.** It counted frames, plus a running `posts decrypted` tally that could never say *which* message went missing. That is why it reported 201/201 and 0% on the canonical accounts while the operator watched those same accounts' other devices receive ~10 of 200.
- **`persistence.ts`** holds the gap-shape rule (`CONTIGUOUS TAIL` vs `scattered`) so `dm-loss` and `dm-multidevice` share one definition. Two copies silently disagreeing is exactly the drift that costs a day.
- **`HARNESS_MD_CANONICAL=1`** runs `dm-multidevice` against the real aged accounts, to reach the last unmeasured cell: fan-out persistence on an aged account. Costs ONE permanent device registration, held to one by stable bot names (`user-a`, `user-a-obs`, `user-b`), so re-running adds nothing. State-file cleanup is skipped in this mode — those files hold real device keysets, and deleting one orphans the device rather than removing it.
- **Two stall detectors.** The lock probe samples in a `finally`, so a critical section that never returns is never sampled and `max=` has only ever meant "the longest hold that COMPLETED". It now registers holds at acquire time and reports any still outstanding. The transport separately tracks handler invocations that started and never settled, which catches a hang anywhere in `handleNewMessage`. Together they localise: outstanding in both means the lock, stuck frames alone means elsewhere.

## What it found

**Aged accounts persist fine on the peer channel.** 200 rounds, 10-minute tail: 201/201 frames each way, 200/200 persisted both directions. Removes aged session state as an explanation.

**Fan-out on an aged account does not.** The extra device persisted 100/200 in both directions, `CONTIGUOUS TAIL from #101`, and never recovered across a 10-minute tail — while every frame arrived at its socket.

**It is not a hang.** Both detectors came back empty. The handler returns; the messages are processed and discarded. Reproduced identically three times, including at half the send gap, so it is count-based rather than time- or rate-based.

## Caveats recorded, not buried

- The 5-round smoke numbers from `dm-cross` are logged explicitly as **not** a measurement, so nobody re-derives a loss finding from them.
- Whether the extra device's ceiling is the same defect as the operator's field symptom is **unresolved** — their real devices received harness traffic during the same runs.
- The measurement log carries the correction that a clean lock histogram cannot rule out a stall, since it only sees holds that finished.

Docs include a bug report for the separate finding this surfaced, already corrected after independent adversarial review (severity downgraded, central claim revised, and the reviewer's own counter-proposal checked and refuted on the data).
