### PR TITLE
feat: resident DM doctor dev panel (T1 of the transport debug tool suite)

### DIFF
--- a/src/components/Router/Router.web.tsx
+++ b/src/components/Router/Router.web.tsx
@@ -88,6 +88,10 @@ const DbInspector = lazyDevImport(
   () => import('@/dev/db-inspector'),
   'DbInspector'
 );
+const DmDoctor = lazyDevImport(
+  () => import('@/dev/dm-doctor'),
+  'DmDoctor'
+);
 
 interface RouterProps {
   user: {
@@ -328,6 +332,16 @@ export function Router({ user, setUser }: RouterProps) {
           element={
             <Suspense fallback={<div>Loading DB inspector...</div>}>
               <DbInspector />
+            </Suspense>
+          }
+        />
+      )}
+      {process.env.NODE_ENV === 'development' && DmDoctor && (
+        <Route
+          path="/dev/dm-doctor"
+          element={
+            <Suspense fallback={<div>Loading DM doctor...</div>}>
+              <DmDoctor />
             </Suspense>
           }
         />

--- a/src/dev/DevMainPage.tsx
+++ b/src/dev/DevMainPage.tsx
@@ -53,6 +53,13 @@ export const DevMainPage: React.FC = () => {
       description: 'Browse IndexedDB with redacted sensitive data',
       path: '/dev/db-inspector',
     },
+    {
+      name: 'DM Doctor',
+      icon: 'bug',
+      description:
+        'Numbered-burst sequence scan, receive-path warning counters, and ghost-conversation detection for the DM-loss investigation',
+      path: '/dev/dm-doctor',
+    },
   ];
 
   const handleNavigate = (path: string) => {

--- a/src/dev/DevNavMenu.tsx
+++ b/src/dev/DevNavMenu.tsx
@@ -48,6 +48,11 @@ const devNavItems: DevNavItem[] = [
     icon: 'database',
     path: '/dev/db-inspector',
   },
+  {
+    name: 'DM Doctor',
+    icon: 'bug',
+    path: '/dev/dm-doctor',
+  },
 ];
 
 interface DevNavMenuProps {

--- a/src/dev/dm-doctor/DmDoctor.tsx
+++ b/src/dev/dm-doctor/DmDoctor.tsx
@@ -1,0 +1,334 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { usePasskeysContext } from '@quilibrium/quilibrium-js-sdk-channels';
+import { Text, Flex, Button, Icon, Input } from '../../components/primitives';
+import { DevNavMenu } from '../DevNavMenu';
+import {
+  scanSequence,
+  findGhostConversations,
+  formatMeasurementRow,
+  type ScanResult,
+  type GhostConversationRow,
+} from './dmDoctorCore';
+import { readAllMessages, readAllConversations } from './dmDoctorDb';
+import {
+  installDmWarningCounters,
+  getDmWarningState,
+  type DmWarningCounterState,
+  type DmWarningKey,
+} from './warningCounters';
+
+const WARNING_LABELS: Record<DmWarningKey, string> = {
+  sessionReplaced: 'SESSION REPLACED by init envelope',
+  unknownInbox: 'DM frame for unknown inbox',
+  decryptFailish: 'decrypt fail/error/unable',
+};
+
+const WARNING_POLL_MS = 5000;
+
+function truncateAddress(address: string): string {
+  if (address.length <= 20) return address;
+  return `${address.slice(0, 10)}…${address.slice(-6)}`;
+}
+
+export const DmDoctor: React.FC = () => {
+  const { currentPasskeyInfo } = usePasskeysContext();
+  const ownAddress = currentPasskeyInfo?.address ?? null;
+
+  const [prefix, setPrefix] = useState('');
+  const [expectedInput, setExpectedInput] = useState('20');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [scanResult, setScanResult] = useState<ScanResult | null>(null);
+  const [scanExpected, setScanExpected] = useState(20);
+  const [scanPrefix, setScanPrefix] = useState('');
+  const [ghosts, setGhosts] = useState<GhostConversationRow[] | null>(null);
+  const [warningState, setWarningState] = useState<DmWarningCounterState | null>(null);
+  const [copyStatus, setCopyStatus] = useState<string | null>(null);
+
+  // Defensive re-install: the panel's own life cycle is not the intended
+  // install point (that's the dev-only startup import in web/main.tsx, so
+  // counting starts at t=0), but installDmWarningCounters() is idempotent, so
+  // calling it here just guarantees the counters exist if this page is ever
+  // opened without that startup wiring having run (e.g. a broken HMR state).
+  useEffect(() => {
+    setWarningState(installDmWarningCounters());
+    const interval = setInterval(() => {
+      setWarningState(getDmWarningState());
+    }, WARNING_POLL_MS);
+    return () => clearInterval(interval);
+  }, []);
+
+  const runScan = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const expected = Math.max(1, parseInt(expectedInput, 10) || 0) || 20;
+      const [messages, conversations] = await Promise.all([
+        readAllMessages(),
+        readAllConversations(),
+      ]);
+      setScanResult(scanSequence(messages, prefix, expected, ownAddress));
+      setGhosts(findGhostConversations(conversations, ownAddress));
+      setScanExpected(expected);
+      setScanPrefix(prefix);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Scan failed');
+    } finally {
+      setLoading(false);
+    }
+  }, [expectedInput, prefix, ownAddress]);
+
+  const copyMeasurementRow = useCallback(async () => {
+    if (!scanResult) return;
+    try {
+      const row = formatMeasurementRow(scanResult, {
+        when: new Date().toISOString().slice(0, 10),
+        run: `DM doctor scan (prefix "${scanPrefix}")`,
+        configuration: ownAddress
+          ? `own=${truncateAddress(ownAddress)}`
+          : 'own address unknown',
+        expected: scanExpected,
+        source: 'DM doctor panel (/dev/dm-doctor)',
+      });
+      await navigator.clipboard.writeText(row);
+      setCopyStatus('Measurement row copied!');
+    } catch {
+      setCopyStatus('Failed to copy');
+    } finally {
+      setTimeout(() => setCopyStatus(null), 2000);
+    }
+  }, [scanResult, scanPrefix, scanExpected, ownAddress]);
+
+  const distribution = scanResult
+    ? Object.entries(scanResult.byConversation).sort((a, b) => b[1] - a[1])
+    : [];
+
+  return (
+    <div className="min-h-screen bg-app">
+      <DevNavMenu currentPath="/dev/dm-doctor" sticky />
+
+      <div className="p-6 mx-auto max-w-5xl">
+        <Flex gap="sm" align="center" className="mb-2">
+          <Icon name="bug" size="xl" className="text-accent" />
+          <div>
+            <Text as="h1" variant="strong" size="2xl" weight="bold">
+              DM Doctor
+            </Text>
+            <Text variant="subtle" size="sm">
+              Resident diagnostic for the DM-loss / misfiling investigation. Own
+              address: {ownAddress ? truncateAddress(ownAddress) : 'unknown (not signed in)'}
+            </Text>
+          </div>
+        </Flex>
+
+        {copyStatus && (
+          <div className="fixed top-4 right-4 bg-surface-2 border border-accent px-4 py-2 rounded-lg shadow-lg z-50">
+            <Text variant="main" size="sm">{copyStatus}</Text>
+          </div>
+        )}
+
+        {/* Controls */}
+        <div className="bg-surface-1 rounded-lg border border-default p-4 mt-6">
+          <Text variant="strong" size="lg" className="mb-3">
+            Sequence scan
+          </Text>
+          <Flex gap="md" align="end" className="flex-wrap">
+            <div className="w-32">
+              <Input
+                label="Prefix"
+                placeholder="e.g. V"
+                value={prefix}
+                onChange={(value: string) => setPrefix(value.slice(0, 1))}
+              />
+            </div>
+            <div className="w-40">
+              <Input
+                label="Expected count"
+                type="number"
+                placeholder="20"
+                value={expectedInput}
+                onChange={(value: string) => setExpectedInput(value)}
+              />
+            </div>
+            <Button variant="primary" onClick={runScan} disabled={loading}>
+              <Icon name={loading ? 'spinner' : 'search'} size="sm" className={loading ? 'animate-spin' : undefined} />
+              {loading ? 'Scanning...' : 'Run'}
+            </Button>
+            {scanResult && (
+              <Button variant="secondary" onClick={copyMeasurementRow}>
+                <Icon name="copy" size="sm" />
+                Copy measurement row
+              </Button>
+            )}
+          </Flex>
+          <Text variant="subtle" size="xs" className="mt-2">
+            Scans the WHOLE messages store for "{'{prefix} N'}" (case-insensitive),
+            same matching as .agents/tools/dm-debug/07-receiver-probe.js.
+          </Text>
+        </div>
+
+        {error && (
+          <div className="bg-red-500/10 border border-red-500/30 rounded-lg p-4 mt-6">
+            <Text variant="strong" className="text-red-500">{error}</Text>
+          </div>
+        )}
+
+        {/* Results */}
+        {scanResult && (
+          <div className="bg-surface-1 rounded-lg border border-default p-4 mt-6">
+            <Flex justify="between" align="center" className="mb-4">
+              <Text variant="strong" size="lg">
+                Results — prefix "{scanPrefix}"
+              </Text>
+              <Text
+                variant="strong"
+                size="xl"
+                className={scanResult.missing.length ? 'text-red-500' : 'text-green-500'}
+              >
+                {scanResult.landed}/{scanExpected} landed
+              </Text>
+            </Flex>
+
+            <Flex gap="lg" className="flex-wrap mb-4">
+              <div>
+                <Text variant="subtle" size="xs">Missing</Text>
+                <Text variant={scanResult.missing.length ? 'strong' : 'main'} size="sm" className={scanResult.missing.length ? 'text-red-500' : ''}>
+                  {scanResult.missing.length ? scanResult.missing.join(', ') : 'none'}
+                </Text>
+              </div>
+              <div>
+                <Text variant="subtle" size="xs">Duplicates</Text>
+                <Text variant={scanResult.duplicates ? 'strong' : 'main'} size="sm" className={scanResult.duplicates ? 'text-yellow-500' : ''}>
+                  {scanResult.duplicates}
+                </Text>
+              </div>
+              <div>
+                <Text variant="subtle" size="xs">Rows scanned across</Text>
+                <Text variant="main" size="sm">{distribution.length} conversation(s)</Text>
+              </div>
+            </Flex>
+
+            <Text variant="strong" size="sm" className="mb-2">Per-conversation distribution</Text>
+            <div className="overflow-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-left border-b border-default">
+                    <th className="py-1 pr-4">Conversation key (spaceId)</th>
+                    <th className="py-1 pr-4">Count</th>
+                    <th className="py-1">Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {distribution.map(([spaceId, count]) => {
+                    const isGhost = Boolean(ownAddress) && spaceId === ownAddress;
+                    return (
+                      <tr key={spaceId} className="border-b border-default/50">
+                        <td className="py-1 pr-4 font-mono">{truncateAddress(spaceId)}</td>
+                        <td className="py-1 pr-4">{count}</td>
+                        <td className="py-1">
+                          {isGhost ? (
+                            <span className="bg-red-500/20 text-red-500 text-xs px-2 py-0.5 rounded font-medium">
+                              GHOST — filed under this account's own address
+                            </span>
+                          ) : (
+                            <span className="text-subtle text-xs">ok</span>
+                          )}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                  {distribution.length === 0 && (
+                    <tr>
+                      <td colSpan={3} className="py-4 text-center text-subtle">
+                        No rows matched this prefix.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+
+        {/* Warnings */}
+        <div className="bg-surface-1 rounded-lg border border-default p-4 mt-6">
+          <Flex justify="between" align="center" className="mb-3">
+            <Flex gap="sm" align="center">
+              <Icon name="warning" size="md" className="text-yellow-500" />
+              <Text variant="strong" size="lg">Warning counters (since app start)</Text>
+            </Flex>
+            <Button variant="ghost" size="sm" onClick={() => setWarningState(getDmWarningState())}>
+              <Icon name="refresh" size="sm" />
+            </Button>
+          </Flex>
+          {warningState?.installedAt && (
+            <Text variant="subtle" size="xs" className="mb-3">
+              Installed at {warningState.installedAt}
+            </Text>
+          )}
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            {(Object.keys(WARNING_LABELS) as DmWarningKey[]).map((key) => (
+              <div key={key} className="bg-surface-2 rounded p-3">
+                <Text variant="subtle" size="xs">{WARNING_LABELS[key]}</Text>
+                <Text
+                  variant="strong"
+                  size="2xl"
+                  className={warningState && warningState.counts[key] > 0 ? 'text-red-500' : ''}
+                >
+                  {warningState?.counts[key] ?? 0}
+                </Text>
+                {warningState && warningState.lastHits[key].length > 0 && (
+                  <Text variant="subtle" size="xs" className="mt-1 block">
+                    last: {warningState.lastHits[key][0]}
+                  </Text>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Ghost conversations */}
+        <div className="bg-surface-1 rounded-lg border border-default p-4 mt-6 mb-8">
+          <Flex gap="sm" align="center" className="mb-3">
+            <Icon name="ghost" size="md" className="text-accent" />
+            <Text variant="strong" size="lg">Ghost / duplicate conversation rows</Text>
+          </Flex>
+          {ghosts === null ? (
+            <Text variant="subtle" size="sm">Run a scan to check for ghost conversations.</Text>
+          ) : ghosts.length === 0 ? (
+            <Text variant="subtle" size="sm">None found.</Text>
+          ) : (
+            <div className="overflow-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-left border-b border-default">
+                    <th className="py-1 pr-4">Address</th>
+                    <th className="py-1 pr-4">Display name</th>
+                    <th className="py-1 pr-4">Last message id</th>
+                    <th className="py-1">Reason</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {ghosts.map((row) => (
+                    <tr key={row.conversationId} className="border-b border-default/50">
+                      <td className="py-1 pr-4 font-mono">{truncateAddress(row.address)}</td>
+                      <td className="py-1 pr-4">{row.displayName || '(none)'}</td>
+                      <td className="py-1 pr-4 font-mono">
+                        {row.lastMessageId ? truncateAddress(row.lastMessageId) : '(none)'}
+                      </td>
+                      <td className="py-1">
+                        <span className="bg-red-500/20 text-red-500 text-xs px-2 py-0.5 rounded font-medium">
+                          {row.reasons.join(', ')}
+                        </span>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/dev/dm-doctor/dmDoctorCore.ts
+++ b/src/dev/dm-doctor/dmDoctorCore.ts
@@ -1,0 +1,230 @@
+/**
+ * DM Doctor — pure core logic.
+ *
+ * No DOM, no IndexedDB, no window/console access. Everything here takes plain
+ * data in and returns plain data out, so it is fully unit-testable without a
+ * browser environment. IndexedDB reads live in `dmDoctorDb.ts`; the console-wrap
+ * warning counters live in `warningCounters.ts`; the page that wires it all
+ * together is `DmDoctor.tsx`.
+ *
+ * This ports the matching logic of the checked-in console probe
+ * (`.agents/tools/dm-debug/07-receiver-probe.js`) so the same numbers a manual
+ * probe run would produce come out of the resident dev panel, plus the two
+ * misfiling/ghost-conversation checks from
+ * `.agents/bugs/2026-07-29-stale-returning-device-dm-sends-vanish-and-misfile.md`.
+ */
+
+/** Minimal shape of a `messages` store row this module needs to read. */
+export interface DmDoctorMessageRow {
+  spaceId: string;
+  channelId?: string;
+  createdDate?: number;
+  content?: {
+    text?: string | string[] | null;
+  } | null;
+}
+
+/** Minimal shape of a `conversations` store row this module needs to read. */
+export interface DmDoctorConversationRow {
+  conversationId: string;
+  type: 'direct' | 'group';
+  address: string;
+  displayName?: string;
+  lastMessageId?: string;
+}
+
+/** One matched sequence number, with where it was filed. */
+export interface ScanHit {
+  n: number;
+  spaceId: string;
+  /** true when this hit's spaceId equals the account's own address — a DM's
+   *  conversation home must be the PEER's address, never the account's own. */
+  misfiled: boolean;
+  createdDate: number;
+}
+
+export interface ScanResult {
+  landed: number;
+  missing: number[];
+  duplicates: number;
+  hits: ScanHit[];
+  byConversation: Record<string, number>;
+}
+
+/** Escape a string for safe use inside a RegExp — the prefix is user input. */
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Scan every message row's text (`^\s*<prefix>\s*(\d+)\s*$`, case-insensitive)
+ * for the numbered-burst pattern the manual test rounds send (e.g. "V 1" …
+ * "V 20"), across the WHOLE messages store — not scoped to any one
+ * conversation, so misfiled rows still get counted. Mirrors
+ * `.agents/tools/dm-debug/07-receiver-probe.js` exactly.
+ */
+export function scanSequence(
+  messages: DmDoctorMessageRow[],
+  prefix: string,
+  expected: number,
+  ownAddress: string | null | undefined
+): ScanResult {
+  const re = new RegExp('^\\s*' + escapeRegExp(prefix) + '\\s*(\\d+)\\s*$', 'i');
+  const hits: ScanHit[] = [];
+
+  for (const message of messages) {
+    const raw = message?.content?.text;
+    const texts = Array.isArray(raw) ? raw : [raw];
+    for (const text of texts) {
+      if (typeof text !== 'string') continue;
+      const match = re.exec(text);
+      if (!match) continue;
+      hits.push({
+        n: Number(match[1]),
+        spaceId: message.spaceId,
+        misfiled: Boolean(ownAddress) && message.spaceId === ownAddress,
+        createdDate: message.createdDate ?? 0,
+      });
+    }
+  }
+
+  const seen = new Set<number>();
+  for (const hit of hits) seen.add(hit.n);
+  const landed = seen.size;
+
+  const missing: number[] = [];
+  for (let i = 1; i <= expected; i++) {
+    if (!seen.has(i)) missing.push(i);
+  }
+
+  const byConversation: Record<string, number> = {};
+  for (const hit of hits) {
+    byConversation[hit.spaceId] = (byConversation[hit.spaceId] ?? 0) + 1;
+  }
+
+  return {
+    landed,
+    missing,
+    duplicates: hits.length - landed,
+    hits,
+    byConversation,
+  };
+}
+
+export type GhostReason = 'self-address' | 'duplicate-peer';
+
+export interface GhostConversationRow {
+  conversationId: string;
+  address: string;
+  displayName: string;
+  lastMessageId?: string;
+  reasons: GhostReason[];
+}
+
+/**
+ * Find conversation rows that are the ghost-conversation artifact described in
+ * bugs/2026-07-29-stale-returning-device-dm-sends-vanish-and-misfile.md:
+ *
+ * - a `direct` row keyed by the account's OWN address (or conversationId) —
+ *   a DM conversation must be keyed by the peer, never by the account itself.
+ * - a `direct` row that shares its `address` with another `direct` row — two
+ *   rows for what should be one peer (a second observed artifact).
+ *
+ * A row can carry both reasons; it appears once in the result either way.
+ */
+export function findGhostConversations(
+  conversations: DmDoctorConversationRow[],
+  ownAddress: string | null | undefined
+): GhostConversationRow[] {
+  const direct = conversations.filter((c) => c.type === 'direct');
+  const byId = new Map<string, GhostConversationRow>();
+
+  const flag = (row: DmDoctorConversationRow, reason: GhostReason) => {
+    const existing = byId.get(row.conversationId);
+    if (existing) {
+      if (!existing.reasons.includes(reason)) existing.reasons.push(reason);
+      return;
+    }
+    byId.set(row.conversationId, {
+      conversationId: row.conversationId,
+      address: row.address,
+      displayName: row.displayName ?? '',
+      lastMessageId: row.lastMessageId,
+      reasons: [reason],
+    });
+  };
+
+  if (ownAddress) {
+    for (const row of direct) {
+      if (row.address === ownAddress || row.conversationId === ownAddress) {
+        flag(row, 'self-address');
+      }
+    }
+  }
+
+  const byAddress = new Map<string, DmDoctorConversationRow[]>();
+  for (const row of direct) {
+    const list = byAddress.get(row.address);
+    if (list) {
+      list.push(row);
+    } else {
+      byAddress.set(row.address, [row]);
+    }
+  }
+  for (const rows of byAddress.values()) {
+    if (rows.length < 2) continue;
+    for (const row of rows) flag(row, 'duplicate-peer');
+  }
+
+  return [...byId.values()];
+}
+
+/** Inputs supplied by the caller — the parts a `ScanResult` cannot know. */
+export interface MeasurementRowMeta {
+  when: string;
+  run: string;
+  configuration: string;
+  /** The expected count the scan was run against (for the "landed/expected" cell). */
+  expected: number;
+  whatItChanged?: string;
+  source?: string;
+}
+
+/**
+ * Format a scan result as a markdown table row matching the convention of
+ * `.agents/docs/transport-measurements.md`
+ * (`| when | run | configuration | class | result | what it changed | source |`).
+ * Always reports class "persistence" — a store scan reads what the app kept,
+ * not what arrived on the wire or decrypted.
+ */
+export function formatMeasurementRow(
+  scanResult: ScanResult,
+  meta: MeasurementRowMeta
+): string {
+  const misfiledCount = scanResult.hits.filter((hit) => hit.misfiled).length;
+
+  const resultParts = [`${scanResult.landed}/${meta.expected} landed`];
+  if (scanResult.missing.length) {
+    resultParts.push(`missing [${scanResult.missing.join(', ')}]`);
+  } else {
+    resultParts.push('none missing');
+  }
+  if (scanResult.duplicates) {
+    resultParts.push(`duplicates ${scanResult.duplicates}`);
+  }
+  if (misfiledCount) {
+    resultParts.push(`${misfiledCount} misfiled (ghost self-conversation)`);
+  }
+
+  const cells = [
+    meta.when,
+    meta.run,
+    meta.configuration,
+    'persistence',
+    resultParts.join(', '),
+    meta.whatItChanged ?? '',
+    meta.source ?? '',
+  ];
+
+  return `| ${cells.map((cell) => cell.replace(/\|/g, '\\|')).join(' | ')} |`;
+}

--- a/src/dev/dm-doctor/dmDoctorDb.ts
+++ b/src/dev/dm-doctor/dmDoctorDb.ts
@@ -1,0 +1,57 @@
+/**
+ * DM Doctor — IndexedDB reads.
+ *
+ * Thin IO layer, deliberately separate from `dmDoctorCore.ts` so the matching
+ * logic stays pure and unit-testable without a browser. Opens `quorum_db`
+ * without a version number (never triggers an upgrade — see
+ * `.agents/docs/quorum-db-schema.md`'s dev gotcha), same as the console probe
+ * this tool replaces (`.agents/tools/dm-debug/07-receiver-probe.js`).
+ */
+
+import type { DmDoctorConversationRow, DmDoctorMessageRow } from './dmDoctorCore';
+
+const DB_NAME = 'quorum_db';
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME);
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () =>
+      reject(request.error ?? new Error(`Failed to open ${DB_NAME}`));
+  });
+}
+
+function readAll<T>(db: IDBDatabase, storeName: string): Promise<T[]> {
+  return new Promise((resolve, reject) => {
+    try {
+      const tx = db.transaction(storeName, 'readonly');
+      const request = tx.objectStore(storeName).getAll();
+      request.onsuccess = () => resolve(request.result as T[]);
+      request.onerror = () =>
+        reject(request.error ?? new Error(`Failed to read ${storeName}`));
+    } catch (err) {
+      reject(err instanceof Error ? err : new Error(String(err)));
+    }
+  });
+}
+
+/** Every row in the `messages` store — the whole store, not one conversation,
+ *  since misfiled rows live under the wrong conversation by definition. */
+export async function readAllMessages(): Promise<DmDoctorMessageRow[]> {
+  const db = await openDb();
+  try {
+    return await readAll<DmDoctorMessageRow>(db, 'messages');
+  } finally {
+    db.close();
+  }
+}
+
+/** Every row in the `conversations` store. */
+export async function readAllConversations(): Promise<DmDoctorConversationRow[]> {
+  const db = await openDb();
+  try {
+    return await readAll<DmDoctorConversationRow>(db, 'conversations');
+  } finally {
+    db.close();
+  }
+}

--- a/src/dev/dm-doctor/index.ts
+++ b/src/dev/dm-doctor/index.ts
@@ -1,0 +1,21 @@
+export { DmDoctor } from './DmDoctor';
+export {
+  scanSequence,
+  findGhostConversations,
+  formatMeasurementRow,
+} from './dmDoctorCore';
+export type {
+  DmDoctorMessageRow,
+  DmDoctorConversationRow,
+  ScanHit,
+  ScanResult,
+  GhostReason,
+  GhostConversationRow,
+  MeasurementRowMeta,
+} from './dmDoctorCore';
+export { readAllMessages, readAllConversations } from './dmDoctorDb';
+export {
+  installDmWarningCounters,
+  getDmWarningState,
+} from './warningCounters';
+export type { DmWarningKey, DmWarningCounterState } from './warningCounters';

--- a/src/dev/dm-doctor/warningCounters.ts
+++ b/src/dev/dm-doctor/warningCounters.ts
@@ -1,0 +1,125 @@
+/**
+ * DM Doctor — resident warning counters.
+ *
+ * Wraps console.log/warn/error/info (dev builds only) to count the three
+ * receive-path warnings that are the tell-tale signs of the DM-loss bugs this
+ * tool exists to surface:
+ *   - "SESSION REPLACED by init envelope"  (src/services/MessageService.ts)
+ *   - "DM frame for unknown inbox"          (src/services/MessageService.ts)
+ *   - /decrypt/i AND /fail|error|unable/i together
+ *
+ * Ports the exact matching logic of the checked-in console probe
+ * (`.agents/tools/dm-debug/07-receiver-probe.js`).
+ *
+ * `@quilibrium/quorum-shared`'s `logger.warn/error/...` look up `console[level]`
+ * fresh on every call (see quorum-shared/src/utils/logger.ts:
+ * `createLogMethod` — `(...args) => { if (shouldLog(level)) console[level](...args); }`),
+ * so wrapping `console[name]` here catches every call through `logger` too,
+ * regardless of install order.
+ *
+ * SECURITY / zero production footprint: this file lives under `src/dev/`, which
+ * `web/vite.config.ts`'s `rolldownOptions.external` excludes from production
+ * builds outright (any module path containing `/src/dev/` is externalized when
+ * `NODE_ENV === 'production'`). The throw below is the same defence-in-depth
+ * `dbDumpUtil.ts` uses: this module must never be *imported* in a production
+ * build, and the one call site that imports it (`web/main.tsx`) only does so
+ * inside a `process.env.NODE_ENV === 'development'` guard — mirroring the
+ * `lazyDevImport` pattern `Router.web.tsx` uses for every other dev route, so
+ * the import is dead-code-eliminated (not just runtime-skipped) in production.
+ */
+
+// Safety check - this module should never be imported in production builds.
+if (typeof process !== 'undefined' && process.env?.NODE_ENV === 'production') {
+  throw new Error(
+    'dm-doctor/warningCounters should not be imported in production builds'
+  );
+}
+
+export type DmWarningKey = 'sessionReplaced' | 'unknownInbox' | 'decryptFailish';
+
+export interface DmWarningCounterState {
+  installedAt: string | null;
+  counts: Record<DmWarningKey, number>;
+  /** Most recent occurrence first, capped at 5, ISO timestamps. */
+  lastHits: Record<DmWarningKey, string[]>;
+}
+
+const MATCHERS: Array<[DmWarningKey, (s: string) => boolean]> = [
+  ['sessionReplaced', (s) => s.includes('SESSION REPLACED by init envelope')],
+  ['unknownInbox', (s) => s.includes('DM frame for unknown inbox')],
+  ['decryptFailish', (s) => /decrypt/i.test(s) && /fail|error|unable/i.test(s)],
+];
+
+const MAX_LAST_HITS = 5;
+
+const state: DmWarningCounterState = {
+  installedAt: null,
+  counts: { sessionReplaced: 0, unknownInbox: 0, decryptFailish: 0 },
+  lastHits: { sessionReplaced: [], unknownInbox: [], decryptFailish: [] },
+};
+
+let installed = false;
+
+/**
+ * Install the console wrap. Idempotent — safe to call more than once (e.g. if
+ * both the startup import and a page mount race), only the first call wraps
+ * console and resets the install timestamp.
+ */
+export function installDmWarningCounters(): DmWarningCounterState {
+  if (installed) return getDmWarningState();
+  if (typeof console === 'undefined') return getDmWarningState();
+
+  installed = true;
+  state.installedAt = new Date().toISOString();
+
+  (['log', 'warn', 'error', 'info'] as const).forEach((name) => {
+    const original = console[name].bind(console);
+    console[name] = (...args: unknown[]) => {
+      try {
+        const text = args
+          .map((arg) => (typeof arg === 'string' ? arg : ''))
+          .join(' ');
+        for (const [key, test] of MATCHERS) {
+          if (!test(text)) continue;
+          state.counts[key]++;
+          const hits = state.lastHits[key];
+          hits.unshift(new Date().toISOString());
+          if (hits.length > MAX_LAST_HITS) hits.length = MAX_LAST_HITS;
+        }
+      } catch {
+        // Instrumentation must never break real logging.
+      }
+      original(...args);
+    };
+  });
+
+  if (typeof window !== 'undefined') {
+    (window as unknown as { __dmWarningCounters: () => DmWarningCounterState }).__dmWarningCounters =
+      getDmWarningState;
+  }
+
+  return getDmWarningState();
+}
+
+/** Read-only snapshot of the current counter state. */
+export function getDmWarningState(): DmWarningCounterState {
+  return {
+    installedAt: state.installedAt,
+    counts: { ...state.counts },
+    lastHits: {
+      sessionReplaced: [...state.lastHits.sessionReplaced],
+      unknownInbox: [...state.lastHits.unknownInbox],
+      decryptFailish: [...state.lastHits.decryptFailish],
+    },
+  };
+}
+
+/** Test-only: reset install state so a fresh test can call install again. */
+export function __resetForTests(): void {
+  installed = false;
+  state.installedAt = null;
+  (Object.keys(state.counts) as DmWarningKey[]).forEach((key) => {
+    state.counts[key] = 0;
+    state.lastHits[key] = [];
+  });
+}

--- a/src/dev/tests/dm-doctor/dmDoctorCore.unit.test.ts
+++ b/src/dev/tests/dm-doctor/dmDoctorCore.unit.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, it } from 'vitest';
+import {
+  scanSequence,
+  findGhostConversations,
+  formatMeasurementRow,
+  type DmDoctorMessageRow,
+  type DmDoctorConversationRow,
+} from '../../dm-doctor/dmDoctorCore';
+
+const OWN = 'own-address-b';
+const PEER = 'peer-address-a';
+
+function msg(
+  n: number,
+  spaceId: string,
+  opts: { prefix?: string; createdDate?: number; textOverride?: string | string[] } = {}
+): DmDoctorMessageRow {
+  const { prefix = 'V', createdDate = 1000 + n, textOverride } = opts;
+  return {
+    spaceId,
+    channelId: spaceId,
+    createdDate,
+    content: { text: textOverride ?? `${prefix} ${n}` },
+  };
+}
+
+describe('scanSequence', () => {
+  it('matches today\'s real-data shape: 20 hits, all filed under the account\'s own address (misfiled)', () => {
+    // Mirrors the 2026-07-29 V-run: 20/20 in the store, every row filed under
+    // spaceId = channelId = the sender's own address instead of the peer's.
+    const messages = Array.from({ length: 20 }, (_, i) => msg(i + 1, OWN));
+    const result = scanSequence(messages, 'V', 20, OWN);
+
+    expect(result.landed).toBe(20);
+    expect(result.missing).toEqual([]);
+    expect(result.duplicates).toBe(0);
+    expect(result.hits).toHaveLength(20);
+    expect(result.hits.every((h) => h.misfiled)).toBe(true);
+    expect(result.byConversation).toEqual({ [OWN]: 20 });
+  });
+
+  it('matches the U-run shape: 17/20 landed, missing [2, 5, 10], not misfiled', () => {
+    const numbers = Array.from({ length: 20 }, (_, i) => i + 1).filter(
+      (n) => ![2, 5, 10].includes(n)
+    );
+    const messages = numbers.map((n) => msg(n, PEER, { prefix: 'U' }));
+    const result = scanSequence(messages, 'U', 20, OWN);
+
+    expect(result.landed).toBe(17);
+    expect(result.missing).toEqual([2, 5, 10]);
+    expect(result.duplicates).toBe(0);
+    expect(result.hits.every((h) => !h.misfiled)).toBe(true);
+  });
+
+  it('counts duplicates when the same number lands more than once', () => {
+    const messages = [
+      msg(1, PEER),
+      msg(1, PEER, { createdDate: 2000 }), // redelivered copy of the same number
+      msg(2, PEER),
+    ];
+    const result = scanSequence(messages, 'V', 2, OWN);
+
+    expect(result.landed).toBe(2);
+    expect(result.missing).toEqual([]);
+    expect(result.duplicates).toBe(1);
+    expect(result.hits).toHaveLength(3);
+  });
+
+  it('reads content.text as a string[] the same way as a plain string', () => {
+    const messages: DmDoctorMessageRow[] = [
+      { spaceId: PEER, content: { text: ['V 1', 'not a match'] } },
+      { spaceId: PEER, content: { text: 'V 2' } },
+    ];
+    const result = scanSequence(messages, 'V', 2, OWN);
+
+    expect(result.landed).toBe(2);
+    expect(result.missing).toEqual([]);
+  });
+
+  it('is case-insensitive on the prefix, matches the probe regex exactly', () => {
+    const messages: DmDoctorMessageRow[] = [
+      { spaceId: PEER, content: { text: 'v1' } },
+      { spaceId: PEER, content: { text: '  V   2  ' } },
+    ];
+    const result = scanSequence(messages, 'V', 2, OWN);
+
+    expect(result.landed).toBe(2);
+  });
+
+  it('ignores non-matching text and rows with missing/non-string content', () => {
+    const messages: DmDoctorMessageRow[] = [
+      { spaceId: PEER, content: { text: 'hello world' } },
+      { spaceId: PEER, content: {} },
+      { spaceId: PEER, content: null },
+      { spaceId: PEER },
+      { spaceId: PEER, content: { text: 'V 1' } },
+    ];
+    const result = scanSequence(messages, 'V', 1, OWN);
+
+    expect(result.landed).toBe(1);
+    expect(result.missing).toEqual([]);
+  });
+
+  it('marks misfiled only when ownAddress is known and matches spaceId', () => {
+    const messages = [msg(1, OWN)];
+    const withoutOwn = scanSequence(messages, 'V', 1, null);
+    const withOwn = scanSequence(messages, 'V', 1, OWN);
+
+    expect(withoutOwn.hits[0].misfiled).toBe(false);
+    expect(withOwn.hits[0].misfiled).toBe(true);
+  });
+
+  it('tallies byConversation across every distinct spaceId seen', () => {
+    const messages = [msg(1, PEER), msg(2, PEER), msg(3, OWN)];
+    const result = scanSequence(messages, 'V', 3, OWN);
+
+    expect(result.byConversation).toEqual({ [PEER]: 2, [OWN]: 1 });
+  });
+
+  it('treats an empty prefix as "just digits", and escapes regex-special prefixes safely', () => {
+    const messages: DmDoctorMessageRow[] = [{ spaceId: PEER, content: { text: '7' } }];
+    expect(scanSequence(messages, '', 7, OWN).landed).toBe(1);
+
+    // A prefix containing a regex metacharacter must be treated literally, not
+    // as part of the pattern (defensive — the UI restricts this to one letter,
+    // but the function itself must not be exploitable/crashable).
+    const weird: DmDoctorMessageRow[] = [{ spaceId: PEER, content: { text: 'V. 1' } }];
+    expect(() => scanSequence(weird, 'V.', 1, OWN)).not.toThrow();
+    expect(scanSequence(weird, 'V.', 1, OWN).landed).toBe(1);
+    expect(scanSequence([{ spaceId: PEER, content: { text: 'VX 1' } }], 'V.', 1, OWN).landed).toBe(0);
+  });
+
+  it('only reports missing numbers within 1..expected, even if higher numbers landed', () => {
+    const messages = [msg(1, PEER), msg(25, PEER)];
+    const result = scanSequence(messages, 'V', 2, OWN);
+
+    expect(result.landed).toBe(2); // both 1 and 25 are distinct landed numbers
+    expect(result.missing).toEqual([2]); // only 2 is missing from the 1..2 range
+  });
+});
+
+function conv(
+  conversationId: string,
+  address: string,
+  overrides: Partial<DmDoctorConversationRow> = {}
+): DmDoctorConversationRow {
+  return {
+    conversationId,
+    type: 'direct',
+    address,
+    displayName: overrides.displayName ?? `name-${address}`,
+    lastMessageId: overrides.lastMessageId,
+    ...overrides,
+  };
+}
+
+describe('findGhostConversations', () => {
+  it('flags a direct row whose address equals the account\'s own address', () => {
+    const rows = [conv(OWN, OWN), conv(PEER, PEER)];
+    const ghosts = findGhostConversations(rows, OWN);
+
+    expect(ghosts).toHaveLength(1);
+    expect(ghosts[0].conversationId).toBe(OWN);
+    expect(ghosts[0].reasons).toEqual(['self-address']);
+  });
+
+  it('flags a direct row whose conversationId (not address) equals the account\'s own address', () => {
+    const rows = [conv(OWN, 'some-other-address'), conv(PEER, PEER)];
+    const ghosts = findGhostConversations(rows, OWN);
+
+    expect(ghosts).toHaveLength(1);
+    expect(ghosts[0].conversationId).toBe(OWN);
+    expect(ghosts[0].reasons).toEqual(['self-address']);
+  });
+
+  it('flags a pair of direct rows sharing the same peer address as duplicate-peer', () => {
+    const rows = [
+      conv('conv-1', PEER, { displayName: 'Alice (old)' }),
+      conv('conv-2', PEER, { displayName: 'Alice (new)' }),
+    ];
+    const ghosts = findGhostConversations(rows, OWN);
+
+    expect(ghosts).toHaveLength(2);
+    expect(ghosts.map((g) => g.conversationId).sort()).toEqual(['conv-1', 'conv-2']);
+    expect(ghosts.every((g) => g.reasons.includes('duplicate-peer'))).toBe(true);
+  });
+
+  it('carries both reasons once, without duplicating the row, when a row matches both criteria', () => {
+    const rows = [conv(OWN, OWN), conv('conv-2', OWN)];
+    const ghosts = findGhostConversations(rows, OWN);
+
+    expect(ghosts).toHaveLength(2);
+    const selfRow = ghosts.find((g) => g.conversationId === OWN)!;
+    expect(selfRow.reasons.sort()).toEqual(['duplicate-peer', 'self-address']);
+  });
+
+  it('ignores group-type rows entirely', () => {
+    const rows: DmDoctorConversationRow[] = [
+      { conversationId: OWN, type: 'group', address: OWN, displayName: 'Some space channel' },
+    ];
+    expect(findGhostConversations(rows, OWN)).toEqual([]);
+  });
+
+  it('returns nothing when there are no ghosts and no duplicates', () => {
+    const rows = [conv('conv-1', PEER), conv('conv-2', 'someone-else')];
+    expect(findGhostConversations(rows, OWN)).toEqual([]);
+  });
+
+  it('does not flag self-address ghosts when ownAddress is unknown', () => {
+    const rows = [conv(OWN, OWN)];
+    expect(findGhostConversations(rows, null)).toEqual([]);
+  });
+});
+
+describe('formatMeasurementRow', () => {
+  it('formats a clean run as a markdown table row', () => {
+    const result = scanSequence(
+      Array.from({ length: 20 }, (_, i) => msg(i + 1, PEER)),
+      'V',
+      20,
+      OWN
+    );
+    const row = formatMeasurementRow(result, {
+      when: '2026-07-30',
+      run: 'DM doctor scan (prefix "V")',
+      configuration: 'own=own-address-b',
+      expected: 20,
+      whatItChanged: 'confirmed clean',
+      source: 'DM doctor panel',
+    });
+
+    expect(row).toBe(
+      '| 2026-07-30 | DM doctor scan (prefix "V") | own=own-address-b | persistence | 20/20 landed, none missing | confirmed clean | DM doctor panel |'
+    );
+  });
+
+  it('reports missing, duplicates and misfiled counts together', () => {
+    const messages = [
+      msg(1, OWN),
+      msg(1, OWN, { createdDate: 2000 }), // duplicate
+      msg(3, OWN),
+    ];
+    const result = scanSequence(messages, 'V', 3, OWN);
+    const row = formatMeasurementRow(result, {
+      when: '2026-07-30',
+      run: 'scan',
+      configuration: 'cfg',
+      expected: 3,
+    });
+
+    expect(row).toContain('2/3 landed');
+    expect(row).toContain('missing [2]');
+    expect(row).toContain('duplicates 1');
+    // All 3 matched rows (including the duplicate) are filed under the
+    // account's own address, so all 3 hits — not just the 2 unique numbers —
+    // are misfiled.
+    expect(row).toContain('3 misfiled (ghost self-conversation)');
+  });
+
+  it('escapes pipe characters in free-text fields so the row stays a valid table row', () => {
+    const result = scanSequence([msg(1, PEER)], 'V', 1, OWN);
+    const row = formatMeasurementRow(result, {
+      when: '2026-07-30',
+      run: 'scan | with a pipe',
+      configuration: 'cfg',
+      expected: 1,
+    });
+
+    expect(row).toContain('scan \\| with a pipe');
+  });
+
+  it('defaults optional fields to empty cells', () => {
+    const result = scanSequence([msg(1, PEER)], 'V', 1, OWN);
+    const row = formatMeasurementRow(result, {
+      when: '2026-07-30',
+      run: 'scan',
+      configuration: 'cfg',
+      expected: 1,
+    });
+
+    const cells = row.split('|').map((c) => c.trim());
+    // | when | run | configuration | class | result | whatItChanged | source |
+    expect(cells[6]).toBe(''); // whatItChanged
+    expect(cells[7]).toBe(''); // source
+  });
+});

--- a/src/dev/tests/dm-doctor/warningCounters.unit.test.ts
+++ b/src/dev/tests/dm-doctor/warningCounters.unit.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  installDmWarningCounters,
+  getDmWarningState,
+  __resetForTests,
+} from '../../dm-doctor/warningCounters';
+
+describe('warningCounters', () => {
+  let originalWarn: typeof console.warn;
+  let originalLog: typeof console.log;
+  let originalError: typeof console.error;
+  let originalInfo: typeof console.info;
+
+  beforeEach(() => {
+    originalWarn = console.warn;
+    originalLog = console.log;
+    originalError = console.error;
+    originalInfo = console.info;
+    __resetForTests();
+  });
+
+  afterEach(() => {
+    console.warn = originalWarn;
+    console.log = originalLog;
+    console.error = originalError;
+    console.info = originalInfo;
+  });
+
+  it('counts the three tell-tale receive-path warnings the probe matches', () => {
+    installDmWarningCounters();
+
+    console.warn('[MessageService] ⚠️ SESSION REPLACED by init envelope', { a: 1 });
+    console.warn('[MessageService] DM frame for unknown inbox — no encryption state, retained unread');
+    console.error('Decryption failed: aead::Error');
+    console.warn('unable to decrypt frame');
+
+    const state = getDmWarningState();
+    expect(state.counts.sessionReplaced).toBe(1);
+    expect(state.counts.unknownInbox).toBe(1);
+    expect(state.counts.decryptFailish).toBe(2);
+  });
+
+  it('does not count unrelated log lines', () => {
+    installDmWarningCounters();
+    console.log('just a normal debug line');
+    console.info('decrypt succeeded'); // "decrypt" present but no fail/error/unable
+
+    const state = getDmWarningState();
+    expect(state.counts.sessionReplaced).toBe(0);
+    expect(state.counts.unknownInbox).toBe(0);
+    expect(state.counts.decryptFailish).toBe(0);
+  });
+
+  it('still calls through to the original console method (never swallows real logging)', () => {
+    const spy = vi.fn();
+    console.warn = spy;
+    installDmWarningCounters();
+
+    console.warn('hello world');
+    expect(spy).toHaveBeenCalledWith('hello world');
+  });
+
+  it('is idempotent: calling install twice does not double-wrap or reset counts', () => {
+    installDmWarningCounters();
+    console.warn('SESSION REPLACED by init envelope');
+    const afterFirst = getDmWarningState();
+
+    installDmWarningCounters();
+    const afterSecond = getDmWarningState();
+
+    expect(afterSecond.installedAt).toBe(afterFirst.installedAt);
+    expect(afterSecond.counts.sessionReplaced).toBe(1);
+  });
+
+  it('keeps only the last 5 hit timestamps per pattern, most recent first', () => {
+    installDmWarningCounters();
+    for (let i = 0; i < 7; i++) {
+      console.warn('SESSION REPLACED by init envelope');
+    }
+    const state = getDmWarningState();
+    expect(state.counts.sessionReplaced).toBe(7);
+    expect(state.lastHits.sessionReplaced).toHaveLength(5);
+  });
+});

--- a/web/main.tsx
+++ b/web/main.tsx
@@ -13,6 +13,23 @@ import { i18n } from '@lingui/core';
 import { I18nProvider } from '@lingui/react';
 import { dynamicActivate, getUserLocale } from '../src/i18n/i18n';
 
+// DM Doctor's warning counters must start counting at t=0, not whenever the
+// /dev/dm-doctor page happens to be opened — so they install here, at the
+// earliest point in app startup, rather than on page mount like the rest of
+// src/dev/'s tools. The `process.env.NODE_ENV === 'development'` guard mirrors
+// `lazyDevImport` in src/components/Router/Router.web.tsx: in a production
+// build NODE_ENV is statically replaced with the literal "production", so this
+// whole branch — including the dynamic import() call — is dead-code-eliminated
+// at build time, never just skipped at runtime. web/vite.config.ts's
+// `rolldownOptions.external` additionally excludes every module under
+// `src/dev/` from production builds outright, so nothing here can ship even if
+// this guard were somehow bypassed.
+if (process.env.NODE_ENV === 'development') {
+  import('../src/dev/dm-doctor/warningCounters').then((m) =>
+    m.installDmWarningCounters()
+  );
+}
+
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {


### PR DESCRIPTION
## Summary

Manual DM-loss test rounds required the operator to paste a console probe
by hand into DevTools before every run. This adds a resident, dev-build-only
diagnostic panel at `/dev/dm-doctor` that replaces that copy-paste step, per
T1 of `.agents/tasks/2026-07-29-transport-debug-workflow-and-tooling.md`.

- **Sequence scan**: reuses the exact matching logic of the checked-in
  console probe (`.agents/tools/dm-debug/07-receiver-probe.js`) — scans the
  whole `messages` store for a numbered burst (`<prefix> N`, case-insensitive)
  and reports landed / missing / duplicates, plus a per-conversation
  distribution table that loudly flags rows filed under the account's own
  address (the misfiling artifact from
  `.agents/bugs/2026-07-29-stale-returning-device-dm-sends-vanish-and-misfile.md`).
- **Warning counters**: wraps `console.log/warn/error/info` (dev builds only)
  to count the three tell-tale receive-path warnings — `SESSION REPLACED by
  init envelope`, `DM frame for unknown inbox`, and decrypt-fail-shaped lines
  — from **app start**, not from whenever the panel happens to be opened. See
  "Startup wiring" below.
- **Ghost conversations**: flags `direct`-type conversation rows keyed by the
  account's own address, and pairs of `direct` rows that share one peer
  address (a second observed artifact from the same bug).
- **Copy measurement row**: formats a scan result as a markdown row matching
  `.agents/docs/transport-measurements.md`'s table convention, for a
  one-click paste into that log.

## Startup wiring

The counters need to start at t=0, not at page mount, so — unlike every
other `src/dev/` tool, which only initializes on page visit — the installer
is imported from `web/main.tsx` itself, at the earliest point in app
startup, gated the same way `Router.web.tsx`'s `lazyDevImport` gates every
other dev route:

```ts
if (process.env.NODE_ENV === 'development') {
  import('../src/dev/dm-doctor/warningCounters').then((m) =>
    m.installDmWarningCounters()
  );
}
```

In production, `NODE_ENV` is statically replaced with the literal
`"production"`, so this whole branch — including the `import()` call itself —
is dead-code-eliminated at build time rather than merely skipped at runtime.
`DmDoctor.tsx` also calls the (idempotent) installer on mount as a defensive
fallback, in case this page is ever opened without the startup wiring having
run.

## Production exclusion — verified, not assumed

`web/vite.config.ts`'s `rolldownOptions.external` already excludes every
module under `src/dev/` from production builds outright, so this needed no
new build config. Verified directly with a real production build:

```
NODE_ENV=production npx vite build --config web/vite.config.ts
grep -rl "dm-doctor\|dmDoctor\|DmDoctor\|__dmWarningCounters" dist/web/assets/*.js   # no matches
grep -rl "db-inspector\|dbDumpUtil\|__dbDump" dist/web/assets/*.js                   # no matches (control: existing dev tool, also absent)
grep -l  "SESSION REPLACED" dist/web/assets/*.js                                    # present (real app string, ships correctly)
```

Zero production footprint, same as the existing `db-inspector` tool used as
a control.

## Files

- `src/dev/dm-doctor/dmDoctorCore.ts` — pure matching/formatting logic (no DOM, no IndexedDB)
- `src/dev/dm-doctor/dmDoctorDb.ts` — IndexedDB reads (`messages`, `conversations`)
- `src/dev/dm-doctor/warningCounters.ts` — resident console-wrap counters
- `src/dev/dm-doctor/DmDoctor.tsx` — the `/dev/dm-doctor` page
- `src/dev/dm-doctor/index.ts` — barrel export (mirrors `db-inspector`)
- `src/dev/tests/dm-doctor/*.unit.test.ts` — 26 unit tests
- `src/components/Router/Router.web.tsx`, `src/dev/DevMainPage.tsx`, `src/dev/DevNavMenu.tsx` — route + nav wiring
- `web/main.tsx` — dev-only startup import

## Test plan

Automated (all run from this branch):
- [x] `npx tsc --noEmit --jsx react-jsx --skipLibCheck` — 0 errors (matches the pre-change baseline)
- [x] `npx vitest run src/dev/tests/dm-doctor` — 26/26 passed
- [x] `npx eslint` on the changed/new files — 0 errors (3 pre-existing warnings, unrelated to this change)
- [x] Production build + dist grep — see above

Manual, for the reviewer (dev build, `yarn dev`):
- [ ] Open `/dev/dm-doctor`. Confirm the own-account address shown in the
      header matches the signed-in account, and the page matches the visual
      style of `/dev/db-inspector`.
- [ ] On the operator's desktop A profile: prefix `U`, expected `20`, Run →
      should report `17/20 landed`, `missing: 2, 5, 10`, `duplicates: 0`.
- [ ] On desktop B's profile: prefix `V`, expected `20`, Run → should report
      `20/20 landed`, and every row in the per-conversation distribution
      table flagged `GHOST — filed under this account's own address`.
- [ ] Ghosts card lists the known ghost/duplicate conversation row(s) on
      whichever profile carries them.
- [ ] Warning counters card shows nonzero counts with a "last:" timestamp if
      the profile has recent `SESSION REPLACED` / `unknown inbox` / decrypt-fail
      log lines; 0 otherwise. Click refresh — counters must not reset.
- [ ] "Copy measurement row" produces a markdown row pasteable directly into
      `.agents/docs/transport-measurements.md`.
- [ ] `/dev` (DevMainPage) and the dev nav bar both show a "DM Doctor" entry
      that navigates correctly.