### PR TITLE
feat: one-paste full report for the DM doctor panel

### DIFF
--- a/src/dev/dm-doctor/DmDoctor.tsx
+++ b/src/dev/dm-doctor/DmDoctor.tsx
@@ -1,13 +1,20 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { usePasskeysContext } from '@quilibrium/quilibrium-js-sdk-channels';
-import { Text, Flex, Button, Icon, Input } from '../../components/primitives';
+import { Text, Flex, Button, Icon, Input, Select } from '../../components/primitives';
 import { DevNavMenu } from '../DevNavMenu';
 import {
   scanSequence,
   findGhostConversations,
+  buildDirectConversationInventory,
   formatMeasurementRow,
+  formatFullReport,
+  computeScanWindowStart,
+  SCAN_WINDOW_LABELS,
   type ScanResult,
+  type ScanWindowOption,
+  type ScanHistoryEntry,
   type GhostConversationRow,
+  type DirectConversationInventory,
 } from './dmDoctorCore';
 import { readAllMessages, readAllConversations } from './dmDoctorDb';
 import {
@@ -25,25 +32,42 @@ const WARNING_LABELS: Record<DmWarningKey, string> = {
 
 const WARNING_POLL_MS = 5000;
 
+const WINDOW_OPTIONS: Array<{ value: ScanWindowOption; label: string }> = (
+  ['since-load', '1h', '6h', '24h', 'all'] as ScanWindowOption[]
+).map((value) => ({ value, label: SCAN_WINDOW_LABELS[value] }));
+
 function truncateAddress(address: string): string {
   if (address.length <= 20) return address;
   return `${address.slice(0, 10)}…${address.slice(-6)}`;
+}
+
+function formatIsoOrNa(ms: number | null): string {
+  return ms === null ? 'n/a' : new Date(ms).toISOString();
 }
 
 export const DmDoctor: React.FC = () => {
   const { currentPasskeyInfo } = usePasskeysContext();
   const ownAddress = currentPasskeyInfo?.address ?? null;
 
+  // "since page load" window option and the report's shared-context field both
+  // key off this — captured once, at mount.
+  const [pageLoadMs] = useState(() => Date.now());
+  const [pageLoadIso] = useState(() => new Date(pageLoadMs).toISOString());
+
   const [prefix, setPrefix] = useState('');
   const [expectedInput, setExpectedInput] = useState('20');
+  const [windowOption, setWindowOption] = useState<ScanWindowOption>('6h');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [scanResult, setScanResult] = useState<ScanResult | null>(null);
   const [scanExpected, setScanExpected] = useState(20);
   const [scanPrefix, setScanPrefix] = useState('');
   const [ghosts, setGhosts] = useState<GhostConversationRow[] | null>(null);
+  const [inventory, setInventory] = useState<DirectConversationInventory | null>(null);
   const [warningState, setWarningState] = useState<DmWarningCounterState | null>(null);
   const [copyStatus, setCopyStatus] = useState<string | null>(null);
+  const [history, setHistory] = useState<ScanHistoryEntry[]>([]);
+  const historyIdRef = useRef(0);
 
   // Defensive re-install: the panel's own life cycle is not the intended
   // install point (that's the dev-only startup import in web/main.tsx, so
@@ -67,16 +91,39 @@ export const DmDoctor: React.FC = () => {
         readAllMessages(),
         readAllConversations(),
       ]);
-      setScanResult(scanSequence(messages, prefix, expected, ownAddress));
+      const startMs = computeScanWindowStart(windowOption, Date.now(), pageLoadMs);
+      const result = scanSequence(messages, prefix, expected, ownAddress, {
+        option: windowOption,
+        startMs,
+      });
+      setScanResult(result);
       setGhosts(findGhostConversations(conversations, ownAddress));
+      setInventory(buildDirectConversationInventory(conversations, messages, ownAddress));
       setScanExpected(expected);
       setScanPrefix(prefix);
+
+      historyIdRef.current += 1;
+      setHistory((prev) => [
+        ...prev,
+        {
+          id: `scan-${historyIdRef.current}`,
+          atIso: new Date().toISOString(),
+          prefix,
+          expected,
+          ownAddress,
+          messagesScanned: messages.length,
+          conversationsScanned: conversations.length,
+          scanResult: result,
+        },
+      ]);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Scan failed');
     } finally {
       setLoading(false);
     }
-  }, [expectedInput, prefix, ownAddress]);
+  }, [expectedInput, prefix, ownAddress, windowOption, pageLoadMs]);
+
+  const clearHistory = useCallback(() => setHistory([]), []);
 
   const copyMeasurementRow = useCallback(async () => {
     if (!scanResult) return;
@@ -98,6 +145,26 @@ export const DmDoctor: React.FC = () => {
       setTimeout(() => setCopyStatus(null), 2000);
     }
   }, [scanResult, scanPrefix, scanExpected, ownAddress]);
+
+  const copyFullReport = useCallback(async () => {
+    try {
+      const report = formatFullReport({
+        generatedAtIso: new Date().toISOString(),
+        ownAddress,
+        pageLoadedAtIso: pageLoadIso,
+        history,
+        ghosts,
+        inventory,
+        warningState,
+      });
+      await navigator.clipboard.writeText(report);
+      setCopyStatus('Full report copied!');
+    } catch {
+      setCopyStatus('Failed to copy');
+    } finally {
+      setTimeout(() => setCopyStatus(null), 2000);
+    }
+  }, [ownAddress, pageLoadIso, history, ghosts, inventory, warningState]);
 
   const distribution = scanResult
     ? Object.entries(scanResult.byConversation).sort((a, b) => b[1] - a[1])
@@ -150,6 +217,18 @@ export const DmDoctor: React.FC = () => {
                 onChange={(value: string) => setExpectedInput(value)}
               />
             </div>
+            <div className="w-44">
+              <Text variant="subtle" size="xs" className="mb-1 block">
+                Window
+              </Text>
+              <Select
+                value={windowOption}
+                options={WINDOW_OPTIONS}
+                onChange={(value: string) => setWindowOption(value as ScanWindowOption)}
+                width="176px"
+                dropdownPlacement="bottom"
+              />
+            </div>
             <Button variant="primary" onClick={runScan} disabled={loading}>
               <Icon name={loading ? 'spinner' : 'search'} size="sm" className={loading ? 'animate-spin' : undefined} />
               {loading ? 'Scanning...' : 'Run'}
@@ -160,10 +239,19 @@ export const DmDoctor: React.FC = () => {
                 Copy measurement row
               </Button>
             )}
+            {history.length > 0 && (
+              <Button variant="primary" onClick={copyFullReport}>
+                <Icon name="copy" size="sm" />
+                Copy full report
+              </Button>
+            )}
           </Flex>
           <Text variant="subtle" size="xs" className="mt-2">
             Scans the WHOLE messages store for "{'{prefix} N'}" (case-insensitive),
-            same matching as .agents/tools/dm-debug/07-receiver-probe.js.
+            same matching as .agents/tools/dm-debug/07-receiver-probe.js. Prefix
+            letters get reused across test rounds, so matches outside the
+            selected window are excluded from the counts below but never hidden
+            from the report.
           </Text>
         </div>
 
@@ -178,7 +266,7 @@ export const DmDoctor: React.FC = () => {
           <div className="bg-surface-1 rounded-lg border border-default p-4 mt-6">
             <Flex justify="between" align="center" className="mb-4">
               <Text variant="strong" size="lg">
-                Results — prefix "{scanPrefix}"
+                Results — prefix "{scanPrefix}" ({SCAN_WINDOW_LABELS[scanResult.window.option]})
               </Text>
               <Text
                 variant="strong"
@@ -188,6 +276,26 @@ export const DmDoctor: React.FC = () => {
                 {scanResult.landed}/{scanExpected} landed
               </Text>
             </Flex>
+
+            {scanResult.window.matchesOutsideWindow > 0 && (
+              <div className="bg-yellow-500/10 border border-yellow-500/30 rounded p-2 mb-4">
+                <Text variant="strong" size="sm" className="text-yellow-500">
+                  {scanResult.window.matchesOutsideWindow} match(es) for this prefix fall OUTSIDE the
+                  selected window (oldest {formatIsoOrNa(scanResult.window.outsideOldestMs)}, newest{' '}
+                  {formatIsoOrNa(scanResult.window.outsideNewestMs)}) — a previous run may have used this
+                  same letter. Not counted in landed/missing above; widen the window to see them.
+                </Text>
+              </div>
+            )}
+
+            {scanResult.window.spanSuspicious && (
+              <div className="bg-yellow-500/10 border border-yellow-500/30 rounded p-2 mb-4">
+                <Text variant="strong" size="sm" className="text-yellow-500">
+                  SPAN-SUSPICIOUS: in-window hits span {Math.round(scanResult.window.spanSeconds ?? 0)}s
+                  (over 30 minutes) — the window likely caught more than one run. Narrow the window.
+                </Text>
+              </div>
+            )}
 
             <Flex gap="lg" className="flex-wrap mb-4">
               <div>
@@ -240,7 +348,7 @@ export const DmDoctor: React.FC = () => {
                   {distribution.length === 0 && (
                     <tr>
                       <td colSpan={3} className="py-4 text-center text-subtle">
-                        No rows matched this prefix.
+                        No rows matched this prefix in-window.
                       </td>
                     </tr>
                   )}
@@ -249,6 +357,57 @@ export const DmDoctor: React.FC = () => {
             </div>
           </div>
         )}
+
+        {/* Scan history */}
+        <div className="bg-surface-1 rounded-lg border border-default p-4 mt-6">
+          <Flex justify="between" align="center" className="mb-3">
+            <Flex gap="sm" align="center">
+              <Icon name="clock" size="md" className="text-accent" />
+              <Text variant="strong" size="lg">Session scan history ({history.length})</Text>
+            </Flex>
+            {history.length > 0 && (
+              <Button variant="ghost" size="sm" onClick={clearHistory}>
+                <Icon name="trash" size="sm" />
+                Clear history
+              </Button>
+            )}
+          </Flex>
+          {history.length === 0 ? (
+            <Text variant="subtle" size="sm">
+              No scans run yet this session. Every scan you run is kept here (and in "Copy full
+              report") until you clear it or reload the page.
+            </Text>
+          ) : (
+            <div className="overflow-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-left border-b border-default">
+                    <th className="py-1 pr-4">#</th>
+                    <th className="py-1 pr-4">Read at</th>
+                    <th className="py-1 pr-4">Prefix</th>
+                    <th className="py-1 pr-4">Window</th>
+                    <th className="py-1 pr-4">Landed</th>
+                    <th className="py-1">Outside window</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {history.map((entry, i) => (
+                    <tr key={entry.id} className="border-b border-default/50">
+                      <td className="py-1 pr-4">{i + 1}</td>
+                      <td className="py-1 pr-4 font-mono">{entry.atIso}</td>
+                      <td className="py-1 pr-4">{entry.prefix}</td>
+                      <td className="py-1 pr-4">{SCAN_WINDOW_LABELS[entry.scanResult.window.option]}</td>
+                      <td className="py-1 pr-4">
+                        {entry.scanResult.landed}/{entry.expected}
+                      </td>
+                      <td className="py-1">{entry.scanResult.window.matchesOutsideWindow}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
 
         {/* Warnings */}
         <div className="bg-surface-1 rounded-lg border border-default p-4 mt-6">
@@ -287,11 +446,11 @@ export const DmDoctor: React.FC = () => {
           </div>
         </div>
 
-        {/* Ghost conversations */}
-        <div className="bg-surface-1 rounded-lg border border-default p-4 mt-6 mb-8">
+        {/* Ghost conversations (flagged summary) */}
+        <div className="bg-surface-1 rounded-lg border border-default p-4 mt-6">
           <Flex gap="sm" align="center" className="mb-3">
             <Icon name="ghost" size="md" className="text-accent" />
-            <Text variant="strong" size="lg">Ghost / duplicate conversation rows</Text>
+            <Text variant="strong" size="lg">Ghost / duplicate conversation rows (flagged summary)</Text>
           </Flex>
           {ghosts === null ? (
             <Text variant="subtle" size="sm">Run a scan to check for ghost conversations.</Text>
@@ -326,6 +485,72 @@ export const DmDoctor: React.FC = () => {
                 </tbody>
               </table>
             </div>
+          )}
+        </div>
+
+        {/* Direct conversations inventory (authoritative — unconditional) */}
+        <div className="bg-surface-1 rounded-lg border border-default p-4 mt-6 mb-8">
+          <Flex gap="sm" align="center" className="mb-1">
+            <Icon name="clipboard-list" size="md" className="text-accent" />
+            <Text variant="strong" size="lg">Direct conversations inventory (every row, unconditionally)</Text>
+          </Flex>
+          <Text variant="subtle" size="xs" className="mb-3">
+            The ghost card above only ever prints its own positives — a suspicious row it doesn't
+            flag looks identical to a row it never saw. This lists every `type: 'direct'` row so you
+            can judge for yourself, plus any messages-store keys with no matching conversation row.
+          </Text>
+          {inventory === null ? (
+            <Text variant="subtle" size="sm">Run a scan to build the inventory.</Text>
+          ) : (
+            <>
+              <Text variant="subtle" size="xs" className="mb-2">
+                total direct rows: {inventory.totalDirectRows}
+              </Text>
+              <div className="overflow-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="text-left border-b border-default">
+                      <th className="py-1 pr-4">Conversation id</th>
+                      <th className="py-1 pr-4">Address</th>
+                      <th className="py-1 pr-4">Display name</th>
+                      <th className="py-1 pr-4">Messages</th>
+                      <th className="py-1">Flags</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {inventory.rows.length === 0 && (
+                      <tr>
+                        <td colSpan={5} className="py-4 text-center text-subtle">
+                          No direct conversation rows and no orphan keys.
+                        </td>
+                      </tr>
+                    )}
+                    {inventory.rows.map((row) => (
+                      <tr key={`${row.conversationId}-${row.address}`} className="border-b border-default/50">
+                        <td className="py-1 pr-4 font-mono">{truncateAddress(row.conversationId)}</td>
+                        <td className="py-1 pr-4 font-mono">{truncateAddress(row.address)}</td>
+                        <td className="py-1 pr-4">{row.displayName}</td>
+                        <td className="py-1 pr-4">{row.messageCount}</td>
+                        <td className="py-1">
+                          {row.flags.length === 0 ? (
+                            <span className="text-subtle text-xs">none</span>
+                          ) : (
+                            row.flags.map((flag) => (
+                              <span
+                                key={flag}
+                                className="bg-red-500/20 text-red-500 text-xs px-2 py-0.5 rounded font-medium mr-1"
+                              >
+                                {flag}
+                              </span>
+                            ))
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </>
           )}
         </div>
       </div>

--- a/src/dev/dm-doctor/dmDoctorCore.ts
+++ b/src/dev/dm-doctor/dmDoctorCore.ts
@@ -12,7 +12,13 @@
  * probe run would produce come out of the resident dev panel, plus the two
  * misfiling/ghost-conversation checks from
  * `.agents/bugs/2026-07-29-stale-returning-device-dm-sends-vanish-and-misfile.md`.
+ *
+ * Also formats the "Copy full report" clipboard block: a self-contained
+ * markdown paste designed for a fresh agent to read with no follow-up
+ * questions. See `formatFullReport` at the bottom of this file.
  */
+
+import type { DmWarningCounterState, DmWarningKey } from './warningCounters';
 
 /** Minimal shape of a `messages` store row this module needs to read. */
 export interface DmDoctorMessageRow {
@@ -31,6 +37,8 @@ export interface DmDoctorConversationRow {
   address: string;
   displayName?: string;
   lastMessageId?: string;
+  /** `conversations.timestamp` per `.agents/docs/quorum-db-schema.md`. */
+  timestamp?: number;
 }
 
 /** One matched sequence number, with where it was filed. */
@@ -43,12 +51,84 @@ export interface ScanHit {
   createdDate: number;
 }
 
+/**
+ * Which time window a scan was restricted to. Prefix letters get reused
+ * across test rounds (run "V 1..20" today, "V 1..20" next month), and a
+ * store-wide scan with no time bound would silently merge both runs into one
+ * "20/20 landed" — masking real loss in the newer run. `startMs` is the
+ * caller-computed epoch-ms cutoff (see `computeScanWindowStart`); hits with
+ * `createdDate` before it are excluded from landed/missing/duplicates/misfiled
+ * but never discarded from the report — see `ScanWindowInfo`.
+ */
+export type ScanWindowOption = 'since-load' | '1h' | '6h' | '24h' | 'all';
+
+export const SCAN_WINDOW_LABELS: Record<ScanWindowOption, string> = {
+  'since-load': 'since page load',
+  '1h': 'last 1h',
+  '6h': 'last 6h',
+  '24h': 'last 24h',
+  all: 'all time',
+};
+
+export interface ScanWindowParam {
+  option: ScanWindowOption;
+  /** Epoch-ms cutoff computed by the caller; null means no cutoff (all time). */
+  startMs: number | null;
+}
+
+/**
+ * Compute the epoch-ms cutoff for a window option. Pure — the caller supplies
+ * "now" and the page-load time so this stays deterministic and testable.
+ */
+export function computeScanWindowStart(
+  option: ScanWindowOption,
+  nowMs: number,
+  pageLoadMs: number | null
+): number | null {
+  switch (option) {
+    case 'since-load':
+      return pageLoadMs;
+    case '1h':
+      return nowMs - 60 * 60 * 1000;
+    case '6h':
+      return nowMs - 6 * 60 * 60 * 1000;
+    case '24h':
+      return nowMs - 24 * 60 * 60 * 1000;
+    case 'all':
+      return null;
+    default:
+      return null;
+  }
+}
+
+/** A span longer than this for an in-window burst means the window probably
+ *  caught more than one run — flagged, not silently reported. */
+const SPAN_SUSPICIOUS_SECONDS = 30 * 60;
+
+export interface ScanWindowInfo {
+  option: ScanWindowOption;
+  startMs: number | null;
+  /** Matches whose createdDate falls before `startMs` — excluded from
+   *  landed/missing/duplicates/misfiled, but always counted, never dropped. */
+  matchesOutsideWindow: number;
+  outsideOldestMs: number | null;
+  outsideNewestMs: number | null;
+  /** First/last in-window hit, and the span between them. */
+  firstHitMs: number | null;
+  lastHitMs: number | null;
+  spanSeconds: number | null;
+  spanSuspicious: boolean;
+}
+
 export interface ScanResult {
   landed: number;
   missing: number[];
   duplicates: number;
+  /** In-window hits only. */
   hits: ScanHit[];
+  /** In-window hits only. */
   byConversation: Record<string, number>;
+  window: ScanWindowInfo;
 }
 
 /** Escape a string for safe use inside a RegExp — the prefix is user input. */
@@ -61,16 +141,18 @@ function escapeRegExp(value: string): string {
  * for the numbered-burst pattern the manual test rounds send (e.g. "V 1" …
  * "V 20"), across the WHOLE messages store — not scoped to any one
  * conversation, so misfiled rows still get counted. Mirrors
- * `.agents/tools/dm-debug/07-receiver-probe.js` exactly.
+ * `.agents/tools/dm-debug/07-receiver-probe.js` exactly, then restricts the
+ * counted set to `window` (default: no restriction, matching the probe).
  */
 export function scanSequence(
   messages: DmDoctorMessageRow[],
   prefix: string,
   expected: number,
-  ownAddress: string | null | undefined
+  ownAddress: string | null | undefined,
+  window: ScanWindowParam = { option: 'all', startMs: null }
 ): ScanResult {
   const re = new RegExp('^\\s*' + escapeRegExp(prefix) + '\\s*(\\d+)\\s*$', 'i');
-  const hits: ScanHit[] = [];
+  const allHits: ScanHit[] = [];
 
   for (const message of messages) {
     const raw = message?.content?.text;
@@ -79,7 +161,7 @@ export function scanSequence(
       if (typeof text !== 'string') continue;
       const match = re.exec(text);
       if (!match) continue;
-      hits.push({
+      allHits.push({
         n: Number(match[1]),
         spaceId: message.spaceId,
         misfiled: Boolean(ownAddress) && message.spaceId === ownAddress,
@@ -87,6 +169,11 @@ export function scanSequence(
       });
     }
   }
+
+  const startMs = window.startMs;
+  const inWindow = (hit: ScanHit) => startMs === null || hit.createdDate >= startMs;
+  const hits = allHits.filter(inWindow);
+  const outsideHits = allHits.filter((hit) => !inWindow(hit));
 
   const seen = new Set<number>();
   for (const hit of hits) seen.add(hit.n);
@@ -102,12 +189,33 @@ export function scanSequence(
     byConversation[hit.spaceId] = (byConversation[hit.spaceId] ?? 0) + 1;
   }
 
+  const hitDates = hits.map((h) => h.createdDate);
+  const firstHitMs = hitDates.length ? Math.min(...hitDates) : null;
+  const lastHitMs = hitDates.length ? Math.max(...hitDates) : null;
+  const spanSeconds =
+    firstHitMs !== null && lastHitMs !== null ? (lastHitMs - firstHitMs) / 1000 : null;
+
+  const outsideDates = outsideHits.map((h) => h.createdDate);
+  const outsideOldestMs = outsideDates.length ? Math.min(...outsideDates) : null;
+  const outsideNewestMs = outsideDates.length ? Math.max(...outsideDates) : null;
+
   return {
     landed,
     missing,
     duplicates: hits.length - landed,
     hits,
     byConversation,
+    window: {
+      option: window.option,
+      startMs,
+      matchesOutsideWindow: outsideHits.length,
+      outsideOldestMs,
+      outsideNewestMs,
+      firstHitMs,
+      lastHitMs,
+      spanSeconds,
+      spanSuspicious: spanSeconds !== null && spanSeconds > SPAN_SUSPICIOUS_SECONDS,
+    },
   };
 }
 
@@ -131,6 +239,12 @@ export interface GhostConversationRow {
  *   rows for what should be one peer (a second observed artifact).
  *
  * A row can carry both reasons; it appears once in the result either way.
+ *
+ * ⚠️ This is a FLAGGED SUMMARY, not the authoritative view — a detector that
+ * only ever prints its own positives is unfalsifiable in the field (a real
+ * desktop showed a suspicious "Unknown User" sidebar row this function did
+ * not flag). For the unconditional listing every direct row is judged
+ * against, see `buildDirectConversationInventory` below.
  */
 export function findGhostConversations(
   conversations: DmDoctorConversationRow[],
@@ -179,6 +293,130 @@ export function findGhostConversations(
   return [...byId.values()];
 }
 
+/** Flags `buildDirectConversationInventory` can attach to a row. `NO-PROFILE`
+ *  is deliberately not implemented: nothing in `DmDoctorConversationRow` lets
+ *  it be checked without a network call, and the brief for this tool is
+ *  explicit that a cheap-or-skip rule applies. */
+export type InventoryFlag =
+  | 'SELF'
+  | 'DUPLICATE-PEER'
+  | 'NO-DISPLAY-NAME'
+  | 'EMPTY'
+  | 'ORPHAN-KEY';
+
+export interface DirectConversationInventoryRow {
+  /** The conversations-store `conversationId` for a real row; for an
+   *  `ORPHAN-KEY` row (a messages-store spaceId with no matching conversation
+   *  row) this is that raw spaceId instead. */
+  conversationId: string;
+  address: string;
+  /** '(none)' when absent or blank — never silently omitted. */
+  displayName: string;
+  /** '(none)' when absent. */
+  lastMessageId: string;
+  /** `conversations.timestamp`; null when absent (always null for orphan rows). */
+  timestamp: number | null;
+  /** Rows in the messages store whose spaceId equals this row's address. */
+  messageCount: number;
+  flags: InventoryFlag[];
+}
+
+export interface DirectConversationInventory {
+  /** Real `type: 'direct'` conversation rows, followed by any `ORPHAN-KEY`
+   *  rows (messages-store keys with no matching conversation row). */
+  rows: DirectConversationInventoryRow[];
+  /** Count of real conversation rows only — excludes orphan entries, so
+   *  "none suspicious" can be told apart from "none read". */
+  totalDirectRows: number;
+}
+
+/**
+ * The authoritative, unconditional inventory of every `type: 'direct'`
+ * conversation row, plus any orphan messages-store keys. Unlike
+ * `findGhostConversations` (which only ever emits its own positives and is
+ * therefore unfalsifiable — a row it doesn't flag looks identical to a row it
+ * never saw), this lists every row so a reader can judge for themselves.
+ */
+export function buildDirectConversationInventory(
+  conversations: DmDoctorConversationRow[],
+  messages: DmDoctorMessageRow[],
+  ownAddress: string | null | undefined
+): DirectConversationInventory {
+  const direct = conversations.filter((c) => c.type === 'direct');
+
+  const countBySpaceId = new Map<string, number>();
+  for (const message of messages) {
+    countBySpaceId.set(message.spaceId, (countBySpaceId.get(message.spaceId) ?? 0) + 1);
+  }
+
+  const rowsPerAddress = new Map<string, number>();
+  for (const row of direct) {
+    rowsPerAddress.set(row.address, (rowsPerAddress.get(row.address) ?? 0) + 1);
+  }
+
+  const rows: DirectConversationInventoryRow[] = direct.map((row) => {
+    const flags: InventoryFlag[] = [];
+    if (ownAddress && (row.address === ownAddress || row.conversationId === ownAddress)) {
+      flags.push('SELF');
+    }
+    if ((rowsPerAddress.get(row.address) ?? 0) > 1) {
+      flags.push('DUPLICATE-PEER');
+    }
+    const hasDisplayName = Boolean(row.displayName && row.displayName.trim());
+    if (!hasDisplayName) {
+      flags.push('NO-DISPLAY-NAME');
+    }
+    const messageCount = countBySpaceId.get(row.address) ?? 0;
+    if (messageCount === 0) {
+      flags.push('EMPTY');
+    }
+    return {
+      conversationId: row.conversationId,
+      address: row.address,
+      displayName: hasDisplayName ? (row.displayName as string) : '(none)',
+      lastMessageId: row.lastMessageId ?? '(none)',
+      timestamp: row.timestamp ?? null,
+      messageCount,
+      flags,
+    };
+  });
+
+  // Orphan detection must check against EVERY conversation row, not just
+  // `direct` ones: the `messages` store holds space/channel traffic too (same
+  // store, distinguished by spaceId/channelId), so scoping this to `direct`
+  // addresses alone would flag every ordinary space channel as an "orphan DM"
+  // and flood the report with false positives. A key counts as known if it
+  // matches a group or direct row's `address`, or the first segment of a
+  // `conversationId` (spaces are keyed "spaceId/channelId" per
+  // .agents/docs/quorum-db-schema.md, so that first segment is the spaceId
+  // messages in that space are actually filed under).
+  const knownKeys = new Set<string>();
+  for (const row of conversations) {
+    if (row.address) knownKeys.add(row.address);
+    const firstSegment = row.conversationId.split('/')[0];
+    if (firstSegment) knownKeys.add(firstSegment);
+  }
+  const orphanRows: DirectConversationInventoryRow[] = [];
+  for (const [spaceId, count] of countBySpaceId.entries()) {
+    if (knownKeys.has(spaceId)) continue;
+    orphanRows.push({
+      conversationId: spaceId,
+      address: spaceId,
+      displayName: '(none)',
+      lastMessageId: '(none)',
+      timestamp: null,
+      messageCount: count,
+      flags: ['ORPHAN-KEY'],
+    });
+  }
+  orphanRows.sort((a, b) => a.conversationId.localeCompare(b.conversationId));
+
+  return {
+    rows: [...rows, ...orphanRows],
+    totalDirectRows: direct.length,
+  };
+}
+
 /** Inputs supplied by the caller — the parts a `ScanResult` cannot know. */
 export interface MeasurementRowMeta {
   when: string;
@@ -190,12 +428,18 @@ export interface MeasurementRowMeta {
   source?: string;
 }
 
+function msToIso(ms: number | null): string {
+  return ms === null ? 'n/a' : new Date(ms).toISOString();
+}
+
 /**
  * Format a scan result as a markdown table row matching the convention of
  * `.agents/docs/transport-measurements.md`
  * (`| when | run | configuration | class | result | what it changed | source |`).
  * Always reports class "persistence" — a store scan reads what the app kept,
- * not what arrived on the wire or decrypted.
+ * not what arrived on the wire or decrypted. The window a scan was restricted
+ * to is part of the result cell: a landed/missing count is not reproducible
+ * without knowing what time range it was computed over.
  */
 export function formatMeasurementRow(
   scanResult: ScanResult,
@@ -215,6 +459,17 @@ export function formatMeasurementRow(
   if (misfiledCount) {
     resultParts.push(`${misfiledCount} misfiled (ghost self-conversation)`);
   }
+  resultParts.push(`window ${SCAN_WINDOW_LABELS[scanResult.window.option]}`);
+  if (scanResult.window.matchesOutsideWindow) {
+    resultParts.push(
+      `${scanResult.window.matchesOutsideWindow} outside window (oldest ${msToIso(
+        scanResult.window.outsideOldestMs
+      )}, newest ${msToIso(scanResult.window.outsideNewestMs)})`
+    );
+  }
+  if (scanResult.window.spanSuspicious) {
+    resultParts.push('SPAN-SUSPICIOUS (in-window burst spans over 30min — window may cover more than one run)');
+  }
 
   const cells = [
     meta.when,
@@ -227,4 +482,224 @@ export function formatMeasurementRow(
   ];
 
   return `| ${cells.map((cell) => cell.replace(/\|/g, '\\|')).join(' | ')} |`;
+}
+
+// ---------------------------------------------------------------------------
+// "Copy full report" — the self-contained paste
+// ---------------------------------------------------------------------------
+
+/** One completed scan run, kept in page state for the session so the full
+ *  report can include every scan since load, not just the latest. */
+export interface ScanHistoryEntry {
+  id: string;
+  /** ISO timestamp of the IndexedDB read this scan was computed from. */
+  atIso: string;
+  prefix: string;
+  expected: number;
+  ownAddress: string | null;
+  /** `messages`/`conversations` store row counts at the time of THIS read —
+   *  distinct from the report's shared-context store size, which reflects
+   *  only the most recent scan. Kept per-scan too since store growth between
+   *  scans in one session is itself diagnostic. */
+  messagesScanned: number;
+  conversationsScanned: number;
+  scanResult: ScanResult;
+}
+
+export interface FullReportInput {
+  generatedAtIso: string;
+  ownAddress: string | null;
+  pageLoadedAtIso: string | null;
+  /** Newest last. */
+  history: ScanHistoryEntry[];
+  /** null = no scan has run yet this session (distinct from `[]`, "scanned, none found"). */
+  ghosts: GhostConversationRow[] | null;
+  inventory: DirectConversationInventory | null;
+  warningState: DmWarningCounterState | null;
+}
+
+export const DM_DOCTOR_RUNBOOK_POINTER = '.agents/tasks/2026-07-29-manual-round-runbook.md';
+
+function formatDistributionLines(
+  scanResult: ScanResult,
+  ownAddress: string | null
+): string[] {
+  const entries = Object.entries(scanResult.byConversation).sort((a, b) => b[1] - a[1]);
+  if (entries.length === 0) return ['  (no rows matched this prefix in-window)'];
+  return entries.map(([spaceId, count]) => {
+    const isGhost = Boolean(ownAddress) && spaceId === ownAddress;
+    const tag = isGhost ? "GHOST — filed under this account's own address" : 'ok';
+    return `  - ${spaceId}: ${count} (${tag})`;
+  });
+}
+
+function formatScanEntry(entry: ScanHistoryEntry, index: number, total: number): string {
+  const { scanResult } = entry;
+  const misfiledCount = scanResult.hits.filter((hit) => hit.misfiled).length;
+  const lines: string[] = [];
+  lines.push(`### Scan ${index + 1} of ${total} — prefix "${entry.prefix}"`);
+  lines.push(`read_at: ${entry.atIso}`);
+  lines.push(`prefix: ${entry.prefix}`);
+  lines.push(`expected: ${entry.expected}`);
+  lines.push(
+    `window: ${SCAN_WINDOW_LABELS[scanResult.window.option]} (cutoff ${msToIso(scanResult.window.startMs)})`
+  );
+  lines.push(`landed: ${scanResult.landed}/${entry.expected}`);
+  lines.push(`missing: ${scanResult.missing.length ? `[${scanResult.missing.join(', ')}]` : 'none'}`);
+  lines.push(`duplicates: ${scanResult.duplicates}`);
+  lines.push(`misfiled: ${misfiledCount}`);
+  lines.push(`matches_outside_window: ${scanResult.window.matchesOutsideWindow}`);
+  lines.push(`outside_window_oldest: ${msToIso(scanResult.window.outsideOldestMs)}`);
+  lines.push(`outside_window_newest: ${msToIso(scanResult.window.outsideNewestMs)}`);
+  lines.push(`first_hit_at: ${msToIso(scanResult.window.firstHitMs)}`);
+  lines.push(`last_hit_at: ${msToIso(scanResult.window.lastHitMs)}`);
+  lines.push(`span_seconds: ${scanResult.window.spanSeconds === null ? 'n/a' : scanResult.window.spanSeconds}`);
+  lines.push(
+    `span_suspicious: ${
+      scanResult.window.spanSuspicious
+        ? 'true (>30min — window likely caught more than one run)'
+        : 'false'
+    }`
+  );
+  lines.push(`messages_store_rows_at_this_scan: ${entry.messagesScanned}`);
+  lines.push(`conversations_store_rows_at_this_scan: ${entry.conversationsScanned}`);
+  lines.push('distribution (conversation key -> matched count):');
+  lines.push(...formatDistributionLines(scanResult, entry.ownAddress));
+  return lines.join('\n');
+}
+
+function formatWarningsSection(state: DmWarningCounterState | null): string {
+  const lines: string[] = ['## Warning counters (since counter install)'];
+  lines.push(`counters_installed_at: ${state?.installedAt ?? 'not installed yet'}`);
+  const keys: DmWarningKey[] = ['sessionReplaced', 'unknownInbox', 'decryptFailish'];
+  for (const key of keys) {
+    const count = state?.counts[key] ?? 0;
+    const last = state?.lastHits[key]?.[0];
+    lines.push(`${key}: count=${count} last=${last ?? 'none'}`);
+  }
+  return lines.join('\n');
+}
+
+function formatGhostsSection(ghosts: GhostConversationRow[] | null): string {
+  const lines: string[] = ['## Ghost / duplicate conversation rows (flagged summary — see inventory below for the unconditional list)'];
+  if (ghosts === null) {
+    lines.push('not scanned yet');
+  } else if (ghosts.length === 0) {
+    lines.push('none found');
+  } else {
+    for (const g of ghosts) {
+      lines.push(
+        `- conversationId=${g.conversationId} address=${g.address} displayName=${
+          g.displayName || '(none)'
+        } lastMessageId=${g.lastMessageId ?? '(none)'} reasons=[${g.reasons.join(', ')}]`
+      );
+    }
+  }
+  return lines.join('\n');
+}
+
+function formatInventoryRowLine(row: DirectConversationInventoryRow): string {
+  const timestamp = row.timestamp === null ? 'none' : new Date(row.timestamp).toISOString();
+  return `- conversationId=${row.conversationId} address=${row.address} displayName=${row.displayName} lastMessageId=${row.lastMessageId} timestamp=${timestamp} messages=${row.messageCount} flags=[${row.flags.join(', ') || 'none'}]`;
+}
+
+function formatInventorySection(inventory: DirectConversationInventory | null): string {
+  const lines: string[] = [
+    '## Direct conversations inventory (authoritative — every direct row, unconditionally)',
+  ];
+  if (inventory === null) {
+    lines.push('not scanned yet');
+    return lines.join('\n');
+  }
+  lines.push(`total_direct_rows: ${inventory.totalDirectRows}`);
+  const directRows = inventory.rows.filter((row) => !row.flags.includes('ORPHAN-KEY'));
+  const orphanRows = inventory.rows.filter((row) => row.flags.includes('ORPHAN-KEY'));
+  if (directRows.length === 0) {
+    lines.push('(no direct conversation rows)');
+  } else {
+    for (const row of directRows) lines.push(formatInventoryRowLine(row));
+  }
+  lines.push(
+    'orphan conversation keys (messages store rows filed under a key with no matching conversations row):'
+  );
+  if (orphanRows.length === 0) {
+    lines.push('none found');
+  } else {
+    for (const row of orphanRows) lines.push(formatInventoryRowLine(row));
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Build the complete "Copy full report" markdown paste: one self-contained
+ * block covering every scan run this session, the shared context, warning
+ * counters, ghost summary, the authoritative direct-conversations inventory,
+ * and every scan's measurement-log row — so a fresh agent reading one paste
+ * never needs a follow-up question. Pure and deterministic: every timestamp
+ * is supplied by the caller, nothing here reads the clock or the DOM.
+ */
+export function formatFullReport(input: FullReportInput): string {
+  const sections: string[] = [];
+
+  sections.push(`### DM doctor report — ${input.generatedAtIso}`);
+  sections.push(`protocol: ${DM_DOCTOR_RUNBOOK_POINTER}`);
+  sections.push('');
+
+  sections.push('## Shared context');
+  sections.push(`own_address: ${input.ownAddress ?? 'unknown (not signed in)'}`);
+  sections.push(`dm_doctor_page_loaded_at: ${input.pageLoadedAtIso ?? 'unknown'}`);
+  sections.push(`scans_in_history: ${input.history.length}`);
+  const latest = input.history[input.history.length - 1] ?? null;
+  sections.push(
+    `messages_store_rows: ${
+      latest ? latest.messagesScanned : 'n/a (no scan run yet)'
+    } (as of the most recent scan below)`
+  );
+  sections.push(
+    `conversations_store_rows: ${
+      latest ? latest.conversationsScanned : 'n/a (no scan run yet)'
+    } (as of the most recent scan below)`
+  );
+  sections.push('');
+
+  sections.push(
+    `## Session scan history (${input.history.length} scan${
+      input.history.length === 1 ? '' : 's'
+    }, oldest first)`
+  );
+  if (input.history.length === 0) {
+    sections.push('no scans run this session');
+    sections.push('');
+  } else {
+    input.history.forEach((entry, i) => {
+      sections.push(formatScanEntry(entry, i, input.history.length));
+      sections.push('');
+    });
+  }
+
+  sections.push(formatWarningsSection(input.warningState));
+  sections.push('');
+  sections.push(formatGhostsSection(input.ghosts));
+  sections.push('');
+  sections.push(formatInventorySection(input.inventory));
+  sections.push('');
+
+  sections.push('## Measurement log rows (paste into .agents/docs/transport-measurements.md)');
+  if (input.history.length === 0) {
+    sections.push('no scans run this session');
+  } else {
+    for (const entry of input.history) {
+      sections.push(
+        formatMeasurementRow(entry.scanResult, {
+          when: entry.atIso.slice(0, 10),
+          run: `DM doctor scan (prefix "${entry.prefix}")`,
+          configuration: entry.ownAddress ? `own=${entry.ownAddress}` : 'own address unknown',
+          expected: entry.expected,
+          source: 'DM doctor panel (/dev/dm-doctor)',
+        })
+      );
+    }
+  }
+
+  return sections.join('\n');
 }

--- a/src/dev/dm-doctor/index.ts
+++ b/src/dev/dm-doctor/index.ts
@@ -2,16 +2,29 @@ export { DmDoctor } from './DmDoctor';
 export {
   scanSequence,
   findGhostConversations,
+  buildDirectConversationInventory,
   formatMeasurementRow,
+  formatFullReport,
+  computeScanWindowStart,
+  SCAN_WINDOW_LABELS,
+  DM_DOCTOR_RUNBOOK_POINTER,
 } from './dmDoctorCore';
 export type {
   DmDoctorMessageRow,
   DmDoctorConversationRow,
   ScanHit,
   ScanResult,
+  ScanWindowOption,
+  ScanWindowParam,
+  ScanWindowInfo,
   GhostReason,
   GhostConversationRow,
+  InventoryFlag,
+  DirectConversationInventoryRow,
+  DirectConversationInventory,
   MeasurementRowMeta,
+  ScanHistoryEntry,
+  FullReportInput,
 } from './dmDoctorCore';
 export { readAllMessages, readAllConversations } from './dmDoctorDb';
 export {

--- a/src/dev/tests/dm-doctor/dmDoctorCore.unit.test.ts
+++ b/src/dev/tests/dm-doctor/dmDoctorCore.unit.test.ts
@@ -2,9 +2,14 @@ import { describe, expect, it } from 'vitest';
 import {
   scanSequence,
   findGhostConversations,
+  buildDirectConversationInventory,
   formatMeasurementRow,
+  formatFullReport,
+  computeScanWindowStart,
+  DM_DOCTOR_RUNBOOK_POINTER,
   type DmDoctorMessageRow,
   type DmDoctorConversationRow,
+  type ScanHistoryEntry,
 } from '../../dm-doctor/dmDoctorCore';
 
 const OWN = 'own-address-b';
@@ -139,6 +144,124 @@ describe('scanSequence', () => {
   });
 });
 
+describe('scanSequence — window default (no window argument)', () => {
+  it('defaults to "all" time with no cutoff — matches every hit, zero outside-window, not span-suspicious', () => {
+    const messages = [msg(1, PEER, { createdDate: 10 }), msg(2, PEER, { createdDate: 20_010 })];
+    const result = scanSequence(messages, 'V', 2, OWN);
+
+    expect(result.window.option).toBe('all');
+    expect(result.window.startMs).toBeNull();
+    expect(result.window.matchesOutsideWindow).toBe(0);
+    expect(result.window.spanSuspicious).toBe(false);
+    expect(result.landed).toBe(2);
+  });
+});
+
+describe('scanSequence — time window filtering', () => {
+  const CUTOFF = 1_000_000; // arbitrary epoch-ms cutoff used across this block
+
+  it('computes landed/missing/duplicates/byConversation from in-window hits only, and never drops the out-of-window matches from the report', () => {
+    const messages = [
+      // three OLD hits, from a previous run reusing the same letter — before the cutoff
+      msg(1, PEER, { createdDate: CUTOFF - 3000 }),
+      msg(2, PEER, { createdDate: CUTOFF - 2000 }),
+      msg(3, PEER, { createdDate: CUTOFF - 1000 }),
+      // three NEW hits, in-window
+      msg(4, PEER, { createdDate: CUTOFF + 1000 }),
+      msg(5, PEER, { createdDate: CUTOFF + 2000 }),
+      msg(6, PEER, { createdDate: CUTOFF + 3000 }),
+    ];
+    const result = scanSequence(messages, 'V', 6, OWN, { option: '1h', startMs: CUTOFF });
+
+    // Old hits (1,2,3) must not count toward landed and must show as missing.
+    expect(result.landed).toBe(3);
+    expect(result.missing).toEqual([1, 2, 3]);
+    expect(result.duplicates).toBe(0);
+    expect(result.byConversation).toEqual({ [PEER]: 3 });
+
+    // But they are never silently dropped — they are reported as outside-window.
+    expect(result.window.matchesOutsideWindow).toBe(3);
+    expect(result.window.outsideOldestMs).toBe(CUTOFF - 3000);
+    expect(result.window.outsideNewestMs).toBe(CUTOFF - 1000);
+  });
+
+  it('reports landed 0 plus a non-zero matchesOutsideWindow when every hit predates the cutoff', () => {
+    const messages = [
+      msg(1, PEER, { createdDate: CUTOFF - 5000 }),
+      msg(2, PEER, { createdDate: CUTOFF - 4000 }),
+    ];
+    const result = scanSequence(messages, 'V', 2, OWN, { option: '1h', startMs: CUTOFF });
+
+    expect(result.landed).toBe(0);
+    expect(result.missing).toEqual([1, 2]);
+    expect(result.hits).toEqual([]);
+    expect(result.byConversation).toEqual({});
+    expect(result.window.matchesOutsideWindow).toBe(2);
+    expect(result.window.firstHitMs).toBeNull();
+    expect(result.window.lastHitMs).toBeNull();
+    expect(result.window.spanSeconds).toBeNull();
+  });
+
+  it('flags spanSuspicious when the in-window burst spans over 30 minutes', () => {
+    const messages = [
+      msg(1, PEER, { createdDate: CUTOFF }),
+      msg(2, PEER, { createdDate: CUTOFF + 40 * 60 * 1000 }), // 40 minutes later
+    ];
+    const result = scanSequence(messages, 'V', 2, OWN, { option: '6h', startMs: CUTOFF - 1 });
+
+    expect(result.window.spanSeconds).toBe(40 * 60);
+    expect(result.window.spanSuspicious).toBe(true);
+  });
+
+  it('does not flag spanSuspicious for a normal tight burst', () => {
+    const messages = [
+      msg(1, PEER, { createdDate: CUTOFF }),
+      msg(2, PEER, { createdDate: CUTOFF + 40_000 }), // 40 seconds later
+    ];
+    const result = scanSequence(messages, 'V', 2, OWN, { option: '6h', startMs: CUTOFF - 1 });
+
+    expect(result.window.spanSeconds).toBe(40);
+    expect(result.window.spanSuspicious).toBe(false);
+  });
+
+  it('"all" time (explicit) behaves exactly as today: no cutoff, nothing outside window', () => {
+    const numbers = Array.from({ length: 20 }, (_, i) => i + 1).filter(
+      (n) => ![2, 5, 10].includes(n)
+    );
+    const messages = numbers.map((n) => msg(n, PEER, { prefix: 'U' }));
+    const result = scanSequence(messages, 'U', 20, OWN, { option: 'all', startMs: null });
+
+    expect(result.landed).toBe(17);
+    expect(result.missing).toEqual([2, 5, 10]);
+    expect(result.duplicates).toBe(0);
+    expect(result.window.matchesOutsideWindow).toBe(0);
+    expect(result.window.spanSuspicious).toBe(false);
+  });
+});
+
+describe('computeScanWindowStart', () => {
+  const NOW = Date.parse('2026-07-29T18:00:00.000Z');
+  const PAGE_LOAD = Date.parse('2026-07-29T17:30:00.000Z');
+
+  it('"since-load" returns the page-load timestamp', () => {
+    expect(computeScanWindowStart('since-load', NOW, PAGE_LOAD)).toBe(PAGE_LOAD);
+  });
+
+  it('"1h"/"6h"/"24h" subtract the matching duration from now', () => {
+    expect(computeScanWindowStart('1h', NOW, PAGE_LOAD)).toBe(NOW - 60 * 60 * 1000);
+    expect(computeScanWindowStart('6h', NOW, PAGE_LOAD)).toBe(NOW - 6 * 60 * 60 * 1000);
+    expect(computeScanWindowStart('24h', NOW, PAGE_LOAD)).toBe(NOW - 24 * 60 * 60 * 1000);
+  });
+
+  it('"all" returns null (no cutoff)', () => {
+    expect(computeScanWindowStart('all', NOW, PAGE_LOAD)).toBeNull();
+  });
+
+  it('"since-load" returns null when the page-load time is unknown', () => {
+    expect(computeScanWindowStart('since-load', NOW, null)).toBeNull();
+  });
+});
+
 function conv(
   conversationId: string,
   address: string,
@@ -150,6 +273,7 @@ function conv(
     address,
     displayName: overrides.displayName ?? `name-${address}`,
     lastMessageId: overrides.lastMessageId,
+    timestamp: overrides.timestamp,
     ...overrides,
   };
 }
@@ -212,8 +336,140 @@ describe('findGhostConversations', () => {
   });
 });
 
+describe('buildDirectConversationInventory', () => {
+  it('returns an empty inventory (rows: [], totalDirectRows: 0) when there are no conversations at all', () => {
+    const inventory = buildDirectConversationInventory([], [], OWN);
+    expect(inventory).toEqual({ rows: [], totalDirectRows: 0 });
+  });
+
+  it('lists a normal, unremarkable direct row with zero flags', () => {
+    const rows = [conv('conv-1', PEER, { displayName: 'Alice', lastMessageId: 'msg-1', timestamp: 500 })];
+    const messages = [msg(1, PEER)];
+    const inventory = buildDirectConversationInventory(rows, messages, OWN);
+
+    expect(inventory.totalDirectRows).toBe(1);
+    expect(inventory.rows).toHaveLength(1);
+    expect(inventory.rows[0]).toEqual({
+      conversationId: 'conv-1',
+      address: PEER,
+      displayName: 'Alice',
+      lastMessageId: 'msg-1',
+      timestamp: 500,
+      messageCount: 1,
+      flags: [],
+    });
+  });
+
+  it('flags SELF when the row is keyed by (or addressed to) the account\'s own address', () => {
+    const byAddress = buildDirectConversationInventory([conv('conv-1', OWN)], [], OWN);
+    expect(byAddress.rows[0].flags).toContain('SELF');
+
+    const byConversationId = buildDirectConversationInventory(
+      [conv(OWN, 'some-other-address')],
+      [],
+      OWN
+    );
+    expect(byConversationId.rows[0].flags).toContain('SELF');
+  });
+
+  it('does not flag SELF when ownAddress is unknown', () => {
+    const inventory = buildDirectConversationInventory([conv('conv-1', OWN)], [], null);
+    expect(inventory.rows[0].flags).not.toContain('SELF');
+  });
+
+  it('flags DUPLICATE-PEER on every row sharing the same address', () => {
+    const rows = [conv('conv-1', PEER), conv('conv-2', PEER), conv('conv-3', 'someone-else')];
+    const inventory = buildDirectConversationInventory(rows, [], OWN);
+
+    const byId = new Map(inventory.rows.map((r) => [r.conversationId, r]));
+    expect(byId.get('conv-1')!.flags).toContain('DUPLICATE-PEER');
+    expect(byId.get('conv-2')!.flags).toContain('DUPLICATE-PEER');
+    expect(byId.get('conv-3')!.flags).not.toContain('DUPLICATE-PEER');
+  });
+
+  it('flags NO-DISPLAY-NAME when displayName is absent or blank, and reports it as "(none)"', () => {
+    const rows = [
+      conv('conv-1', PEER, { displayName: undefined }),
+      conv('conv-2', 'someone-else', { displayName: '   ' }),
+    ];
+    const inventory = buildDirectConversationInventory(rows, [], OWN);
+
+    for (const row of inventory.rows) {
+      expect(row.flags).toContain('NO-DISPLAY-NAME');
+      expect(row.displayName).toBe('(none)');
+    }
+  });
+
+  it('flags EMPTY when zero messages are filed under the row\'s address', () => {
+    const inventory = buildDirectConversationInventory([conv('conv-1', PEER)], [], OWN);
+    expect(inventory.rows[0].messageCount).toBe(0);
+    expect(inventory.rows[0].flags).toContain('EMPTY');
+  });
+
+  it('counts messages by address across the WHOLE store (not scoped to any prefix)', () => {
+    const rows = [conv('conv-1', PEER)];
+    const messages = [msg(1, PEER, { textOverride: 'hello' }), msg(2, PEER, { textOverride: 'V 9' })];
+    const inventory = buildDirectConversationInventory(rows, messages, OWN);
+    expect(inventory.rows[0].messageCount).toBe(2);
+    expect(inventory.rows[0].flags).not.toContain('EMPTY');
+  });
+
+  it('carries multiple flags at once on the same row', () => {
+    // Keyed by own address (SELF), shares that address with another row
+    // (DUPLICATE-PEER), no display name, and no messages filed under it.
+    const rows = [conv('conv-1', OWN, { displayName: undefined }), conv('conv-2', OWN)];
+    const inventory = buildDirectConversationInventory(rows, [], OWN);
+    const row1 = inventory.rows.find((r) => r.conversationId === 'conv-1')!;
+    expect(row1.flags.sort()).toEqual(['DUPLICATE-PEER', 'EMPTY', 'NO-DISPLAY-NAME', 'SELF']);
+  });
+
+  it('ignores group-type rows for the direct listing', () => {
+    const rows: DmDoctorConversationRow[] = [
+      { conversationId: 'space-1/chan-1', type: 'group', address: 'space-1', displayName: 'A channel' },
+    ];
+    const inventory = buildDirectConversationInventory(rows, [], OWN);
+    expect(inventory.totalDirectRows).toBe(0);
+    expect(inventory.rows.filter((r) => !r.flags.includes('ORPHAN-KEY'))).toEqual([]);
+  });
+
+  it('flags ORPHAN-KEY for a messages-store spaceId with no matching conversation row', () => {
+    const rows = [conv('conv-1', PEER)];
+    const messages = [msg(1, PEER), msg(1, 'ghost-key-with-no-row')];
+    const inventory = buildDirectConversationInventory(rows, messages, OWN);
+
+    const orphan = inventory.rows.find((r) => r.conversationId === 'ghost-key-with-no-row');
+    expect(orphan).toBeDefined();
+    expect(orphan!.flags).toEqual(['ORPHAN-KEY']);
+    expect(orphan!.address).toBe('ghost-key-with-no-row');
+    expect(orphan!.displayName).toBe('(none)');
+    expect(orphan!.lastMessageId).toBe('(none)');
+    expect(orphan!.timestamp).toBeNull();
+    expect(orphan!.messageCount).toBe(1);
+    // Orphans are not counted in totalDirectRows — that count is real conversation rows only.
+    expect(inventory.totalDirectRows).toBe(1);
+  });
+
+  it('does NOT flag a spaceId as orphan when it matches a GROUP row\'s address or conversationId prefix', () => {
+    // Regression guard: the messages store holds space/channel traffic in the
+    // same table as DMs. If orphan detection only checked `direct` addresses,
+    // every ordinary space channel would be misreported as an "orphan DM".
+    const rows: DmDoctorConversationRow[] = [
+      { conversationId: 'space-1/chan-1', type: 'group', address: 'space-1', displayName: 'A channel' },
+    ];
+    const messages = [msg(1, 'space-1')];
+    const inventory = buildDirectConversationInventory(rows, messages, OWN);
+    expect(inventory.rows.some((r) => r.flags.includes('ORPHAN-KEY'))).toBe(false);
+  });
+
+  it('sorts orphan rows by key for a stable, diffable report', () => {
+    const messages = [msg(1, 'zzz-key'), msg(1, 'aaa-key')];
+    const inventory = buildDirectConversationInventory([], messages, OWN);
+    expect(inventory.rows.map((r) => r.conversationId)).toEqual(['aaa-key', 'zzz-key']);
+  });
+});
+
 describe('formatMeasurementRow', () => {
-  it('formats a clean run as a markdown table row', () => {
+  it('formats a clean run as a markdown table row, including the window it was computed over', () => {
     const result = scanSequence(
       Array.from({ length: 20 }, (_, i) => msg(i + 1, PEER)),
       'V',
@@ -230,7 +486,7 @@ describe('formatMeasurementRow', () => {
     });
 
     expect(row).toBe(
-      '| 2026-07-30 | DM doctor scan (prefix "V") | own=own-address-b | persistence | 20/20 landed, none missing | confirmed clean | DM doctor panel |'
+      '| 2026-07-30 | DM doctor scan (prefix "V") | own=own-address-b | persistence | 20/20 landed, none missing, window all time | confirmed clean | DM doctor panel |'
     );
   });
 
@@ -282,5 +538,230 @@ describe('formatMeasurementRow', () => {
     // | when | run | configuration | class | result | whatItChanged | source |
     expect(cells[6]).toBe(''); // whatItChanged
     expect(cells[7]).toBe(''); // source
+  });
+
+  it('reports the outside-window count and SPAN-SUSPICIOUS flag when present', () => {
+    const CUTOFF = 1_000_000;
+    const messages = [
+      msg(1, PEER, { createdDate: CUTOFF - 5000 }), // outside
+      msg(2, PEER, { createdDate: CUTOFF }),
+      msg(3, PEER, { createdDate: CUTOFF + 40 * 60 * 1000 }), // 40 min later -> suspicious span
+    ];
+    const result = scanSequence(messages, 'V', 3, OWN, { option: '6h', startMs: CUTOFF - 1 });
+    const row = formatMeasurementRow(result, {
+      when: '2026-07-30',
+      run: 'scan',
+      configuration: 'cfg',
+      expected: 3,
+    });
+
+    expect(row).toContain('window last 6h');
+    expect(row).toContain('1 outside window');
+    expect(row).toContain('SPAN-SUSPICIOUS');
+  });
+});
+
+describe('formatFullReport', () => {
+  function historyEntry(overrides: Partial<ScanHistoryEntry> = {}): ScanHistoryEntry {
+    const messages = Array.from({ length: 20 }, (_, i) => msg(i + 1, PEER));
+    const scanResult = scanSequence(messages, 'V', 20, OWN);
+    return {
+      id: 'scan-1',
+      atIso: '2026-07-29T18:10:00.000Z',
+      prefix: 'V',
+      expected: 20,
+      ownAddress: OWN,
+      messagesScanned: messages.length,
+      conversationsScanned: 3,
+      scanResult,
+      ...overrides,
+    };
+  }
+
+  it('includes the header and protocol pointer', () => {
+    const report = formatFullReport({
+      generatedAtIso: '2026-07-29T19:00:00.000Z',
+      ownAddress: OWN,
+      pageLoadedAtIso: '2026-07-29T18:00:00.000Z',
+      history: [],
+      ghosts: null,
+      inventory: null,
+      warningState: null,
+    });
+
+    expect(report).toContain('### DM doctor report — 2026-07-29T19:00:00.000Z');
+    expect(report).toContain(`protocol: ${DM_DOCTOR_RUNBOOK_POINTER}`);
+  });
+
+  it('emits the full own address, never truncated', () => {
+    const longAddress = 'QmQuCGpEgVKpYZKYuFu2J49zHXnA8vZtEqHMtpB4imXST1';
+    const report = formatFullReport({
+      generatedAtIso: '2026-07-29T19:00:00.000Z',
+      ownAddress: longAddress,
+      pageLoadedAtIso: null,
+      history: [],
+      ghosts: null,
+      inventory: null,
+      warningState: null,
+    });
+    expect(report).toContain(`own_address: ${longAddress}`);
+    expect(report).not.toContain('…');
+  });
+
+  it('handles the empty-history case distinctly (no scans, not an error)', () => {
+    const report = formatFullReport({
+      generatedAtIso: '2026-07-29T19:00:00.000Z',
+      ownAddress: OWN,
+      pageLoadedAtIso: '2026-07-29T18:00:00.000Z',
+      history: [],
+      ghosts: null,
+      inventory: null,
+      warningState: null,
+    });
+
+    expect(report).toContain('scans_in_history: 0');
+    expect(report).toContain('no scans run this session');
+    expect(report).toContain('not scanned yet'); // ghosts + inventory sections
+  });
+
+  it('includes every scan in history, oldest first, with per-scan detail and distribution', () => {
+    const uMessages = Array.from({ length: 20 }, (_, i) => i + 1)
+      .filter((n) => ![2, 5, 10].includes(n))
+      .map((n) => msg(n, PEER, { prefix: 'U' }));
+    const uScan = scanSequence(uMessages, 'U', 20, OWN);
+    const vMessages = Array.from({ length: 20 }, (_, i) => msg(i + 1, OWN));
+    const vScan = scanSequence(vMessages, 'V', 20, OWN);
+
+    const history: ScanHistoryEntry[] = [
+      historyEntry({ id: 'scan-1', prefix: 'U', atIso: '2026-07-29T18:00:00.000Z', scanResult: uScan, messagesScanned: uMessages.length }),
+      historyEntry({ id: 'scan-2', prefix: 'V', atIso: '2026-07-29T18:20:00.000Z', scanResult: vScan, messagesScanned: vMessages.length }),
+    ];
+
+    const report = formatFullReport({
+      generatedAtIso: '2026-07-29T19:00:00.000Z',
+      ownAddress: OWN,
+      pageLoadedAtIso: '2026-07-29T17:00:00.000Z',
+      history,
+      ghosts: null,
+      inventory: null,
+      warningState: null,
+    });
+
+    expect(report).toContain('scans_in_history: 2');
+    // Both scans present, in order (U before V in the text).
+    const uIndex = report.indexOf('### Scan 1 of 2 — prefix "U"');
+    const vIndex = report.indexOf('### Scan 2 of 2 — prefix "V"');
+    expect(uIndex).toBeGreaterThan(-1);
+    expect(vIndex).toBeGreaterThan(uIndex);
+
+    expect(report).toContain('landed: 17/20');
+    expect(report).toContain('missing: [2, 5, 10]');
+    expect(report).toContain('landed: 20/20');
+    expect(report).toContain('misfiled: 20');
+    // Distribution line, labelled as the ghost case for the V scan.
+    expect(report).toContain(`${OWN}: 20 (GHOST — filed under this account's own address)`);
+    // Measurement rows for both scans appear at the end.
+    expect(report).toContain('DM doctor scan (prefix "U")');
+    expect(report).toContain('DM doctor scan (prefix "V")');
+  });
+
+  it('renders "none found" for an empty ghosts list, distinct from "not scanned yet"', () => {
+    const report = formatFullReport({
+      generatedAtIso: '2026-07-29T19:00:00.000Z',
+      ownAddress: OWN,
+      pageLoadedAtIso: null,
+      history: [historyEntry()],
+      ghosts: [],
+      inventory: { rows: [], totalDirectRows: 0 },
+      warningState: null,
+    });
+
+    expect(report).toContain('## Ghost / duplicate conversation rows');
+    // "none found" appears right after the ghosts header, not "not scanned yet".
+    const ghostsIdx = report.indexOf('## Ghost / duplicate conversation rows');
+    const nextSectionIdx = report.indexOf('## Direct conversations inventory');
+    const ghostsBody = report.slice(ghostsIdx, nextSectionIdx);
+    expect(ghostsBody).toContain('none found');
+    expect(ghostsBody).not.toContain('not scanned yet');
+  });
+
+  it('renders ghost rows and the full inventory (direct + orphan) when present', () => {
+    const ghosts = findGhostConversations([conv(OWN, OWN)], OWN);
+    const inventory = buildDirectConversationInventory(
+      [conv(OWN, OWN), conv('conv-2', PEER)],
+      [msg(1, PEER), msg(1, 'orphan-key')],
+      OWN
+    );
+
+    const report = formatFullReport({
+      generatedAtIso: '2026-07-29T19:00:00.000Z',
+      ownAddress: OWN,
+      pageLoadedAtIso: null,
+      history: [historyEntry()],
+      ghosts,
+      inventory,
+      warningState: null,
+    });
+
+    expect(report).toContain(`conversationId=${OWN}`);
+    expect(report).toContain('reasons=[self-address]');
+    expect(report).toContain('total_direct_rows: 2');
+    expect(report).toContain('flags=[SELF, EMPTY]');
+    expect(report).toContain('orphan conversation keys');
+    expect(report).toContain('conversationId=orphan-key');
+    expect(report).toContain('flags=[ORPHAN-KEY]');
+  });
+
+  it('renders warning counters with counts and last-hit timestamps, distinguishing "0, never installed" from "0, nothing happened yet"', () => {
+    const neverInstalled = formatFullReport({
+      generatedAtIso: '2026-07-29T19:00:00.000Z',
+      ownAddress: OWN,
+      pageLoadedAtIso: null,
+      history: [],
+      ghosts: null,
+      inventory: null,
+      warningState: null,
+    });
+    expect(neverInstalled).toContain('counters_installed_at: not installed yet');
+
+    const installedButQuiet = formatFullReport({
+      generatedAtIso: '2026-07-29T19:00:00.000Z',
+      ownAddress: OWN,
+      pageLoadedAtIso: null,
+      history: [],
+      ghosts: null,
+      inventory: null,
+      warningState: {
+        installedAt: '2026-07-29T18:00:00.000Z',
+        counts: { sessionReplaced: 0, unknownInbox: 2, decryptFailish: 0 },
+        lastHits: { sessionReplaced: [], unknownInbox: ['2026-07-29T18:05:00.000Z'], decryptFailish: [] },
+      },
+    });
+    expect(installedButQuiet).toContain('counters_installed_at: 2026-07-29T18:00:00.000Z');
+    expect(installedButQuiet).toContain('sessionReplaced: count=0 last=none');
+    expect(installedButQuiet).toContain('unknownInbox: count=2 last=2026-07-29T18:05:00.000Z');
+  });
+
+  it('reports matches_outside_window and span metrics per scan', () => {
+    const CUTOFF = 1_000_000;
+    const messages = [
+      msg(1, PEER, { createdDate: CUTOFF - 5000 }),
+      msg(2, PEER, { createdDate: CUTOFF }),
+    ];
+    const windowed = scanSequence(messages, 'V', 2, OWN, { option: '1h', startMs: CUTOFF - 1 });
+    const entry = historyEntry({ scanResult: windowed });
+
+    const report = formatFullReport({
+      generatedAtIso: '2026-07-29T19:00:00.000Z',
+      ownAddress: OWN,
+      pageLoadedAtIso: null,
+      history: [entry],
+      ghosts: null,
+      inventory: null,
+      warningState: null,
+    });
+
+    expect(report).toContain('matches_outside_window: 1');
+    expect(report).toContain('window: last 1h');
   });
 });


### PR DESCRIPTION
Follow-up to #275, driven by live use during the 2026-07-29 test round.

## Why

The panel's copy button emitted a single measurement row, so every round still needed the operator to relay details by hand (duplicates, misfiling, which conversation each message landed in, ghost rows, warning counters). It also scanned all of time, which silently masks new loss whenever a test letter is reused.

## What changed

- **Copy full report** — one paste containing every scan of the session, per-conversation distribution with misfile flags, warning counters with timestamps, store sizes, and the ready-made measurement rows.
- **Scan time window** (default last 6h, selectable) — landed/missing/duplicates are computed in-window; out-of-window matches are reported with their timestamps rather than silently dropped, plus a span-suspicious flag when one window catches two runs.
- **Direct-conversation inventory** — every direct row listed unconditionally with flags (SELF / DUPLICATE-PEER / EMPTY / NO-DISPLAY-NAME / ORPHAN-KEY), because a card that prints only its own positives cannot be falsified in the field. Orphan conversation keys (messages filed under a key with no conversations row) are surfaced too.

## Verification

- 58/58 unit tests pass (`npx vitest run src/dev/tests/dm-doctor`)
- `npx tsc --noEmit --jsx react-jsx --skipLibCheck` clean
- Production exclusion unchanged: everything stays under `src/dev/`, which the web build marks external (proven by bundle grep in #275)

## Proven in real use

This code produced the evening round's readings before merge: it identified 17/20 missing [1, 6, 11] on two independent receivers, flagged a ghost self-conversation holding 20 misfiled messages, and surfaced an ORPHAN-KEY row with 3 permanently unreachable messages. Details in `.agents/docs/transport-measurements.md` § ROUND X.