### PR TITLE
fix: long links no longer break the composer or vanish on send

### DIFF
--- a/src/components/message/MessageComposer.scss
+++ b/src/components/message/MessageComposer.scss
@@ -5,6 +5,10 @@
 /* Auto-resizing textarea container */
 .message-composer-textarea-container {
   flex: 1;
+  /* Flex items default to `min-width: auto`, so an unbreakable string (a long
+     URL) sets the item's minimum to its min-content width and stretches the
+     row, pushing the send button out of view. */
+  min-width: 0;
 }
 
 /* Textarea specific styles */
@@ -26,7 +30,9 @@
   font-size: $text-base;
   white-space: pre-wrap;
   word-wrap: break-word;
-  overflow-wrap: break-word;
+  /* `anywhere` (not `break-word`) so a long unbroken URL also lowers the
+     element's min-content width instead of only wrapping visually. */
+  overflow-wrap: anywhere;
   resize: none;
   /* min-height and max-height removed - now calculated dynamically in JavaScript */
   transition: height $duration-100 ease;
@@ -78,7 +84,9 @@
   font-size: $text-base;
   white-space: pre-wrap;
   word-wrap: break-word;
-  overflow-wrap: break-word;
+  /* `anywhere` (not `break-word`) so a long unbroken URL also lowers the
+     element's min-content width instead of only wrapping visually. */
+  overflow-wrap: anywhere;
   resize: none;
   transition: height $duration-100 ease;
   vertical-align: middle;

--- a/src/components/message/MessageMarkdownRenderer.tsx
+++ b/src/components/message/MessageMarkdownRenderer.tsx
@@ -22,6 +22,8 @@ import {
   processURLs,
   convertHeadersToH3,
   fixUnclosedCodeBlocks,
+  getProtectedRegions,
+  isInProtectedRegion,
 } from '@quilibrium/quorum-shared';
 import { remarkTwemoji, getEmojiOnlySize } from '../../utils/remarkTwemoji';
 import { InviteLink } from './InviteLink';
@@ -72,9 +74,15 @@ const isInviteLink = (url: string): boolean => {
 
 // Process invite links to convert them to markdown image syntax with special alt text
 const processInviteLinks = (text: string): string => {
+  // Skip URLs inside code or existing markdown links. Rewriting the destination
+  // of `[label](invite-url)` into `[label](![invite-card](invite-url))` produced
+  // an unparseable href, which react-markdown dropped — the message rendered as
+  // plain text with no link at all.
+  const protectedRegions = getProtectedRegions(text);
+
   // Replace invite links with markdown image syntax
-  return text.replace(/https?:\/\/[^\s<>"{}|\\^`[\]]+/g, (url) => {
-    if (isInviteLink(url)) {
+  return text.replace(/https?:\/\/[^\s<>"{}|\\^`[\]]+/g, (url, offset: number) => {
+    if (isInviteLink(url) && !isInProtectedRegion(offset, protectedRegions)) {
       // Use markdown image syntax with special alt text (similar to YouTube embeds)
       return `![invite-card](${url})`;
     }

--- a/src/dev/tests/components/MessageMarkdownRenderer.test.tsx
+++ b/src/dev/tests/components/MessageMarkdownRenderer.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+// Keep the tree light: the invite card and the YouTube facade pull in app state
+// we don't need to exercise the markdown pipeline.
+vi.mock('@/components/message/InviteLink', () => ({
+  InviteLink: ({ inviteLink }: { inviteLink: string }) => (
+    <div data-testid="invite-card" data-invite-link={inviteLink} />
+  ),
+}));
+vi.mock('@/components/ui/YouTubeFacade', () => ({
+  YouTubeFacade: ({ videoId }: { videoId: string }) => (
+    <div data-testid="youtube-embed" data-video-id={videoId} />
+  ),
+}));
+
+import { MessageMarkdownRenderer } from '@/components/message/MessageMarkdownRenderer';
+
+const INVITE_URL =
+  'https://app.quorummessenger.com/invite/#spaceId=QmZM3AKwKfMprQZvSk3Mpgii2JS31TS5izHrwJe1itprrG&configKey=9e390fd97e0a61aecdce931c7f3dab04d0e57b8da89a50510981be5394714eda';
+
+describe('MessageMarkdownRenderer — invite links', () => {
+  it('renders a markdown-linked invite as a real anchor, not plain text', () => {
+    render(<MessageMarkdownRenderer content={`[Quorum Space](${INVITE_URL})`} />);
+
+    const link = screen.getByRole('link', { name: 'Quorum Space' });
+    expect(link).toHaveAttribute('href', INVITE_URL);
+    // The label must not leak the stray `)` left behind by a mangled destination.
+    expect(screen.queryByText(/\)/)).not.toBeInTheDocument();
+  });
+
+  it('still renders a bare invite URL as an invite card', () => {
+    render(<MessageMarkdownRenderer content={INVITE_URL} />);
+
+    expect(screen.getByTestId('invite-card')).toHaveAttribute('data-invite-link', INVITE_URL);
+  });
+
+  it('leaves an invite URL inside inline code untouched', () => {
+    render(<MessageMarkdownRenderer content={`\`${INVITE_URL}\``} />);
+
+    expect(screen.queryByTestId('invite-card')).not.toBeInTheDocument();
+    expect(screen.getByText(INVITE_URL)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Repro: paste a long invite link into the composer, e.g.

```
[Quorum Space](https://app.quorummessenger.com/invite/#spaceId=QmZM3AK…&configKey=9e390fd9…)
```

Two independent bugs, one repro.

## 1. Composer stretched, send button pushed out of view

`.message-composer-textarea-container` is a flex item, and flex items default to `min-width: auto`. An unbreakable string sets the item's minimum to its min-content width, so the whole row grew wider than the panel and the send button went off-screen.

- `min-width: 0` on the container.
- `overflow-wrap: anywhere` (not `break-word`) on both editors, so a long URL also *lowers* min-content width rather than only wrapping visually.

## 2. Sent link rendered as plain text

`processInviteLinks` rewrote every invite URL in the message, including one already sitting inside a markdown link's destination:

```
[Quorum Space](URL)  →  [Quorum Space](![invite-card](URL))
```

That destination isn't a valid URL, so react-markdown's url transform dropped the `href`, the `a` renderer fell through to its no-href branch, and the message came out as bare text with a stray `)`.

Fix: skip URLs inside protected regions (fenced/inline code and existing markdown links), reusing `getProtectedRegions` / `isInProtectedRegion` from quorum-shared — the same helpers `processURLs`, `processMentions` and the message-link pass already use. `processInviteLinks` was the only step in the pipeline not doing this.

Side effect of the same fix: an invite URL inside backticks now stays literal instead of turning into an invite card.

## What to check

- Paste that link into the composer: the row should stay put and the send button stay visible; the URL wraps.
- Send it: it renders as a clickable **Quorum Space** link.
- A bare invite URL (no markdown syntax) still renders the invite card, unchanged.

## Tests

New `src/dev/tests/components/MessageMarkdownRenderer.test.tsx` covers markdown-linked invite, bare invite, and invite-in-inline-code. Two of the three fail without the renderer change (verified by stashing it). Full suite: 630 passed / 41 files. `tsc --noEmit` clean.