### PR TITLE
fix: show the invite card only for a link standing alone on its line

### DIFF
--- a/src/components/message/MessageMarkdownRenderer.tsx
+++ b/src/components/message/MessageMarkdownRenderer.tsx
@@ -72,7 +72,16 @@ const isInviteLink = (url: string): boolean => {
   return validPrefixes.some(prefix => url.startsWith(prefix));
 };
 
-// Process invite links to convert them to markdown image syntax with special alt text
+/**
+ * Turn an invite link into the invite card, but ONLY when the link stands alone
+ * on its own line — the same rule `processStandaloneYouTubeUrls` applies to
+ * YouTube embeds. An invite the sender wrote *into* a sentence, gave a label to,
+ * or quoted in code is something they wrote deliberately, so it stays a plain
+ * (auto-truncated) link rather than being swallowed by a card.
+ *
+ * The in-app share flow sends the bare link as the whole message body, so the
+ * card still renders for it.
+ */
 const processInviteLinks = (text: string): string => {
   // Skip URLs inside code or existing markdown links. Rewriting the destination
   // of `[label](invite-url)` into `[label](![invite-card](invite-url))` produced
@@ -82,11 +91,20 @@ const processInviteLinks = (text: string): string => {
 
   // Replace invite links with markdown image syntax
   return text.replace(/https?:\/\/[^\s<>"{}|\\^`[\]]+/g, (url, offset: number) => {
-    if (isInviteLink(url) && !isInProtectedRegion(offset, protectedRegions)) {
-      // Use markdown image syntax with special alt text (similar to YouTube embeds)
-      return `![invite-card](${url})`;
+    if (!isInviteLink(url) || isInProtectedRegion(offset, protectedRegions)) {
+      return url;
     }
-    return url;
+
+    // Standalone check: the URL must be the only thing on its line.
+    const lineStart = text.lastIndexOf('\n', offset - 1) + 1;
+    const nextNewline = text.indexOf('\n', offset + url.length);
+    const lineEnd = nextNewline === -1 ? text.length : nextNewline;
+    if (text.slice(lineStart, lineEnd).trim() !== url) {
+      return url;
+    }
+
+    // Use markdown image syntax with special alt text (similar to YouTube embeds)
+    return `![invite-card](${url})`;
   });
 };
 

--- a/src/dev/tests/components/MessageMarkdownRenderer.test.tsx
+++ b/src/dev/tests/components/MessageMarkdownRenderer.test.tsx
@@ -19,26 +19,87 @@ import { MessageMarkdownRenderer } from '@/components/message/MessageMarkdownRen
 const INVITE_URL =
   'https://app.quorummessenger.com/invite/#spaceId=QmZM3AKwKfMprQZvSk3Mpgii2JS31TS5izHrwJe1itprrG&configKey=9e390fd97e0a61aecdce931c7f3dab04d0e57b8da89a50510981be5394714eda';
 
+// The invite card replaces the link entirely, so "card" and "plain link" are
+// mutually exclusive outcomes — every case below asserts both directions.
+const expectCard = () => {
+  expect(screen.getByTestId('invite-card')).toHaveAttribute('data-invite-link', INVITE_URL);
+  expect(screen.queryByRole('link')).not.toBeInTheDocument();
+};
+const expectNoCard = () => {
+  expect(screen.queryByTestId('invite-card')).not.toBeInTheDocument();
+};
+
 describe('MessageMarkdownRenderer — invite links', () => {
-  it('renders a markdown-linked invite as a real anchor, not plain text', () => {
-    render(<MessageMarkdownRenderer content={`[Quorum Space](${INVITE_URL})`} />);
+  describe('card only when the link stands alone on its line', () => {
+    it('shows the card for a bare link that is the whole message', () => {
+      render(<MessageMarkdownRenderer content={INVITE_URL} />);
+      expectCard();
+    });
 
-    const link = screen.getByRole('link', { name: 'Quorum Space' });
-    expect(link).toHaveAttribute('href', INVITE_URL);
-    // The label must not leak the stray `)` left behind by a mangled destination.
-    expect(screen.queryByText(/\)/)).not.toBeInTheDocument();
+    it('shows the card for a bare link alone on its own line among prose', () => {
+      render(<MessageMarkdownRenderer content={`come join us\n${INVITE_URL}\nsee you there`} />);
+      expectCard();
+      expect(screen.getByText(/come join us/)).toBeInTheDocument();
+    });
+
+    it('keeps a mid-sentence link as a plain link, not a card', () => {
+      render(<MessageMarkdownRenderer content={`join here ${INVITE_URL} thanks`} />);
+      expectNoCard();
+      expect(screen.getByRole('link')).toHaveAttribute('href', INVITE_URL);
+    });
+
+    it('keeps a labelled markdown link as a plain link, not a card', () => {
+      render(<MessageMarkdownRenderer content={`[Quorum Space](${INVITE_URL})`} />);
+
+      expectNoCard();
+      const link = screen.getByRole('link', { name: 'Quorum Space' });
+      expect(link).toHaveAttribute('href', INVITE_URL);
+      // No stray `)` left over from a mangled link destination.
+      expect(screen.queryByText(/\)/)).not.toBeInTheDocument();
+    });
+
+    it('leaves a link inside inline code untouched', () => {
+      render(<MessageMarkdownRenderer content={`\`${INVITE_URL}\``} />);
+
+      expectNoCard();
+      expect(screen.getByText(INVITE_URL)).toBeInTheDocument();
+    });
+
+    it('handles one labelled and one bare link in the same message', () => {
+      render(
+        <MessageMarkdownRenderer content={`[Quorum Space](${INVITE_URL})\n${INVITE_URL}`} />
+      );
+
+      expect(screen.getByTestId('invite-card')).toHaveAttribute('data-invite-link', INVITE_URL);
+      expect(screen.getByRole('link', { name: 'Quorum Space' })).toHaveAttribute('href', INVITE_URL);
+    });
   });
 
-  it('still renders a bare invite URL as an invite card', () => {
-    render(<MessageMarkdownRenderer content={INVITE_URL} />);
+  describe('long links are truncated for display', () => {
+    const LONG =
+      'https://example.com/a/very/long/path/that/keeps/going/and/going/and/going?q=1234567890';
 
-    expect(screen.getByTestId('invite-card')).toHaveAttribute('data-invite-link', INVITE_URL);
-  });
+    it('truncates an auto-linked URL to 50 chars but keeps the full href', () => {
+      render(<MessageMarkdownRenderer content={LONG} />);
 
-  it('leaves an invite URL inside inline code untouched', () => {
-    render(<MessageMarkdownRenderer content={`\`${INVITE_URL}\``} />);
+      const link = screen.getByRole('link');
+      expect(link.textContent).toBe(`${LONG.substring(0, 50)}...`);
+      expect(link).toHaveAttribute('href', LONG);
+      expect(link).toHaveAttribute('title', LONG);
+    });
 
-    expect(screen.queryByTestId('invite-card')).not.toBeInTheDocument();
-    expect(screen.getByText(INVITE_URL)).toBeInTheDocument();
+    it('truncates a mid-sentence invite link too', () => {
+      render(<MessageMarkdownRenderer content={`join here ${INVITE_URL} thanks`} />);
+
+      const link = screen.getByRole('link');
+      expect(link.textContent).toBe(`${INVITE_URL.substring(0, 50)}...`);
+      expect(link).toHaveAttribute('href', INVITE_URL);
+    });
+
+    it('never truncates an author-written label', () => {
+      render(<MessageMarkdownRenderer content={`[my link](${LONG})`} />);
+
+      expect(screen.getByRole('link').textContent).toBe('my link');
+    });
   });
 });


### PR DESCRIPTION
Follow-up to #279. Settles what "standalone" means for an invite link, and makes it match what the renderer already does for YouTube embeds.

## Rule

The invite card renders **only when the link is the whole line**. Anything else stays a plain link.

| message | renders |
|---|---|
| bare link, whole message | invite card |
| bare link alone on its own line among prose | invite card |
| `join here <link> thanks` | plain link (truncated) |
| `[Quorum Space](<link>)` | plain link with the author's label |
| `` `<link>` `` in backticks | literal text |

The reasoning: a link the sender wrote *into* a sentence, gave a label to, or quoted in code is deliberate authorship, and replacing it with a card loses their wording. A link on its own line is the "here, take this" gesture the card is for.

`processStandaloneYouTubeUrls` has always worked this way; invites were the odd one out.

**No change to the in-app share flow** — `InvitationService.sendInviteToUser` sends the bare link as the entire message body, so it still gets the card.

## Long links

Verified rather than assumed: auto-linked URLs are already truncated to 50 characters with the full URL kept on `href` and `title`, and author-written labels are never touched. That behaviour had no test coverage, so it's now pinned — a mid-sentence invite link renders as `https://app.quorummessenger.com/invite/#spaceId=Qm...`.

## What to check

- Send a bare invite link → card, as before.
- Send `[Quorum Space](invite-link)` → clickable **Quorum Space** link, no card.
- Send `join us <invite-link> ok?` → truncated plain link inline in the sentence, no card.

## Tests

`MessageMarkdownRenderer.test.tsx` grows to 9 cases covering both directions of the rule plus truncation. Full suite: 636 passed / 41 files. `tsc --noEmit` clean.

## Mobile

Mobile does none of this yet — it detects invites with its own markdown-unaware helpers in `InviteLinkCard.tsx`, so a labelled invite produces a broken card (the extractor swallows the closing paren into the configKey) plus a dangling `[Quorum Space](`. Tracked separately; this PR is desktop only.