### PR TITLE
fix: deregister this device before reset wipes its keys

### DIFF
--- a/.agents/tasks/2026-07-21-device-registration-ghost-accumulation-cross-platform.md
+++ b/.agents/tasks/2026-07-21-device-registration-ghost-accumulation-cross-platform.md
@@ -154,15 +154,81 @@ deliberate deviations. Files: `src/utils/deviceRegistration.ts` (pure),
   safe to try because the upload is already best-effort, so a hub rejection just
   leaves today's single ghost. `planDeviceDeregistration` returns `last-device`
   so the choice is one line to flip once the server behaviour is known.
-- **Deviation — the two cleanups run in parallel, not sequentially**, under one
-  3s budget: different transports, no ordering between them, so the user waits
-  for the slower rather than the sum.
+- **Deviation — the two cleanups run in parallel, not sequentially:** different
+  transports, no ordering between them, so the user waits for the slower rather
+  than the sum. They are bounded and reported **independently** (`{hub, spaces}`)
+  — see the review findings below for why sharing one budget was a bug.
 - Added a `Resetting...` button state: the goodbye can take up to 3s and a
   dead-looking button invites a double click. New i18n string, not yet extracted
   into the catalogs (renders English until the next translation batch).
 - `KeyDB` deletion deliberately NOT bundled (see "Secondary" below).
 - Not yet verified on real hardware — the observable two-device check in step 5
   below is still outstanding.
+
+#### Review findings, and what they change for Slice 2 (2026-07-28)
+
+Three independent review passes (code review, silent-failure hunt, security)
+found **two real bugs in the first implementation**, both in the *composition*
+rather than in either component — the isolated unit tests for the pure filter
+and the flush barrier passed throughout. Mobile must not repeat them:
+
+1. **The flush barrier's answer was computed and discarded.** `revokeInSpaces`
+   awaited `flushOutbound` and dropped the boolean, and the aggregate read only
+   the hub leg, so unsent frames were reported as a clean goodbye. This is the
+   worse half to lose silently: on failure the hub entry is already gone, so
+   nothing points at the problem, while every space still trusts the device's
+   signing key.
+2. **A slow revoke overwrote a hub write that had already succeeded.** One
+   shared budget + `Promise.all` meant the outer timeout won whenever the socket
+   leg timed out, so the user was told the device might still be listed when it
+   had already been removed. **Bound and report each leg independently**
+   (`DeregisterOutcome = {hub, spaces}`).
+
+Also fixed, all worth checking on mobile:
+
+- **Budget vs the client's own timeout.** The 3s cap abandoned the hub POST
+  under merely-slow networks — the desktop API client allows 22s + 2 retries for
+  that same call, and the request had no `keepalive`, so the reload killed it.
+  Now 8s for the hub leg with an explicit `timeout` passed through so the client
+  aborts at our deadline instead of orphaning a request. **Check what mobile's
+  registration upload timeout is before picking a budget.**
+- **Diagnostics were invisible in production.** `@quilibrium/quorum-shared`'s
+  `logger` gates on `detectEnvironment()`, which is false when
+  `NODE_ENV === 'production'`, so every `logger.warn` on this path was a no-op
+  in exactly the build where the data is about to be destroyed. Desktop uses
+  `console.warn` here deliberately. Mobile: `__DEV__` gates the same logger, so
+  the same trap applies.
+- **Stale-list clobber.** The cached device list could be minutes old (settings
+  left open) and the upload replaces it wholesale, so a device registered
+  elsewhere meanwhile would be silently deleted. Desktop now re-reads
+  immediately before planning and skips the write if the re-read fails. Mobile's
+  `removeDeviceFromRegistration` fetches internally — verify it re-reads rather
+  than trusting a snapshot.
+- **Socket identity in the flush.** `send()` on a closing socket drops silently,
+  so an empty buffer on a *reconnected* socket said nothing about the previous
+  socket's frames. The barrier now compares instance identity.
+
+Known-and-accepted after review:
+
+- **The `useSuspenseQuery` concern was a non-issue.** `RegistrationProvider`
+  holds an observer on the same query key for the whole session, so the cache is
+  always warm and a background refetch changes `fetchStatus`, not `status` — no
+  suspension of the settings modal.
+- **`planDeviceDeregistration` survived the security pass** — no input removes
+  the wrong device or more than intended; malformed entries are kept, never
+  dropped; `thisInboxAddress` comes only from the local keyset, never from hub
+  data.
+- **The console warning is still wiped by the reload** (DevTools clears on
+  navigation by default). The reviewer's suggestion — encode the outcome in the
+  reload URL and show a real notice on the freshly-booted screen — is a genuinely
+  better answer and is left as a follow-up, since it lands UI in the onboarding
+  screen rather than in this fix.
+- **The security pass independently re-derived the `KeyDB` gap** and rates it
+  Critical *because the reset copy explicitly promises to delete private keys*.
+  Still deliberately out of scope here; see "Secondary" below. One dependency it
+  surfaced: desktop's "allow removing the last device" choice is low-risk partly
+  *because* `KeyDB` survives, so re-examine that decision if/when `KeyDB`
+  deletion ships.
 
 ### Slice 2 — Mobile (mirror)
 
@@ -338,3 +404,6 @@ without calling it out.
 - New consequence documented: with the flip live, each reset cycle also accumulates stale signing-key admissions in members' space_member_devices stores — ghost problem has a second dimension.
 - Verified intact: DangerZone wipe sequence (no KeyDB delete), RegistrationPersister branch structure (line 115 corruption-only path, 158 reuse, 187-210 re-append), SDK buildAndUploadRegistration always-mints (now ~5857), mobile reuse/dedupe/last-device guard, deviceKeys.ts master-key anchor + LWW.
 - Pointer refreshes: SDK path needs @quilibrium/ scope; mobile keyService is services/onboarding/keyService.ts (875, ~903-909, ~520-545, ~722-724); App.tsx route now 135; added edge-case note that a failed wipe also re-admits the revoked signing key via on-connect re-announce (symmetric self-heal).
+
+## Updates
+- **2026-07-31 15:35**: Slice 1 (desktop) implemented + independently reviewed (3 passes). Review found 2 real composition bugs (discarded flush result; slow leg overwriting the other's success) — both fixed and now mutation-checked by 8 new hook tests. See 'Review findings' section for what Slice 2 must avoid.

--- a/.agents/tasks/2026-07-21-device-registration-ghost-accumulation-cross-platform.md
+++ b/.agents/tasks/2026-07-21-device-registration-ghost-accumulation-cross-platform.md
@@ -1,7 +1,7 @@
 ---
 type: task
 title: "Ghost device accumulation on reset/logout — deregister-before-wipe (desktop + mobile)"
-status: PLAN — not started
+status: IN PROGRESS — Slice 1 (desktop) implemented on `fix/deregister-device-before-reset-wipe`; Slice 2 (mobile) not started
 priority: medium (UX/hygiene; not a security hole, but pollutes the device list and per-device-signing admissions)
 created: 2026-07-21
 platforms: quorum-desktop + quorum-mobile (+ optional quilibrium-js-sdk-channels hardening)
@@ -123,6 +123,47 @@ still present**, then wipe. Both platforms already have the code:
 6. Unit test the "reconstruct registration without current device" pure logic
    (input device list + this inbox → expected remaining list; last-device case).
 
+#### Slice 1 implementation notes (2026-07-28, branch `fix/deregister-device-before-reset-wipe`)
+
+Shipped as planned, plus one thing the plan didn't anticipate and three
+deliberate deviations. Files: `src/utils/deviceRegistration.ts` (pure),
+`src/hooks/business/user/useDeregisterThisDevice.ts`, `DangerZone.tsx`,
+`WebsocketProvider.tsx`; 13 unit tests.
+
+- **The plan's await-before-wipe discipline was NOT enough for the revoke
+  broadcast, and this is the important finding for Slice 2.**
+  `broadcastDeviceRevocations` only calls `enqueueOutbound`, which appends to a
+  queue drained by a detached `processOutbound()` loop; `ws.send()` then only
+  fills the browser's socket buffer. So awaiting it proves the statements were
+  *signed and queued*, not sent — `location.reload()` discards both the queue
+  and the buffer, and the revoke would have vanished exactly as silently as the
+  fire-and-forget HTTP upload the plan warned about. Added
+  `flushOutbound(timeoutMs)` to `WebSocketProvider`: a sentinel enqueued behind
+  the caller's frames (FIFO + serial loop ⇒ it runs only after they are sent),
+  then polls `bufferedAmount` to 0. Short-circuits on a non-OPEN socket so an
+  offline reset stays instant. Mutation-checked: resolving the barrier early
+  kills 4 of its 5 tests.
+- **Deviation — no user-facing failure notice.** The plan wanted a non-blocking
+  notice when the deregister fails. The reset ends in `window.location.reload()`
+  microseconds later, so any toast/callout would be unobservable theatre. Shipped
+  a `console.warn` breadcrumb instead. If a real notice is wanted it has to move
+  *before* the confirm (e.g. an offline hint next to the button) — a UX decision,
+  not a wiring one.
+- **Deviation — desktop attempts the last-device removal** (mobile refuses it).
+  The open question about an empty `device_registrations` is still open; this is
+  safe to try because the upload is already best-effort, so a hub rejection just
+  leaves today's single ghost. `planDeviceDeregistration` returns `last-device`
+  so the choice is one line to flip once the server behaviour is known.
+- **Deviation — the two cleanups run in parallel, not sequentially**, under one
+  3s budget: different transports, no ordering between them, so the user waits
+  for the slower rather than the sum.
+- Added a `Resetting...` button state: the goodbye can take up to 3s and a
+  dead-looking button invites a double click. New i18n string, not yet extracted
+  into the catalogs (renders English until the next translation batch).
+- `KeyDB` deletion deliberately NOT bundled (see "Secondary" below).
+- Not yet verified on real hardware — the observable two-device check in step 5
+  below is still outstanding.
+
 ### Slice 2 — Mobile (mirror)
 
 1. In the reset flow (`ProfileModal.handleResetAppData` → before `signOut()`, or
@@ -135,6 +176,12 @@ still present**, then wipe. Both platforms already have the code:
    broadcasts it on device *removal* (via the `deviceKeyStatements` service,
    `services/space/deviceKeyStatements.ts`) — reuse that path for the current
    device's inbox address, awaited with timeout.
+   **Check mobile's send path for the same enqueue-is-not-sent trap desktop
+   had** (see Slice 1 notes): if the broadcast hands frames to a queue or a
+   WebSocket wrapper rather than awaiting the actual send, awaiting it proves
+   nothing and mobile needs its own flush barrier before the storage wipe.
+   Mobile has no `location.reload()`, but `clearAllSecureStorage()` destroys the
+   signing key mid-flight, which loses the frames just as effectively.
 3. Then `clearAllMMKVStorage()` + `clearAllSecureStorage()` as today.
 4. **Observable outcome:** same as desktop, verified statically + on a real
    device pair (mobile: prefer statically-verifiable change per quorum-atlas;
@@ -259,12 +306,15 @@ section above.)
 
 ## Files (anticipated)
 
-Desktop:
-- `src/components/modals/UserSettingsModal/DangerZone.tsx` — deregister +
-  revoke-broadcast steps + best-effort/timeout + notice; optional KeyDB delete.
-- (wiring) registration context / keyset access + `broadcastDeviceRevocations`
-  (from `useMessageDB()`) into DangerZone.
-- new unit test for the reconstruct-without-current-device logic.
+Desktop (DONE — see Slice 1 implementation notes):
+- `src/utils/deviceRegistration.ts` — `planDeviceDeregistration` (pure).
+- `src/hooks/business/user/useDeregisterThisDevice.ts` — upload + revoke under
+  one bounded budget, best-effort.
+- `src/components/modals/UserSettingsModal/DangerZone.tsx` — goodbye before the
+  wipe + `Resetting...` state.
+- `src/components/context/WebsocketProvider.tsx` — `flushOutbound` barrier.
+- `src/dev/tests/utils/deviceRegistration.unit.test.ts` (8),
+  `src/dev/tests/components/websocketFlushOutbound.unit.test.tsx` (5).
 
 Mobile:
 - `components/ProfileModal.tsx` (`handleResetAppData`, ~852) and/or

--- a/src/components/context/WebsocketProvider.tsx
+++ b/src/components/context/WebsocketProvider.tsx
@@ -255,6 +255,10 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
     if (wsRef.current?.readyState !== WebSocket.OPEN) return Promise.resolve(false);
 
     const deadline = Date.now() + timeoutMs;
+    // The frames are being sent on THIS socket. send() on a closing socket
+    // drops silently, so if a reconnect swaps in a fresh one mid-flush, an
+    // empty buffer on the new socket says nothing about the old one's frames.
+    const sendingOn = wsRef.current;
 
     const queueDrained = new Promise<void>((resolve) => {
       enqueueOutbound(async () => {
@@ -266,7 +270,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
     const bufferDrained = async (): Promise<boolean> => {
       while (Date.now() < deadline) {
         const ws = wsRef.current;
-        if (!ws || ws.readyState !== WebSocket.OPEN) return false;
+        if (!ws || ws !== sendingOn || ws.readyState !== WebSocket.OPEN) return false;
         if (ws.bufferedAmount === 0) return true;
         await new Promise((r) => setTimeout(r, FLUSH_POLL_MS));
       }

--- a/src/components/context/WebsocketProvider.tsx
+++ b/src/components/context/WebsocketProvider.tsx
@@ -17,6 +17,7 @@ interface WebSocketContextValue {
   connected: boolean;
   setMessageHandler: (handler: MessageHandler) => void;
   enqueueOutbound: (message: OutboundMessage) => void;
+  flushOutbound: (timeoutMs?: number) => Promise<boolean>;
   setResubscribe: (resubscribe: () => Promise<void>) => void;
 }
 
@@ -28,6 +29,11 @@ interface WebSocketProviderProps {
 
 // Grace period before reporting disconnect (prevents flicker during reconnection)
 const DISCONNECT_GRACE_MS = 3000;
+
+// How long flushOutbound() waits for the socket's own send buffer to drain, and
+// how often it re-checks. Short: its only caller is tearing the page down.
+const FLUSH_TIMEOUT_MS = 3000;
+const FLUSH_POLL_MS = 25;
 
 export function WebSocketProvider({ children }: WebSocketProviderProps) {
   const [connected, setConnected] = useState(false);
@@ -224,6 +230,55 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
     processOutbound(); // Only process outbound - independent from inbound
   };
 
+  /**
+   * Resolve once everything enqueued BEFORE this call has actually been handed
+   * to the network, or false if that can't be confirmed in time.
+   *
+   * enqueueOutbound() only appends to a queue that a detached processOutbound()
+   * loop drains, and ws.send() only copies into the browser's socket buffer.
+   * Neither tells a caller its frames left the machine — which normally doesn't
+   * matter, because the page stays alive and the queue drains on its own. It
+   * matters for the one caller that is about to destroy the page (reset app
+   * data → location.reload()), since the reload discards both the queue and the
+   * unsent buffer. Its goodbye frames (revoke-device) would vanish silently.
+   *
+   * Two barriers: a sentinel enqueued behind the caller's frames, which the
+   * FIFO loop only reaches after ws.send()-ing all of them, then bufferedAmount
+   * reaching 0 so the bytes are off to the OS rather than sitting in the buffer.
+   *
+   * Never rejects and never waits on a closed socket — resetting while offline
+   * must stay instant.
+   */
+  const flushOutbound = (
+    timeoutMs: number = FLUSH_TIMEOUT_MS
+  ): Promise<boolean> => {
+    if (wsRef.current?.readyState !== WebSocket.OPEN) return Promise.resolve(false);
+
+    const deadline = Date.now() + timeoutMs;
+
+    const queueDrained = new Promise<void>((resolve) => {
+      enqueueOutbound(async () => {
+        resolve();
+        return [];
+      });
+    });
+
+    const bufferDrained = async (): Promise<boolean> => {
+      while (Date.now() < deadline) {
+        const ws = wsRef.current;
+        if (!ws || ws.readyState !== WebSocket.OPEN) return false;
+        if (ws.bufferedAmount === 0) return true;
+        await new Promise((r) => setTimeout(r, FLUSH_POLL_MS));
+      }
+      return false;
+    };
+
+    return Promise.race([
+      queueDrained.then(bufferDrained),
+      new Promise<boolean>((resolve) => setTimeout(() => resolve(false), timeoutMs)),
+    ]);
+  };
+
   const setMessageHandler = (handler: MessageHandler) => {
     handlerRef.current = handler;
     processInbound(); // Process any queued inbound messages now that handler is set
@@ -237,6 +292,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
     connected,
     setMessageHandler,
     enqueueOutbound,
+    flushOutbound,
     setResubscribe,
   };
 

--- a/src/components/modals/UserSettingsModal/DangerZone.tsx
+++ b/src/components/modals/UserSettingsModal/DangerZone.tsx
@@ -26,10 +26,18 @@ const DangerZone: React.FunctionComponent = () => {
       // bug in here) must never stop the user from resetting — people reset
       // precisely when things are broken. The cost of failing is one stale
       // entry they can remove by hand from another device.
-      const outcome = await deregisterThisDevice().catch(() => 'failed' as const);
-      if (outcome !== 'deregistered') {
+      const outcome = await deregisterThisDevice().catch((err) => {
+        console.warn('[Reset] deregistration threw', err);
+        return { hub: 'failed', spaces: 'failed' } as const;
+      });
+      if (outcome.hub !== 'ok') {
         console.warn(
-          `[Reset] device deregistration ${outcome} — this device may stay listed until removed manually`
+          `[Reset] hub deregistration ${outcome.hub} — this device may stay listed until removed manually`
+        );
+      }
+      if (outcome.spaces !== 'ok') {
+        console.warn(
+          `[Reset] space revocation ${outcome.spaces} — other members may keep trusting this device's signing key`
         );
       }
 

--- a/src/components/modals/UserSettingsModal/DangerZone.tsx
+++ b/src/components/modals/UserSettingsModal/DangerZone.tsx
@@ -3,16 +3,36 @@ import { Button, Callout, Icon, Input } from '../../primitives';
 import { Trans } from '@lingui/react/macro';
 import { t } from '@lingui/core/macro';
 import { useQueryClient } from '@tanstack/react-query';
+import { useDeregisterThisDevice } from '../../../hooks/business/user/useDeregisterThisDevice';
 
 const DangerZone: React.FunctionComponent = () => {
   const queryClient = useQueryClient();
+  const deregisterThisDevice = useDeregisterThisDevice();
   const [confirmInput, setConfirmInput] = React.useState('');
   const [resetError, setResetError] = React.useState<string | null>(null);
+  const [isResetting, setIsResetting] = React.useState(false);
 
   const isConfirmed = confirmInput.trim().toLowerCase() === 'reset';
 
   const handleResetAppData = async () => {
+    setIsResetting(true);
     try {
+      // Say goodbye BEFORE anything is destroyed. The device keyset below is
+      // the only handle to this device's hub entry and the only key that can
+      // revoke its space signing admission, so wiping first strands both and
+      // every reset+re-login appends a fresh entry instead of replacing one.
+      //
+      // The catch is load-bearing: a goodbye that fails (offline, hub down, a
+      // bug in here) must never stop the user from resetting — people reset
+      // precisely when things are broken. The cost of failing is one stale
+      // entry they can remove by hand from another device.
+      const outcome = await deregisterThisDevice().catch(() => 'failed' as const);
+      if (outcome !== 'deregistered') {
+        console.warn(
+          `[Reset] device deregistration ${outcome} — this device may stay listed until removed manually`
+        );
+      }
+
       // Clear React Query cache
       queryClient.clear();
 
@@ -38,6 +58,7 @@ const DangerZone: React.FunctionComponent = () => {
     } catch (error) {
       console.error('Failed to reset app data:', error);
       setResetError((error as Error)?.message === 'blocked' ? 'blocked' : 'unknown');
+      setIsResetting(false);
     }
   };
 
@@ -80,10 +101,14 @@ const DangerZone: React.FunctionComponent = () => {
             <Button
               type="danger"
               className="!w-auto !inline-flex"
-              disabled={!isConfirmed}
+              disabled={!isConfirmed || isResetting}
               onClick={handleResetAppData}
             >
-              <Trans>Confirm Reset</Trans>
+              {isResetting ? (
+                <Trans>Resetting...</Trans>
+              ) : (
+                <Trans>Confirm Reset</Trans>
+              )}
             </Button>
           </div>
         </div>

--- a/src/dev/tests/components/websocketFlushOutbound.unit.test.tsx
+++ b/src/dev/tests/components/websocketFlushOutbound.unit.test.tsx
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, waitFor, act } from '@testing-library/react';
+import {
+  WebSocketProvider,
+  useWebSocket,
+} from '@/components/context/WebsocketProvider';
+
+/**
+ * flushOutbound() is the barrier that makes deregister-before-wipe real: reset
+ * broadcasts revoke-device frames and then reloads the page, and a reload
+ * discards both the outbound queue and the socket's send buffer. If the barrier
+ * resolves early the frames vanish silently — the failure mode that looks fine
+ * in every test that doesn't check the wire.
+ */
+
+class FakeWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+
+  static last: FakeWebSocket | null = null;
+
+  readyState = FakeWebSocket.CONNECTING;
+  bufferedAmount = 0;
+  sent: string[] = [];
+
+  onopen: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+
+  constructor(_url: string) {
+    FakeWebSocket.last = this;
+    // The real socket opens asynchronously; mirror that so the provider's
+    // onopen handler runs the way it does in a browser.
+    setTimeout(() => {
+      this.readyState = FakeWebSocket.OPEN;
+      this.onopen?.();
+    }, 0);
+  }
+
+  send(message: string) {
+    this.sent.push(message);
+  }
+
+  close() {
+    this.readyState = FakeWebSocket.CLOSED;
+  }
+}
+
+type Ctx = ReturnType<typeof useWebSocket>;
+
+const Probe: React.FunctionComponent<{ onReady: (ctx: Ctx) => void }> = ({
+  onReady,
+}) => {
+  onReady(useWebSocket());
+  return null;
+};
+
+const renderProvider = async () => {
+  let ctx: Ctx | null = null;
+  render(
+    <WebSocketProvider>
+      <Probe onReady={(c) => (ctx = c)} />
+    </WebSocketProvider>
+  );
+
+  await waitFor(() => {
+    expect(FakeWebSocket.last?.readyState).toBe(FakeWebSocket.OPEN);
+  });
+
+  return { ctx: ctx as unknown as Ctx, socket: FakeWebSocket.last! };
+};
+
+describe('WebSocketProvider.flushOutbound', () => {
+  let originalWebSocket: typeof WebSocket;
+
+  beforeEach(() => {
+    originalWebSocket = global.WebSocket;
+    global.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+    FakeWebSocket.last = null;
+  });
+
+  afterEach(() => {
+    global.WebSocket = originalWebSocket;
+    vi.restoreAllMocks();
+  });
+
+  it('resolves only after frames queued before it reach the socket', async () => {
+    const { ctx, socket } = await renderProvider();
+
+    // A slow action, the way a real one is: signing and serializing happen
+    // inside the queued closure, not before it.
+    await act(async () => {
+      ctx.enqueueOutbound(async () => {
+        await new Promise((r) => setTimeout(r, 30));
+        return ['revoke-device'];
+      });
+    });
+
+    let flushed = false;
+    await act(async () => {
+      flushed = await ctx.flushOutbound(1000);
+    });
+
+    expect(flushed).toBe(true);
+    expect(socket.sent).toEqual(['revoke-device']);
+  });
+
+  it('waits for every queued frame, not just the first', async () => {
+    const { ctx, socket } = await renderProvider();
+
+    await act(async () => {
+      ctx.enqueueOutbound(async () => {
+        await new Promise((r) => setTimeout(r, 20));
+        return ['space-1'];
+      });
+      ctx.enqueueOutbound(async () => ['space-2', 'space-3']);
+    });
+
+    await act(async () => {
+      await ctx.flushOutbound(1000);
+    });
+
+    expect(socket.sent).toEqual(['space-1', 'space-2', 'space-3']);
+  });
+
+  it('waits for the socket send buffer to drain', async () => {
+    const { ctx, socket } = await renderProvider();
+
+    // Bytes handed to send() but not yet on the wire — a reload here would
+    // still lose them, so the barrier must not resolve.
+    socket.bufferedAmount = 512;
+    setTimeout(() => {
+      socket.bufferedAmount = 0;
+    }, 60);
+
+    let flushed = false;
+    await act(async () => {
+      flushed = await ctx.flushOutbound(1000);
+    });
+
+    expect(flushed).toBe(true);
+    expect(socket.bufferedAmount).toBe(0);
+  });
+
+  it('reports failure instead of hanging when the buffer never drains', async () => {
+    const { ctx, socket } = await renderProvider();
+    socket.bufferedAmount = 512;
+
+    let flushed = true;
+    await act(async () => {
+      flushed = await ctx.flushOutbound(120);
+    });
+
+    // Bounded: the caller proceeds with the wipe rather than being stuck.
+    expect(flushed).toBe(false);
+  });
+
+  it('returns immediately when the socket is not open (offline reset)', async () => {
+    const { ctx, socket } = await renderProvider();
+    socket.readyState = FakeWebSocket.CLOSED;
+
+    const started = Date.now();
+    let flushed = true;
+    await act(async () => {
+      flushed = await ctx.flushOutbound(5000);
+    });
+
+    expect(flushed).toBe(false);
+    // Must not sit on the timeout — resetting while offline stays instant.
+    expect(Date.now() - started).toBeLessThan(1000);
+  });
+});

--- a/src/dev/tests/hooks/useDeregisterThisDevice.unit.test.ts
+++ b/src/dev/tests/hooks/useDeregisterThisDevice.unit.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+/**
+ * The two cleanups this hook performs fail independently and are reported
+ * independently. Both bugs this file exists to prevent lived in the
+ * composition, not in either piece: the flush barrier's answer was computed and
+ * then discarded, and a slow revoke leg overwrote a hub write that had already
+ * succeeded. Testing planDeviceDeregistration and flushOutbound in isolation
+ * caught neither.
+ */
+
+const mocks = vi.hoisted(() => ({
+  address: 'user-address',
+  keyset: {
+    userKeyset: { user_key: { public_key: [1, 2, 3], private_key: [4, 5, 6] } },
+    deviceKeyset: { inbox_keyset: { inbox_address: 'this-device' } },
+  } as any,
+  refetch: vi.fn(),
+  upload: vi.fn(),
+  broadcast: vi.fn(),
+  flush: vi.fn(),
+  construct: vi.fn(),
+}));
+
+vi.mock('@quilibrium/quilibrium-js-sdk-channels', () => ({
+  usePasskeysContext: () => ({ currentPasskeyInfo: { address: mocks.address } }),
+  channel: {
+    ConstructUserRegistration: (...args: unknown[]) => mocks.construct(...args),
+  },
+}));
+
+vi.mock('@/hooks/queries', () => ({
+  useRegistration: () => ({ refetch: mocks.refetch }),
+}));
+
+vi.mock('@/components/context/useRegistrationContext', () => ({
+  useRegistrationContext: () => ({ keyset: mocks.keyset }),
+}));
+
+vi.mock('@/components/context/useMessageDB', () => ({
+  useMessageDB: () => ({ broadcastDeviceRevocations: mocks.broadcast }),
+}));
+
+vi.mock('@/components/context/WebsocketProvider', () => ({
+  useWebSocket: () => ({ flushOutbound: mocks.flush }),
+}));
+
+vi.mock('@/hooks/mutations/useUploadRegistration', () => ({
+  useUploadRegistration: () => mocks.upload,
+}));
+
+import { useDeregisterThisDevice } from '@/hooks/business/user/useDeregisterThisDevice';
+
+const device = (inbox: string) => ({ inbox_registration: { inbox_address: inbox } });
+
+const hubReturns = (...devices: ReturnType<typeof device>[]) => {
+  mocks.refetch.mockResolvedValue({
+    data: { registration: { device_registrations: devices } },
+    error: null,
+  });
+};
+
+const runDeregister = async () => {
+  const { result } = renderHook(() => useDeregisterThisDevice());
+  let outcome: Awaited<ReturnType<typeof result.current>>;
+  await act(async () => {
+    outcome = await result.current();
+  });
+  return outcome!;
+};
+
+describe('useDeregisterThisDevice', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    mocks.keyset = {
+      userKeyset: { user_key: { public_key: [1, 2, 3], private_key: [4, 5, 6] } },
+      deviceKeyset: { inbox_keyset: { inbox_address: 'this-device' } },
+    };
+    hubReturns(device('this-device'), device('other-device'));
+    mocks.construct.mockResolvedValue({ signed: true });
+    mocks.upload.mockResolvedValue(undefined);
+    mocks.broadcast.mockResolvedValue(undefined);
+    mocks.flush.mockResolvedValue(true);
+  });
+
+  it('removes this device from the hub list and confirms the revoke on the wire', async () => {
+    const outcome = await runDeregister();
+
+    expect(outcome).toEqual({ hub: 'ok', spaces: 'ok' });
+    // Re-signed with only the other device left.
+    const [, remaining, added] = mocks.construct.mock.calls[0];
+    expect(remaining).toEqual([device('other-device')]);
+    expect(added).toEqual([]);
+    expect(mocks.broadcast).toHaveBeenCalledWith(['this-device']);
+  });
+
+  it('reports the spaces leg failed when the flush is not confirmed', async () => {
+    // The bug this guards: flushOutbound's answer was awaited and discarded, so
+    // frames that never left the machine were reported as a clean goodbye.
+    mocks.flush.mockResolvedValue(false);
+
+    const outcome = await runDeregister();
+
+    expect(outcome.spaces).toBe('failed');
+  });
+
+  it('does not let a failing spaces leg mask a successful hub write', async () => {
+    // The bug this guards: one shared budget meant a slow revoke resolved the
+    // whole thing to 'failed', so the user was told the device might still be
+    // listed when it had already been removed.
+    mocks.flush.mockImplementation(
+      () => new Promise((resolve) => setTimeout(() => resolve(false), 50))
+    );
+
+    const outcome = await runDeregister();
+
+    expect(outcome).toEqual({ hub: 'ok', spaces: 'failed' });
+    expect(mocks.upload).toHaveBeenCalled();
+  });
+
+  it('does not let a failing hub leg mask a successful revoke', async () => {
+    mocks.upload.mockRejectedValue(new Error('hub unreachable'));
+
+    const outcome = await runDeregister();
+
+    expect(outcome).toEqual({ hub: 'failed', spaces: 'ok' });
+  });
+
+  it('skips both legs, and every network call, when the keyset is not ready', async () => {
+    // RegistrationPersister fills the keyset ~200ms after mount; typing RESET
+    // faster than that must not crash or sign with a half-built keyset.
+    mocks.keyset = { userKeyset: undefined, deviceKeyset: undefined };
+
+    const outcome = await runDeregister();
+
+    expect(outcome).toEqual({ hub: 'skipped', spaces: 'skipped' });
+    expect(mocks.upload).not.toHaveBeenCalled();
+    expect(mocks.broadcast).not.toHaveBeenCalled();
+  });
+
+  it('does not write a stale device list when the list cannot be re-read', async () => {
+    // Uploading replaces the list wholesale, so acting on a stale snapshot
+    // would silently delete a device registered elsewhere since then.
+    mocks.refetch.mockResolvedValue({ data: undefined, error: new Error('offline') });
+
+    const outcome = await runDeregister();
+
+    expect(outcome.hub).toBe('failed');
+    expect(mocks.construct).not.toHaveBeenCalled();
+    expect(mocks.upload).not.toHaveBeenCalled();
+  });
+
+  it('still revokes in spaces when the hub list no longer lists this device', async () => {
+    // Another device already removed it. Signing admissions are anchored to the
+    // master key, not the device list, so the two can be out of step.
+    hubReturns(device('other-device'));
+
+    const outcome = await runDeregister();
+
+    expect(outcome).toEqual({ hub: 'ok', spaces: 'ok' });
+    expect(mocks.upload).not.toHaveBeenCalled(); // nothing to write
+    expect(mocks.broadcast).toHaveBeenCalledWith(['this-device']);
+  });
+
+  it('aborts the hub upload at its own deadline rather than leaving it in flight', async () => {
+    await runDeregister();
+
+    // A request outliving the page is how the write silently went missing.
+    expect(mocks.upload).toHaveBeenCalledWith(
+      expect.objectContaining({ timeout: expect.any(Number) })
+    );
+  });
+});

--- a/src/dev/tests/utils/deviceRegistration.unit.test.ts
+++ b/src/dev/tests/utils/deviceRegistration.unit.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { planDeviceDeregistration } from '../../../utils/deviceRegistration';
+
+const device = (inbox: string) => ({
+  inbox_registration: { inbox_address: inbox },
+});
+
+const inboxes = (devices: { inbox_registration: { inbox_address: string } }[]) =>
+  devices.map((d) => d.inbox_registration.inbox_address);
+
+describe('planDeviceDeregistration', () => {
+  it('drops this device and keeps the others, in order', () => {
+    const devices = [device('phone'), device('laptop'), device('work-pc')];
+
+    const plan = planDeviceDeregistration(devices, 'laptop');
+
+    expect(plan.status).toBe('ok');
+    expect(inboxes(plan.remainingDevices)).toEqual(['phone', 'work-pc']);
+  });
+
+  it('reports last-device when this was the only entry', () => {
+    const plan = planDeviceDeregistration([device('laptop')], 'laptop');
+
+    expect(plan.status).toBe('last-device');
+    expect(plan.remainingDevices).toEqual([]);
+  });
+
+  it('reports not-listed when this device is absent (already removed elsewhere)', () => {
+    const devices = [device('phone'), device('work-pc')];
+
+    const plan = planDeviceDeregistration(devices, 'laptop');
+
+    // Unchanged list, so the caller skips a pointless re-sign and upload.
+    expect(plan.status).toBe('not-listed');
+    expect(inboxes(plan.remainingDevices)).toEqual(['phone', 'work-pc']);
+  });
+
+  it('reports not-listed for an empty, undefined, or null device list', () => {
+    expect(planDeviceDeregistration([], 'laptop').status).toBe('not-listed');
+    expect(planDeviceDeregistration(undefined, 'laptop').status).toBe('not-listed');
+    expect(planDeviceDeregistration(null, 'laptop').status).toBe('not-listed');
+  });
+
+  it('reports not-listed when the local inbox address is missing', () => {
+    // The keyset guard should catch this first; belt and braces so a blank
+    // address can never filter every device off the account.
+    const devices = [device('phone'), device('laptop')];
+
+    expect(planDeviceDeregistration(devices, undefined).status).toBe('not-listed');
+    expect(inboxes(planDeviceDeregistration(devices, '').remainingDevices)).toEqual([
+      'phone',
+      'laptop',
+    ]);
+  });
+
+  it('removes every entry sharing this inbox address', () => {
+    // Duplicates shouldn't exist, but a half-failed earlier write could leave
+    // one; the goodbye must not leave a copy of itself behind.
+    const devices = [device('laptop'), device('phone'), device('laptop')];
+
+    const plan = planDeviceDeregistration(devices, 'laptop');
+
+    expect(plan.status).toBe('ok');
+    expect(inboxes(plan.remainingDevices)).toEqual(['phone']);
+  });
+
+  it('leaves malformed entries untouched rather than dropping them', () => {
+    const devices = [{}, { inbox_registration: {} }, device('laptop')];
+
+    const plan = planDeviceDeregistration(devices, 'laptop');
+
+    expect(plan.status).toBe('ok');
+    expect(plan.remainingDevices).toHaveLength(2);
+  });
+
+  it('does not mutate the input list', () => {
+    const devices = [device('phone'), device('laptop')];
+
+    planDeviceDeregistration(devices, 'laptop');
+
+    expect(inboxes(devices)).toEqual(['phone', 'laptop']);
+  });
+});

--- a/src/hooks/business/user/useDeregisterThisDevice.ts
+++ b/src/hooks/business/user/useDeregisterThisDevice.ts
@@ -1,0 +1,132 @@
+import { useCallback } from 'react';
+import {
+  usePasskeysContext,
+  channel as secureChannel,
+} from '@quilibrium/quilibrium-js-sdk-channels';
+import { logger } from '@quilibrium/quorum-shared';
+import { useRegistration } from '../../queries';
+import { useRegistrationContext } from '../../../components/context/useRegistrationContext';
+import { useMessageDB } from '../../../components/context/useMessageDB';
+import { useWebSocket } from '../../../components/context/WebsocketProvider';
+import { useUploadRegistration } from '../../mutations/useUploadRegistration';
+import { planDeviceDeregistration } from '../../../utils/deviceRegistration';
+
+export type DeregisterOutcome =
+  /** This device is no longer in the hub device list (uploaded, or already absent). */
+  | 'deregistered'
+  /** Couldn't attempt it — no keyset yet. Caller proceeds; a ghost may remain. */
+  | 'skipped'
+  /** Attempted and failed or timed out. Caller proceeds; a ghost may remain. */
+  | 'failed';
+
+/**
+ * Total budget for the goodbye. Both steps run in parallel, so this is roughly
+ * the worst case a user waits after confirming a reset — long enough for a
+ * round trip on a slow connection, short enough not to feel broken.
+ */
+export const DEREGISTER_TIMEOUT_MS = 3000;
+
+const withTimeout = <T,>(promise: Promise<T>, ms: number, fallback: T): Promise<T> =>
+  Promise.race([
+    promise,
+    new Promise<T>((resolve) => setTimeout(() => resolve(fallback), ms)),
+  ]);
+
+/**
+ * Remove THIS device from the account before its keys are destroyed.
+ *
+ * Reset wipes the local device keyset, which is the only handle to this
+ * device's hub entry and the only key that can revoke its per-space signing
+ * admission. Wiping first therefore orphans both: the hub entry can only be
+ * cleared by hand from another device, and every reset+re-login cycle appends a
+ * fresh one (10+ entries for 3-4 real devices on a test account). So the
+ * goodbye has to happen while the keys still exist.
+ *
+ * Two independent cleanups, run in parallel under one bounded budget:
+ *   1. hub UserRegistration — re-sign the device list without this device
+ *   2. spaces — master-signed revoke-device tombstones, flushed to the socket
+ *
+ * Best-effort by design: a reset must work offline and when things are already
+ * broken, so every failure path resolves rather than throws, and the caller
+ * always proceeds to the wipe. The cost of failure is one leftover entry the
+ * user can remove by hand, which beats a reset that refuses to run.
+ */
+export const useDeregisterThisDevice = () => {
+  const { currentPasskeyInfo } = usePasskeysContext();
+  const { keyset } = useRegistrationContext();
+  const { data: registration } = useRegistration({
+    address: currentPasskeyInfo?.address!,
+  });
+  const uploadRegistration = useUploadRegistration();
+  const { broadcastDeviceRevocations } = useMessageDB();
+  const { flushOutbound } = useWebSocket();
+
+  return useCallback(
+    async (timeoutMs: number = DEREGISTER_TIMEOUT_MS): Promise<DeregisterOutcome> => {
+      const thisInbox = keyset?.deviceKeyset?.inbox_keyset?.inbox_address;
+
+      // RegistrationPersister populates the keyset ~200ms after mount; a user
+      // who types RESET faster than that gets the old behavior, not a crash.
+      if (!keyset?.userKeyset || !thisInbox) {
+        logger.warn('[Deregister] no keyset at reset time — skipping the goodbye');
+        return 'skipped';
+      }
+
+      const { status, remainingDevices } = planDeviceDeregistration(
+        registration?.registration?.device_registrations,
+        thisInbox
+      );
+
+      const removeFromHub = async (): Promise<boolean> => {
+        if (status === 'not-listed') return true; // already absent — nothing to write
+        try {
+          const updated = await secureChannel.ConstructUserRegistration(
+            keyset.userKeyset,
+            remainingDevices,
+            [] // no new devices
+          );
+          await uploadRegistration({
+            address: currentPasskeyInfo!.address,
+            registration: updated,
+          });
+          return true;
+        } catch (err) {
+          logger.warn('[Deregister] hub deregister failed', { err, status });
+          return false;
+        }
+      };
+
+      // Revoke even when the hub entry was already gone: the signing admission
+      // is anchored to the master key, not the device list, so the two can be
+      // out of step. Idempotent (LWW) if another device already revoked it.
+      const revokeInSpaces = async (): Promise<void> => {
+        try {
+          await broadcastDeviceRevocations([thisInbox]);
+          // Enqueueing isn't sending. Without this the reload cancels the
+          // frames and the revoke silently never happens.
+          await flushOutbound(timeoutMs);
+        } catch (err) {
+          logger.warn('[Deregister] revoke broadcast failed', err);
+        }
+      };
+
+      // Parallel: independent transports with no ordering between them, so the
+      // user waits for the slower one rather than both.
+      const hubRemoved = await withTimeout(
+        Promise.all([removeFromHub(), revokeInSpaces()]).then(([ok]) => ok),
+        timeoutMs,
+        false
+      );
+
+      return hubRemoved ? 'deregistered' : 'failed';
+    },
+    [
+      keyset,
+      registration,
+      currentPasskeyInfo,
+      uploadRegistration,
+      broadcastDeviceRevocations,
+      flushOutbound,
+    ]
+  );
+};

--- a/src/hooks/business/user/useDeregisterThisDevice.ts
+++ b/src/hooks/business/user/useDeregisterThisDevice.ts
@@ -3,7 +3,6 @@ import {
   usePasskeysContext,
   channel as secureChannel,
 } from '@quilibrium/quilibrium-js-sdk-channels';
-import { logger } from '@quilibrium/quorum-shared';
 import { useRegistration } from '../../queries';
 import { useRegistrationContext } from '../../../components/context/useRegistrationContext';
 import { useMessageDB } from '../../../components/context/useMessageDB';
@@ -11,25 +10,40 @@ import { useWebSocket } from '../../../components/context/WebsocketProvider';
 import { useUploadRegistration } from '../../mutations/useUploadRegistration';
 import { planDeviceDeregistration } from '../../../utils/deviceRegistration';
 
-export type DeregisterOutcome =
-  /** This device is no longer in the hub device list (uploaded, or already absent). */
-  | 'deregistered'
-  /** Couldn't attempt it — no keyset yet. Caller proceeds; a ghost may remain. */
-  | 'skipped'
-  /** Attempted and failed or timed out. Caller proceeds; a ghost may remain. */
-  | 'failed';
+export type LegOutcome =
+  /** Confirmed done. */
+  | 'ok'
+  /** Attempted, not confirmed — assume it didn't happen. */
+  | 'failed'
+  /** Couldn't attempt it (no keyset yet). */
+  | 'skipped';
+
+export interface DeregisterOutcome {
+  /** The hub's device list no longer includes this device. */
+  hub: LegOutcome;
+  /** revoke-device tombstones for this device reached the wire. */
+  spaces: LegOutcome;
+}
 
 /**
- * Total budget for the goodbye. Both steps run in parallel, so this is roughly
- * the worst case a user waits after confirming a reset — long enough for a
- * round trip on a slow connection, short enough not to feel broken.
+ * Per-leg budgets. Separate on purpose: the hub leg is an HTTP round trip the
+ * API client itself allows 22s for, while the socket leg either drains quickly
+ * or is not going to. Collapsing them into one budget made a slow revoke report
+ * the hub write as failed even after it had succeeded.
+ *
+ * The legs run in parallel, so the user waits for the longer one, not the sum.
  */
-export const DEREGISTER_TIMEOUT_MS = 3000;
+export const HUB_TIMEOUT_MS = 8000;
+export const SPACES_TIMEOUT_MS = 4000;
+/** Re-reading the device list is on the critical path, so keep it tight. */
+export const REFETCH_TIMEOUT_MS = 4000;
 
-const withTimeout = <T,>(promise: Promise<T>, ms: number, fallback: T): Promise<T> =>
+const TIMED_OUT = Symbol('timed-out');
+
+const withTimeout = <T,>(promise: Promise<T>, ms: number): Promise<T | typeof TIMED_OUT> =>
   Promise.race([
     promise,
-    new Promise<T>((resolve) => setTimeout(() => resolve(fallback), ms)),
+    new Promise<typeof TIMED_OUT>((resolve) => setTimeout(() => resolve(TIMED_OUT), ms)),
   ]);
 
 /**
@@ -38,95 +52,122 @@ const withTimeout = <T,>(promise: Promise<T>, ms: number, fallback: T): Promise<
  * Reset wipes the local device keyset, which is the only handle to this
  * device's hub entry and the only key that can revoke its per-space signing
  * admission. Wiping first therefore orphans both: the hub entry can only be
- * cleared by hand from another device, and every reset+re-login cycle appends a
+ * cleared by hand from another device, and every reset + re-login appends a
  * fresh one (10+ entries for 3-4 real devices on a test account). So the
  * goodbye has to happen while the keys still exist.
  *
- * Two independent cleanups, run in parallel under one bounded budget:
+ * Two independent cleanups, reported separately because they fail separately:
  *   1. hub UserRegistration — re-sign the device list without this device
  *   2. spaces — master-signed revoke-device tombstones, flushed to the socket
  *
  * Best-effort by design: a reset must work offline and when things are already
  * broken, so every failure path resolves rather than throws, and the caller
- * always proceeds to the wipe. The cost of failure is one leftover entry the
- * user can remove by hand, which beats a reset that refuses to run.
+ * always proceeds to the wipe. The cost of failure is a leftover entry the user
+ * can remove by hand, which beats a reset that refuses to run.
+ *
+ * Diagnostics use console rather than the shared logger deliberately: that
+ * logger compiles out when NODE_ENV is production, and this path leaves no
+ * other trace — by the time anything could be inspected, the data is gone.
  */
 export const useDeregisterThisDevice = () => {
   const { currentPasskeyInfo } = usePasskeysContext();
   const { keyset } = useRegistrationContext();
-  const { data: registration } = useRegistration({
+  const { refetch: refetchRegistration } = useRegistration({
     address: currentPasskeyInfo?.address!,
   });
   const uploadRegistration = useUploadRegistration();
   const { broadcastDeviceRevocations } = useMessageDB();
   const { flushOutbound } = useWebSocket();
 
-  return useCallback(
-    async (timeoutMs: number = DEREGISTER_TIMEOUT_MS): Promise<DeregisterOutcome> => {
-      const thisInbox = keyset?.deviceKeyset?.inbox_keyset?.inbox_address;
+  return useCallback(async (): Promise<DeregisterOutcome> => {
+    const thisInbox = keyset?.deviceKeyset?.inbox_keyset?.inbox_address;
 
-      // RegistrationPersister populates the keyset ~200ms after mount; a user
-      // who types RESET faster than that gets the old behavior, not a crash.
-      if (!keyset?.userKeyset || !thisInbox) {
-        logger.warn('[Deregister] no keyset at reset time — skipping the goodbye');
-        return 'skipped';
+    // RegistrationPersister populates the keyset ~200ms after mount; a user who
+    // types RESET faster than that gets the old behavior, not a crash.
+    if (!keyset?.userKeyset || !thisInbox) {
+      console.warn('[Deregister] no keyset at reset time — skipping the goodbye');
+      return { hub: 'skipped', spaces: 'skipped' };
+    }
+
+    const removeFromHub = async (): Promise<LegOutcome> => {
+      try {
+        // Re-read the list first. The cached copy can be minutes old (settings
+        // left open) and the upload replaces the list wholesale, so a device
+        // registered elsewhere in the meantime would be silently deleted. If
+        // the re-read fails the hub is unreachable and the upload would fail
+        // too, so skipping is strictly safer than writing a stale list.
+        const fresh = await withTimeout(refetchRegistration(), REFETCH_TIMEOUT_MS);
+        if (fresh === TIMED_OUT || fresh.error) {
+          console.warn('[Deregister] could not re-read the device list', fresh);
+          return 'failed';
+        }
+
+        const { status, remainingDevices } = planDeviceDeregistration(
+          fresh.data?.registration?.device_registrations,
+          thisInbox
+        );
+
+        if (status === 'not-listed') return 'ok'; // already absent — nothing to write
+
+        const updated = await secureChannel.ConstructUserRegistration(
+          keyset.userKeyset,
+          remainingDevices,
+          [] // no new devices
+        );
+        await uploadRegistration({
+          address: currentPasskeyInfo!.address,
+          registration: updated,
+          // Abort at our own deadline instead of leaving a request in flight
+          // for the reload to cancel. The client's 22s default outlives the
+          // page, which is how the write silently went missing.
+          timeout: HUB_TIMEOUT_MS,
+        });
+        return 'ok';
+      } catch (err) {
+        console.warn('[Deregister] hub deregister failed', err);
+        return 'failed';
       }
+    };
 
-      const { status, remainingDevices } = planDeviceDeregistration(
-        registration?.registration?.device_registrations,
-        thisInbox
-      );
-
-      const removeFromHub = async (): Promise<boolean> => {
-        if (status === 'not-listed') return true; // already absent — nothing to write
-        try {
-          const updated = await secureChannel.ConstructUserRegistration(
-            keyset.userKeyset,
-            remainingDevices,
-            [] // no new devices
-          );
-          await uploadRegistration({
-            address: currentPasskeyInfo!.address,
-            registration: updated,
-          });
-          return true;
-        } catch (err) {
-          logger.warn('[Deregister] hub deregister failed', { err, status });
-          return false;
+    // Revoke even when the hub entry was already gone: the signing admission is
+    // anchored to the master key, not the device list, so the two can be out of
+    // step. Idempotent (LWW) if another device already revoked it.
+    const revokeInSpaces = async (): Promise<LegOutcome> => {
+      try {
+        await broadcastDeviceRevocations([thisInbox]);
+        // Enqueueing isn't sending. Without confirming the flush, the reload
+        // cancels the frames and the revoke silently never happens — so the
+        // barrier's answer decides this leg's outcome rather than being
+        // discarded.
+        const flushed = await flushOutbound(SPACES_TIMEOUT_MS);
+        if (!flushed) {
+          console.warn('[Deregister] revoke frames were not confirmed on the wire');
+          return 'failed';
         }
-      };
+        return 'ok';
+      } catch (err) {
+        console.warn('[Deregister] revoke broadcast failed', err);
+        return 'failed';
+      }
+    };
 
-      // Revoke even when the hub entry was already gone: the signing admission
-      // is anchored to the master key, not the device list, so the two can be
-      // out of step. Idempotent (LWW) if another device already revoked it.
-      const revokeInSpaces = async (): Promise<void> => {
-        try {
-          await broadcastDeviceRevocations([thisInbox]);
-          // Enqueueing isn't sending. Without this the reload cancels the
-          // frames and the revoke silently never happens.
-          await flushOutbound(timeoutMs);
-        } catch (err) {
-          logger.warn('[Deregister] revoke broadcast failed', err);
-        }
-      };
+    // Independently bounded so a slow leg can never overwrite the other leg's
+    // result, and parallel because they share no ordering.
+    const [hub, spaces] = await Promise.all([
+      withTimeout(removeFromHub(), HUB_TIMEOUT_MS),
+      withTimeout(revokeInSpaces(), SPACES_TIMEOUT_MS),
+    ]);
 
-      // Parallel: independent transports with no ordering between them, so the
-      // user waits for the slower one rather than both.
-      const hubRemoved = await withTimeout(
-        Promise.all([removeFromHub(), revokeInSpaces()]).then(([ok]) => ok),
-        timeoutMs,
-        false
-      );
-
-      return hubRemoved ? 'deregistered' : 'failed';
-    },
-    [
-      keyset,
-      registration,
-      currentPasskeyInfo,
-      uploadRegistration,
-      broadcastDeviceRevocations,
-      flushOutbound,
-    ]
-  );
+    return {
+      hub: hub === TIMED_OUT ? 'failed' : hub,
+      spaces: spaces === TIMED_OUT ? 'failed' : spaces,
+    };
+  }, [
+    keyset,
+    refetchRegistration,
+    currentPasskeyInfo,
+    uploadRegistration,
+    broadcastDeviceRevocations,
+    flushOutbound,
+  ]);
 };

--- a/src/hooks/mutations/useUploadRegistration.ts
+++ b/src/hooks/mutations/useUploadRegistration.ts
@@ -11,11 +11,18 @@ export const useUploadRegistration = () => {
     async ({
       address,
       registration,
+      timeout,
     }: {
       address: string;
       registration: channel.UserRegistration;
+      /**
+       * Override the client's default. Callers that are about to tear the page
+       * down need the request aborted at their own deadline rather than left
+       * in flight for a reload to cancel.
+       */
+      timeout?: number;
     }) => {
-      await apiClient.postUser(address, registration);
+      await apiClient.postUser(address, registration, { timeout });
 
       invalidateRegistration({ address });
     },

--- a/src/utils/deviceRegistration.ts
+++ b/src/utils/deviceRegistration.ts
@@ -1,0 +1,61 @@
+/**
+ * Device-list reconstruction for deregister-before-wipe.
+ *
+ * Kept pure (no keyset, no network, no SDK types) so the one rule that decides
+ * whether a reset leaves a ghost behind — which entries survive — is testable
+ * without a hub or a registration context.
+ */
+
+/** Structural shape of a hub device entry; the SDK's DeviceRegistration satisfies it. */
+type DeviceLike = {
+  inbox_registration?: { inbox_address?: string };
+};
+
+export type DeviceDeregistrationStatus =
+  /** This device was listed and other devices remain. */
+  | 'ok'
+  /** This device was listed and was the only one, so the list goes empty. */
+  | 'last-device'
+  /** Nothing to upload: empty list, no local inbox address, or this device isn't listed. */
+  | 'not-listed';
+
+export interface DeviceDeregistrationPlan<T> {
+  status: DeviceDeregistrationStatus;
+  /** The list to re-sign and upload. Equals the input when status is 'not-listed'. */
+  remainingDevices: T[];
+}
+
+/**
+ * Work out the device list to upload when THIS device removes itself.
+ *
+ * 'last-device' is reported rather than refused: the caller decides, and on
+ * desktop an upload the hub rejects is already handled as best-effort, so
+ * attempting it costs nothing and fully cleans single-device accounts if the
+ * hub accepts an empty list. (Mobile's removeDeviceFromRegistration refuses
+ * this case outright — a deliberate divergence, see the ghost-accumulation task.)
+ */
+export function planDeviceDeregistration<T extends DeviceLike>(
+  devices: readonly T[] | undefined | null,
+  thisInboxAddress: string | undefined | null
+): DeviceDeregistrationPlan<T> {
+  const all = devices ? [...devices] : [];
+
+  if (!thisInboxAddress || all.length === 0) {
+    return { status: 'not-listed', remainingDevices: all };
+  }
+
+  const remainingDevices = all.filter(
+    (device) => device.inbox_registration?.inbox_address !== thisInboxAddress
+  );
+
+  // Nothing matched — another device already removed this one, or the hub list
+  // predates it. Uploading the unchanged list would be a pointless write.
+  if (remainingDevices.length === all.length) {
+    return { status: 'not-listed', remainingDevices: all };
+  }
+
+  return {
+    status: remainingDevices.length === 0 ? 'last-device' : 'ok',
+    remainingDevices,
+  };
+}


### PR DESCRIPTION
Reset destroyed the local device keyset without first removing that device from the hub `UserRegistration` or revoking its per-space signing admission. The keyset is the only handle to both, so wiping it orphaned them, and each reset + re-login minted a fresh keyset and appended a new entry. A test account used across 3-4 physical devices had accumulated 10+ device entries.

Now the reset says goodbye while the keys still exist.

## What changed

- **`planDeviceDeregistration`** (pure, `src/utils/deviceRegistration.ts`): rebuild the device list without this device. Reports `last-device` and `not-listed` rather than deciding, so the caller skips pointless writes, and a blank inbox address can never filter every device off the account.
- **`useDeregisterThisDevice`**: re-sign and upload the reduced list, and broadcast a master-signed `revoke-device` tombstone per space (reusing the machinery #249 shipped for Security-modal device removal). The two legs are bounded and reported independently as `{hub, spaces}`, because they fail independently.
- **`flushOutbound`** on `WebSocketProvider` — see below.
- **`DangerZone`**: the goodbye runs before the wipe, and the button shows a `Resetting...` state.

## The non-obvious part

Awaiting `broadcastDeviceRevocations` is not enough. It only calls `enqueueOutbound`, which appends to a queue drained by a detached `processOutbound()` loop, and `ws.send()` then only fills the browser's socket buffer. Awaiting it proves the statements were signed and queued, not sent — and `location.reload()` discards both the queue and the buffer, so the revoke frames would have vanished exactly as silently as a fire-and-forget HTTP request.

`flushOutbound` gives a real barrier: a sentinel enqueued behind the caller's frames (the loop is FIFO and serial, so it runs only after they have been sent), then polls `bufferedAmount` to 0. It compares socket identity, since `send()` on a closing socket drops silently and an empty buffer on a reconnected socket says nothing about the previous one's frames. It short-circuits on a non-OPEN socket so an offline reset stays instant.

## Fixed after independent review

Three review passes found two real bugs in the first commit, both in the composition rather than in either piece, which is why the isolated tests missed them:

1. **The flush barrier's answer was computed and discarded.** `revokeInSpaces` awaited `flushOutbound` and dropped the boolean, and the aggregate read only the hub leg, so unsent frames were reported as a clean goodbye. This is the worse half to lose silently: on failure the hub entry is already gone, so nothing points at the problem, while every space still trusts the device's signing key.
2. **A slow revoke overwrote a hub write that had already succeeded**, telling the user their device might still be listed when it had already been removed.

Also from review:

- The original 3s cap abandoned the hub POST under merely-slow networks — the API client allows 22s with 2 retries for that same call, and the request had no `keepalive`. The hub leg now has its own 8s budget and passes an explicit `timeout` so the client aborts at our deadline rather than leaving a request for the reload to kill.
- Diagnostics moved from `@quilibrium/quorum-shared`'s `logger` to `console`: that logger gates on `NODE_ENV !== 'production'`, so every warning on this path was a no-op in exactly the build where the data is about to be destroyed.
- The device list is re-read immediately before planning. The cached copy could be minutes old with settings left open, and the upload replaces it wholesale, so a device registered elsewhere meanwhile would have been silently deleted. A failed re-read now skips the write rather than uploading a stale list.

Review also confirmed two non-issues: adding a `useSuspenseQuery` to `DangerZone` cannot suspend the modal (`RegistrationProvider` holds an observer on the same key all session, so the cache is always warm), and `planDeviceDeregistration` has no input that removes the wrong device or more than intended.

## Failure behaviour

Best-effort throughout: every path resolves rather than throws, and the wipe always proceeds. People reset precisely when things are broken, so a failed goodbye must never block it.

## Tests

21 new unit tests, full suite 657 passing. Mutation-checked rather than assumed: resolving the flush barrier early kills 4 of its 5 tests; discarding the flush result kills 2 hook tests; collapsing the two budgets kills 1.

## Deliberately not included

`KeyDB` still survives a reset despite the copy promising "including your private keys". The security pass rates this Critical on its own merits, but it is pre-existing on `main`, interacts with the app-lock / duress-wipe work, and is tracked in the task file rather than folded in here. Note the dependency: allowing last-device removal is low-risk partly *because* `KeyDB` survives, so that decision needs revisiting if `KeyDB` deletion ships.

## Not yet verified

The two-device observable check (reset device A, confirm it disappears from B's device list instead of piling up) still needs real hardware. Mobile is Slice 2, not started — the task file now carries a checklist of the same traps for the mobile implementation.

Task: `.agents/tasks/2026-07-21-device-registration-ghost-accumulation-cross-platform.md`
