### PR TITLE
fix: config save filter no longer wipes or publishes a truncated Spaces list

### DIFF
--- a/src/dev/tests/services/ConfigService.unit.test.tsx
+++ b/src/dev/tests/services/ConfigService.unit.test.tsx
@@ -392,4 +392,83 @@ describe('ConfigService - Unit Tests', () => {
       );
     });
   });
+
+  describe('5. saveConfig() - upload narrowing must not touch local state', () => {
+    const mockKeyset = {
+      userKeyset: {
+        user_key: {
+          private_key: new Uint8Array(57),
+          public_key: new Uint8Array(57),
+        },
+      } as any,
+      deviceKeyset: {} as any,
+    };
+
+    // The config lists three Spaces across a folder, but the local DB only
+    // holds space-1 with a usable encryption state. That is the state a device
+    // is in mid-sync, and it is what previously truncated the nav.
+    const partialDbConfig = () => ({
+      address: 'user-partial',
+      spaceIds: ['space-1', 'space-2', 'space-3'],
+      items: [
+        { type: 'space', id: 'space-1' },
+        { type: 'space', id: 'space-2' },
+        { type: 'folder', id: 'folder-1', name: 'Work', spaceIds: ['space-1', 'space-3'] },
+      ],
+      allowSync: true,
+      timestamp: 0,
+    }) as any;
+
+    const arrangePartialDb = () => {
+      mockDeps.messageDB.getSpaces = vi.fn().mockResolvedValue([{ spaceId: 'space-1' }]);
+      mockDeps.messageDB.getSpaceKeys = vi.fn().mockResolvedValue([]);
+      mockDeps.messageDB.getEncryptionStates = vi.fn().mockResolvedValue([{ id: 'enc-1' }]);
+      mockDeps.messageDB.getBookmarks = vi.fn().mockResolvedValue([]);
+      mockDeps.messageDB.getAllUserNotes = vi.fn().mockResolvedValue([]);
+      mockDeps.apiClient.postUserSettings = vi.fn().mockResolvedValue({});
+      vi.spyOn(global.crypto.subtle, 'importKey').mockResolvedValue({} as CryptoKey);
+      return vi
+        .spyOn(global.crypto.subtle, 'encrypt')
+        .mockResolvedValue(new Uint8Array(16).buffer as ArrayBuffer);
+    };
+
+    it('persists the full Space list locally even when the DB is incomplete', async () => {
+      arrangePartialDb();
+
+      await configService.saveConfig({ config: partialDbConfig(), keyset: mockKeyset });
+
+      const saved = mockDeps.messageDB.saveUserConfig.mock.calls[0][0];
+      expect(saved.spaceIds).toEqual(['space-1', 'space-2', 'space-3']);
+      expect(saved.items).toHaveLength(3);
+      // The folder keeps both of its Spaces: filtering must not mutate it
+      expect(saved.items[2].spaceIds).toEqual(['space-1', 'space-3']);
+    });
+
+    it('still narrows the uploaded payload to Spaces that have keys', async () => {
+      const encryptSpy = arrangePartialDb();
+
+      await configService.saveConfig({ config: partialDbConfig(), keyset: mockKeyset });
+
+      const uploaded = JSON.parse(
+        Buffer.from(encryptSpy.mock.calls[0][2] as Uint8Array).toString('utf-8')
+      );
+      expect(uploaded.spaceIds).toEqual(['space-1']);
+      expect(uploaded.spaceKeys.map((k: any) => k.spaceId)).toEqual(['space-1']);
+      // space-2 dropped, and the folder keeps only its keyed Space
+      expect(uploaded.items).toEqual([
+        { type: 'space', id: 'space-1' },
+        { type: 'folder', id: 'folder-1', name: 'Work', spaceIds: ['space-1'] },
+      ]);
+    });
+
+    it('caches the full Space list, not the narrowed upload', async () => {
+      arrangePartialDb();
+      const setQueryDataSpy = vi.spyOn(queryClient, 'setQueryData');
+
+      await configService.saveConfig({ config: partialDbConfig(), keyset: mockKeyset });
+
+      const cached = setQueryDataSpy.mock.calls.at(-1)?.[1] as any;
+      expect(cached.spaceIds).toEqual(['space-1', 'space-2', 'space-3']);
+    });
+  });
 });

--- a/src/dev/tests/services/ConfigService.unit.test.tsx
+++ b/src/dev/tests/services/ConfigService.unit.test.tsx
@@ -393,7 +393,7 @@ describe('ConfigService - Unit Tests', () => {
     });
   });
 
-  describe('5. saveConfig() - upload narrowing must not touch local state', () => {
+  describe('5. saveConfig() - truncated Space lists stay local', () => {
     const mockKeyset = {
       userKeyset: {
         user_key: {
@@ -444,23 +444,6 @@ describe('ConfigService - Unit Tests', () => {
       expect(saved.items[2].spaceIds).toEqual(['space-1', 'space-3']);
     });
 
-    it('still narrows the uploaded payload to Spaces that have keys', async () => {
-      const encryptSpy = arrangePartialDb();
-
-      await configService.saveConfig({ config: partialDbConfig(), keyset: mockKeyset });
-
-      const uploaded = JSON.parse(
-        Buffer.from(encryptSpy.mock.calls[0][2] as Uint8Array).toString('utf-8')
-      );
-      expect(uploaded.spaceIds).toEqual(['space-1']);
-      expect(uploaded.spaceKeys.map((k: any) => k.spaceId)).toEqual(['space-1']);
-      // space-2 dropped, and the folder keeps only its keyed Space
-      expect(uploaded.items).toEqual([
-        { type: 'space', id: 'space-1' },
-        { type: 'folder', id: 'folder-1', name: 'Work', spaceIds: ['space-1'] },
-      ]);
-    });
-
     it('caches the full Space list, not the narrowed upload', async () => {
       arrangePartialDb();
       const setQueryDataSpy = vi.spyOn(queryClient, 'setQueryData');
@@ -469,6 +452,67 @@ describe('ConfigService - Unit Tests', () => {
 
       const cached = setQueryDataSpy.mock.calls.at(-1)?.[1] as any;
       expect(cached.spaceIds).toEqual(['space-1', 'space-2', 'space-3']);
+    });
+
+    it('does not publish a Space list truncated by an incomplete DB', async () => {
+      arrangePartialDb();
+
+      await configService.saveConfig({ config: partialDbConfig(), keyset: mockKeyset });
+
+      // Publishing this would make every other device adopt the shorter list
+      expect(mockDeps.apiClient.postUserSettings).not.toHaveBeenCalled();
+    });
+
+    it('keeps tombstones unsent when the upload is held', async () => {
+      arrangePartialDb();
+      const withTombstones = {
+        ...partialDbConfig(),
+        deletedBookmarkIds: ['bk-1'],
+        deletedUserNoteAddresses: ['addr-1'],
+      };
+
+      await configService.saveConfig({ config: withTombstones, keyset: mockKeyset });
+
+      // Clearing these without syncing would resurrect the deletions elsewhere
+      const saved = mockDeps.messageDB.saveUserConfig.mock.calls[0][0];
+      expect(saved.deletedBookmarkIds).toEqual(['bk-1']);
+      expect(saved.deletedUserNoteAddresses).toEqual(['addr-1']);
+    });
+
+    it('still publishes when the user removed a Space, so removals propagate', async () => {
+      // The user left space-2: the caller already took it out of spaceIds, but
+      // it is still sitting in the local DB with a valid encryption state.
+      // Nothing is dropped by narrowing, so this must publish as normal.
+      const afterLeaving = {
+        address: 'user-left',
+        spaceIds: ['space-1'],
+        items: [{ type: 'space', id: 'space-1' }],
+        allowSync: true,
+        timestamp: 0,
+      } as any;
+
+      mockDeps.messageDB.getSpaces = vi
+        .fn()
+        .mockResolvedValue([{ spaceId: 'space-1' }, { spaceId: 'space-2' }]);
+      mockDeps.messageDB.getSpaceKeys = vi.fn().mockResolvedValue([]);
+      mockDeps.messageDB.getEncryptionStates = vi.fn().mockResolvedValue([{ id: 'enc-1' }]);
+      mockDeps.messageDB.getBookmarks = vi.fn().mockResolvedValue([]);
+      mockDeps.messageDB.getAllUserNotes = vi.fn().mockResolvedValue([]);
+      mockDeps.apiClient.postUserSettings = vi.fn().mockResolvedValue({});
+      vi.spyOn(global.crypto.subtle, 'importKey').mockResolvedValue({} as CryptoKey);
+      const encryptSpy = vi
+        .spyOn(global.crypto.subtle, 'encrypt')
+        .mockResolvedValue(new Uint8Array(16).buffer as ArrayBuffer);
+
+      await configService.saveConfig({ config: afterLeaving, keyset: mockKeyset });
+
+      expect(mockDeps.apiClient.postUserSettings).toHaveBeenCalled();
+      const uploaded = JSON.parse(
+        Buffer.from(encryptSpy.mock.calls[0][2] as Uint8Array).toString('utf-8')
+      );
+      // space-2 is gone from the published list, and its key with it
+      expect(uploaded.spaceIds).toEqual(['space-1']);
+      expect(uploaded.spaceKeys.map((k: any) => k.spaceId)).toEqual(['space-1']);
     });
   });
 });

--- a/src/dev/tests/services/ConfigService.unit.test.tsx
+++ b/src/dev/tests/services/ConfigService.unit.test.tsx
@@ -495,7 +495,14 @@ describe('ConfigService - Unit Tests', () => {
         .fn()
         .mockResolvedValue([{ spaceId: 'space-1' }, { spaceId: 'space-2' }]);
       mockDeps.messageDB.getSpaceKeys = vi.fn().mockResolvedValue([]);
-      mockDeps.messageDB.getEncryptionStates = vi.fn().mockResolvedValue([{ id: 'enc-1' }]);
+      // Faithful to the real removal paths (SpaceService.deleteSpace, the
+      // self-kicked branch in MessageService): the leaving Space's encryption
+      // state is deleted BEFORE saveConfig runs, so space-2 has none here.
+      mockDeps.messageDB.getEncryptionStates = vi
+        .fn()
+        .mockImplementation(({ conversationId }: { conversationId: string }) =>
+          Promise.resolve(conversationId.startsWith('space-1') ? [{ id: 'enc-1' }] : [])
+        );
       mockDeps.messageDB.getBookmarks = vi.fn().mockResolvedValue([]);
       mockDeps.messageDB.getAllUserNotes = vi.fn().mockResolvedValue([]);
       mockDeps.apiClient.postUserSettings = vi.fn().mockResolvedValue({});
@@ -513,6 +520,56 @@ describe('ConfigService - Unit Tests', () => {
       // space-2 is gone from the published list, and its key with it
       expect(uploaded.spaceIds).toEqual(['space-1']);
       expect(uploaded.spaceKeys.map((k: any) => k.spaceId)).toEqual(['space-1']);
+      // A published save earns a fresh timestamp
+      const saved = mockDeps.messageDB.saveUserConfig.mock.calls[0][0];
+      expect(saved.timestamp).toBeGreaterThan(0);
+    });
+
+    it('does not advance the stored timestamp when the upload is held', async () => {
+      arrangePartialDb();
+
+      await configService.saveConfig({
+        config: { ...partialDbConfig(), timestamp: 1000 },
+        keyset: mockKeyset,
+      });
+
+      // getConfig resolves purely by timestamp and never merges the losing
+      // side, so claiming to be newer than the server without having published
+      // would make this device ignore every remote config while it holds.
+      const saved = mockDeps.messageDB.saveUserConfig.mock.calls[0][0];
+      expect(saved.timestamp).toBe(1000);
+    });
+
+    it('holds when a listed Space is absent from the local DB entirely', async () => {
+      // The EncryptionService re-key path (ensureKeyForSpace) writes the new
+      // spaceId into the config before the Space row exists under that id, so
+      // getSpaces() cannot see it yet. Narrowing must hold, not publish a
+      // config that silently drops the Space from every other device.
+      const midRename = {
+        address: 'user-rename',
+        spaceIds: ['space-new'],
+        items: [{ type: 'space', id: 'space-new' }],
+        allowSync: true,
+        timestamp: 500,
+      } as any;
+
+      mockDeps.messageDB.getSpaces = vi.fn().mockResolvedValue([]);
+      mockDeps.messageDB.getSpaceKeys = vi.fn().mockResolvedValue([]);
+      mockDeps.messageDB.getEncryptionStates = vi.fn().mockResolvedValue([]);
+      mockDeps.messageDB.getBookmarks = vi.fn().mockResolvedValue([]);
+      mockDeps.messageDB.getAllUserNotes = vi.fn().mockResolvedValue([]);
+      mockDeps.apiClient.postUserSettings = vi.fn().mockResolvedValue({});
+      vi.spyOn(global.crypto.subtle, 'importKey').mockResolvedValue({} as CryptoKey);
+      vi.spyOn(global.crypto.subtle, 'encrypt').mockResolvedValue(
+        new Uint8Array(16).buffer as ArrayBuffer
+      );
+
+      await configService.saveConfig({ config: midRename, keyset: mockKeyset });
+
+      expect(mockDeps.apiClient.postUserSettings).not.toHaveBeenCalled();
+      const saved = mockDeps.messageDB.saveUserConfig.mock.calls[0][0];
+      expect(saved.spaceIds).toEqual(['space-new']);
+      expect(saved.timestamp).toBe(500);
     });
   });
 });

--- a/src/services/ConfigService.ts
+++ b/src/services/ConfigService.ts
@@ -496,64 +496,77 @@ export class ConfigService {
       const finalSpaceIds = new Set(uploadConfig.spaceIds);
       uploadConfig.spaceKeys = config.spaceKeys.filter(sk => finalSpaceIds.has(sk.spaceId));
 
-      // Uploading fewer Spaces than we hold is how one device's incomplete DB
-      // becomes every device's truncated nav: this config wins on timestamp, and
-      // getConfig applies a remote Space list verbatim. Loud, because the
-      // encryption-state warning above stays silent when a Space is absent from
-      // the local DB entirely rather than present-but-unkeyed.
-      if (uploadConfig.spaceIds.length < config.spaceIds.length) {
+      // A Space dropped here is one this device still wants but cannot prove a
+      // key for right now: an incomplete local DB, not a removal. Deliberate
+      // removals never reach this branch, because leaving or deleting a Space
+      // takes it out of config.spaceIds before saveConfig runs — nothing is
+      // dropped, and the upload proceeds exactly as before. So removals still
+      // propagate to other devices on the existing mechanism.
+      //
+      // Publishing a truncated list is what turns one device's incomplete DB
+      // into every device's problem: this config wins on timestamp, and
+      // getConfig applies a remote Space list verbatim, so every other device
+      // adopts the shorter list. Hold the upload and let a later save publish
+      // the full list once the missing Spaces have synced.
+      // See .agents/bugs/2026-01-09-config-sync-space-loss-race-condition.md
+      const droppedSpaceIds = config.spaceIds.filter(id => !finalSpaceIds.has(id));
+
+      if (droppedSpaceIds.length > 0) {
+        // Local-only, exactly like an allowSync:false save: the config below is
+        // still persisted with the full list, tombstones are deliberately NOT
+        // cleared (nothing synced), and the next save retries the publish.
         logger.warn(
-          `[ConfigService] Uploading a narrower Space list than this device holds (${uploadConfig.spaceIds.length}/${config.spaceIds.length}); other devices will adopt the shorter list:`,
-          config.spaceIds.filter(id => !finalSpaceIds.has(id))
+          `[ConfigService] NOT publishing — would upload ${uploadConfig.spaceIds.length}/${config.spaceIds.length} Spaces; the change is local-only until these finish syncing:`,
+          droppedSpaceIds
         );
+      } else {
+        const iv = crypto.getRandomValues(new Uint8Array(12));
+        const configJson = JSON.stringify(uploadConfig);
+        const ciphertext =
+          Buffer.from(
+            await window.crypto.subtle.encrypt(
+              { name: 'AES-GCM', iv: iv },
+              subtleKey,
+              Buffer.from(configJson, 'utf-8')
+            )
+          ).toString('hex') + Buffer.from(iv).toString('hex');
+
+        const signature = Buffer.from(
+          JSON.parse(
+            ch.js_sign_ed448(
+              Buffer.from(
+                new Uint8Array(userKey.user_key.private_key)
+              ).toString('base64'),
+              Buffer.from(
+                new Uint8Array([
+                  ...new Uint8Array(Buffer.from(ciphertext, 'utf-8')),
+                  ...int64ToBytes(ts),
+                ])
+              ).toString('base64')
+            )
+          ),
+          'base64'
+        ).toString('hex');
+
+        logger.log('[ConfigService] Posting settings to server...', {
+          address: config.address,
+          timestamp: ts,
+        });
+        await this.apiClient.postUserSettings(config.address, {
+          user_address: config.address,
+          user_public_key: Buffer.from(
+            new Uint8Array(userKey.user_key.public_key)
+          ).toString('hex'),
+          user_config: ciphertext,
+          timestamp: ts,
+          signature: signature,
+        });
+        logger.log('[ConfigService] Settings posted successfully');
+
+        // Reset tombstones only after successful sync (Phase 7: Critical Fix)
+        config.deletedBookmarkIds = [];
+        config.deletedUserNoteAddresses = [];
       }
-
-      const iv = crypto.getRandomValues(new Uint8Array(12));
-      const configJson = JSON.stringify(uploadConfig);
-      const ciphertext =
-        Buffer.from(
-          await window.crypto.subtle.encrypt(
-            { name: 'AES-GCM', iv: iv },
-            subtleKey,
-            Buffer.from(configJson, 'utf-8')
-          )
-        ).toString('hex') + Buffer.from(iv).toString('hex');
-
-      const signature = Buffer.from(
-        JSON.parse(
-          ch.js_sign_ed448(
-            Buffer.from(
-              new Uint8Array(userKey.user_key.private_key)
-            ).toString('base64'),
-            Buffer.from(
-              new Uint8Array([
-                ...new Uint8Array(Buffer.from(ciphertext, 'utf-8')),
-                ...int64ToBytes(ts),
-              ])
-            ).toString('base64')
-          )
-        ),
-        'base64'
-      ).toString('hex');
-
-      logger.log('[ConfigService] Posting settings to server...', {
-        address: config.address,
-        timestamp: ts,
-      });
-      await this.apiClient.postUserSettings(config.address, {
-        user_address: config.address,
-        user_public_key: Buffer.from(
-          new Uint8Array(userKey.user_key.public_key)
-        ).toString('hex'),
-        user_config: ciphertext,
-        timestamp: ts,
-        signature: signature,
-      });
-      logger.log('[ConfigService] Settings posted successfully');
-
-      // Reset tombstones only after successful sync (Phase 7: Critical Fix)
-      config.deletedBookmarkIds = [];
-      config.deletedUserNoteAddresses = [];
     }
 
     logger.log('[ConfigService] Saving config to local DB...');

--- a/src/services/ConfigService.ts
+++ b/src/services/ConfigService.ts
@@ -456,28 +456,6 @@ export class ConfigService {
         );
       }
 
-      // Ensure spaceIds and items only include spaces that have encryption keys
-      // This prevents server validation errors when some spaces don't have complete encryption data
-      const validSpaceIds = new Set(config.spaceKeys.map(sk => sk.spaceId));
-      config.spaceIds = config.spaceIds.filter(id => validSpaceIds.has(id));
-      if (config.items) {
-        config.items = config.items.filter(item => {
-          if (item.type === 'space') {
-            return validSpaceIds.has(item.id);
-          } else {
-            // For folders, filter out spaces without encryption keys
-            item.spaceIds = item.spaceIds.filter(id => validSpaceIds.has(id));
-            // Remove empty folders
-            return item.spaceIds.length > 0;
-          }
-        });
-      }
-
-      // After filtering spaceIds/items, also filter spaceKeys to only include spaces that are still in spaceIds
-      // This ensures bidirectional consistency: spaceIds ⟷ spaceKeys
-      const finalSpaceIds = new Set(config.spaceIds);
-      config.spaceKeys = config.spaceKeys.filter(sk => finalSpaceIds.has(sk.spaceId));
-
       // Collect bookmarks before encryption (Phase 7: Sync Integration)
       config.bookmarks = await this.messageDB.getBookmarks();
       // Note: deletedBookmarkIds will be reset AFTER successful sync
@@ -486,8 +464,52 @@ export class ConfigService {
       config.userNotes = await this.messageDB.getAllUserNotes();
       // Note: deletedUserNoteAddresses will be reset AFTER successful sync
 
+      // Build the payload we POST. The server rejects a config whose spaceIds
+      // and spaceKeys disagree, so the parcel is narrowed to Spaces this device
+      // can currently prove it holds encryption keys for.
+      //
+      // This narrowing MUST stay on `uploadConfig`. `config` is what we persist
+      // to IndexedDB and push into the React Query cache below; trimming it
+      // there deletes Spaces from this device's own nav whenever the local DB is
+      // momentarily incomplete, which is how a device silently wipes its own
+      // Space list. Note the copies below: folder items are cloned rather than
+      // mutated, because a shallow spread still shares those nested objects.
+      // See .agents/bugs/2026-01-09-config-sync-space-loss-race-condition.md
+      const uploadConfig: UserConfig = { ...config };
+      const validSpaceIds = new Set(config.spaceKeys.map(sk => sk.spaceId));
+      uploadConfig.spaceIds = config.spaceIds.filter(id => validSpaceIds.has(id));
+      if (config.items) {
+        uploadConfig.items = config.items
+          .map(item =>
+            item.type === 'space'
+              ? item
+              : // Clone folders: filtering in place would corrupt `config.items`
+                { ...item, spaceIds: item.spaceIds.filter(id => validSpaceIds.has(id)) }
+          )
+          // Drop unkeyed Spaces, and folders left empty by the line above
+          .filter(item =>
+            item.type === 'space' ? validSpaceIds.has(item.id) : item.spaceIds.length > 0
+          );
+      }
+
+      // Bidirectional consistency: spaceIds ⟷ spaceKeys, as the server requires
+      const finalSpaceIds = new Set(uploadConfig.spaceIds);
+      uploadConfig.spaceKeys = config.spaceKeys.filter(sk => finalSpaceIds.has(sk.spaceId));
+
+      // Uploading fewer Spaces than we hold is how one device's incomplete DB
+      // becomes every device's truncated nav: this config wins on timestamp, and
+      // getConfig applies a remote Space list verbatim. Loud, because the
+      // encryption-state warning above stays silent when a Space is absent from
+      // the local DB entirely rather than present-but-unkeyed.
+      if (uploadConfig.spaceIds.length < config.spaceIds.length) {
+        logger.warn(
+          `[ConfigService] Uploading a narrower Space list than this device holds (${uploadConfig.spaceIds.length}/${config.spaceIds.length}); other devices will adopt the shorter list:`,
+          config.spaceIds.filter(id => !finalSpaceIds.has(id))
+        );
+      }
+
       const iv = crypto.getRandomValues(new Uint8Array(12));
-      const configJson = JSON.stringify(config);
+      const configJson = JSON.stringify(uploadConfig);
       const ciphertext =
         Buffer.from(
           await window.crypto.subtle.encrypt(

--- a/src/services/ConfigService.ts
+++ b/src/services/ConfigService.ts
@@ -512,13 +512,21 @@ export class ConfigService {
       const droppedSpaceIds = config.spaceIds.filter(id => !finalSpaceIds.has(id));
 
       if (droppedSpaceIds.length > 0) {
-        // Local-only, exactly like an allowSync:false save: the config below is
-        // still persisted with the full list, tombstones are deliberately NOT
-        // cleared (nothing synced), and the next save retries the publish.
+        // Local-only: the config below is still persisted with the full list,
+        // and tombstones are deliberately NOT cleared, since nothing synced.
         logger.warn(
           `[ConfigService] NOT publishing — would upload ${uploadConfig.spaceIds.length}/${config.spaceIds.length} Spaces; the change is local-only until these finish syncing:`,
           droppedSpaceIds
         );
+
+        // Keep the timestamp we came in with. getConfig resolves purely by
+        // timestamp and does not merge the losing side, so a device that
+        // advanced its local timestamp without the server agreeing would treat
+        // its own config as newer than every remote one and quietly stop
+        // applying other devices' changes for as long as it keeps holding.
+        // Publishing is what earns the right to a newer timestamp. `ts` still
+        // gates the cache write below, so the UI updates as usual.
+        config.timestamp = configInput.timestamp ?? 0;
       } else {
         const iv = crypto.getRandomValues(new Uint8Array(12));
         const configJson = JSON.stringify(uploadConfig);


### PR DESCRIPTION
`saveConfig` narrows the Space list to Spaces it can prove a key for, because the server rejects a config whose `spaceIds` and `spaceKeys` disagree. That narrowing mutated the same object that is persisted to IndexedDB and pushed into the React Query cache, and the narrowed list was then published — so a device with a momentarily incomplete local DB emptied its own nav *and* every other device's, since `getConfig` applies a remote Space list verbatim with no merge.

Reported twice in three days: all Spaces vanished from the sidebar while remaining in IndexedDB, recoverable via Settings → Restore Spaces.

## Changes

- **Narrow a separate upload payload.** The parcel we POST is built as its own object; local state keeps the full list. Folder items are cloned rather than filtered in place, since a shallow spread still shares the nested objects.
- **Refuse to publish a truncated list.** If narrowing dropped a Space the caller still wanted, save locally, warn, and let a later save publish. Deliberate removals are unaffected: leaving or deleting a Space takes it out of `spaceIds` before `saveConfig` runs, so nothing is dropped by narrowing and the upload proceeds as before.
- **A held save keeps its incoming timestamp.** `getConfig` resolves purely by timestamp and never merges the losing side, so advancing it without the server agreeing would make the device treat its own config as newer than every remote one and silently stop applying other devices' changes.

## Known limitation

Nothing retries a held save. A Space that can never be keyed (bloated encryption state, or never synced to this device) stops the device publishing config changes until it syncs or is removed. It fails safe — stale settings, not lost Spaces — and the warning makes it visible. Tracked in the umbrella task with the tombstone work that removes the dead end.

## Tests

5 new cases in `ConfigService.unit.test.tsx`, each verified to fail against the unpatched source. Full suite: 664 passing.

## Scope

Does not make the Spaces list converge across devices — `getConfig` still applies a remote list verbatim. See `.agents/tasks/2026-07-31-spaces-list-cross-device-sync.md` for the per-device-pair state and the remaining work.
