### PR TITLE
fix: recover a DM partner's name and avatar on an established session

### DIFF
--- a/.agents/INDEX.md
+++ b/.agents/INDEX.md
@@ -214,6 +214,8 @@ This is the main index for all documentation, bug reports, and task management.
 - [Durable multi-device: per-device signing keys via master-signed device statements](tasks/2026-07-19-per-device-signing-keys-registration-anchored.md)
 - [Space deletion: instant + offline UX, and stop leaking ghost spaces](tasks/2026-07-19-space-deletion-ghost-cleanup.md)
 - [Make the Spaces list identical on every device](tasks/2026-07-31-spaces-list-cross-device-sync.md)
+- [DM unread dot never clears](tasks/2026-08-01-dm-unread-dot-stale-previews-snapshot.md) — the DM list renders a frozen snapshot of the conversation rows; read state never reaches it
+- [DM partner identity never recovers on an established session](tasks/2026-08-01-dm-partner-identity-lost-on-established-sessions.md) — desktop decrypts the sender's name/avatar on every DM frame and throws it away; mobile already applies it
 
 ### .Archived
 - [🚀 Search Performance Optimization - Revised Implementation Plan](tasks/.archived/2025-11-12-search-performance-optimization-original.md)

--- a/.agents/tasks/2026-08-01-dm-partner-identity-lost-on-established-sessions.md
+++ b/.agents/tasks/2026-08-01-dm-partner-identity-lost-on-established-sessions.md
@@ -1,0 +1,383 @@
+---
+type: task
+title: "DM partner identity never recovers on an established session (desktop discards the profile it decrypts)"
+status: open
+priority: high
+created: 2026-08-01
+updated: 2026-08-01
+severity: user-visible — a DM partner renders forever as "Unknown User" / truncated address
+area: DM receive path / conversation-row identity / mobile parity
+repos: quorum-desktop (fix), quorum-mobile (reference implementation — already correct)
+related_tasks:
+  - ".agents/tasks/2026-08-01-dm-unread-dot-stale-previews-snapshot.md"
+related_bugs:
+  - ".agents/bugs/2026-06-13-space-members-missing-no-join-row.md"
+  - ".agents/bugs/.solved/2025-12-18-dm-unknown-user-identity-not-revealed.md"
+related_docs:
+  - ".agents/docs/features/identity-resolution-and-profile-sync.md"
+  - ".agents/docs/debugging/dm-architecture-and-debug-playbook.md"
+related_tools:
+  - ".agents/tools/dm-debug/05-profile-sources.js"
+---
+
+# DM partner identity never recovers on an established session
+
+## §0. The one-paragraph version
+
+Desktop's DM receive path decrypts frames that **contain the sender's display name and
+avatar**, reads that field to decide which ratchet-state shape to persist, and then
+throws it away. Identity therefore only ever lands during session *setup* (init envelope
+or the one-time reply-confirm). Once a DM session is established, the partner can send
+any number of messages and none of them refresh identity. If the row was a placeholder at
+that moment, and the partner has no public profile to fall back on, the conversation is
+stuck showing "Unknown User" / a truncated address permanently. **Mobile does not have
+this bug** — it applies the decrypted profile on the ordinary receive path. This is a
+parity fix, not a new design.
+
+## §1. Reported symptom (2026-08-01)
+
+A DM between two test accounts, **both on desktop**. Partner B renders with no identity,
+and the two surfaces disagree about how to say so:
+
+| Surface | Renders | Why |
+|---|---|---|
+| DM sidebar list | `Unknown User` + `?` avatar | passes the raw row value through, **from a stale snapshot** (see below) |
+| Conversation header | `QmYVto…LjDd` + `Q` initials | demotes the `"Unknown User"` literal, falls through to the address |
+
+> 🔴 **The sidebar has a second, independent staleness source.** Per the sibling task
+> `2026-08-01-dm-unread-dot-stale-previews-snapshot.md`, the DM list does not render the
+> live conversation rows — it renders a frozen copy held in the `['conversation-previews']`
+> query, keyed **only** on `conversationId:lastMessageId`. A profile update changes
+> `displayName` / `icon` but **no** `lastMessageId`, so the key never changes and the
+> snapshot is served indefinitely while the sidebar stays mounted.
+>
+> `useConversationsWithProfileBackfill` already invalidates `Conversations/direct` and
+> `Conversation` after its write-back — but **not** `['conversation-previews']`. So even
+> today, a successful backfill updates the header and leaves the sidebar wrong. The
+> `primaryUsername` re-attach hack at `DirectMessageContactsList.tsx:70-78` exists because
+> of exactly this, and it patches only that one field.
+>
+> **Consequence for this task: Slice 1 can land and work, and the sidebar may still look
+> broken until remount.** Do not read that as Slice 1 having failed — check the header and
+> IndexedDB first.
+
+Operator notes, taken as given (not independently verified here):
+
+- **B has no published public profile.** This removes the last automatic recovery path
+  (`useConversationsWithProfileBackfill`), which is why the row never self-heals.
+- **It used to render correctly, then stopped.** Consistent with §4's history finding:
+  the working period was a fresh session where identity landed at init/confirm, and
+  something later reset the session or the row. These are heavily reused test accounts.
+- B sending more messages does not fix it. That is the core bug, not a symptom of the
+  test data.
+
+## §2. Root cause (confirmed in code)
+
+`DoubleRatchetInboxDecrypt` returns a union. The second variant carries `user_profile`:
+
+```ts
+// node_modules/@quilibrium/quilibrium-js-sdk-channels/dist/index.d.ts:778
+declare const DoubleRatchetInboxDecrypt: (…) =>
+  | { ratchet_state: string; message: string }
+  | { receiving_inbox; user_profile: UserProfile; tag; sending_inbox; ratchet_state; message };
+```
+
+The sender populates it on every send — `ActionQueueHandlers.ts:735-741` passes
+`senderDisplayName` / `senderUserIcon` into `DoubleRatchetInboxEncrypt` (this was the
+2025-12-18 fix, still in place).
+
+The receiver reads it at `MessageService.ts:4108` purely as a shape discriminator:
+
+```ts
+if (maybeInit.user_profile) {
+  advancedState = JSON.stringify({ ratchet_state: keep(maybeInit.ratchet_state), … });
+} else { … }
+```
+
+…and then discards it 50 lines later at `MessageService.ts:4155-4160`:
+
+```ts
+return {
+  outcome: 'ok' as const,
+  content,
+  sentAccept: fresh.sentAccept,
+  updatedUserProfile: undefined,   // ← the bug
+};
+```
+
+### The four ways identity can reach a DM row, and why all four are dead here
+
+| # | Path | Code | Fires when | Dead because |
+|---|---|---|---|---|
+| 1 | init envelope | `MessageService.ts:3679-3683` | first frame of a NEW session | session is established |
+| 2 | `ConfirmDoubleRatchetSenderSession` | `MessageService.ts:4037-4039` | one-time reply-confirm | already consumed |
+| 3 | `dm-update-profile` control msg | `MessageService.ts:690`, `:740` | partner *edits* their profile | B hasn't edited |
+| 4 | public-profile pull + write-back | `useConversationsWithProfileBackfill.ts` | partner opted into a public profile | B has none |
+
+Path 5 — "learn it from the messages they're already sending you" — is the one that
+should always work, and it is the one desktop discards.
+
+### The storage layer is fine
+
+The fix the operator remembered **did ship**, in two of its three pieces:
+
+| Piece | Where | Status |
+|---|---|---|
+| Persist partner identity to IndexedDB | `MessageDB.tsx:365-380` | ✅ shipped 2025-12-18 |
+| Update it only when they push a change | `MessageService.ts:740-762` | ✅ shipped |
+| **Capture it from incoming messages** | `MessageService.ts:4159` | ❌ init/confirm only |
+
+`addOrUpdateConversation` merges with `??`, so it cannot blank a good value. Feed it and
+it works. It is simply never fed on an established session.
+
+## §3. Mobile is already correct — this is a parity fix
+
+`quorum-mobile/context/WebSocketContext.tsx:4739-4741`:
+
+```ts
+const rowProfile = isSelfSyncEcho ? undefined : msgResult.user_profile;
+const senderDisplayName = rowProfile?.display_name || existingConversation?.displayName || resolvedSenderAddress.substring(0, 8);
+const senderIcon       = rowProfile?.user_icon    || existingConversation?.icon        || '';
+```
+
+Note the `isSelfSyncEcho` guard: on a multi-device self-echo the `user_profile` is
+*ours*, not the partner's, and must not be written to the partner's row. Desktop's
+existing init and confirm branches already apply the equivalent guard
+(`… .user_address != self_address`), so the same shape is available at the fix site
+(`self_address` is a parameter of the enclosing `handleNewMessage`, declared at
+`MessageService.ts:3417`).
+
+## §4. History — this is NOT a #236 regression
+
+Checked `54759a208^` (the commit before *"fix: serialize DM Double Ratchet state
+operations per conversation (#236)"*). The pre-#236 `DoubleRatchetInboxDecrypt` branch
+also never assigned `updatedUserProfile`; it used `maybeInit.user_profile` only as a
+shape discriminator, exactly as today. #236 made an existing implicit gap explicit by
+writing `undefined` where the variable had previously just been left unassigned.
+
+**The gap is long-standing.** Do not go looking for a regression window.
+
+## §5. Relationship to the spaces bug — same disease, different organ
+
+`.agents/bugs/2026-06-13-space-members-missing-no-join-row.md` describes the same
+structural failure on the space side: identity rides only on control messages (`join` /
+`update-profile`), ordinary message traffic never writes it, and desktop's control
+messages are fire-and-forget with no durable replay (mobile has hub-log catch-up).
+
+**The two fixes are not the same, and the spaces doc's reasoning must not be copied
+here.** That doc explicitly rejected "recover identity from message traffic" for three
+reasons. All three fail for DMs:
+
+| Spaces rejection | Why it does not apply to DMs |
+|---|---|
+| *"mobile doesn't do it → desktop-only divergence"* | **False for DMs.** Mobile does exactly this (§3). Desktop is the one diverging. |
+| *"writes canonical shared protocol state from a derived source"* | The `conversations` row is **local render state**, not `space_members`. The repo already write-throughs to it (`MessageDB.tsx:369`, `useConversationsWithProfileBackfill.ts:183`). |
+| *"a `post` carries no name/avatar, so the win is marginal"* | **False for DMs.** The decrypted frame carries `user_profile` directly, authenticated, from the sender. |
+
+So: **fix the DM side now** (cheap, parity-restoring, low blast radius). The spaces side
+still needs the hub-log architecture decision (port-from-mobile candidate #32, lead-dev
+call). Do not bundle them.
+
+## §5b. Does this heal conversations that are ALREADY broken? (and do we need a "fix" button?)
+
+Short answer: **Slice 3 is the heal mechanism, Slice 1 is best-effort, and a repair button
+cannot work here.**
+
+| Mechanism | Heals existing rows? | Requires |
+|---|---|---|
+| Slice 1 (capture from frames) | **Best-effort.** Heals the moment B sends a frame that carries `user_profile`. Since that is the union's second variant and not necessarily every frame, timing is not guaranteed. | A's client updated; B sends something |
+| Slice 3 (re-broadcast on reconnect) | **Yes, deterministically.** On B's next connect, B pushes `dm-update-profile` to every DM partner; A's `handleDMProfileUpdate` writes it to the row. No user action on either side. | **Both** clients updated (both users are on desktop here) |
+| A "repair identities" button | **No.** See below. | — |
+
+### Why a button cannot fix this, unlike the missing-Spaces button
+
+The missing-Spaces button works because the data is **already on the device** — it
+re-derives the list from the synced `UserConfig` blob. Here there is nothing to re-derive:
+A has no local copy of B's name or avatar, by definition. The identity can only come from
+
+1. a frame B sends that carries `user_profile` (Slice 1),
+2. a `dm-update-profile` B pushes (Slice 3), or
+3. B's public profile — **which B does not have** (§1).
+
+A button on A's side could at most force a public-profile refetch and invalidate the
+caches. For a partner with no public profile that is a no-op. It would produce a "Fix"
+button that visibly does nothing, which is worse than no button.
+
+**Recommendation:** implement Slice 3 and treat it as the migration path for existing
+broken conversations. Do not build a repair button for this.
+
+### The one repair action that *would* be legitimate
+
+Clearing the poisoned `"Unknown User"` / `/unknown.png` literals off existing rows (Slice
+4 writes them today) so they fall back cleanly to the address render instead of asserting
+a name the app does not have. That is cosmetic cleanup, not identity recovery, and it
+belongs with Slice 4 as a one-shot migration rather than a user-facing button.
+
+## §6. Work — vertical slices
+
+### §6.0 Branching and sequencing
+
+**This task and `2026-08-01-dm-unread-dot-stale-previews-snapshot.md` are separate
+branches and separate PRs. Do not merge them into one.** They are different bugs that
+happen to surface on the same screen: this one is "the data never arrives" (DM receive
+path, protocol-adjacent); that one is "the data arrives but the render layer serves a
+stale copy" (React Query cache shape). Combining them would put Double Ratchet receive
+code and a cache refactor in a single unreviewable diff, in the area with this repo's
+worst regression history.
+
+**One-way dependency: land the previews task FIRST.**
+
+1. It removes the cause that Slice 2's `['conversation-previews']` invalidation item only
+   works around. Doing this task first means adding an invalidation the other task then
+   deletes, in the same lines — a guaranteed conflict.
+2. It gives a trustworthy test surface. While the snapshot is stale the sidebar lies, so
+   "did B's avatar appear?" is not answerable there. Verify via the conversation header
+   and IndexedDB until it lands.
+
+Recommended order, one PR per step:
+
+| # | Step | Observable outcome |
+|---|---|---|
+| 1 | previews snapshot task | sidebar renders live conversation rows |
+| 2 | **Slice 1** (this task) | B sends one message → name + avatar land and survive reload |
+| 3 | **Slice 3** (this task) | already-broken conversations heal on next reconnect |
+| 4 | **Slices 2 + 4** (this task) | consistent empty-state render; no placeholder stamping |
+
+Slice 1 ships alone before Slice 3: it is ~6 lines and immediately testable, whereas
+Slice 3 needs a cooldown design and the mobile-parity question in its own checklist
+answered first.
+
+### Slice 1 — Partner identity lands from ordinary messages *(the fix)*
+
+**User-visible outcome:** open the stuck DM, have B send **one** message from their
+desktop. B's real name and avatar appear in the conversation header, the message list,
+and the sidebar — and are still there after a full reload.
+
+`MessageService.ts:4155-4160`:
+
+```ts
+return {
+  outcome: 'ok' as const,
+  content,
+  sentAccept: fresh.sentAccept,
+  updatedUserProfile:
+    maybeInit.user_profile && maybeInit.user_profile.user_address !== self_address
+      ? maybeInit.user_profile
+      : undefined,
+};
+```
+
+Nothing downstream needs to change: the caller at `:4186` already assigns
+`updatedUserProfile = dm.updatedUserProfile`, and `:5643` / `:5690` already prefer it
+over the stored row before calling `saveMessage` + `addOrUpdateConversation`, which
+persists to IndexedDB.
+
+- [ ] Apply the change with the self-address guard
+- [ ] Verify it does not fire on a multi-device self-echo (§3's `isSelfSyncEcho` case)
+- [ ] `npx tsc --noEmit --jsx react-jsx --skipLibCheck` clean
+- [ ] Behavioural test per the outcome above, desktop ↔ desktop
+
+> ⚠️ **Scope caveat, verify during implementation:** `user_profile` is present only on the
+> union's second variant, not necessarily on *every* frame. So this improves recovery from
+> "never" to "whenever the ratchet re-emits sender info" — which may still not be every
+> message. **Measure how often it actually fires** before closing this task; if it turns
+> out to be rare, Slice 3 becomes the load-bearing fix rather than a nice-to-have.
+
+### Slice 2 — One consistent "no identity yet" render
+
+**User-visible outcome:** the sidebar and the conversation header say the same thing about
+an unidentified contact. No more `Unknown User` + `?` in the list sitting next to
+`QmYVto…LjDd` + `Q` in the header.
+
+Today only `DirectMessage.tsx:266-276` demotes the `"Unknown User"` literal and the
+default icon before rendering. The sidebar surfaces pass the raw row value straight
+through:
+
+- `DirectMessageContact.tsx:93` (expanded row)
+- `DirectMessageContactsList.tsx:381` (collapsed strip)
+
+- [ ] Extract the demotion (`localName && localName !== 'Unknown User' ? … : undefined`,
+      same for the default icon) into one shared helper
+- [ ] Use it on all three surfaces
+- [ ] Decide the single canonical empty-state render — recommend the header's
+      (truncated address + address-derived initials), since it matches mobile and does
+      not assert a name the app does not have
+- [ ] **Bust the previews snapshot on identity change.** Add
+      `['conversation-previews']` to the invalidations in
+      `useConversationsWithProfileBackfill.ts:184-191` and in `handleDMProfileUpdate`
+      (`MessageService.ts:758-761`). Without this the sidebar keeps serving the pre-update
+      copy (see the callout in §1) and Slice 1 will look like it did nothing. Coordinate
+      with `2026-08-01-dm-unread-dot-stale-previews-snapshot.md`, which proposes fixing
+      the snapshot's cause rather than adding another invalidation — **if that task lands
+      first, this item may be unnecessary.** Check before implementing.
+
+### Slice 3 — Heal already-broken rows without requiring a profile edit
+
+**User-visible outcome:** conversations that are *already* stuck recover on the next
+reconnect, without either user opening settings and re-saving their profile.
+
+`broadcastProfileToAllDMs` (`MessageService.ts:535`) has exactly one caller —
+`MessageDB.tsx:492`, in the profile-save flow. There is no on-reconnect re-broadcast.
+This mirrors the space-side gap where mobile re-broadcasts `update-profile` on every
+connect and desktop does neither.
+
+- [ ] Fire `broadcastProfileToAllDMs` on WS (re)connect, debounced/cooldowned so a flappy
+      connection cannot spam every DM partner
+- [ ] Confirm it is safe when no session is established yet (the method already logs and
+      skips per-partner failures)
+- [ ] **Open question:** does mobile re-broadcast the DM profile on connect, or only the
+      space `update-profile`? Verify before implementing, so desktop does not diverge in
+      the other direction.
+
+### Slice 4 — Stop writing the placeholder into the row on send *(low priority)*
+
+**User-visible outcome:** no behavioural change expected; this is hygiene. A row with no
+known identity stays *empty* rather than being stamped `"Unknown User"` / `/unknown.png`.
+
+`MessageService.ts:3390-3400` — every outgoing message calls `addOrUpdateConversation`
+with `conversation?.conversation?.displayName ?? 'Unknown User'` and
+`?? DefaultImages.UNKNOWN_USER`. Because `??` only fires on nullish, this cannot clobber
+a real name. It does convert "no identity yet" into "explicitly placeholder", which makes
+the row harder to reason about and is the reason the sidebar has a literal string to
+render in the first place.
+
+- [ ] Pass `undefined` instead of the placeholders, and let the render layer decide
+- [ ] Confirm `addOrUpdateConversation`'s `if (display_name || user_icon)` guard then
+      correctly skips the write
+
+## §7. How to verify / diagnose
+
+Run as **user A**, DevTools console:
+
+1. `.agents/tools/dm-debug/05-profile-sources.js` — per DM, the stored row's name/icon
+   side by side with the public-profile API. Columns that matter: `storedName`,
+   `storedIconIsDefault`, `pubHasImage`, `sidebarCanRecoverAvatar`.
+2. Before the fix: the affected row shows a placeholder name/icon and
+   `sidebarCanRecoverAvatar: "NO source"` (B has no public profile).
+3. After Slice 1: have B send one message, re-run — the stored row should now carry B's
+   real `display_name` and a non-default icon.
+
+Reload the app between steps. The whole point is that the value **persists**, not that it
+renders once from an in-memory fallback.
+
+## §8. Files of interest
+
+| Concern | File |
+|---|---|
+| The discard (fix site) | `src/services/MessageService.ts:4155-4160` |
+| Shape discriminator that proves the data is there | `src/services/MessageService.ts:4108` |
+| Init-envelope capture (works) | `src/services/MessageService.ts:3679-3683` |
+| Confirm-branch capture (works) | `src/services/MessageService.ts:4037-4039` |
+| Consumer of `updatedUserProfile` | `src/services/MessageService.ts:4186`, `:5643`, `:5690` |
+| Persist to IndexedDB | `src/components/context/MessageDB.tsx:354-380` |
+| `dm-update-profile` receive | `src/services/MessageService.ts:690`, `:740-762` |
+| `dm-update-profile` send (profile-save only) | `src/services/MessageService.ts:535`, `MessageDB.tsx:492` |
+| Sender attaches name/avatar | `src/services/ActionQueueHandlers.ts:735-741` |
+| Public-profile fallback + write-back | `src/hooks/business/conversations/useConversationsWithProfileBackfill.ts` |
+| Header demotion (only surface that does it) | `src/components/direct/DirectMessage.tsx:266-276` |
+| Sidebar raw pass-through | `src/components/direct/DirectMessageContact.tsx:93`, `DirectMessageContactsList.tsx:381` |
+| Send-path placeholder stamping | `src/services/MessageService.ts:3390-3400` |
+| Mobile reference implementation | `quorum-mobile/context/WebSocketContext.tsx:4739-4741` |
+
+---
+*Last updated: 2026-08-01*

--- a/.agents/tasks/2026-08-01-dm-unread-dot-stale-previews-snapshot.md
+++ b/.agents/tasks/2026-08-01-dm-unread-dot-stale-previews-snapshot.md
@@ -1,0 +1,275 @@
+---
+type: task
+title: "DM unread dot never clears — the list renders a frozen snapshot of the conversation rows"
+status: open — analysed, not started
+priority: high
+created: 2026-08-01
+updated: 2026-08-01
+severity: UX (the DM list lies about read state; the primary daily-use surface)
+area: DM contacts list / read-state propagation (React Query cache shape)
+repos: quorum-desktop (implement here). quorum-mobile is affected by a DIFFERENT,
+  unrelated gap — see §6. Do NOT implement mobile changes from this task.
+related:
+  - .agents/bugs/.solved/dm-mark-all-read-no-immediate-ui-update.md (same fingerprint,
+    fixed by overlaying a context instead of fixing the staleness — see §1.3)
+  - .agents/docs/features/notification-indicators-system.md (documents the invalidation
+    fan-out that is missing one key)
+---
+
+# DM unread dot never clears
+
+## §0. What the operator sees
+
+1. Open a DM, read it, leave without replying → the unread dot is still on the row.
+2. Exchange messages in a DM, leave → the unread dot is still on the row.
+3. Sometimes it clears on its own after navigating into a Space and back. That is not
+   randomness, it is the sidebar unmounting and remounting (§2.3).
+
+The NavRail "Messages" dot clears correctly. Only the per-contact rows in the DM list are
+wrong. Spaces and channels are unaffected.
+
+## §1. Root cause
+
+**The DM list does not render the live conversation rows. It renders a frozen copy of
+them held inside the previews query.**
+
+### §1.1 The read path
+
+[`DirectMessageContactsList.tsx:66-78`](../../src/components/direct/DirectMessageContactsList.tsx#L66-L78):
+
+```
+useConversationPolling()                 → fresh rows from IndexedDB every 2s ✅
+  └─ useConversationsWithProfileBackfill()  (pass-through)
+       └─ useConversationPreviews()
+            → useQuery(['conversation-previews', messageIdMap])
+              queryFn returns { ...conv, preview, previewIcon }
+              ── a FULL COPY of every conversation row, including
+                 lastReadTimestamp and timestamp
+                 └─ unread = c.lastReadTimestamp < c.timestamp   ← reads the COPY
+```
+
+The `unread` flag is computed at
+[`DirectMessageContactsList.tsx:502-507`](../../src/components/direct/DirectMessageContactsList.tsx#L502-L507)
+(expanded list) and
+[`:348-351`](../../src/components/direct/DirectMessageContactsList.tsx#L348-L351)
+(collapsed strip) — both off `conversationsWithPreviews`, i.e. off the copy. The live
+polled row is never consulted for read state.
+
+### §1.2 Why the copy never refreshes
+
+[`useConversationPreviews.ts:16-22`](../../src/hooks/business/conversations/useConversationPreviews.ts#L16-L22)
+keys the query **only on `conversationId:lastMessageId` pairs**:
+
+```ts
+const messageIdMap = useMemo(
+  () => Object.fromEntries(conversations.map((c) => [c.conversationId, c.lastMessageId])),
+  [conversations.map((c) => `${c.conversationId}:${c.lastMessageId}`).join(',')]
+);
+return useQuery({
+  queryKey: ['conversation-previews', messageIdMap],
+  staleTime: 30000,
+  refetchOnWindowFocus: false,   // and there is no refetchInterval
+  ...
+});
+```
+
+Reading a DM advances `lastReadTimestamp`. It changes **no** `lastMessageId`. So the key
+does not change, and React Query keeps serving the pre-read snapshot. `staleTime: 30000`
+is not a 30-second self-heal: a stale query only refetches on a new observer mounting, on
+window focus (disabled here), on reconnect, or on invalidation. A re-render of a mounted
+observer does nothing. **The snapshot is stale indefinitely while the sidebar stays
+mounted.**
+
+### §1.3 The missing invalidation
+
+[`useUpdateReadTime.ts:38-96`](../../src/hooks/business/conversations/useUpdateReadTime.ts#L38-L96)
+invalidates nine keys after the DB write — `Conversation`, `mention-counts` ×2,
+`reply-counts` ×2, `mention-notifications`, `reply-notifications`, `unread-counts` ×3,
+`Conversations/direct`. It never invalidates `['conversation-previews']`.
+
+The invalidator that *does* cover it,
+[`useInvalidateConversation.ts:16`](../../src/hooks/queries/conversation/useInvalidateConversation.ts#L16),
+is not the one this mutation uses.
+
+### §1.4 Corroboration — this has been patched around twice already
+
+- [`dm-mark-all-read-no-immediate-ui-update.md`](../bugs/.solved/dm-mark-all-read-no-immediate-ui-update.md)
+  records exactly this fingerprint (rail dot clears, contact rows don't) and was closed by
+  building [`DmReadStateContext.tsx`](../../src/context/DmReadStateContext.tsx) to overlay
+  a forced read timestamp on top of the stale list. The cause was never removed.
+- The `primaryUsername` re-attach hack at
+  [`DirectMessageContactsList.tsx:70-78`](../../src/components/direct/DirectMessageContactsList.tsx#L70-L78)
+  exists because the same snapshot also drops QNS names attached after it was taken. Its
+  own comment says so.
+
+Two independent workarounds for one cause is the strongest signal that the cause is worth
+fixing rather than papering over a third time.
+
+## §2. Why each symptom follows
+
+### §2.1 Opened, read, left without replying
+DB updated ✅ → poll returns the correct row ✅ → previews key unchanged → stale snapshot
+rendered → dot stays. Direct hit.
+
+### §2.2 "Still there after I replied"
+While you are inside the DM the dot is suppressed regardless of state, by
+`props.unread && address !== props.address`
+([`DirectMessageContact.tsx:103`](../../src/components/direct/DirectMessageContact.tsx#L103)).
+So the visible sequence is:
+
+1. Peer's message lands → new `lastMessageId` → key changes → snapshot recomputed as
+   `unread: true`. Correct at that instant.
+2. You are in the conversation; the dot is hidden by the active-row rule.
+3. You read it. The 2s interval writes the read time to IndexedDB. No `lastMessageId`
+   changed, no previews invalidation → **the `unread: true` snapshot survives.**
+4. You leave. The active-row suppression lifts. Dot.
+
+### §2.3 Why it sometimes clears by itself
+Navigating to a Space swaps the sidebar and unmounts `DirectMessageContactsList`. Coming
+back mounts a new observer on an already-stale query → `refetchOnMount` fires → fresh
+snapshot. This is why it reads as "keeps showing" rather than "always shows", and it is
+the reason the bug has survived: the obvious manual re-test accidentally clears it.
+
+## §3. ⚠️ The defect that MUST land in the same PR
+
+[`MessageService.ts:3396-3407`](../../src/services/MessageService.ts#L3396-L3407) — the
+optimistic conversation-row write on outbound DM send:
+
+```ts
+await this.addOrUpdateConversation(
+  queryClient,
+  address,
+  Date.now(),           // timestamp — evaluated AFTER encrypt + enqueue
+  message.createdDate,  // lastReadTimestamp — stamped BEFORE all of that
+  ...
+);
+```
+
+`Date.now()` here is strictly later than `message.createdDate`, so the row it writes is
+`lastReadTimestamp < timestamp` — **unread the instant you send a message.**
+
+Today the previews snapshot masks this, because that optimistic write keeps the old
+`lastMessageId` and therefore never reaches the rendered copy. **Remove the mask in §4.1
+and this becomes a new, louder bug: every message you send marks its own conversation
+unread.** Both must land together.
+
+Fix: pass `message.createdDate` for both arguments (or `Math.max` of the two). Verify the
+same shape at [`:3664-3670`](../../src/services/MessageService.ts#L3664-L3670) and
+[`:3806-3812`](../../src/services/MessageService.ts#L3806-L3812) while in there — see §5.
+
+## §4. Slices
+
+Each slice ends in something observable without reading a diff.
+
+### §4.1 — Slice 1: the DM list reads live read-state (+ §3)
+
+**Change:** make `useConversationPreviews` stop copying conversation rows. It should
+return only the preview payload — `Map<conversationId, { preview, previewIcon }>` keyed by
+`lastMessageId`, which is the only thing that genuinely needs caching. Merge it onto the
+live polled rows at render time in `DirectMessageContactsList`.
+
+Then apply the §3 fix in the same commit.
+
+**Why this shape and not just adding the missing invalidation:** invalidating
+`['conversation-previews']` from `useUpdateReadTime` fixes today's symptom and leaves the
+trap armed for every other field on the row — it already caught `primaryUsername`, and it
+will catch the next one. It also forces a re-read of N messages from IndexedDB on every
+read-time write. Option B is the acceptable hotfix if this needs to ship before the
+refactor is reviewed; it is not the destination.
+
+**Operator-visible outcome:**
+- Open a DM, read it, click away → dot gone immediately, name back to normal weight.
+- Exchange messages, leave the conversation → no dot.
+- Send a message to a quiet contact → that contact does **not** acquire a dot.
+- Preview text and timestamps still correct and still update on new messages.
+
+### §4.2 — Slice 2: delete the workarounds the fix makes redundant
+
+Only after Slice 1 is operator-verified.
+
+- Drop the `primaryUsername` re-attach block
+  ([`DirectMessageContactsList.tsx:70-78`](../../src/components/direct/DirectMessageContactsList.tsx#L70-L78)) —
+  live rows already carry it.
+- Evaluate removing [`DmReadStateContext`](../../src/context/DmReadStateContext.tsx)
+  entirely. "Mark all as read" writes to the DB and the list now reads the DB, so the
+  forced-timestamp overlay should be dead weight. Consumers to check:
+  `DirectMessageContactsList`, `useDirectMessageUnreadCount`, `useSpaceContextMenu`.
+
+**Operator-visible outcome:** "Mark all as read" from the DM context menu still clears
+every dot instantly, with the overlay gone. QNS `name.q` names still render in the list.
+
+### §4.3 — Slice 3: a regression test that would have caught this
+
+The failure is not visible in a component snapshot — it needs the *sequence*. Cover:
+"row is unread → read time is written → row is read", asserting on what the list computes,
+with no `lastMessageId` change anywhere in between. See [`.agents/tasks/messagedb/`](messagedb/)
+for the existing DB-test harness conventions.
+
+**Operator-visible outcome:** a named test in the suite that fails on `main` and passes on
+the branch.
+
+## §5. Secondary defects found in the same area
+
+Real, independently reproducible, **not** required for §4. Each is small enough to be its
+own PR; none should be bundled into Slice 1.
+
+| # | Where | Problem |
+|---|---|---|
+| 1 | [`MessageService.ts:3664`](../../src/services/MessageService.ts#L3664), [`:3806`](../../src/services/MessageService.ts#L3806) | Init path passes `lastReadTimestamp: 0` hardcoded into `addOrUpdateConversation`, force-marking an already-read conversation unread in the list cache. Should pass `conversation?.conversation?.lastReadTimestamp ?? 0`. |
+| 2 | [`MessageDB.tsx:374`](../../src/components/context/MessageDB.tsx#L374) vs [`messages.ts:1367`](../../src/db/messages.ts#L1367) | `conversation.timestamp` is written from two different clocks — `envelope.timestamp` (server/inbox) on one path, `message.createdDate` (sender) on the other. The entire unread comparison hangs off this field. Pick one and document it. |
+| 3 | [`messages.ts:1367`](../../src/db/messages.ts#L1367) | `saveMessage` sets `timestamp` and `lastMessageId` unconditionally, no `Math.max` guard. `MessageService.saveMessage` re-puts the **target** message when a reaction arrives, so reacting to an old message **regresses** the conversation's timestamp, sort position, preview and `lastMessageId`. |
+| 4 | [`messages.ts:1042-1066`](../../src/db/messages.ts#L1042-L1066) | `saveReadTime` reads the row in a `readonly` transaction and writes the whole spread row back in a separate `readwrite` one. A message landing in between is silently clobbered. Should be a single `readwrite` transaction and monotonic: `Math.max(existing.lastReadTimestamp ?? 0, ts)`. |
+| 5 | [`MessageService.ts:5647`](../../src/services/MessageService.ts#L5647) | Inbound DM `saveMessage` omits `currentUserAddress`, so a self-echo arriving from your own second device does not advance `lastReadTimestamp`. Every other call site passes it. |
+| 6 | [`useDirectMessagesList.ts:73-84`](../../src/hooks/business/conversations/useDirectMessagesList.ts#L73-L84) | `saveReadTime` is exported and never consumed — a second, divergent read-time write path (it uses `useInvalidateConversation`, which is the *correct* invalidator) sitting there waiting to be wired up by mistake. Delete it, or make it the one true path. |
+| 7 | [`useDirectMessageUnreadCount.ts:65`](../../src/hooks/business/messages/useDirectMessageUnreadCount.ts#L65) | `staleTime: 90000` means the NavRail dot is correct only as long as every write path remembers to invalidate `['unread-counts', 'direct-messages']`. It works today; it is the same class of fragility as §1.3. |
+
+Defect 6 is worth doing alongside Slice 2 — it is three lines and it removes a live
+footgun.
+
+## §6. Mobile — different problem, do not fold it in
+
+This fix does not carry over. Mobile's DM unread indicator is not wired up at all:
+
+- `quorum-mobile/app/(tabs)/messages/index.tsx:209` and
+  `quorum-mobile/components/Chat/DirectMessagesList.tsx:86` both compute
+  `hasUnread = conv.lastReadTimestamp ? conv.timestamp > conv.lastReadTimestamp : false`.
+  The truthiness guard means `0`/`undefined` reads as **read** — the opposite of desktop's
+  `(lastRead ?? 0) < timestamp`, so a never-opened conversation shows no dot.
+- **Nothing in the mobile repo ever writes `lastReadTimestamp`.** The only occurrence
+  outside type declarations is `lastReadTimestamp: undefined` in
+  `quorum-mobile/components/NewConversationModal.tsx:169`. There is no `saveReadTime`
+  equivalent anywhere.
+
+So the mobile badge can never turn on, and if it did there would be no way to turn it off.
+Mobile already tracks this: `quorum-mobile/.agents/tasks/.todo/2026-06-18-channel-unread-dot-lastread-timestamp.md`
+opens with "No per-channel last-read timestamp."
+
+**Therefore:** do not treat "check it on mobile" as a verification step for this task —
+there is nothing there to verify. Mobile needs its own task to build the read-state write
+path first. When it does, adopt desktop's `(lastRead ?? 0) < timestamp` semantics so the
+two platforms agree on what a fresh conversation means.
+
+## §7. Verification (desktop, two accounts)
+
+Nothing here is checkable from a diff. Run all of it manually before closing.
+
+1. **Read, no reply.** B sends to A → A's list shows the dot → A opens the DM, waits 3s,
+   clicks another contact → **dot gone immediately**, name weight back to normal.
+2. **Full exchange.** B sends → A opens → A replies → B replies → A reads → A leaves →
+   **no dot**.
+3. **Send to a quiet contact** (the §3 case). A sends to C, who has said nothing → C's row
+   **never** acquires a dot, not even for a frame.
+4. **Genuine unread still works.** A is on a Space screen; B sends → A's DM list shows the
+   dot and the NavRail dot, and the row sorts to the top with the right preview.
+5. **Mark all as read** from the DM context menu clears every dot instantly (regression
+   guard for Slice 2).
+6. **Collapsed strip.** Repeat 1 and 4 with the sidebar collapsed — it renders from the
+   same array ([`:346-351`](../../src/components/direct/DirectMessageContactsList.tsx#L346-L351))
+   and must behave identically.
+7. **Muted conversations** stay dot-free throughout.
+8. **No unmount cheating.** Never navigate into a Space and back while checking — that
+   remounts the sidebar and refetches the query, which hides the bug (§2.3). Click between
+   DM contacts only.
+
+---
+*Last updated: 2026-08-01*

--- a/src/components/context/MessageDB.tsx
+++ b/src/components/context/MessageDB.tsx
@@ -540,6 +540,47 @@ const MessageDBProvider: FC<MessageDBContextProps> = ({ children }) => {
       setMessageHandler((message) =>
         handleNewMessage(selfAddress, keyset, message)
       );
+      // Push our identity to every DM partner. An established DM session
+      // carries no sender profile, so a partner whose row is still a
+      // placeholder cannot learn who we are from ordinary traffic — this is
+      // their only recovery path when they have no public profile to fall back
+      // on. The per-partner dedup gate makes an unchanged identity a wire
+      // no-op, so repeated calls cost nothing. Mirrors mobile.
+      //
+      // Deliberately NOT wired only into setResubscribe: on a fresh page load
+      // the socket opens before this effect registers that callback, so
+      // resubscribe fires on later RE-connects but never on startup. The
+      // listen-frame block below has the same race and works around it the
+      // same way (a startup timer that duplicates the resubscribe work).
+      const fireDmProfileRebroadcast = () => {
+        const ks = actionQueueServiceRef.current?.getUserKeyset();
+        // TEMPORARY diagnostics — REMOVE before the PR.
+        logger.warn('[DMIdentity] identity push fired', {
+          haveActionQueue: Boolean(actionQueueServiceRef.current),
+          haveKeyset: Boolean(ks),
+          haveMessageService: Boolean(messageServiceRef.current),
+          selfAddress: selfAddress?.slice(0, 12),
+        });
+        if (!ks) {
+          logger.warn('[DMIdentity] ABORT: ActionQueue keyset not ready yet');
+          return;
+        }
+        if (!messageServiceRef.current) {
+          logger.warn('[DMIdentity] ABORT: MessageService not ready yet');
+          return;
+        }
+        messageServiceRef.current
+          .rebroadcastProfileToAllDMsOnConnect(selfAddress, ks)
+          .catch((err) =>
+            logger.warn('[DMIdentity] identity push threw', { err })
+          );
+      };
+      // TEMPORARY manual trigger — REMOVE before the PR. Exercises the send
+      // path from the console without waiting on connect timing:
+      //   __quorumPushDmProfile()
+      (window as unknown as Record<string, unknown>).__quorumPushDmProfile =
+        fireDmProfileRebroadcast;
+
       setResubscribe(async () => {
         enqueueOutbound(async () => {
           const conversations = await messageDB.getAllEncryptionStates();
@@ -552,43 +593,13 @@ const MessageDBProvider: FC<MessageDBContextProps> = ({ children }) => {
             }),
           ];
         });
-
-        // Push our identity to every DM partner on connect. An established DM
-        // session carries no sender profile, so a partner whose row is still a
-        // placeholder cannot learn who we are from ordinary traffic — this is
-        // their only recovery path when they have no public profile to fall
-        // back on. Per-partner dedup gate makes an unchanged identity a wire
-        // no-op, so a flapping connection does not spam. Mirrors mobile.
         // Staggered so it never competes with the listen frame above.
-        // TEMPORARY diagnostics in this block — REMOVE before the PR.
-        const fireDmProfileRebroadcast = () => {
-          const ks = actionQueueServiceRef.current?.getUserKeyset();
-          logger.warn('[DMIdentity] on-connect hook fired', {
-            haveActionQueue: Boolean(actionQueueServiceRef.current),
-            haveKeyset: Boolean(ks),
-            haveMessageService: Boolean(messageServiceRef.current),
-            selfAddress: selfAddress?.slice(0, 12),
-          });
-          if (!ks) {
-            logger.warn('[DMIdentity] ABORT: ActionQueue keyset not ready yet');
-            return;
-          }
-          if (!messageServiceRef.current) {
-            logger.warn('[DMIdentity] ABORT: MessageService not ready yet');
-            return;
-          }
-          messageServiceRef.current
-            .rebroadcastProfileToAllDMsOnConnect(selfAddress, ks)
-            .catch((err) =>
-              logger.warn('[DMIdentity] on-connect rebroadcast threw', { err })
-            );
-        };
         setTimeout(fireDmProfileRebroadcast, 4000);
-        // Manual trigger, so the send path can be exercised without waiting on
-        // connect timing: run `__quorumPushDmProfile()` in the console.
-        (window as unknown as Record<string, unknown>).__quorumPushDmProfile =
-          fireDmProfileRebroadcast;
       });
+
+      // Startup path — see the race note above. Runs alongside the existing
+      // 10s space-sync block so a cold load also pushes identity.
+      setTimeout(fireDmProfileRebroadcast, 10000);
       setTimeout(async () => {
         enqueueOutbound(async () => {
           const conversations = await messageDB.getAllEncryptionStates();

--- a/src/components/context/MessageDB.tsx
+++ b/src/components/context/MessageDB.tsx
@@ -287,6 +287,9 @@ const MessageDBProvider: FC<MessageDBContextProps> = ({ children }) => {
   const queryClient = useQueryClient();
   const { apiClient } = useQuorumApiClient();
   const { setMessageHandler, enqueueOutbound, setResubscribe } = useWebSocket();
+  // Pending on-reconnect identity push, so a flapping socket replaces the
+  // pending broadcast instead of stacking another one behind it.
+  const dmProfilePushTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const invalidateConversation = useInvalidateConversation();
   const navigate = useNavigate();
 
@@ -576,8 +579,16 @@ const MessageDBProvider: FC<MessageDBContextProps> = ({ children }) => {
             }),
           ];
         });
-        // Staggered so it never competes with the listen frame above.
-        setTimeout(fireDmProfileRebroadcast, 4000);
+        // Staggered so it never competes with the listen frame above. Reconnects
+        // fire on a flat 1s retry, so without clearing the previous timer a
+        // flapping socket stacks up independent pending broadcasts.
+        if (dmProfilePushTimerRef.current !== null) {
+          clearTimeout(dmProfilePushTimerRef.current);
+        }
+        dmProfilePushTimerRef.current = setTimeout(
+          fireDmProfileRebroadcast,
+          4000
+        );
       });
 
       // Startup path — see the race note above. Runs alongside the existing

--- a/src/components/context/MessageDB.tsx
+++ b/src/components/context/MessageDB.tsx
@@ -67,6 +67,10 @@ import { useNavigate } from 'react-router';
 // Web: uses multiformats directly
 // Native: uses React Native compatible implementations
 import { sha256, base58btc } from '../../utils/crypto';
+import {
+  hasProfileContent,
+  preferIncomingProfileField,
+} from '../../utils/conversationProfile';
 import { t } from '@lingui/core/macro';
 
 type MessageDBContextValue = {
@@ -362,15 +366,21 @@ const MessageDBProvider: FC<MessageDBContextProps> = ({ children }) => {
 
     // Persist profile updates to IndexedDB (not just React Query cache)
     // This ensures profile data survives page refresh
-    if (updatedUserProfile?.display_name || updatedUserProfile?.user_icon) {
+    if (hasProfileContent(updatedUserProfile)) {
       try {
         const existing = await messageDB.getConversation({ conversationId });
         if (existing?.conversation) {
           await messageDB.saveConversation({
             ...existing.conversation,
-            displayName:
-              updatedUserProfile.display_name ?? existing.conversation.displayName,
-            icon: updatedUserProfile.user_icon ?? existing.conversation.icon,
+            // Empty incoming field = absent, never "clear". See conversationProfile.ts.
+            displayName: preferIncomingProfileField(
+              updatedUserProfile?.display_name,
+              existing.conversation.displayName
+            ),
+            icon: preferIncomingProfileField(
+              updatedUserProfile?.user_icon,
+              existing.conversation.icon
+            ),
             timestamp: Math.max(timestamp, existing.conversation.timestamp),
           });
         }
@@ -395,8 +405,16 @@ const MessageDBProvider: FC<MessageDBContextProps> = ({ children }) => {
               const existingConv = page.conversations.find(
                 (c: Conversation) => c.conversationId === conversationId
               );
-              const newDisplayName = updatedUserProfile?.display_name ?? existingConv?.displayName;
-              const newIcon = updatedUserProfile?.user_icon ?? existingConv?.icon;
+              // Same rule as the IndexedDB merge above: an empty incoming
+              // field must not blank the cached value.
+              const newDisplayName = preferIncomingProfileField(
+                updatedUserProfile?.display_name,
+                existingConv?.displayName
+              );
+              const newIcon = preferIncomingProfileField(
+                updatedUserProfile?.user_icon,
+                existingConv?.icon
+              );
 
               return {
                 ...page,
@@ -522,7 +540,7 @@ const MessageDBProvider: FC<MessageDBContextProps> = ({ children }) => {
       setMessageHandler((message) =>
         handleNewMessage(selfAddress, keyset, message)
       );
-      setResubscribe(async () =>
+      setResubscribe(async () => {
         enqueueOutbound(async () => {
           const conversations = await messageDB.getAllEncryptionStates();
           return [
@@ -533,8 +551,25 @@ const MessageDBProvider: FC<MessageDBContextProps> = ({ children }) => {
                 .concat(keyset.deviceKeyset.inbox_keyset.inbox_address),
             }),
           ];
-        })
-      );
+        });
+
+        // Push our identity to every DM partner on connect. An established DM
+        // session carries no sender profile, so a partner whose row is still a
+        // placeholder cannot learn who we are from ordinary traffic — this is
+        // their only recovery path when they have no public profile to fall
+        // back on. Per-partner dedup gate makes an unchanged identity a wire
+        // no-op, so a flapping connection does not spam. Mirrors mobile.
+        // Staggered so it never competes with the listen frame above.
+        setTimeout(() => {
+          const ks = actionQueueServiceRef.current?.getUserKeyset();
+          if (!ks) return;
+          messageServiceRef.current
+            ?.rebroadcastProfileToAllDMsOnConnect(selfAddress, ks)
+            .catch((err) =>
+              logger.warn('[DMProfile] on-connect rebroadcast failed', { err })
+            );
+        }, 4000);
+      });
       setTimeout(async () => {
         enqueueOutbound(async () => {
           const conversations = await messageDB.getAllEncryptionStates();

--- a/src/components/context/MessageDB.tsx
+++ b/src/components/context/MessageDB.tsx
@@ -554,32 +554,15 @@ const MessageDBProvider: FC<MessageDBContextProps> = ({ children }) => {
       // same way (a startup timer that duplicates the resubscribe work).
       const fireDmProfileRebroadcast = () => {
         const ks = actionQueueServiceRef.current?.getUserKeyset();
-        // TEMPORARY diagnostics — REMOVE before the PR.
-        logger.warn('[DMIdentity] identity push fired', {
-          haveActionQueue: Boolean(actionQueueServiceRef.current),
-          haveKeyset: Boolean(ks),
-          haveMessageService: Boolean(messageServiceRef.current),
-          selfAddress: selfAddress?.slice(0, 12),
-        });
-        if (!ks) {
-          logger.warn('[DMIdentity] ABORT: ActionQueue keyset not ready yet');
-          return;
-        }
-        if (!messageServiceRef.current) {
-          logger.warn('[DMIdentity] ABORT: MessageService not ready yet');
-          return;
-        }
+        // Either ref being unset means we ran before init finished; the other
+        // scheduled call (startup vs reconnect) covers it.
+        if (!ks || !messageServiceRef.current) return;
         messageServiceRef.current
           .rebroadcastProfileToAllDMsOnConnect(selfAddress, ks)
           .catch((err) =>
-            logger.warn('[DMIdentity] identity push threw', { err })
+            logger.warn('[DMProfile] identity push failed', { err })
           );
       };
-      // TEMPORARY manual trigger — REMOVE before the PR. Exercises the send
-      // path from the console without waiting on connect timing:
-      //   __quorumPushDmProfile()
-      (window as unknown as Record<string, unknown>).__quorumPushDmProfile =
-        fireDmProfileRebroadcast;
 
       setResubscribe(async () => {
         enqueueOutbound(async () => {

--- a/src/components/context/MessageDB.tsx
+++ b/src/components/context/MessageDB.tsx
@@ -560,15 +560,34 @@ const MessageDBProvider: FC<MessageDBContextProps> = ({ children }) => {
         // back on. Per-partner dedup gate makes an unchanged identity a wire
         // no-op, so a flapping connection does not spam. Mirrors mobile.
         // Staggered so it never competes with the listen frame above.
-        setTimeout(() => {
+        // TEMPORARY diagnostics in this block — REMOVE before the PR.
+        const fireDmProfileRebroadcast = () => {
           const ks = actionQueueServiceRef.current?.getUserKeyset();
-          if (!ks) return;
+          logger.warn('[DMIdentity] on-connect hook fired', {
+            haveActionQueue: Boolean(actionQueueServiceRef.current),
+            haveKeyset: Boolean(ks),
+            haveMessageService: Boolean(messageServiceRef.current),
+            selfAddress: selfAddress?.slice(0, 12),
+          });
+          if (!ks) {
+            logger.warn('[DMIdentity] ABORT: ActionQueue keyset not ready yet');
+            return;
+          }
+          if (!messageServiceRef.current) {
+            logger.warn('[DMIdentity] ABORT: MessageService not ready yet');
+            return;
+          }
           messageServiceRef.current
-            ?.rebroadcastProfileToAllDMsOnConnect(selfAddress, ks)
+            .rebroadcastProfileToAllDMsOnConnect(selfAddress, ks)
             .catch((err) =>
-              logger.warn('[DMProfile] on-connect rebroadcast failed', { err })
+              logger.warn('[DMIdentity] on-connect rebroadcast threw', { err })
             );
-        }, 4000);
+        };
+        setTimeout(fireDmProfileRebroadcast, 4000);
+        // Manual trigger, so the send path can be exercised without waiting on
+        // connect timing: run `__quorumPushDmProfile()` in the console.
+        (window as unknown as Record<string, unknown>).__quorumPushDmProfile =
+          fireDmProfileRebroadcast;
       });
       setTimeout(async () => {
         enqueueOutbound(async () => {

--- a/src/components/direct/DirectMessage.tsx
+++ b/src/components/direct/DirectMessage.tsx
@@ -32,7 +32,10 @@ import type { TypingScope } from '@quilibrium/quorum-shared';
 import { t } from '@lingui/core/macro';
 import { i18n } from '@lingui/core';
 import { ClickToCopyContent } from '../ui';
-import { DefaultImages } from '../../utils';
+import {
+  realDisplayNameOrUndefined,
+  realIconOrUndefined,
+} from '../../utils/identityPlaceholder';
 import { isTouchDevice } from '../../utils/platform';
 
 import { GlobalSearch } from '../search';
@@ -263,17 +266,12 @@ const DirectMessage: React.FC<{}> = () => {
       // address and the avatar to address-derived initials — matching mobile
       // and preserving privacy: no name/pfp is shown until the peer replies or
       // has opted into a public profile.
-      const localName = conversation.conversation.displayName;
-      const localIcon = conversation.conversation.icon;
       m[address!] = {
         displayName:
-          localName && localName !== t`Unknown User`
-            ? localName
-            : pubName,
+          realDisplayNameOrUndefined(conversation.conversation.displayName) ??
+          pubName,
         userIcon:
-          localIcon && localIcon !== DefaultImages.UNKNOWN_USER
-            ? localIcon
-            : pubIcon,
+          realIconOrUndefined(conversation.conversation.icon) ?? pubIcon,
         primaryUsername: pubQns,
         address: address!,
       };

--- a/src/components/direct/DirectMessageContact.tsx
+++ b/src/components/direct/DirectMessageContact.tsx
@@ -4,6 +4,7 @@ import { formatAddress } from '@quilibrium/quorum-shared';
 import { UserAvatar } from '../user/UserAvatar';
 import { ResolvedName } from '../user/ResolvedName';
 import { resolveMemberName } from '../../utils/resolveMemberName';
+import { realIconOrUndefined } from '../../utils/identityPlaceholder';
 import { Icon } from '../primitives';
 import { formatConversationTime } from '../../utils/dateFormatting';
 import { useLongPressWithDefaults } from '../../hooks/useLongPress';
@@ -91,8 +92,12 @@ const DirectMessageContact: React.FunctionComponent<{
       {/* Avatar with optional unread dot, muted badge, favorite border */}
       <div className="relative flex-shrink-0">
         <UserAvatar
-          userIcon={props.userIcon}
-          displayName={props.displayName || formatAddress(props.address)}
+          // Placeholder name/icon must not reach the avatar: the literal
+          // 'Unknown User' renders a "?" while the header shows address
+          // initials for the same row. Feed it the RESOLVED name so the
+          // initials match the label underneath.
+          userIcon={realIconOrUndefined(props.userIcon)}
+          displayName={resolvedName.name}
           address={props.address}
           size={44}
           className={

--- a/src/components/direct/DirectMessageContactsList.tsx
+++ b/src/components/direct/DirectMessageContactsList.tsx
@@ -15,6 +15,7 @@ import {
 } from '../primitives';
 import { UserAvatar } from '../user/UserAvatar';
 import { resolveMemberName, formatResolvedName } from '../../utils/resolveMemberName';
+import { realIconOrUndefined } from '../../utils/identityPlaceholder';
 import { useModalContext } from '../context/ModalProvider';
 import { useConversationPolling } from '../../hooks';
 import { useConversationPreviews } from '../../hooks/business/conversations/useConversationPreviews';
@@ -379,8 +380,17 @@ const DirectMessageContactsList: React.FC<DirectMessageContactsListProps> = ({ f
                 >
                   <div className="direct-messages-strip-avatar">
                     <UserAvatar
-                      displayName={c.displayName || ''}
-                      userIcon={c.icon}
+                      // Same resolved identity as the expanded row and the
+                      // tooltip above — a placeholder must never reach here.
+                      displayName={
+                        resolveMemberName({
+                          address: c.address,
+                          displayName: c.displayName,
+                          primaryUsername: (c as { primaryUsername?: string })
+                            .primaryUsername,
+                        }).name
+                      }
+                      userIcon={realIconOrUndefined(c.icon)}
                       address={c.address}
                       size={44}
                     />

--- a/src/dev/tests/harness/deps.ts
+++ b/src/dev/tests/harness/deps.ts
@@ -13,6 +13,7 @@ import type { QueryClient } from '@tanstack/react-query';
 import type { MessageDB } from '../../../db/messages';
 import type { QuorumApiClient } from '../../../api/baseTypes';
 import type { WsTransport } from './transport';
+import { preferIncomingProfileField } from '../../../utils/conversationProfile';
 
 type Ref<T> = { current: T };
 
@@ -94,9 +95,17 @@ export function makeDeps(input: DepsInput) {
         if (existing?.conversation) {
           await messageDB.saveConversation({
             ...existing.conversation,
-            displayName:
-              updatedUserProfile?.display_name ?? existing.conversation.displayName,
-            icon: updatedUserProfile?.user_icon ?? existing.conversation.icon,
+            // Must match MessageDB.addOrUpdateConversation exactly — the harness
+            // exists to reproduce production behaviour, so a divergent merge here
+            // would hide the very bug it is meant to catch.
+            displayName: preferIncomingProfileField(
+              updatedUserProfile?.display_name,
+              existing.conversation.displayName
+            ),
+            icon: preferIncomingProfileField(
+              updatedUserProfile?.user_icon,
+              existing.conversation.icon
+            ),
             timestamp: Math.max(timestamp, existing.conversation.timestamp),
           });
         }

--- a/src/dev/tests/utils/conversationProfile.test.ts
+++ b/src/dev/tests/utils/conversationProfile.test.ts
@@ -1,0 +1,62 @@
+// Pins the merge semantics for a DM partner's identity arriving on an incoming
+// frame. The rule is one word — EMPTY MEANS ABSENT — and the whole point of
+// these tests is that flipping `||` back to `??` (which reads as an equivalent
+// tidy-up) turns a blank avatar into silent data loss.
+//
+// Context: .agents/tasks/2026-08-01-dm-partner-identity-lost-on-established-sessions.md
+
+import { describe, it, expect } from 'vitest';
+import {
+  hasProfileContent,
+  preferIncomingProfileField,
+} from '../../../utils/conversationProfile';
+
+describe('preferIncomingProfileField', () => {
+  it('takes a real incoming value over the stored one (partner renamed)', () => {
+    expect(preferIncomingProfileField('Bob', 'Unknown User')).toBe('Bob');
+  });
+
+  it('keeps the stored value when the incoming field is undefined', () => {
+    expect(preferIncomingProfileField(undefined, 'Bob')).toBe('Bob');
+  });
+
+  // THE REGRESSION. `'' ?? stored` is `''` — with `??` this test fails and a
+  // partner who simply never set an avatar wipes the icon we already had.
+  it('keeps the stored value when the incoming field is an empty string', () => {
+    expect(preferIncomingProfileField('', 'data:image/png;base64,AAAA')).toBe(
+      'data:image/png;base64,AAAA'
+    );
+  });
+
+  it('returns undefined only when neither side has anything', () => {
+    expect(preferIncomingProfileField(undefined, undefined)).toBeUndefined();
+    expect(preferIncomingProfileField('', undefined)).toBeUndefined();
+  });
+
+  it('fills an absent stored value from the incoming one (first identity ever seen)', () => {
+    expect(preferIncomingProfileField('Bob', undefined)).toBe('Bob');
+  });
+});
+
+describe('hasProfileContent', () => {
+  it('is true when either field carries something', () => {
+    expect(hasProfileContent({ display_name: 'Bob' })).toBe(true);
+    expect(hasProfileContent({ user_icon: 'data:image/png;base64,AAAA' })).toBe(true);
+  });
+
+  it('is false for an absent, empty, or fully blank profile', () => {
+    expect(hasProfileContent(undefined)).toBe(false);
+    expect(hasProfileContent({})).toBe(false);
+    expect(hasProfileContent({ display_name: '', user_icon: '' })).toBe(false);
+  });
+
+  // The guard and the merge must agree: anything that passes the guard must be
+  // able to change at least one field, or we persist a no-op write.
+  it('agrees with the merge — a passing profile always changes something', () => {
+    const incoming = { display_name: 'Bob', user_icon: '' };
+    expect(hasProfileContent(incoming)).toBe(true);
+    expect(preferIncomingProfileField(incoming.display_name, 'Unknown User')).toBe('Bob');
+    // ...while the blank icon leaves the stored one alone.
+    expect(preferIncomingProfileField(incoming.user_icon, 'stored-icon')).toBe('stored-icon');
+  });
+});

--- a/src/dev/tests/utils/dmProfileGate.test.ts
+++ b/src/dev/tests/utils/dmProfileGate.test.ts
@@ -10,6 +10,8 @@ import {
   dmProfileSignature,
   shouldSendDmProfile,
   recordDmProfileSend,
+  claimDmProfileSend,
+  releaseDmProfileSend,
   RESEND_INTERVAL_MS,
 } from '../../../utils/dmProfileGate';
 
@@ -22,6 +24,10 @@ const SIG = dmProfileSignature({ displayName: 'Bob', userIcon: 'icon' });
 
 beforeEach(() => {
   localStorage.clear();
+  // In-flight claims are module-local, so they must be cleared between tests
+  // or a claim leaks into the next one.
+  releaseDmProfileSend(SELF, PARTNER, SIG);
+  releaseDmProfileSend(SELF, OTHER_PARTNER, SIG);
 });
 
 describe('dmProfileSignature', () => {
@@ -92,6 +98,27 @@ describe('shouldSendDmProfile', () => {
   it('is per-self-address — a different account starts fresh', () => {
     recordDmProfileSend(SELF, PARTNER, SIG, T0);
     expect(shouldSendDmProfile('QmOtherSelf', PARTNER, SIG, T0)).toBe(true);
+  });
+
+  // The persisted record is only written AFTER the network send resolves, so
+  // two overlapping broadcast runs (the startup timer and a reconnect timer can
+  // overlap by design) would both read "not yet sent" and both transmit a real
+  // encrypted DM. The in-flight claim closes that window.
+  it('does not double-send while an identical send is in flight', () => {
+    expect(shouldSendDmProfile(SELF, PARTNER, SIG, T0)).toBe(true);
+    claimDmProfileSend(SELF, PARTNER, SIG);
+    expect(shouldSendDmProfile(SELF, PARTNER, SIG, T0)).toBe(false);
+  });
+
+  it('reopens after the claim is released, so a failed send retries', () => {
+    claimDmProfileSend(SELF, PARTNER, SIG);
+    releaseDmProfileSend(SELF, PARTNER, SIG);
+    expect(shouldSendDmProfile(SELF, PARTNER, SIG, T0)).toBe(true);
+  });
+
+  it('claims are per-partner — one in flight does not block another', () => {
+    claimDmProfileSend(SELF, PARTNER, SIG);
+    expect(shouldSendDmProfile(SELF, OTHER_PARTNER, SIG, T0)).toBe(true);
   });
 
   // Upgrade path: the pre-expiry format stored a bare signature string with no

--- a/src/dev/tests/utils/dmProfileGate.test.ts
+++ b/src/dev/tests/utils/dmProfileGate.test.ts
@@ -1,20 +1,24 @@
-// The dedup gate has two opposite failure modes, both bad:
+// The send gate has two opposite failure modes, both bad:
 //   - too loose  → every reconnect re-sends a real DM to every partner
-//   - too strict → the on-connect heal never fires and partners stay stuck
-// These tests pin both edges.
+//   - too strict → a lost frame means the partner NEVER learns our identity
+// These tests pin both edges, including the expiry that bounds the second one.
 //
 // Context: .agents/tasks/2026-08-01-dm-partner-identity-lost-on-established-sessions.md
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
   dmProfileSignature,
-  readDmProfileGate,
-  writeDmProfileGate,
+  shouldSendDmProfile,
+  recordDmProfileSend,
+  RESEND_INTERVAL_MS,
 } from '../../../utils/dmProfileGate';
 
 const SELF = 'QmSelfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
 const PARTNER = 'QmPartnerBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
 const OTHER_PARTNER = 'QmPartnerCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC';
+
+const T0 = 1_750_000_000_000;
+const SIG = dmProfileSignature({ displayName: 'Bob', userIcon: 'icon' });
 
 beforeEach(() => {
   localStorage.clear();
@@ -54,34 +58,53 @@ describe('dmProfileSignature', () => {
   });
 });
 
-describe('the gate', () => {
+describe('shouldSendDmProfile', () => {
   // The heal case: we have never told this partner who we are, so the very
-  // first on-connect broadcast MUST go out.
-  it('is open for a partner we have never sent to', () => {
-    expect(readDmProfileGate(SELF, PARTNER)).toBeNull();
+  // first push MUST go out.
+  it('sends to a partner we have never sent to', () => {
+    expect(shouldSendDmProfile(SELF, PARTNER, SIG, T0)).toBe(true);
   });
 
-  it('closes for the exact payload already sent', () => {
-    const sig = dmProfileSignature({ displayName: 'Bob', userIcon: 'icon' });
-    writeDmProfileGate(SELF, PARTNER, sig);
-    expect(readDmProfileGate(SELF, PARTNER)).toBe(sig);
+  it('does not re-send the same identity on the next connect', () => {
+    recordDmProfileSend(SELF, PARTNER, SIG, T0);
+    expect(shouldSendDmProfile(SELF, PARTNER, SIG, T0 + 60_000)).toBe(false);
   });
 
-  it('reopens when the identity changes', () => {
-    writeDmProfileGate(SELF, PARTNER, dmProfileSignature({ displayName: 'Bob' }));
-    const renamed = dmProfileSignature({ displayName: 'Roberta' });
-    expect(readDmProfileGate(SELF, PARTNER)).not.toBe(renamed);
+  it('sends immediately when the identity changed', () => {
+    recordDmProfileSend(SELF, PARTNER, SIG, T0);
+    const renamed = dmProfileSignature({ displayName: 'Roberta', userIcon: 'icon' });
+    expect(shouldSendDmProfile(SELF, PARTNER, renamed, T0 + 1)).toBe(true);
+  });
+
+  // The anti-loss retry. Without this, a single dropped frame leaves the
+  // partner on a placeholder permanently — observed live 2026-08-01.
+  it('re-sends an unchanged identity once the interval has elapsed', () => {
+    recordDmProfileSend(SELF, PARTNER, SIG, T0);
+    expect(shouldSendDmProfile(SELF, PARTNER, SIG, T0 + RESEND_INTERVAL_MS - 1)).toBe(false);
+    expect(shouldSendDmProfile(SELF, PARTNER, SIG, T0 + RESEND_INTERVAL_MS)).toBe(true);
   });
 
   it('is per-partner — sending to one does not gate another', () => {
-    const sig = dmProfileSignature({ displayName: 'Bob' });
-    writeDmProfileGate(SELF, PARTNER, sig);
-    expect(readDmProfileGate(SELF, OTHER_PARTNER)).toBeNull();
+    recordDmProfileSend(SELF, PARTNER, SIG, T0);
+    expect(shouldSendDmProfile(SELF, OTHER_PARTNER, SIG, T0)).toBe(true);
   });
 
   it('is per-self-address — a different account starts fresh', () => {
-    const sig = dmProfileSignature({ displayName: 'Bob' });
-    writeDmProfileGate(SELF, PARTNER, sig);
-    expect(readDmProfileGate('QmOtherSelf', PARTNER)).toBeNull();
+    recordDmProfileSend(SELF, PARTNER, SIG, T0);
+    expect(shouldSendDmProfile('QmOtherSelf', PARTNER, SIG, T0)).toBe(true);
+  });
+
+  // Upgrade path: the pre-expiry format stored a bare signature string with no
+  // timestamp. It must not be read as "sent at epoch 0", which would make every
+  // partner instantly due for a resend on the first connect after deploy.
+  it('does not stampede on a legacy bare-signature record', () => {
+    localStorage.setItem(`quorum:dm-profile-broadcast:${SELF}:${PARTNER}`, SIG);
+    expect(shouldSendDmProfile(SELF, PARTNER, SIG, T0)).toBe(false);
+  });
+
+  it('still honours a changed identity over a legacy record', () => {
+    localStorage.setItem(`quorum:dm-profile-broadcast:${SELF}:${PARTNER}`, SIG);
+    const renamed = dmProfileSignature({ displayName: 'Roberta' });
+    expect(shouldSendDmProfile(SELF, PARTNER, renamed, T0)).toBe(true);
   });
 });

--- a/src/dev/tests/utils/dmProfileGate.test.ts
+++ b/src/dev/tests/utils/dmProfileGate.test.ts
@@ -1,0 +1,87 @@
+// The dedup gate has two opposite failure modes, both bad:
+//   - too loose  → every reconnect re-sends a real DM to every partner
+//   - too strict → the on-connect heal never fires and partners stay stuck
+// These tests pin both edges.
+//
+// Context: .agents/tasks/2026-08-01-dm-partner-identity-lost-on-established-sessions.md
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  dmProfileSignature,
+  readDmProfileGate,
+  writeDmProfileGate,
+} from '../../../utils/dmProfileGate';
+
+const SELF = 'QmSelfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+const PARTNER = 'QmPartnerBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
+const OTHER_PARTNER = 'QmPartnerCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('dmProfileSignature', () => {
+  it('is stable for the same payload regardless of key order', () => {
+    expect(dmProfileSignature({ displayName: 'Bob', userIcon: 'icon' })).toBe(
+      dmProfileSignature({ userIcon: 'icon', displayName: 'Bob' })
+    );
+  });
+
+  it('changes when a value changes (a rename must re-broadcast)', () => {
+    expect(dmProfileSignature({ displayName: 'Bob' })).not.toBe(
+      dmProfileSignature({ displayName: 'Roberta' })
+    );
+  });
+
+  // Presence matters: an avatar-only push and a name-only push are different
+  // messages and must not gate each other out.
+  it('distinguishes name-only from avatar-only', () => {
+    expect(dmProfileSignature({ displayName: 'Bob' })).not.toBe(
+      dmProfileSignature({ userIcon: 'Bob' })
+    );
+  });
+
+  it('treats an empty field as absent, matching the wire builder', () => {
+    expect(dmProfileSignature({ displayName: 'Bob', userIcon: '' })).toBe(
+      dmProfileSignature({ displayName: 'Bob' })
+    );
+  });
+
+  it('treats an explicitly empty bio as present (a deliberate clear)', () => {
+    expect(dmProfileSignature({ displayName: 'Bob', bio: '' })).not.toBe(
+      dmProfileSignature({ displayName: 'Bob' })
+    );
+  });
+});
+
+describe('the gate', () => {
+  // The heal case: we have never told this partner who we are, so the very
+  // first on-connect broadcast MUST go out.
+  it('is open for a partner we have never sent to', () => {
+    expect(readDmProfileGate(SELF, PARTNER)).toBeNull();
+  });
+
+  it('closes for the exact payload already sent', () => {
+    const sig = dmProfileSignature({ displayName: 'Bob', userIcon: 'icon' });
+    writeDmProfileGate(SELF, PARTNER, sig);
+    expect(readDmProfileGate(SELF, PARTNER)).toBe(sig);
+  });
+
+  it('reopens when the identity changes', () => {
+    writeDmProfileGate(SELF, PARTNER, dmProfileSignature({ displayName: 'Bob' }));
+    const renamed = dmProfileSignature({ displayName: 'Roberta' });
+    expect(readDmProfileGate(SELF, PARTNER)).not.toBe(renamed);
+  });
+
+  it('is per-partner — sending to one does not gate another', () => {
+    const sig = dmProfileSignature({ displayName: 'Bob' });
+    writeDmProfileGate(SELF, PARTNER, sig);
+    expect(readDmProfileGate(SELF, OTHER_PARTNER)).toBeNull();
+  });
+
+  it('is per-self-address — a different account starts fresh', () => {
+    const sig = dmProfileSignature({ displayName: 'Bob' });
+    writeDmProfileGate(SELF, PARTNER, sig);
+    expect(readDmProfileGate('QmOtherSelf', PARTNER)).toBeNull();
+  });
+});

--- a/src/dev/tests/utils/identityPlaceholder.test.ts
+++ b/src/dev/tests/utils/identityPlaceholder.test.ts
@@ -1,0 +1,95 @@
+// Pins the "we don't know who this is yet" rule. Three surfaces used to carry
+// their own copy of it and drifted apart, which is why the DM sidebar showed
+// "Unknown User" with a "?" avatar while the header showed "QmYVto…LjDd" with
+// a "Q" avatar for the SAME row.
+//
+// Context: .agents/tasks/2026-08-01-dm-partner-identity-lost-on-established-sessions.md
+
+import { describe, it, expect } from 'vitest';
+import {
+  UNKNOWN_USER_PLACEHOLDER,
+  isPlaceholderDisplayName,
+  isPlaceholderIcon,
+  realDisplayNameOrUndefined,
+  realIconOrUndefined,
+} from '../../../utils/identityPlaceholder';
+import { DefaultImages } from '../../../utils';
+import { resolveMemberName } from '../../../utils/resolveMemberName';
+
+const ADDRESS = 'QmYVtoS6E7T4TL4pSomethingSomethingLjDd';
+
+describe('isPlaceholderDisplayName', () => {
+  it('treats the stored literal, empty and nullish as placeholders', () => {
+    expect(isPlaceholderDisplayName(UNKNOWN_USER_PLACEHOLDER)).toBe(true);
+    expect(isPlaceholderDisplayName('')).toBe(true);
+    expect(isPlaceholderDisplayName(undefined)).toBe(true);
+    expect(isPlaceholderDisplayName(null)).toBe(true);
+  });
+
+  it('treats a real name as real', () => {
+    expect(isPlaceholderDisplayName('GattoPardo')).toBe(false);
+  });
+
+  // The literal is stored in English at write time, so the check must NOT be
+  // translated — a row written before a language switch must still be seen as
+  // a placeholder.
+  it('matches the English literal exactly, not a translation', () => {
+    expect(isPlaceholderDisplayName('Utente sconosciuto')).toBe(false);
+  });
+});
+
+describe('isPlaceholderIcon', () => {
+  it('treats the default image, empty and nullish as placeholders', () => {
+    expect(isPlaceholderIcon(DefaultImages.UNKNOWN_USER)).toBe(true);
+    expect(isPlaceholderIcon('')).toBe(true);
+    expect(isPlaceholderIcon(undefined)).toBe(true);
+  });
+
+  it('treats a real avatar as real', () => {
+    expect(isPlaceholderIcon('data:image/png;base64,AAAA')).toBe(false);
+  });
+});
+
+describe('demotion helpers', () => {
+  it('return undefined for placeholders so callers fall through', () => {
+    expect(realDisplayNameOrUndefined(UNKNOWN_USER_PLACEHOLDER)).toBeUndefined();
+    expect(realIconOrUndefined(DefaultImages.UNKNOWN_USER)).toBeUndefined();
+  });
+
+  it('pass real values through untouched', () => {
+    expect(realDisplayNameOrUndefined('GattoPardo')).toBe('GattoPardo');
+    expect(realIconOrUndefined('data:image/png;base64,AAAA')).toBe(
+      'data:image/png;base64,AAAA'
+    );
+  });
+});
+
+// The integration that actually caused the reported bug: every name surface
+// goes through resolveMemberName, so demoting there is what makes the sidebar
+// and the header agree.
+describe('resolveMemberName treats the placeholder as no name', () => {
+  it('falls through to the address instead of rendering the placeholder', () => {
+    const resolved = resolveMemberName({
+      address: ADDRESS,
+      displayName: UNKNOWN_USER_PLACEHOLDER,
+    });
+    expect(resolved.name).not.toBe(UNKNOWN_USER_PLACEHOLDER);
+    expect(resolved.isQnsVerified).toBe(false);
+  });
+
+  it('still prefers a real name', () => {
+    expect(
+      resolveMemberName({ address: ADDRESS, displayName: 'GattoPardo' }).name
+    ).toBe('GattoPardo');
+  });
+
+  it('lets the QNS name win over the placeholder', () => {
+    const resolved = resolveMemberName({
+      address: ADDRESS,
+      displayName: UNKNOWN_USER_PLACEHOLDER,
+      primaryUsername: 'gattopardo',
+    });
+    expect(resolved.name).toBe('gattopardo');
+    expect(resolved.isQnsVerified).toBe(true);
+  });
+});

--- a/src/dev/tests/utils/identityPlaceholder.test.ts
+++ b/src/dev/tests/utils/identityPlaceholder.test.ts
@@ -30,11 +30,20 @@ describe('isPlaceholderDisplayName', () => {
     expect(isPlaceholderDisplayName('GattoPardo')).toBe(false);
   });
 
-  // The literal is stored in English at write time, so the check must NOT be
-  // translated — a row written before a language switch must still be seen as
-  // a placeholder.
-  it('matches the English literal exactly, not a translation', () => {
-    expect(isPlaceholderDisplayName('Utente sconosciuto')).toBe(false);
+  // Rows are written with the Lingui `t` macro, which evaluates at the ACTIVE
+  // locale — so an Italian user's new DM row holds "Utente sconosciuto", and
+  // the check has to consult the current locale's spelling too. Lingui THROWS
+  // if no locale is activated, and this suite runs without one, which is
+  // exactly the early-startup condition the app can hit. So this asserts the
+  // safety contract: consulting the locale must never throw out of an identity
+  // check, it must degrade to the English literal.
+  it('does not throw when no locale is activated', () => {
+    expect(() => isPlaceholderDisplayName('anything')).not.toThrow();
+    expect(isPlaceholderDisplayName(UNKNOWN_USER_PLACEHOLDER)).toBe(true);
+  });
+
+  it('does not treat an unrelated name as a placeholder', () => {
+    expect(isPlaceholderDisplayName('Utente Reale')).toBe(false);
   });
 });
 

--- a/src/hooks/business/conversations/useConversationsWithProfileBackfill.ts
+++ b/src/hooks/business/conversations/useConversationsWithProfileBackfill.ts
@@ -35,20 +35,16 @@ import { publicProfileQueryKey } from '../user/useUserPublicProfile';
 import { useMessageDB } from '../../../components/context/useMessageDB';
 import { buildConversationsKey } from '../../queries/conversations/buildConversationsKey';
 import { buildConversationKey } from '../../queries/conversation/buildConversationKey';
-import { DefaultImages } from '../../../utils';
+import {
+  isPlaceholderDisplayName,
+  isPlaceholderIcon,
+} from '../../../utils/identityPlaceholder';
 import { logger } from '@quilibrium/quorum-shared';
 
-// "Unknown User" is the literal placeholder stored on rows with no real name
-// (MessageService.ts). We can't import the runtime-translated t`Unknown User`
-// here without coupling to the i18n macro, and the stored value is the
-// English literal at write time, so match that constant directly.
-const UNKNOWN_USER_NAME = 'Unknown User';
-
-const isPlaceholderName = (name?: string): boolean =>
-  !name || name === UNKNOWN_USER_NAME;
-
-const isPlaceholderIcon = (icon?: string): boolean =>
-  !icon || icon === DefaultImages.UNKNOWN_USER;
+// The placeholder rule lives in utils/identityPlaceholder — same definition the
+// render surfaces use, so a row this hook considers fillable is exactly a row
+// the UI considers identity-less.
+const isPlaceholderName = isPlaceholderDisplayName;
 
 /**
  * A conversation row augmented with the partner's QNS primary username, sourced

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -576,6 +576,10 @@ export class MessageService {
       // Mirrors mobile's MMKV gate (services/dm/dmProfileService.ts).
       const signature = dmProfileSignature(msg);
       if (readDmProfileGate(selfUserAddress, partnerAddress) === signature) {
+        // TEMPORARY diagnostic — REMOVE before the PR.
+        logger.warn('[DMIdentity] SKIPPED (gate closed, already sent this exact payload)', {
+          partner: partnerAddress.slice(0, 16),
+        });
         continue;
       }
 
@@ -587,9 +591,16 @@ export class MessageService {
           keyset,
         );
         writeDmProfileGate(selfUserAddress, partnerAddress, signature);
+        // TEMPORARY diagnostic — REMOVE before the PR.
+        logger.warn('[DMIdentity] SENT dm-update-profile', {
+          partner: partnerAddress.slice(0, 16),
+          displayName,
+          iconLength: userIcon?.length ?? 0,
+        });
       } catch (err) {
-        logger.warn('[DMProfile] broadcast to partner failed', {
+        logger.warn('[DMIdentity] SEND FAILED', {
           err,
+          message: (err as Error)?.message,
           partner: partnerAddress.slice(0, 16),
         });
       }
@@ -623,9 +634,21 @@ export class MessageService {
       });
       const displayName = config?.name || '';
       const userIcon = config?.profile_image || '';
+      // TEMPORARY diagnostic — REMOVE before the PR.
+      logger.warn('[DMIdentity] on-connect rebroadcast starting', {
+        self: selfUserAddress?.slice(0, 12),
+        haveConfig: Boolean(config),
+        displayName: displayName || '(empty)',
+        iconLength: userIcon.length,
+      });
       // Nothing to advertise yet (fresh account, config not synced) — sending
       // empty fields would be a wire no-op the receiver ignores anyway.
-      if (!displayName && !userIcon) return;
+      if (!displayName && !userIcon) {
+        logger.warn(
+          '[DMIdentity] ABORT: config carries no name and no avatar — nothing to advertise'
+        );
+        return;
+      }
       // Bio is deliberately omitted: the DM identity push gates bio on the
       // public-profile toggle (legacy DM behaviour), and this path has no
       // access to that decision. Name + avatar only, matching mobile.

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -85,8 +85,8 @@ import { findStaleBucket, restoreStaleBucket } from '../utils/dmStaleBucketRetry
 import { orderSessionsForSend } from '../utils/sessionSelection';
 import {
   dmProfileSignature,
-  readDmProfileGate,
-  writeDmProfileGate,
+  shouldSendDmProfile,
+  recordDmProfileSend,
 } from '../utils/dmProfileGate';
 import { UndecryptableFrameTracker, frameKey } from '../utils/frameRetry';
 import { ThreadService } from './ThreadService';
@@ -575,11 +575,7 @@ export class MessageService {
       // failure leaves the gate open and the next connect retries.
       // Mirrors mobile's MMKV gate (services/dm/dmProfileService.ts).
       const signature = dmProfileSignature(msg);
-      if (readDmProfileGate(selfUserAddress, partnerAddress) === signature) {
-        // TEMPORARY diagnostic — REMOVE before the PR.
-        logger.warn('[DMIdentity] SKIPPED (gate closed, already sent this exact payload)', {
-          partner: partnerAddress.slice(0, 16),
-        });
+      if (!shouldSendDmProfile(selfUserAddress, partnerAddress, signature)) {
         continue;
       }
 
@@ -590,17 +586,22 @@ export class MessageService {
           selfUserAddress,
           keyset,
         );
-        writeDmProfileGate(selfUserAddress, partnerAddress, signature);
-        // TEMPORARY diagnostic — REMOVE before the PR.
-        logger.warn('[DMIdentity] SENT dm-update-profile', {
-          partner: partnerAddress.slice(0, 16),
-          displayName,
-          iconLength: userIcon?.length ?? 0,
-        });
+        recordDmProfileSend(selfUserAddress, partnerAddress, signature);
       } catch (err) {
-        logger.warn('[DMIdentity] SEND FAILED', {
+        // A contact row with no established session is the normal case for a
+        // never-messaged contact, not a fault: there is no session to encrypt
+        // to, and there is no conversation to fix either. Stay quiet about it
+        // so the genuine failures below remain visible. The gate is NOT
+        // recorded, so this partner is retried once a session exists.
+        const message = (err as Error)?.message ?? '';
+        if (message.includes('No established sessions available')) {
+          logger.debug('[DMProfile] no session with partner yet — skipping', {
+            partner: partnerAddress.slice(0, 16),
+          });
+          continue;
+        }
+        logger.warn('[DMProfile] broadcast to partner failed', {
           err,
-          message: (err as Error)?.message,
           partner: partnerAddress.slice(0, 16),
         });
       }
@@ -634,21 +635,9 @@ export class MessageService {
       });
       const displayName = config?.name || '';
       const userIcon = config?.profile_image || '';
-      // TEMPORARY diagnostic — REMOVE before the PR.
-      logger.warn('[DMIdentity] on-connect rebroadcast starting', {
-        self: selfUserAddress?.slice(0, 12),
-        haveConfig: Boolean(config),
-        displayName: displayName || '(empty)',
-        iconLength: userIcon.length,
-      });
       // Nothing to advertise yet (fresh account, config not synced) — sending
       // empty fields would be a wire no-op the receiver ignores anyway.
-      if (!displayName && !userIcon) {
-        logger.warn(
-          '[DMIdentity] ABORT: config carries no name and no avatar — nothing to advertise'
-        );
-        return;
-      }
+      if (!displayName && !userIcon) return;
       // Bio is deliberately omitted: the DM identity push gates bio on the
       // public-profile toggle (legacy DM behaviour), and this path has no
       // access to that decision. Name + avatar only, matching mobile.
@@ -839,14 +828,6 @@ export class MessageService {
     };
 
     await this.messageDB.saveConversation(merged);
-
-    // TEMPORARY (branch fix/dm-identity-from-established-session): confirms the
-    // on-connect rebroadcast lands and heals the row. REMOVE before the PR.
-    logger.warn('[DMIdentity] applied dm-update-profile from partner', {
-      partner: senderAddress.slice(0, 16),
-      displayName: merged.displayName,
-      iconLength: merged.icon?.length ?? 0,
-    });
 
     if (queryClient) {
       queryClient.invalidateQueries({ queryKey: buildConversationsKey({ type: 'direct' }) });
@@ -4189,20 +4170,6 @@ export class MessageService {
               ratchet_state: string;
               message: string;
             };
-
-            // TEMPORARY (branch fix/dm-identity-from-established-session):
-            // measures how often an established-session frame actually carries
-            // the sender's identity. `user_profile` is only on the init-carrying
-            // variant of the decrypt union, so this is the open question in
-            // Slice 1 of the task. REMOVE before opening the PR.
-            logger.warn('[DMIdentity] established-session frame decrypted', {
-              conversationId: conversationId?.slice(0, 16),
-              hasUserProfile: Boolean(maybeInit.user_profile),
-              displayName: maybeInit.user_profile?.display_name ?? '(none)',
-              iconLength: maybeInit.user_profile?.user_icon?.length ?? 0,
-              profileAddress: maybeInit.user_profile?.user_address?.slice(0, 12) ?? '(none)',
-              selfAddress: self_address?.slice(0, 12),
-            });
 
             let advancedState: string;
             // If the retry pruned a bucket to get here, put it back: those keys

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -87,7 +87,10 @@ import {
   dmProfileSignature,
   shouldSendDmProfile,
   recordDmProfileSend,
+  claimDmProfileSend,
+  releaseDmProfileSend,
 } from '../utils/dmProfileGate';
+import { preferIncomingProfileField } from '../utils/conversationProfile';
 import { UndecryptableFrameTracker, frameKey } from '../utils/frameRetry';
 import { ThreadService } from './ThreadService';
 import type { Ref } from '../types/ref';
@@ -579,6 +582,8 @@ export class MessageService {
         continue;
       }
 
+      // Claim BEFORE the await, release in `finally` — see dmProfileGate.
+      claimDmProfileSend(selfUserAddress, partnerAddress, signature);
       try {
         await this.encryptAndSendDm(
           partnerAddress,
@@ -604,6 +609,10 @@ export class MessageService {
           err,
           partner: partnerAddress.slice(0, 16),
         });
+      } finally {
+        // Runs on the `continue` above too, so a no-session partner is not
+        // wedged shut for the rest of the session.
+        releaseDmProfileSend(selfUserAddress, partnerAddress, signature);
       }
     }
   }
@@ -5729,9 +5738,23 @@ export class MessageService {
           return;
         }
 
-        const profileToUse = updatedUserProfile ?? {
-          user_icon: conversation.conversation?.icon,
-          display_name: conversation.conversation?.displayName,
+        // MERGE, never replace. `?? existing` was safe only while
+        // updatedUserProfile was always undefined on this path; now that a
+        // decrypted frame can supply one, a partial profile (real name, blank
+        // avatar — an ordinary partner with no picture set) would otherwise be
+        // passed through whole. db.saveMessage writes icon/displayName onto the
+        // conversation row UNCONDITIONALLY (src/db/messages.ts), and it runs
+        // BEFORE addOrUpdateConversation's guarded merge below, so a blank
+        // field here permanently wipes a known-good stored value.
+        const profileToUse = {
+          user_icon: preferIncomingProfileField(
+            updatedUserProfile?.user_icon,
+            conversation.conversation?.icon
+          ),
+          display_name: preferIncomingProfileField(
+            updatedUserProfile?.display_name,
+            conversation.conversation?.displayName
+          ),
         };
         await this.saveMessage(
           decryptedContent,
@@ -5776,9 +5799,16 @@ export class MessageService {
           conversationId.split('/')[0],
           decryptedContent.channelId,
           keys.sending_inbox ? 'direct' : 'group',
-          updatedUserProfile ?? {
-            user_icon: conversation.conversation?.icon,
-            display_name: conversation.conversation?.displayName,
+          // Merge, not replace — see the sibling branch above.
+          {
+            user_icon: preferIncomingProfileField(
+              updatedUserProfile?.user_icon,
+              conversation.conversation?.icon
+            ),
+            display_name: preferIncomingProfileField(
+              updatedUserProfile?.display_name,
+              conversation.conversation?.displayName
+            ),
           }
         );
 

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -83,6 +83,11 @@ import { dmRatchetMutex } from '../utils/keyedMutex';
 import { isStaleInitEnvelope } from '../utils/initEnvelopeGuard';
 import { findStaleBucket, restoreStaleBucket } from '../utils/dmStaleBucketRetry';
 import { orderSessionsForSend } from '../utils/sessionSelection';
+import {
+  dmProfileSignature,
+  readDmProfileGate,
+  writeDmProfileGate,
+} from '../utils/dmProfileGate';
 import { UndecryptableFrameTracker, frameKey } from '../utils/frameRetry';
 import { ThreadService } from './ThreadService';
 import type { Ref } from '../types/ref';
@@ -563,6 +568,17 @@ export class MessageService {
         ...(bio !== undefined ? { bio } : {}),
       };
 
+      // Dedup gate. The on-connect rebroadcast fires on EVERY ws.onopen, and
+      // each send here is a real encrypted DM on the wire. Skip a send whose
+      // payload is byte-identical to the last one this device recorded for
+      // this (self, partner). Recorded only AFTER a successful send, so a
+      // failure leaves the gate open and the next connect retries.
+      // Mirrors mobile's MMKV gate (services/dm/dmProfileService.ts).
+      const signature = dmProfileSignature(msg);
+      if (readDmProfileGate(selfUserAddress, partnerAddress) === signature) {
+        continue;
+      }
+
       try {
         await this.encryptAndSendDm(
           partnerAddress,
@@ -570,12 +586,58 @@ export class MessageService {
           selfUserAddress,
           keyset,
         );
+        writeDmProfileGate(selfUserAddress, partnerAddress, signature);
       } catch (err) {
         logger.warn('[DMProfile] broadcast to partner failed', {
           err,
           partner: partnerAddress.slice(0, 16),
         });
       }
+    }
+  }
+
+  /**
+   * On-connect DM identity rebroadcast.
+   *
+   * An established DM session never carries the sender's identity (the decrypt
+   * union only exposes `user_profile` on its init-carrying variant, measured
+   * absent on every established-session frame), so a partner whose row is still
+   * a placeholder has no way to learn who we are from ordinary traffic. Pushing
+   * our current global identity on connect is the recovery path — and the only
+   * one that works for a partner with no published public profile.
+   *
+   * Mirrors mobile, which already rebroadcasts to all DM partners on reconnect
+   * (quorum-mobile context/WebSocketContext.tsx ~6270). Cheap by construction:
+   * the per-partner gate above makes an unchanged identity a no-op on the wire.
+   */
+  async rebroadcastProfileToAllDMsOnConnect(
+    selfUserAddress: string,
+    keyset: {
+      deviceKeyset: secureChannel.DeviceKeyset;
+      userKeyset: secureChannel.UserKeyset;
+    },
+  ): Promise<void> {
+    try {
+      const config = await this.messageDB.getUserConfig({
+        address: selfUserAddress,
+      });
+      const displayName = config?.name || '';
+      const userIcon = config?.profile_image || '';
+      // Nothing to advertise yet (fresh account, config not synced) — sending
+      // empty fields would be a wire no-op the receiver ignores anyway.
+      if (!displayName && !userIcon) return;
+      // Bio is deliberately omitted: the DM identity push gates bio on the
+      // public-profile toggle (legacy DM behaviour), and this path has no
+      // access to that decision. Name + avatar only, matching mobile.
+      await this.broadcastProfileToAllDMs(
+        displayName,
+        userIcon,
+        undefined,
+        selfUserAddress,
+        keyset,
+      );
+    } catch (err) {
+      logger.warn('[DMProfile] on-connect rebroadcast failed', { err });
     }
   }
 
@@ -754,6 +816,14 @@ export class MessageService {
     };
 
     await this.messageDB.saveConversation(merged);
+
+    // TEMPORARY (branch fix/dm-identity-from-established-session): confirms the
+    // on-connect rebroadcast lands and heals the row. REMOVE before the PR.
+    logger.warn('[DMIdentity] applied dm-update-profile from partner', {
+      partner: senderAddress.slice(0, 16),
+      displayName: merged.displayName,
+      iconLength: merged.icon?.length ?? 0,
+    });
 
     if (queryClient) {
       queryClient.invalidateQueries({ queryKey: buildConversationsKey({ type: 'direct' }) });
@@ -4097,6 +4167,20 @@ export class MessageService {
               message: string;
             };
 
+            // TEMPORARY (branch fix/dm-identity-from-established-session):
+            // measures how often an established-session frame actually carries
+            // the sender's identity. `user_profile` is only on the init-carrying
+            // variant of the decrypt union, so this is the open question in
+            // Slice 1 of the task. REMOVE before opening the PR.
+            logger.warn('[DMIdentity] established-session frame decrypted', {
+              conversationId: conversationId?.slice(0, 16),
+              hasUserProfile: Boolean(maybeInit.user_profile),
+              displayName: maybeInit.user_profile?.display_name ?? '(none)',
+              iconLength: maybeInit.user_profile?.user_icon?.length ?? 0,
+              profileAddress: maybeInit.user_profile?.user_address?.slice(0, 12) ?? '(none)',
+              selfAddress: self_address?.slice(0, 12),
+            });
+
             let advancedState: string;
             // If the retry pruned a bucket to get here, put it back: those keys
             // are the ONLY way to read genuinely delayed frames, and persisting
@@ -4158,7 +4242,22 @@ export class MessageService {
               outcome: 'ok' as const,
               content,
               sentAccept: fresh.sentAccept,
-              updatedUserProfile: undefined,
+              // Carry the sender's identity through when the frame has it.
+              // `user_profile` is only on the init-carrying variant of the
+              // decrypt union (hence the guard above at `maybeInit.user_profile`),
+              // but dropping it meant a DM partner's name/avatar could ONLY ever
+              // be learned during session setup: once established, no amount of
+              // traffic refreshed it, so a partner with no public profile stayed
+              // on the placeholder forever. Mobile applies it on this same path
+              // (quorum-mobile WebSocketContext.tsx ~4739).
+              // Self-address guard mirrors the Confirm branch: on a multi-device
+              // self-echo the profile is OURS, and must not overwrite the
+              // partner's conversation row.
+              updatedUserProfile:
+                maybeInit.user_profile &&
+                maybeInit.user_profile.user_address != self_address
+                  ? maybeInit.user_profile
+                  : undefined,
             };
           } catch (decryptError) {
             // Double Ratchet spec: on a decrypt/authentication failure, discard the

--- a/src/utils/conversationProfile.ts
+++ b/src/utils/conversationProfile.ts
@@ -1,0 +1,55 @@
+// Merge rules for a DM partner's identity (display name + avatar) arriving on
+// an incoming frame, applied against what we already have stored on the
+// conversation row.
+//
+// THE RULE: an EMPTY incoming field means "absent", never "clear it".
+//
+// This is not a style preference — `??` here is a live data-loss bug. The
+// persist guard (`hasProfileContent`) is truthy, so a frame carrying a real
+// display_name but a blank user_icon (any partner who has not set an avatar)
+// passes the guard and reaches the merge. With `??`, that blank overwrites a
+// perfectly good stored icon, because `'' ?? x` is `''`.
+//
+// A deliberate clear is expressed elsewhere and never as an empty field on an
+// ordinary frame: `dm-update-profile` carries explicit intent, and its handler
+// (MessageService.handleDMProfileUpdate) is likewise truthy-guarded. Mobile
+// applies the same `||` semantics on its equivalent merge
+// (quorum-mobile context/WebSocketContext.tsx ~4740).
+//
+// See .agents/tasks/2026-08-01-dm-partner-identity-lost-on-established-sessions.md
+
+/** The identity fields carried on a decrypted frame / SDK `UserProfile`. */
+export interface IncomingPartnerProfile {
+  display_name?: string;
+  user_icon?: string;
+}
+
+/**
+ * True when an incoming profile carries anything worth persisting. Mirrors the
+ * merge's own notion of "present": whitespace-free emptiness is absence.
+ */
+export const hasProfileContent = (
+  profile?: IncomingPartnerProfile
+): boolean => Boolean(profile?.display_name || profile?.user_icon);
+
+/**
+ * Prefer a non-empty incoming profile field over the stored one.
+ *
+ * Overloaded so a caller merging against a guaranteed-present stored value
+ * (an existing conversation row) gets `string` back rather than
+ * `string | undefined`.
+ */
+export function preferIncomingProfileField(
+  incoming: string | undefined,
+  stored: string
+): string;
+export function preferIncomingProfileField(
+  incoming: string | undefined,
+  stored: string | undefined
+): string | undefined;
+export function preferIncomingProfileField(
+  incoming: string | undefined,
+  stored: string | undefined
+): string | undefined {
+  return incoming || stored;
+}

--- a/src/utils/dmProfileGate.ts
+++ b/src/utils/dmProfileGate.ts
@@ -26,7 +26,17 @@ import { logger } from '@quilibrium/quorum-shared';
 
 const GATE_PREFIX = 'quorum:dm-profile-broadcast';
 
-/** Re-send an unchanged identity at most this often, per partner. */
+/**
+ * Re-send an unchanged identity at most this often, per partner.
+ *
+ * ⚠️ PLACEHOLDER VALUE — chosen to bound an anti-loss retry, not researched.
+ * It pays a cost on EVERY pair to fix a failure that occurs on a small fraction
+ * of pairs, so it scales with the user base rather than with the problem
+ * (~6 GB/day at 10k users × 20 partners × 30 KB avatars). Better shapes
+ * (receiver-driven request, fingerprint-first, backoff) are being evaluated in
+ * .agents/tasks/2026-08-01-identity-announce-cadence-research.md — do not treat
+ * this constant as settled, and do not copy it into the space implementation.
+ */
 export const RESEND_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24h
 
 /** The identity fields that actually go on the wire. */

--- a/src/utils/dmProfileGate.ts
+++ b/src/utils/dmProfileGate.ts
@@ -102,11 +102,20 @@ const readRecord = (
   return { sig: raw, at: Date.now() };
 };
 
+// In-flight claims, process-local. The persisted record is only written AFTER
+// encryptAndSendDm resolves (a real crypto + network round trip), so two
+// overlapping broadcast runs — the startup timer and a reconnect timer can
+// overlap by design — would both read "not yet sent" and both send a real
+// encrypted DM to the same partner. Claiming synchronously here closes that
+// window. Not persisted: a reload legitimately means nothing is in flight.
+const inFlight = new Set<string>();
+
 /**
  * Should we send this payload to this partner right now?
  *
  * True when we have never sent to them, when the identity has changed, or when
- * the last send is older than RESEND_INTERVAL_MS (the anti-loss retry).
+ * the last send is older than RESEND_INTERVAL_MS (the anti-loss retry) — and
+ * only when no equivalent send is already in flight.
  *
  * `now` is injectable so the expiry is testable without faking the clock.
  */
@@ -116,10 +125,35 @@ export const shouldSendDmProfile = (
   signature: string,
   now: number = Date.now()
 ): boolean => {
+  if (inFlight.has(`${gateKey(selfAddress, partnerAddress)}|${signature}`)) {
+    return false;
+  }
   const record = readRecord(selfAddress, partnerAddress);
   if (!record) return true;
   if (record.sig !== signature) return true;
   return now - record.at >= RESEND_INTERVAL_MS;
+};
+
+/**
+ * Claim a send synchronously, before awaiting it. Must be paired with
+ * `releaseDmProfileSend` in a `finally` so a failed send does not wedge the
+ * partner shut until reload.
+ */
+export const claimDmProfileSend = (
+  selfAddress: string,
+  partnerAddress: string,
+  signature: string
+): void => {
+  inFlight.add(`${gateKey(selfAddress, partnerAddress)}|${signature}`);
+};
+
+/** Release an in-flight claim, whether the send succeeded or threw. */
+export const releaseDmProfileSend = (
+  selfAddress: string,
+  partnerAddress: string,
+  signature: string
+): void => {
+  inFlight.delete(`${gateKey(selfAddress, partnerAddress)}|${signature}`);
 };
 
 /**

--- a/src/utils/dmProfileGate.ts
+++ b/src/utils/dmProfileGate.ts
@@ -1,0 +1,79 @@
+// Per-partner dedup gate for the `dm-update-profile` broadcast.
+//
+// The on-connect rebroadcast fires on EVERY ws.onopen, and every send it makes
+// is a real encrypted DM on the wire (plus a push on the receiving device). A
+// user with 30 DM partners on a flaky connection would otherwise emit 30
+// messages per reconnect, forever, to say nothing new.
+//
+// The gate records the exact payload last successfully sent to each partner and
+// skips a byte-identical resend. Recording happens only AFTER a successful
+// send, so a failure leaves the gate open and the next connect retries.
+//
+// Desktop counterpart of mobile's MMKV gate in
+// quorum-mobile/services/dm/dmProfileService.ts.
+//
+// See .agents/tasks/2026-08-01-dm-partner-identity-lost-on-established-sessions.md
+
+import { logger } from '@quilibrium/quorum-shared';
+
+const GATE_PREFIX = 'quorum:dm-profile-broadcast';
+
+/** The identity fields that actually go on the wire. */
+export interface DmProfileWirePayload {
+  displayName?: string;
+  userIcon?: string;
+  bio?: string;
+}
+
+/**
+ * Canonical signature of the exact wire payload.
+ *
+ * Field PRESENCE matters as well as value: an avatar-only push and a
+ * name-only push are different messages and must not gate each other. Built
+ * from an explicit key order so it never depends on object insertion order.
+ */
+export const dmProfileSignature = (payload: DmProfileWirePayload): string => {
+  const canonical: Record<string, string> = {};
+  if (payload.displayName) canonical.displayName = payload.displayName;
+  if (payload.userIcon) canonical.userIcon = payload.userIcon;
+  if (payload.bio !== undefined) canonical.bio = payload.bio;
+  return JSON.stringify(
+    Object.keys(canonical)
+      .sort()
+      .map((k) => [k, canonical[k]])
+  );
+};
+
+const gateKey = (selfAddress: string, partnerAddress: string): string =>
+  `${GATE_PREFIX}:${selfAddress}:${partnerAddress}`;
+
+/**
+ * The signature last successfully sent to this partner, or null if we have
+ * never sent one (or storage is unavailable — in which case we deliberately
+ * fail OPEN and re-send, since a redundant identity push is harmless whereas a
+ * missed one leaves the partner stuck on a placeholder).
+ */
+export const readDmProfileGate = (
+  selfAddress: string,
+  partnerAddress: string
+): string | null => {
+  try {
+    return localStorage.getItem(gateKey(selfAddress, partnerAddress));
+  } catch (err) {
+    logger.warn('[DMProfile] gate read failed — treating as not-yet-sent', { err });
+    return null;
+  }
+};
+
+/** Record a successful send. Storage failures are non-fatal (gate stays open). */
+export const writeDmProfileGate = (
+  selfAddress: string,
+  partnerAddress: string,
+  signature: string
+): void => {
+  try {
+    localStorage.setItem(gateKey(selfAddress, partnerAddress), signature);
+  } catch (err) {
+    logger.warn('[DMProfile] gate write failed — will re-send next connect', { err });
+  }
+};

--- a/src/utils/dmProfileGate.ts
+++ b/src/utils/dmProfileGate.ts
@@ -1,22 +1,33 @@
-// Per-partner dedup gate for the `dm-update-profile` broadcast.
+// Per-partner send gate for the `dm-update-profile` broadcast.
 //
-// The on-connect rebroadcast fires on EVERY ws.onopen, and every send it makes
-// is a real encrypted DM on the wire (plus a push on the receiving device). A
-// user with 30 DM partners on a flaky connection would otherwise emit 30
-// messages per reconnect, forever, to say nothing new.
+// The identity push runs on every connect, and every send it makes is a real
+// encrypted DM on the wire (plus a push on the receiving device). A user with
+// 30 DM partners on a flaky connection would otherwise emit 30 messages per
+// reconnect, forever, to say nothing new. So: skip a byte-identical resend.
 //
-// The gate records the exact payload last successfully sent to each partner and
-// skips a byte-identical resend. Recording happens only AFTER a successful
-// send, so a failure leaves the gate open and the next connect retries.
+// BUT a pure "sent once, never again" gate makes convergence depend on a
+// single frame arriving. This transport is documented-unreliable, and the
+// failure is permanent and silent: the sender believes the partner knows who
+// they are, the partner renders a placeholder forever, and nothing retries.
+// Observed live on 2026-08-01 — a closed gate on one side while the other side
+// still showed "Unknown User".
 //
-// Desktop counterpart of mobile's MMKV gate in
-// quorum-mobile/services/dm/dmProfileService.ts.
+// So the gate EXPIRES. An unchanged identity is re-sent at most once per
+// RESEND_INTERVAL_MS per partner, which bounds the wire cost to ~1 message per
+// partner per day while guaranteeing the identity eventually lands.
+//
+// Desktop counterpart of mobile's MMKV gate
+// (quorum-mobile/services/dm/dmProfileService.ts), plus the expiry, which
+// mobile does not have.
 //
 // See .agents/tasks/2026-08-01-dm-partner-identity-lost-on-established-sessions.md
 
 import { logger } from '@quilibrium/quorum-shared';
 
 const GATE_PREFIX = 'quorum:dm-profile-broadcast';
+
+/** Re-send an unchanged identity at most this often, per partner. */
+export const RESEND_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24h
 
 /** The identity fields that actually go on the wire. */
 export interface DmProfileWirePayload {
@@ -30,7 +41,7 @@ export interface DmProfileWirePayload {
  *
  * Field PRESENCE matters as well as value: an avatar-only push and a
  * name-only push are different messages and must not gate each other. Built
- * from an explicit key order so it never depends on object insertion order.
+ * from an explicit sorted key order so it never depends on insertion order.
  */
 export const dmProfileSignature = (payload: DmProfileWirePayload): string => {
   const canonical: Record<string, string> = {};
@@ -47,32 +58,86 @@ export const dmProfileSignature = (payload: DmProfileWirePayload): string => {
 const gateKey = (selfAddress: string, partnerAddress: string): string =>
   `${GATE_PREFIX}:${selfAddress}:${partnerAddress}`;
 
-/**
- * The signature last successfully sent to this partner, or null if we have
- * never sent one (or storage is unavailable — in which case we deliberately
- * fail OPEN and re-send, since a redundant identity push is harmless whereas a
- * missed one leaves the partner stuck on a placeholder).
- */
-export const readDmProfileGate = (
+interface GateRecord {
+  sig: string;
+  at: number;
+}
+
+const readRecord = (
   selfAddress: string,
   partnerAddress: string
-): string | null => {
+): GateRecord | null => {
+  let raw: string | null;
   try {
-    return localStorage.getItem(gateKey(selfAddress, partnerAddress));
+    raw = localStorage.getItem(gateKey(selfAddress, partnerAddress));
   } catch (err) {
+    // Storage unavailable — fail OPEN. A redundant identity push is harmless;
+    // a missed one leaves the partner stuck on a placeholder.
     logger.warn('[DMProfile] gate read failed — treating as not-yet-sent', { err });
     return null;
   }
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      parsed !== null &&
+      typeof parsed === 'object' &&
+      !Array.isArray(parsed) &&
+      typeof (parsed as GateRecord).sig === 'string' &&
+      typeof (parsed as GateRecord).at === 'number'
+    ) {
+      return {
+        sig: (parsed as GateRecord).sig,
+        at: (parsed as GateRecord).at,
+      };
+    }
+  } catch {
+    // Not JSON at all — fall through to the legacy branch.
+  }
+  // Pre-expiry format stored a BARE SIGNATURE string. Note that a signature is
+  // itself valid JSON (an array), so it parses cleanly — which is exactly why
+  // the shape check above matters more than the try/catch. Stamp it as sent
+  // "now" rather than at epoch 0, so upgrading does not make every partner
+  // instantly due for a resend on the first connect after deploy.
+  return { sig: raw, at: Date.now() };
 };
 
-/** Record a successful send. Storage failures are non-fatal (gate stays open). */
-export const writeDmProfileGate = (
+/**
+ * Should we send this payload to this partner right now?
+ *
+ * True when we have never sent to them, when the identity has changed, or when
+ * the last send is older than RESEND_INTERVAL_MS (the anti-loss retry).
+ *
+ * `now` is injectable so the expiry is testable without faking the clock.
+ */
+export const shouldSendDmProfile = (
   selfAddress: string,
   partnerAddress: string,
-  signature: string
+  signature: string,
+  now: number = Date.now()
+): boolean => {
+  const record = readRecord(selfAddress, partnerAddress);
+  if (!record) return true;
+  if (record.sig !== signature) return true;
+  return now - record.at >= RESEND_INTERVAL_MS;
+};
+
+/**
+ * Record a successful send. Call ONLY after the send resolves, so a failure
+ * leaves the gate open and the next connect retries.
+ * Storage failures are non-fatal (gate simply stays open).
+ */
+export const recordDmProfileSend = (
+  selfAddress: string,
+  partnerAddress: string,
+  signature: string,
+  now: number = Date.now()
 ): void => {
   try {
-    localStorage.setItem(gateKey(selfAddress, partnerAddress), signature);
+    localStorage.setItem(
+      gateKey(selfAddress, partnerAddress),
+      JSON.stringify({ sig: signature, at: now } satisfies GateRecord)
+    );
   } catch (err) {
     logger.warn('[DMProfile] gate write failed — will re-send next connect', { err });
   }

--- a/src/utils/identityPlaceholder.ts
+++ b/src/utils/identityPlaceholder.ts
@@ -1,0 +1,47 @@
+// The "we don't know who this is yet" rule, in one place.
+//
+// `'Unknown User'` and the default avatar are PLACEHOLDERS written into storage
+// when no identity is known — they are not a name and not a picture. Treating
+// them as real values is what made the DM sidebar and the conversation header
+// disagree: the header demoted them and fell through to the truncated address,
+// the sidebar rendered them literally, so the same row read as "Unknown User"
+// with a "?" avatar in one place and "QmYVto…LjDd" with a "Q" avatar in the
+// other.
+//
+// The literal is stored in English at write time (MessageService /
+// NewDirectMessageModal), so it is matched as a constant here and deliberately
+// NOT run through the i18n macro — a translated UI must still recognise a row
+// written before the language changed.
+//
+// Spaces have the same class of placeholder problem (see
+// .agents/bugs/2026-06-13-space-members-missing-no-join-row.md); this module is
+// the intended home for that rule too if it is fixed the same way.
+
+import { DefaultImages } from '../utils';
+
+/** The literal written to a conversation row when no identity is known. */
+export const UNKNOWN_USER_PLACEHOLDER = 'Unknown User';
+
+/** True when a stored display name carries no real identity. */
+export const isPlaceholderDisplayName = (name?: string | null): boolean =>
+  !name || name === UNKNOWN_USER_PLACEHOLDER;
+
+/** True when a stored avatar carries no real identity. */
+export const isPlaceholderIcon = (icon?: string | null): boolean =>
+  !icon || icon === DefaultImages.UNKNOWN_USER;
+
+/**
+ * The display name if it is real, else `undefined` — so callers fall through
+ * to whatever their next precedence step is (public profile, then address).
+ */
+export const realDisplayNameOrUndefined = (
+  name?: string | null
+): string | undefined => (isPlaceholderDisplayName(name) ? undefined : name!);
+
+/**
+ * The avatar if it is real, else `undefined` — so `UserAvatar` degrades to
+ * address/name-derived initials rather than rendering a placeholder image.
+ */
+export const realIconOrUndefined = (
+  icon?: string | null
+): string | undefined => (isPlaceholderIcon(icon) ? undefined : icon!);

--- a/src/utils/identityPlaceholder.ts
+++ b/src/utils/identityPlaceholder.ts
@@ -8,23 +8,51 @@
 // with a "?" avatar in one place and "QmYVto…LjDd" with a "Q" avatar in the
 // other.
 //
-// The literal is stored in English at write time (MessageService /
-// NewDirectMessageModal), so it is matched as a constant here and deliberately
-// NOT run through the i18n macro — a translated UI must still recognise a row
-// written before the language changed.
+// MATCHING IS LOCALE-AWARE, AND HAS TO BE. The write sites use the Lingui `t`
+// macro (NewDirectMessageModal.tsx, MessageService.ts), which evaluates at the
+// ACTIVE LOCALE — so an Italian user's brand-new DM row is persisted as
+// "Utente sconosciuto", not "Unknown User". Matching only the English literal
+// would treat that as a real name and render it verbatim forever, which is the
+// exact bug this module exists to kill, just scoped to non-English users.
+//
+// So we match BOTH: the English literal (rows written by an English client, or
+// before a language switch) AND the current locale's translation. Neither alone
+// is sufficient, because a single row's language depends on the locale that was
+// active when it was written, which can differ from the one active now.
 //
 // Spaces have the same class of placeholder problem (see
 // .agents/bugs/2026-06-13-space-members-missing-no-join-row.md); this module is
 // the intended home for that rule too if it is fixed the same way.
 
+import { t } from '@lingui/core/macro';
 import { DefaultImages } from '../utils';
 
-/** The literal written to a conversation row when no identity is known. */
+/**
+ * The canonical (English) literal. Rows may hold a translation of this instead
+ * — always test with `isPlaceholderDisplayName`, never `=== this`.
+ */
 export const UNKNOWN_USER_PLACEHOLDER = 'Unknown User';
 
-/** True when a stored display name carries no real identity. */
+/**
+ * The active locale's rendering of the placeholder, or undefined if no locale
+ * is activated yet.
+ *
+ * Lingui THROWS on a translation call before `dynamicActivate` has run, and
+ * this predicate is reachable from render paths that can execute during early
+ * startup. An identity check must never be the thing that breaks the app, so a
+ * missing locale degrades to "English literal only" rather than propagating.
+ */
+const localisedPlaceholder = (): string | undefined => {
+  try {
+    return t`Unknown User`;
+  } catch {
+    return undefined;
+  }
+};
+
+/** True when a stored display name carries no real identity, in any locale. */
 export const isPlaceholderDisplayName = (name?: string | null): boolean =>
-  !name || name === UNKNOWN_USER_PLACEHOLDER;
+  !name || name === UNKNOWN_USER_PLACEHOLDER || name === localisedPlaceholder();
 
 /** True when a stored avatar carries no real identity. */
 export const isPlaceholderIcon = (icon?: string | null): boolean =>

--- a/src/utils/resolveMemberName.ts
+++ b/src/utils/resolveMemberName.ts
@@ -1,4 +1,5 @@
 import { resolveDisplayName as resolveSharedDisplayName } from '@quilibrium/quorum-shared';
+import { realDisplayNameOrUndefined } from './identityPlaceholder';
 
 export interface ResolvedMemberName {
   /** The readable name to display. Never empty (falls back to the address). */
@@ -38,7 +39,13 @@ export function resolveMemberName(
   const { name, isQnsVerified } = resolveSharedDisplayName(
     {
       address: member.address,
-      display_name: member.displayName ?? undefined,
+      // The stored `'Unknown User'` literal is a placeholder, not a name.
+      // Demote it here — the single choke point every name surface goes
+      // through — so the ladder continues to QNS and then the truncated
+      // address instead of rendering the placeholder verbatim. Without this
+      // the sidebar showed "Unknown User" while the header, which demoted it
+      // inline, showed the address for the very same row.
+      display_name: realDisplayNameOrUndefined(member.displayName),
       primary_username: member.primaryUsername ?? undefined,
     },
     { spaceOverrideName: opts.spaceOverrideName },


### PR DESCRIPTION
A DM partner could render permanently as "Unknown User" or a truncated address, with no way to recover. Identity only ever reached the local conversation row during Double Ratchet session *setup*, so once a session was established nothing refreshed it, and a partner who has not published a public profile had no recovery path at all. Sending more messages did not help.

This restores parity with mobile, which already does both halves of the fix.

## The fix

**Keep the identity we decrypt.** The `DoubleRatchetInboxDecrypt` branch read `user_profile` to pick a ratchet-state shape and then returned `updatedUserProfile: undefined`, discarding the sender's name and avatar. It now carries them through, guarded on self-address so a multi-device self-echo cannot overwrite a partner's row. Measured on a live session, that field is absent on ordinary established-session frames, so this is necessary but not sufficient on its own.

**Announce identity on connect.** This is the actual recovery path, and the only one that works for a partner with no public profile. Previously identity was pushed only when the user saved their profile. A per-partner dedup gate keeps an unchanged identity a no-op on the wire; the gate expires after 24h so a single lost frame cannot break convergence permanently. Fired from both a startup timer and on reconnect, because a cold load opens the socket before the reconnect hook is registered.

**One placeholder rule.** The same row rendered as "Unknown User" with a "?" avatar in the DM list and as a truncated address with initials in the header. Three surfaces each carried their own copy of the "is this a placeholder" rule and only one applied it. The rule now lives in `utils/identityPlaceholder` and is applied inside `resolveMemberName`, the choke point every name surface already goes through. Matching is locale-aware: the placeholder is written with the i18n macro, so a non-English row holds a translated string.

**Empty means absent.** Incoming profile fields now merge with `||` rather than `??`. A frame carrying a real name and a blank avatar (any partner with no picture set) would otherwise overwrite a known-good stored icon with an empty string.

## Review findings addressed

An independent review pass caught three defects, two of them introduced by this branch:

1. `db.saveMessage` writes identity onto the conversation row unconditionally and runs *before* the guarded merge, so a partial profile wiped a good icon. Both call sites now merge instead of substituting wholesale.
2. Placeholder matching was locale-blind, which regressed non-English users. Fixed, and made safe against the i18n layer throwing before a locale is activated.
3. Overlapping broadcasts could double-send, since the gate was only recorded after the network call resolved. Added a synchronous in-flight claim plus timer cancellation.

## Notes

- The 24h re-announce interval is a placeholder, annotated as such in the code. It scales with the user base rather than with the failure rate, and a better cadence is being researched separately.
- A related issue in spaces has the same root cause and is tracked separately.

## Verification

- `tsc --noEmit` clean
- 703 tests passing across 48 files, including new coverage for the merge rule, the placeholder rule, and the gate (expiry, in-flight claim, legacy-format migration)
- Confirmed end to end on two desktop clients: a partner stuck on a placeholder recovered with no user action and no refresh
