### PR TITLE
fix: DB Inspector reads the live DB schema instead of a hardcoded version

### DIFF
--- a/.agents/docs/quorum-db-schema.md
+++ b/.agents/docs/quorum-db-schema.md
@@ -16,6 +16,7 @@ Quick reference for debugging and creating console snippets.
 |----------|-------|
 | **Database Name** | `quorum_db` |
 | **Current Version** | 14 |
+| **Version Constant** | `src/db/dbVersion.ts` (`QUORUM_DB_VERSION`) |
 | **Schema Location** | `src/db/messages.ts` |
 
 > **Dev gotcha (not a real-user issue):** IndexedDB only runs upgrades on a
@@ -28,6 +29,17 @@ Quick reference for debugging and creating console snippets.
 > versioned build, so they can't hit this. The app closes its own connection on
 > `versionchange` (so a delete/upgrade isn't blocked by its own tab); a second
 > open tab can still block it.
+
+> **Writing a dev tool or console snippet that reads this DB?** Open it with
+> `openQuorumDb()` (`src/dev/openQuorumDb.ts`), or with a bare
+> `indexedDB.open('quorum_db')` — **never with an explicit version**. IndexedDB
+> throws `VersionError` when the requested version is lower than the stored one,
+> so a hardcoded version constant breaks the tool on the next schema bump (this
+> is what silently killed the DB Inspector between v7 and v14). Read `db.version`
+> and `db.objectStoreNames` afterwards to discover the live schema. Note that a
+> version-less open still *creates* the database at v1 if it is missing, which
+> makes `MessageDB.init()` skip its `oldVersion < 1` block and leave the app with
+> no stores — `openQuorumDb()` aborts and rolls that back for you.
 
 ---
 
@@ -656,6 +668,11 @@ for (const s of stores) console.log(s, await countStore(s));
 | 13 | Added: search_indices store (persisted MiniSearch full-text indices) |
 | 14 | Added: space_member_devices store (per-device space signing keys — durable multi-device) |
 
+**When you bump this:** update `QUORUM_DB_VERSION` in `src/db/dbVersion.ts` (the
+only place the number lives), add the row above, and classify any new store in
+`src/dev/db-inspector/dbDumpUtil.ts` as safe or sensitive —
+`src/dev/tests/db/dbInspectorCoverage.test.ts` fails until you do.
+
 ---
 
-*Last updated: 2026-07-20*
+*Last updated: 2026-08-01*

--- a/src/db/dbVersion.ts
+++ b/src/db/dbVersion.ts
@@ -1,0 +1,16 @@
+/**
+ * Single source of truth for the IndexedDB name and schema version.
+ *
+ * Kept in its own module (rather than as constants inside `messages.ts`) so dev
+ * tools and tests can import the expected version without pulling in the whole
+ * `MessageDB` class and its MiniSearch dependency.
+ *
+ * Bump `QUORUM_DB_VERSION` whenever you add a store or an index in
+ * `messages.ts`'s `onupgradeneeded` chain, and update
+ * `.agents/docs/quorum-db-schema.md`.
+ */
+
+export const QUORUM_DB_NAME = 'quorum_db';
+
+/** Schema version the app opens the database at. */
+export const QUORUM_DB_VERSION = 14;

--- a/src/db/messages.ts
+++ b/src/db/messages.ts
@@ -7,6 +7,7 @@ import type { SpaceNotificationSettings } from '../types/notifications';
 import type { IconColor } from '../components/space/IconPicker/types';
 import type { IconName } from '../components/primitives';
 import type { QueueTask, TaskStatus, QueueStats } from '../types/actionQueue';
+import { QUORUM_DB_NAME, QUORUM_DB_VERSION } from './dbVersion';
 import MiniSearch, { type Options } from 'minisearch';
 
 export interface EncryptedMessage {
@@ -202,8 +203,8 @@ interface StoredSearchIndex {
 
 export class MessageDB {
   private db: IDBDatabase | null = null;
-  private readonly DB_NAME = 'quorum_db';
-  private readonly DB_VERSION = 14;
+  private readonly DB_NAME = QUORUM_DB_NAME;
+  private readonly DB_VERSION = QUORUM_DB_VERSION;
   private searchIndices: Map<string, MiniSearch<SearchableMessage>> = new Map();
   private indexLoadPromises: Map<string, Promise<void>> = new Map();
   private dirtyIndices: Set<string> = new Set();

--- a/src/dev/README.md
+++ b/src/dev/README.md
@@ -70,15 +70,30 @@ Comprehensive development suite for building and managing cross-platform compone
 
 - `DbInspector.tsx` - Visual UI for browsing all database stores
 - `dbDumpUtil.ts` - Core dump logic with security redaction
-- Shows record counts for all 14 stores
+- Shows record counts for every store found in the database
 - Click any store to browse its records (with sensitive data redacted)
 - Copy buttons to export safe JSON for debugging
-- Console commands: `__dbDump()`, `__dbCounts()`, `__dbStore(name)`
+- Console commands: `__dbDump()`, `__dbCounts()`, `__dbStore(name)`, `__dbInfo()`
+
+**Schema drift is designed out** (it used to break the tool on every schema bump):
+- The version and the store list are read from the live database at runtime via
+  `openQuorumDb()` — nothing about the schema is hardcoded here
+- Never open `quorum_db` with an explicit version from a dev tool: IndexedDB
+  throws `VersionError` when the requested version is lower than the stored one,
+  which is exactly what a stale constant produces
+- A store present in the DB but not classified in `dbDumpUtil.ts` is fully
+  redacted and flagged in the UI, so new stores fail closed rather than leaking
+- `src/dev/tests/db/dbInspectorCoverage.test.ts` fails CI if a store is added to
+  `messages.ts` without being classified, or if the tool lists one that no longer exists
+- The header warns when the live DB version differs from `QUORUM_DB_VERSION`
+  (`src/db/dbVersion.ts`), which is the branch-switching gotcha in
+  `.agents/docs/quorum-db-schema.md`
 
 **Security Features**:
 - Private keys show as `[REDACTED:64chars]`
 - Public keys show truncated (first 8 + last 4 chars)
 - Encryption states show as `[ENCRYPTED_STATE:Xbytes]`
+- Private user notes and serialized search indices are redacted
 - Safe to use with real accounts
 
 ### 🧭 Navigation System

--- a/src/dev/db-inspector/DbInspector.tsx
+++ b/src/dev/db-inspector/DbInspector.tsx
@@ -7,20 +7,18 @@ import {
 } from '../../components/primitives';
 import { DevNavMenu } from '../DevNavMenu';
 import {
-  getStoreCounts,
+  getDbInfo,
   dumpStore,
   dumpDatabase,
   formatDumpForCopy,
-  ALL_STORES,
-  SENSITIVE_STORES,
+  classifyStore,
+  type DbInfo,
   type StoreName,
   type StoreDump,
 } from './dbDumpUtil';
 
-const SENSITIVE_SET = new Set<string>(SENSITIVE_STORES);
-
 export const DbInspector: React.FC = () => {
-  const [counts, setCounts] = useState<Record<string, number> | null>(null);
+  const [info, setInfo] = useState<DbInfo | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [selectedStore, setSelectedStore] = useState<StoreName | null>(null);
@@ -28,7 +26,7 @@ export const DbInspector: React.FC = () => {
   const [storeLoading, setStoreLoading] = useState(false);
   const [copyStatus, setCopyStatus] = useState<string | null>(null);
 
-  // Load store counts on mount
+  // Load the live schema (version + stores + counts) on mount
   useEffect(() => {
     loadCounts();
   }, []);
@@ -37,8 +35,8 @@ export const DbInspector: React.FC = () => {
     setLoading(true);
     setError(null);
     try {
-      const result = await getStoreCounts();
-      setCounts(result);
+      const result = await getDbInfo();
+      setInfo(result);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load database');
     } finally {
@@ -86,9 +84,11 @@ export const DbInspector: React.FC = () => {
     }
   };
 
-  const totalRecords = counts
-    ? Object.values(counts).reduce((a, b) => a + b, 0)
+  const totalRecords = info
+    ? Object.values(info.counts).reduce((a, b) => a + b, 0)
     : 0;
+
+  const versionMismatch = info != null && info.dbVersion !== info.appDbVersion;
 
   return (
     <div className="min-h-screen bg-app">
@@ -104,7 +104,9 @@ export const DbInspector: React.FC = () => {
                 DB Inspector
               </Text>
               <Text variant="subtle" size="sm">
-                IndexedDB browser with redacted sensitive data
+                {info
+                  ? `${info.dbName} v${info.dbVersion} · IndexedDB browser with redacted sensitive data`
+                  : 'IndexedDB browser with redacted sensitive data'}
               </Text>
             </div>
           </Flex>
@@ -154,6 +156,38 @@ export const DbInspector: React.FC = () => {
           </div>
         )}
 
+        {/* Schema drift: the DB on this origin isn't the one this build writes.
+            Usually means branch-switching against the same localhost origin —
+            see the dev gotcha in .agents/docs/quorum-db-schema.md. */}
+        {!loading && versionMismatch && info && (
+          <div className="bg-yellow-500/10 border border-yellow-500/30 rounded-lg p-4 mb-6">
+            <Text variant="strong" className="text-yellow-500">
+              Schema drift: database is at v{info.dbVersion}, this build expects v
+              {info.appDbVersion}
+            </Text>
+            <Text variant="subtle" size="sm" className="mt-1">
+              {info.missingStores.length > 0
+                ? `Missing stores: ${info.missingStores.join(', ')}. `
+                : ''}
+              Reset the DB (Settings → Danger Zone → Reset App Data) or reload the app to
+              let it upgrade.
+            </Text>
+          </div>
+        )}
+
+        {/* Stores present in the DB that have no redaction rule yet */}
+        {!loading && info && info.unclassifiedStores.length > 0 && (
+          <div className="bg-yellow-500/10 border border-yellow-500/30 rounded-lg p-4 mb-6">
+            <Text variant="strong" className="text-yellow-500">
+              Unclassified stores: {info.unclassifiedStores.join(', ')}
+            </Text>
+            <Text variant="subtle" size="sm" className="mt-1">
+              Every field is redacted until they are added to SAFE_STORES or
+              SENSITIVE_STORES in dbDumpUtil.ts.
+            </Text>
+          </div>
+        )}
+
         {/* Loading state */}
         {loading && (
           <div className="text-center py-12">
@@ -163,7 +197,7 @@ export const DbInspector: React.FC = () => {
         )}
 
         {/* Main content */}
-        {!loading && counts && (
+        {!loading && info && (
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
             {/* Store list */}
             <div className="lg:col-span-1">
@@ -174,9 +208,10 @@ export const DbInspector: React.FC = () => {
                 </Flex>
 
                 <div className="space-y-2">
-                  {ALL_STORES.map((storeName) => {
-                    const count = counts[storeName] || 0;
-                    const isSensitive = SENSITIVE_SET.has(storeName);
+                  {info.stores.map((storeName) => {
+                    const count = info.counts[storeName] || 0;
+                    const classification = classifyStore(storeName);
+                    const isSensitive = classification !== 'safe';
                     const isSelected = selectedStore === storeName;
 
                     return (
@@ -196,7 +231,11 @@ export const DbInspector: React.FC = () => {
                                 name="lock"
                                 size="xs"
                                 className="text-yellow-500"
-                                title="Contains redacted data"
+                                title={
+                                  classification === 'unclassified'
+                                    ? 'Unclassified store — all fields redacted'
+                                    : 'Contains redacted data'
+                                }
                               />
                             )}
                             <Text
@@ -257,9 +296,11 @@ export const DbInspector: React.FC = () => {
                         <Text variant="strong" size="lg" className="font-mono">
                           {storeData.name}
                         </Text>
-                        {SENSITIVE_SET.has(storeData.name) && (
+                        {storeData.classification !== 'safe' && (
                           <span className="bg-yellow-500/20 text-yellow-500 text-xs px-2 py-0.5 rounded">
-                            Redacted
+                            {storeData.classification === 'unclassified'
+                              ? 'Unclassified'
+                              : 'Redacted'}
                           </span>
                         )}
                       </Flex>
@@ -303,6 +344,7 @@ export const DbInspector: React.FC = () => {
             <div><span className="text-accent">__dbDump(true)</span> - Dump all stores including messages</div>
             <div><span className="text-accent">__dbCounts()</span> - Show record counts table</div>
             <div><span className="text-accent">__dbStore('action_queue')</span> - Dump specific store</div>
+            <div><span className="text-accent">__dbInfo()</span> - Live DB version, store list, drift</div>
           </div>
         </div>
       </div>

--- a/src/dev/db-inspector/dbDumpUtil.ts
+++ b/src/dev/db-inspector/dbDumpUtil.ts
@@ -7,17 +7,29 @@
  * SECURITY: Private keys and encryption states are redacted but their
  * presence/length is preserved for debugging purposes.
  *
+ * SCHEMA DRIFT: this module deliberately knows NOTHING about the current schema
+ * version or store list up front — both are read from the live database at
+ * runtime (see `openDb` / `listStores`). A hardcoded `DB_VERSION` here used to
+ * go stale on every schema bump and made the whole tool throw `VersionError`
+ * (IndexedDB refuses to open an existing DB at a LOWER version than it is
+ * stamped at). The only schema knowledge left is the redaction classification
+ * below, and stores missing from it are redacted by default (fail closed) and
+ * flagged in the UI. `dbInspectorCoverage.test.ts` fails the moment a new store
+ * is added to `messages.ts` without being classified here.
+ *
  * NOTE: This file is in src/dev/ which is only included in development builds.
  * Additional runtime checks ensure functions are not exposed in production.
  */
+
+import { QUORUM_DB_NAME, QUORUM_DB_VERSION } from '../../db/dbVersion';
+import { openQuorumDb } from '../openQuorumDb';
 
 // Safety check - this module should never be imported in production
 if (typeof process !== 'undefined' && process.env?.NODE_ENV === 'production') {
   throw new Error('db-inspector should not be imported in production builds');
 }
 
-const DB_NAME = 'quorum_db';
-const DB_VERSION = 7;
+const DB_NAME = QUORUM_DB_NAME;
 
 // Stores that are safe to dump in full
 const SAFE_STORES = [
@@ -31,6 +43,9 @@ const SAFE_STORES = [
   'muted_users',
   'action_queue',
   'deleted_messages',
+  'channel_threads',
+  'thread_read_times',
+  'space_member_devices',
 ] as const;
 
 // Stores with sensitive data that need redaction
@@ -40,13 +55,34 @@ const SENSITIVE_STORES = [
   'latest_states',
   'user_config',
   'space_members',
+  'user_notes',
+  'search_indices',
 ] as const;
 
 type SafeStore = (typeof SAFE_STORES)[number];
 type SensitiveStore = (typeof SENSITIVE_STORES)[number];
-type StoreName = SafeStore | SensitiveStore;
+/** A store this module knows how to classify. Discovery returns plain strings,
+ *  since the live DB may hold stores newer than this list. */
+type KnownStore = SafeStore | SensitiveStore;
+type StoreName = string;
 
-const ALL_STORES: StoreName[] = [...SAFE_STORES, ...SENSITIVE_STORES];
+const CLASSIFIED_STORES: KnownStore[] = [...SAFE_STORES, ...SENSITIVE_STORES];
+
+/** Stores this module can classify, in a stable display order. Note this is NOT
+ *  the list the tool dumps — that comes from the live DB. */
+const ALL_STORES: KnownStore[] = CLASSIFIED_STORES;
+
+const CLASSIFIED_SET = new Set<string>(CLASSIFIED_STORES);
+const SENSITIVE_SET = new Set<string>(SENSITIVE_STORES);
+
+/** Redaction state of a store, as reported in dumps and in the UI. */
+export type StoreClassification = 'safe' | 'sensitive' | 'unclassified';
+
+export function classifyStore(storeName: string): StoreClassification {
+  if (SENSITIVE_SET.has(storeName)) return 'sensitive';
+  if (CLASSIFIED_SET.has(storeName)) return 'safe';
+  return 'unclassified';
+}
 
 /**
  * Redact a sensitive string, preserving length info
@@ -123,9 +159,49 @@ function redactSpaceMember(record: Record<string, unknown>): Record<string, unkn
 }
 
 /**
+ * Redact a user_notes record. The note body is a private annotation one user
+ * wrote about another and is never synced — keep it out of pasted dumps.
+ */
+function redactUserNote(record: Record<string, unknown>): Record<string, unknown> {
+  return {
+    ...record,
+    note: redactString(record.note, 'note'),
+  };
+}
+
+/**
+ * Redact a search_indices record. `serializedIndex` is the full message corpus
+ * for a conversation — both private and large enough to swamp a dump.
+ */
+function redactSearchIndex(record: Record<string, unknown>): Record<string, unknown> {
+  return {
+    ...record,
+    serializedIndex: redactString(record.serializedIndex, 'serializedIndex'),
+  };
+}
+
+/**
+ * Fallback redaction for a store this module doesn't know about yet (added to
+ * `messages.ts` without being classified here). Field names survive so the
+ * shape is still debuggable; every value is replaced by a type/size descriptor
+ * so nothing sensitive can leak from a store nobody has reviewed.
+ */
+function redactUnclassified(record: Record<string, unknown>): Record<string, unknown> {
+  const redacted: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(record)) {
+    if (value === null) redacted[key] = '[NULL]';
+    else if (value === undefined) redacted[key] = '[MISSING]';
+    else if (typeof value === 'string') redacted[key] = `[UNCLASSIFIED:string:${value.length}chars]`;
+    else if (Array.isArray(value)) redacted[key] = `[UNCLASSIFIED:array:${value.length}items]`;
+    else redacted[key] = `[UNCLASSIFIED:${typeof value}]`;
+  }
+  return redacted;
+}
+
+/**
  * Apply redaction to a record based on store name
  */
-function redactRecord(storeName: StoreName, record: Record<string, unknown>): Record<string, unknown> {
+function redactRecord(storeName: string, record: Record<string, unknown>): Record<string, unknown> {
   switch (storeName) {
     case 'space_keys':
       return redactSpaceKey(record);
@@ -136,20 +212,30 @@ function redactRecord(storeName: StoreName, record: Record<string, unknown>): Re
       return redactUserConfig(record);
     case 'space_members':
       return redactSpaceMember(record);
+    case 'user_notes':
+      return redactUserNote(record);
+    case 'search_indices':
+      return redactSearchIndex(record);
     default:
-      return record;
+      return classifyStore(storeName) === 'safe' ? record : redactUnclassified(record);
   }
 }
 
-/**
- * Open the database
- */
+/** Open at whatever version the database is currently stamped at — see
+ *  `openQuorumDb` for why no version is passed. */
 async function openDb(): Promise<IDBDatabase> {
-  return new Promise((resolve, reject) => {
-    const req = indexedDB.open(DB_NAME, DB_VERSION);
-    req.onsuccess = () => resolve(req.result);
-    req.onerror = () => reject(new Error(`Failed to open database: ${req.error?.message}`));
-  });
+  return openQuorumDb(DB_NAME);
+}
+
+/** Store names present in the live database, in a stable order: classified
+ *  stores first (in declaration order), then anything unrecognised. */
+function listStores(db: IDBDatabase): string[] {
+  const present = new Set(Array.from(db.objectStoreNames));
+  const known = CLASSIFIED_STORES.filter((name) => present.has(name));
+  const unknown = Array.from(present)
+    .filter((name) => !CLASSIFIED_SET.has(name))
+    .sort();
+  return [...known, ...unknown];
 }
 
 /**
@@ -190,7 +276,7 @@ async function countStore(db: IDBDatabase, storeName: string): Promise<number> {
 export interface DbDumpOptions {
   /** Include full records (default: true for stores with <100 records) */
   includeRecords?: boolean;
-  /** Stores to include (default: all) */
+  /** Stores to include (default: every store present in the database) */
   stores?: StoreName[];
   /** Max records per store (default: 100) */
   maxRecords?: number;
@@ -203,14 +289,63 @@ export interface StoreDump {
   count: number;
   records?: unknown[];
   truncated?: boolean;
+  /** How this store's records were redacted. */
+  classification?: StoreClassification;
 }
 
 export interface DbDump {
   timestamp: string;
   dbName: string;
+  /** Version the live database is actually stamped at. */
   dbVersion: number;
+  /** Version this build of the app opens the database at. A mismatch means the
+   *  DB predates the running build (or was written by a newer branch). */
+  appDbVersion: number;
   stores: StoreDump[];
   summary: Record<string, number>;
+  /** Stores found in the database that this tool has no redaction rule for. */
+  unclassifiedStores?: string[];
+}
+
+/** Live schema shape, read from the database rather than assumed. */
+export interface DbInfo {
+  dbName: string;
+  dbVersion: number;
+  appDbVersion: number;
+  stores: string[];
+  counts: Record<string, number>;
+  unclassifiedStores: string[];
+  /** Classified stores the live database doesn't have (usually: the DB predates
+   *  a schema bump and needs a reset — see the dev gotcha in
+   *  `.agents/docs/quorum-db-schema.md`). */
+  missingStores: string[];
+}
+
+/**
+ * Read the live database's version, store list and record counts.
+ */
+export async function getDbInfo(): Promise<DbInfo> {
+  const db = await openDb();
+
+  try {
+    const stores = listStores(db);
+    const counts: Record<string, number> = {};
+    for (const storeName of stores) {
+      counts[storeName] = await countStore(db, storeName);
+    }
+
+    return {
+      dbName: DB_NAME,
+      dbVersion: db.version,
+      appDbVersion: QUORUM_DB_VERSION,
+      stores,
+      counts,
+      unclassifiedStores: stores.filter((name) => !CLASSIFIED_SET.has(name)),
+      missingStores: CLASSIFIED_STORES.filter((name) => !stores.includes(name)),
+    };
+  } finally {
+    db.close();
+  }
 }
 
 /**
@@ -219,26 +354,35 @@ export interface DbDump {
 export async function dumpDatabase(options: DbDumpOptions = {}): Promise<DbDump> {
   const {
     includeRecords = true,
-    stores = ALL_STORES,
+    stores,
     maxRecords = 100,
     includeMessages = false,
   } = options;
 
   const db = await openDb();
+  const present = listStores(db);
+  const selected = stores ? stores.filter((name) => present.includes(name)) : present;
+
   const result: DbDump = {
     timestamp: new Date().toISOString(),
     dbName: DB_NAME,
-    dbVersion: DB_VERSION,
+    dbVersion: db.version,
+    appDbVersion: QUORUM_DB_VERSION,
     stores: [],
     summary: {},
   };
 
+  const unclassified = selected.filter((name) => !CLASSIFIED_SET.has(name));
+  if (unclassified.length > 0) result.unclassifiedStores = unclassified;
+
   try {
-    for (const storeName of stores) {
+    for (const storeName of selected) {
+      const classification = classifyStore(storeName);
+
       // Skip messages by default (can be very large)
       if (storeName === 'messages' && !includeMessages) {
         const count = await countStore(db, storeName);
-        result.stores.push({ name: storeName, count, records: undefined });
+        result.stores.push({ name: storeName, count, records: undefined, classification });
         result.summary[storeName] = count;
         continue;
       }
@@ -247,17 +391,17 @@ export async function dumpDatabase(options: DbDumpOptions = {}): Promise<DbDump>
       result.summary[storeName] = count;
 
       if (!includeRecords) {
-        result.stores.push({ name: storeName, count });
+        result.stores.push({ name: storeName, count, classification });
         continue;
       }
 
       const records = await readStore(db, storeName);
-      const isSensitive = (SENSITIVE_STORES as readonly string[]).includes(storeName);
 
-      // Redact if sensitive
-      const processedRecords = isSensitive
-        ? records.map((r) => redactRecord(storeName as StoreName, r as Record<string, unknown>))
-        : records;
+      // Redact unless the store is on the known-safe list (fail closed)
+      const processedRecords =
+        classification === 'safe'
+          ? records
+          : records.map((r) => redactRecord(storeName, r as Record<string, unknown>));
 
       // Truncate if too many
       const truncated = processedRecords.length > maxRecords;
@@ -268,6 +412,7 @@ export async function dumpDatabase(options: DbDumpOptions = {}): Promise<DbDump>
         count,
         records: finalRecords,
         truncated: truncated || undefined,
+        classification,
       });
     }
   } finally {
@@ -284,13 +429,21 @@ export async function dumpStore(storeName: StoreName, maxRecords = 100): Promise
   const db = await openDb();
 
   try {
+    if (!db.objectStoreNames.contains(storeName)) {
+      throw new Error(
+        `Store "${storeName}" is not in ${DB_NAME} v${db.version}. ` +
+          `The database may predate this build (app expects v${QUORUM_DB_VERSION}) — reset it from Settings → Danger Zone.`
+      );
+    }
+
+    const classification = classifyStore(storeName);
     const count = await countStore(db, storeName);
     const records = await readStore(db, storeName);
-    const isSensitive = (SENSITIVE_STORES as readonly string[]).includes(storeName);
 
-    const processedRecords = isSensitive
-      ? records.map((r) => redactRecord(storeName, r as Record<string, unknown>))
-      : records;
+    const processedRecords =
+      classification === 'safe'
+        ? records
+        : records.map((r) => redactRecord(storeName, r as Record<string, unknown>));
 
     const truncated = processedRecords.length > maxRecords;
     const finalRecords = truncated ? processedRecords.slice(0, maxRecords) : processedRecords;
@@ -300,6 +453,7 @@ export async function dumpStore(storeName: StoreName, maxRecords = 100): Promise
       count,
       records: finalRecords,
       truncated: truncated || undefined,
+      classification,
     };
   } finally {
     db.close();
@@ -307,20 +461,10 @@ export async function dumpStore(storeName: StoreName, maxRecords = 100): Promise
 }
 
 /**
- * Get counts for all stores
+ * Get counts for every store present in the database
  */
 export async function getStoreCounts(): Promise<Record<string, number>> {
-  const db = await openDb();
-  const counts: Record<string, number> = {};
-
-  try {
-    for (const storeName of ALL_STORES) {
-      counts[storeName] = await countStore(db, storeName);
-    }
-  } finally {
-    db.close();
-  }
-
+  const { counts } = await getDbInfo();
   return counts;
 }
 
@@ -341,32 +485,39 @@ export async function quickDump(includeMessages = false): Promise<string> {
 
 // Expose to window in development
 if (typeof window !== 'undefined' && import.meta.env?.DEV) {
-   
+
   (window as any).__dbDump = async (includeMessages = false) => {
     const json = await quickDump(includeMessages);
     console.log(json);
     return json;
   };
 
-   
+
   (window as any).__dbCounts = async () => {
     const counts = await getStoreCounts();
     console.table(counts);
     return counts;
   };
 
-   
+
   (window as any).__dbStore = async (storeName: string, maxRecords = 50) => {
-    const dump = await dumpStore(storeName as StoreName, maxRecords);
+    const dump = await dumpStore(storeName, maxRecords);
     console.log(JSON.stringify(dump, null, 2));
     return dump;
   };
 
+
+  (window as any).__dbInfo = async () => {
+    const info = await getDbInfo();
+    console.log(info);
+    return info;
+  };
+
   console.log(
-    '%c[Dev] DB Inspector available: __dbDump(), __dbCounts(), __dbStore(name)',
+    '%c[Dev] DB Inspector available: __dbDump(), __dbCounts(), __dbStore(name), __dbInfo()',
     'color: #22c55e; font-weight: bold'
   );
 }
 
-export { ALL_STORES, SAFE_STORES, SENSITIVE_STORES };
-export type { StoreName };
+export { ALL_STORES, SAFE_STORES, SENSITIVE_STORES, CLASSIFIED_STORES };
+export type { StoreName, KnownStore };

--- a/src/dev/db-inspector/index.ts
+++ b/src/dev/db-inspector/index.ts
@@ -2,11 +2,22 @@ export { DbInspector } from './DbInspector';
 export {
   dumpDatabase,
   dumpStore,
+  getDbInfo,
   getStoreCounts,
   quickDump,
   formatDumpForCopy,
+  classifyStore,
   ALL_STORES,
   SAFE_STORES,
   SENSITIVE_STORES,
+  CLASSIFIED_STORES,
 } from './dbDumpUtil';
-export type { DbDump, StoreDump, DbDumpOptions, StoreName } from './dbDumpUtil';
+export type {
+  DbDump,
+  DbInfo,
+  StoreDump,
+  DbDumpOptions,
+  StoreClassification,
+  StoreName,
+  KnownStore,
+} from './dbDumpUtil';

--- a/src/dev/dm-doctor/dmDoctorDb.ts
+++ b/src/dev/dm-doctor/dmDoctorDb.ts
@@ -8,17 +8,11 @@
  * this tool replaces (`.agents/tools/dm-debug/07-receiver-probe.js`).
  */
 
+import { openQuorumDb } from '../openQuorumDb';
 import type { DmDoctorConversationRow, DmDoctorMessageRow } from './dmDoctorCore';
 
-const DB_NAME = 'quorum_db';
-
 function openDb(): Promise<IDBDatabase> {
-  return new Promise((resolve, reject) => {
-    const request = indexedDB.open(DB_NAME);
-    request.onsuccess = () => resolve(request.result);
-    request.onerror = () =>
-      reject(request.error ?? new Error(`Failed to open ${DB_NAME}`));
-  });
+  return openQuorumDb();
 }
 
 function readAll<T>(db: IDBDatabase, storeName: string): Promise<T[]> {

--- a/src/dev/openQuorumDb.ts
+++ b/src/dev/openQuorumDb.ts
@@ -1,0 +1,57 @@
+/**
+ * Shared read-only opener for `quorum_db`, used by the dev tools (DB Inspector,
+ * DM Doctor).
+ *
+ * Two rules, both learned the hard way:
+ *
+ * 1. **Never pass a version.** IndexedDB refuses to open an existing database at
+ *    a LOWER version than it is stamped at (`VersionError`), so any hardcoded
+ *    version here goes stale — and breaks the tool — on the next schema bump.
+ *    A version-less open takes the database exactly as it is and never fires an
+ *    upgrade. Read `db.version` / `db.objectStoreNames` afterwards to learn the
+ *    live schema.
+ *
+ * 2. **A version-less open still CREATES the database if it is missing**, at
+ *    version 1 with no stores. That is worse than an error: `MessageDB.init()`
+ *    only creates its initial stores when `oldVersion < 1`, so a stray v1
+ *    database leaves the app with no stores at all. An upgrade event here means
+ *    the database was absent, so the creation is aborted and rolled back and the
+ *    caller gets a clear error instead.
+ */
+
+import { QUORUM_DB_NAME } from '../db/dbVersion';
+
+export class QuorumDbMissingError extends Error {
+  constructor(dbName: string) {
+    super(`Database "${dbName}" does not exist yet. Open the app and sign in first.`);
+    this.name = 'QuorumDbMissingError';
+  }
+}
+
+export function openQuorumDb(dbName = QUORUM_DB_NAME): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(dbName);
+    let missing = false;
+
+    req.onupgradeneeded = (event) => {
+      missing = true;
+      (event.target as IDBOpenDBRequest).transaction?.abort();
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => {
+      if (!missing) {
+        reject(req.error ?? new Error(`Failed to open ${dbName}`));
+        return;
+      }
+      // Belt and braces: don't rely on every engine rolling the aborted
+      // creation back identically. Nothing holds a connection after an aborted
+      // upgrade, so this can't block, and it can only ever target a database we
+      // just created ourselves.
+      const del = indexedDB.deleteDatabase(dbName);
+      const done = () => reject(new QuorumDbMissingError(dbName));
+      del.onsuccess = done;
+      del.onerror = done;
+      del.onblocked = done;
+    };
+  });
+}

--- a/src/dev/tests/db/dbInspectorCoverage.test.ts
+++ b/src/dev/tests/db/dbInspectorCoverage.test.ts
@@ -1,0 +1,145 @@
+import 'fake-indexeddb/auto';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { MessageDB } from '../../../db/messages';
+import { QUORUM_DB_VERSION } from '../../../db/dbVersion';
+import {
+  getDbInfo,
+  dumpDatabase,
+  dumpStore,
+  classifyStore,
+  CLASSIFIED_STORES,
+} from '../../db-inspector/dbDumpUtil';
+
+// Guards the DB Inspector against schema drift. It used to hardcode
+// `DB_VERSION = 7` and a fixed store list, so every schema bump silently broke
+// it: opening an existing v14 database at v7 throws VersionError, and stores
+// added after v7 were invisible. These tests fail the moment either kind of
+// drift reappears.
+describe('DB Inspector - schema coverage', () => {
+  let db: MessageDB;
+
+  beforeEach(async () => {
+    const FDBFactory = (await import('fake-indexeddb/lib/FDBFactory')).default;
+    globalThis.indexedDB = new FDBFactory();
+    db = new MessageDB();
+    await db.init(); // creates quorum_db at the app's current DB_VERSION
+  });
+
+  it('opens the database at whatever version the app created it at', async () => {
+    const info = await getDbInfo();
+
+    expect(info.dbVersion).toBe(QUORUM_DB_VERSION);
+    expect(info.appDbVersion).toBe(QUORUM_DB_VERSION);
+    expect(info.dbName).toBe('quorum_db');
+  });
+
+  it('classifies every store the app actually creates', async () => {
+    const info = await getDbInfo();
+
+    // A new store in messages.ts with no entry in SAFE_STORES/SENSITIVE_STORES
+    // lands here. Classify it in dbDumpUtil.ts rather than deleting this
+    // assertion — unclassified stores are fully redacted and unreadable.
+    expect(info.unclassifiedStores).toEqual([]);
+  });
+
+  it('knows about no stores the app does not create', async () => {
+    const info = await getDbInfo();
+
+    // The reverse drift: a store removed from (or renamed in) messages.ts but
+    // still listed in dbDumpUtil.ts.
+    expect(info.missingStores).toEqual([]);
+  });
+
+  it('discovers stores from the live database, not a hardcoded list', async () => {
+    const info = await getDbInfo();
+
+    expect(info.stores.length).toBe(CLASSIFIED_STORES.length);
+    // Spot-check stores added after the stale v7 list was written.
+    expect(info.stores).toContain('space_member_devices');
+    expect(info.stores).toContain('search_indices');
+    expect(info.stores).toContain('user_notes');
+  });
+
+  it('dumps every store without throwing', async () => {
+    const dump = await dumpDatabase();
+
+    expect(dump.dbVersion).toBe(QUORUM_DB_VERSION);
+    expect(dump.stores.map((s) => s.name).sort()).toEqual([...(await getDbInfo()).stores].sort());
+    expect(dump.unclassifiedStores).toBeUndefined();
+  });
+
+  it('reports a helpful error for a store that is not in the database', async () => {
+    await expect(dumpStore('not_a_real_store')).rejects.toThrow(/not in quorum_db/);
+  });
+});
+
+describe('DB Inspector - redaction', () => {
+  beforeEach(async () => {
+    const FDBFactory = (await import('fake-indexeddb/lib/FDBFactory')).default;
+    globalThis.indexedDB = new FDBFactory();
+    await new MessageDB().init();
+  });
+
+  it('redacts private keys in space_keys', async () => {
+    const write = (store: string, value: unknown) =>
+      new Promise<void>((resolve, reject) => {
+        const req = indexedDB.open('quorum_db');
+        req.onsuccess = () => {
+          const idb = req.result;
+          const tx = idb.transaction(store, 'readwrite');
+          tx.objectStore(store).put(value);
+          tx.oncomplete = () => {
+            idb.close();
+            resolve();
+          };
+          tx.onerror = () => {
+            idb.close();
+            reject(tx.error);
+          };
+        };
+        req.onerror = () => reject(req.error);
+      });
+
+    await write('space_keys', {
+      spaceId: 'space-1',
+      keyId: 'key-1',
+      privateKey: 'super-secret-private-key',
+      publicKey: 'pub'.repeat(10),
+    });
+
+    const dump = await dumpStore('space_keys');
+    const record = dump.records?.[0] as Record<string, unknown>;
+
+    expect(dump.classification).toBe('sensitive');
+    expect(record.privateKey).toMatch(/^\[REDACTED:\d+chars\]$/);
+    expect(JSON.stringify(dump)).not.toContain('super-secret-private-key');
+  });
+
+  it('treats an unknown store as sensitive rather than dumping it raw', () => {
+    expect(classifyStore('some_future_store')).toBe('unclassified');
+    expect(classifyStore('space_keys')).toBe('sensitive');
+    expect(classifyStore('messages')).toBe('safe');
+  });
+});
+
+describe('DB Inspector - missing database', () => {
+  beforeEach(async () => {
+    const FDBFactory = (await import('fake-indexeddb/lib/FDBFactory')).default;
+    globalThis.indexedDB = new FDBFactory();
+  });
+
+  it('does not create an empty v1 database when none exists', async () => {
+    // A version-less open would otherwise create quorum_db at v1, which makes
+    // MessageDB.init() skip its `oldVersion < 1` block and leave the app with
+    // no object stores at all.
+    await expect(getDbInfo()).rejects.toThrow(/does not exist yet/);
+
+    const dbs = await indexedDB.databases();
+    expect(dbs.find((d) => d.name === 'quorum_db')).toBeUndefined();
+
+    // And the app can still create it normally afterwards.
+    await new MessageDB().init();
+    const info = await getDbInfo();
+    expect(info.dbVersion).toBe(QUORUM_DB_VERSION);
+  });
+});


### PR DESCRIPTION
The `/dev/db-inspector` tool was dead, not just stale: it opened `quorum_db` at a hardcoded `DB_VERSION = 7` while the app is at 14. IndexedDB refuses to open an existing database at a lower version than it is stamped at, so every call threw `VersionError`. Its hardcoded store list was stuck at v7 too, hiding `channel_threads`, `thread_read_times`, `user_notes`, `search_indices` and `space_member_devices`.

## The fix

Open with **no version** and read `db.version` / `db.objectStoreNames` from the live connection. Nothing about the schema is hardcoded in the tool any more, so a schema bump cannot break it.

A version-less open does create the database at v1 when it is missing, which would make `MessageDB.init()` skip its `oldVersion < 1` block and leave the app with no stores at all. The new shared opener (`src/dev/openQuorumDb.ts`) aborts that upgrade, rolls it back, and reports a clear error instead. DM Doctor had the same hole and now uses the same opener.

## Guards against it rotting again

- **Fail-closed redaction** — a store present in the database with no redaction rule has every field replaced by a type/size descriptor and is flagged in the UI, instead of being silently invisible as before.
- **CI coverage test** — `dbInspectorCoverage.test.ts` builds the real database via `MessageDB` and fails if a store is unclassified, if the tool lists one that no longer exists, or if opening or dumping throws.
- **Drift banner** — `QUORUM_DB_VERSION` now lives alone in `src/db/dbVersion.ts` (the single place the number exists, imported by `messages.ts`), and the inspector header warns when the live database version differs from it. That surfaces the branch-switching gotcha already documented in the schema reference.

Also classifies the five previously missing stores (`user_notes` and `search_indices` redact, since they hold private annotations and the full message corpus respectively; the other three are safe) and adds `__dbInfo()` to the console helpers.

## Verification

`yarn tsc --noEmit` clean; full suite green (712 tests, 49 files), including 9 new tests covering version discovery, store coverage in both directions, redaction, and the missing-database guard.