### PR TITLE
fix: restore yarn lint by ignoring .worktrees, and clear the 4 errors it masked

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,6 +12,13 @@ export default [
       'mobile/android/**',
       'mobile/ios/**',
       'node_modules/**',
+      // Git worktrees live here by convention and are full second checkouts,
+      // each with its own tsconfig.json. Without this, typescript-eslint finds
+      // several candidate tsconfigRootDirs and fails to parse EVERY file:
+      //   "No tsconfigRootDir was set, and multiple candidate TSConfigRootDirs
+      //    are present" — 1383 errors, none of them real.
+      // Already in .gitignore; eslint's flat config does not read that.
+      '.worktrees/**',
       '**/*.config.js',
       'public/wasm_exec.js',
       'mobile/babel.config.js',

--- a/src/components/space/FolderButton.tsx
+++ b/src/components/space/FolderButton.tsx
@@ -41,7 +41,9 @@ const FolderButton: React.FC<FolderButtonProps> = ({
   try {
     const dragContext = useDragStateContext();
     shouldHideTooltip = dragContext.isDragging || dragContext.isContextMenuOpen;
-  } catch {}
+  } catch {
+    /* no drag provider above us — leave the tooltip visible */
+  }
 
   const showIndicators = !isExpanded;
 

--- a/src/dev/scrollDebug.ts
+++ b/src/dev/scrollDebug.ts
@@ -179,7 +179,7 @@ class ScrollDebug {
     this.events = [];
     this.origin = null;
     this.sessionLabel = null;
-    try { sessionStorage.removeItem(STORAGE_KEY); } catch {}
+    try { sessionStorage.removeItem(STORAGE_KEY); } catch { /* sessionStorage unavailable */ }
     // eslint-disable-next-line no-console
     console.log(`${TAG} cleared.`);
   }

--- a/src/dev/tests/hooks/fetchSpaceMentions.unit.test.ts
+++ b/src/dev/tests/hooks/fetchSpaceMentions.unit.test.ts
@@ -1,4 +1,7 @@
-/* globals are injected by vitest (globals: true) — no import needed */
+// Test globals are injected by vitest (globals: true) — no import needed.
+// NB: keep this a LINE comment. As a block comment starting with the word
+// "globals", eslint parses it as a `/* globals */` configuration directive and
+// errors on the rest of the sentence.
 import { fetchSpaceMentions } from '../../../hooks/business/mentions/fetchSpaceMentions';
 
 const ME = 'QmMeAddr0000000000000000000000000000000000';

--- a/src/dev/tests/utils/resolveMemberName.unit.test.ts
+++ b/src/dev/tests/utils/resolveMemberName.unit.test.ts
@@ -37,7 +37,7 @@ describe('resolveMemberName', () => {
     expect(r.isQnsVerified).toBe(false);
     // address-only fallback — non-empty, derived from the address
     expect(r.name.length).toBeGreaterThan(0);
-    expect(ADDR).toContain(r.name.replace(/[…\.]/g, '').slice(0, 4));
+    expect(ADDR).toContain(r.name.replace(/[….]/g, '').slice(0, 4));
   });
 
   it('treats empty/whitespace names as absent', async () => {


### PR DESCRIPTION
`yarn lint` has been unusable: it reported **1383 errors, none of them real**.

## Cause

eslint's flat config does not read `.gitignore`. So even though `.worktrees/` is
ignored by git, eslint walked into `.worktrees/<name>/` — a full second checkout
with its own `tsconfig.json`. typescript-eslint then found several candidate
`tsconfigRootDir`s and failed to parse **every file in the repo**:

```
Parsing error: No tsconfigRootDir was set, and multiple candidate
TSConfigRootDirs are present
```

Anyone using the project's own worktree convention hits this.

## Fix

Add `.worktrees/**` to the ignore list. That drops 1384 problems to 284, of
which 4 were real errors the parse failure had been masking. All four are fixed
here, and all are behaviour-preserving:

- **Two empty `catch {}` blocks** (`FolderButton`, `scrollDebug`). Both are
  deliberate; they now carry a comment saying why.
- **`fetchSpaceMentions.unit.test.ts`** opened with a block comment starting
  with the word `globals`, which eslint parses as a `/* globals */`
  *configuration directive* and then errors on the rest of the sentence. Made it
  a line comment, and noted the trap so it does not come back.
- **An unnecessary escape** (`\.`) inside a character class in
  `resolveMemberName.unit.test.ts`.

## Verification

- `npx eslint . --quiet` is clean (zero errors)
- 712 tests pass
- `npx tsc --noEmit --jsx react-jsx --skipLibCheck` clean
