### PR TITLE
fix: saving a message no longer erases a conversation's name and avatar

### DIFF
--- a/.agents/INDEX.md
+++ b/.agents/INDEX.md
@@ -124,6 +124,7 @@ This is the main index for all documentation, bug reports, and task management.
 - [announce-keys flooding → unbounded per-device admission store](bugs/2026-07-20-announce-keys-flooding-unbounded-admissions.md)
 - [Join-binding hijack: unauthenticated member rebind/blank](bugs/2026-07-20-join-binding-hijack-unauthenticated-member-rebind.md)
 - [Electron keeps the master private key unlocked on disk](bugs/2026-07-31-electron-master-key-at-rest-no-user-secret.md)
+- [Space sync member reconciliation is blind to — and erases — the global identity slot](bugs/2026-08-01-space-sync-member-delta-blind-to-and-erases-global-slot.md)
 - [Reset App Data leaves private keys behind (desktop)](bugs/2026-07-31-reset-app-data-leaves-private-keys-in-keydb.md)
 
 ### Solved Issues

--- a/.agents/bugs/2026-08-01-space-sync-member-delta-blind-to-and-erases-global-slot.md
+++ b/.agents/bugs/2026-08-01-space-sync-member-delta-blind-to-and-erases-global-slot.md
@@ -1,0 +1,151 @@
+---
+type: bug
+title: "Space sync member reconciliation is blind to the global identity slot, and erases it on apply"
+status: open — UNVERIFIED, found by code reading; reproduction steps in §4
+priority: high (if confirmed) — it disables the one mechanism that should make a space identity cadence unnecessary
+created: 2026-08-01
+updated: 2026-08-01
+severity: user-visible — space members render as a truncated address; existing identity can be lost
+area: space sync protocol / space_members / identity resolution
+repos: quorum-desktop (both defects), quorum-shared (defect 1's hash)
+related_bugs:
+  - "2026-06-13-space-members-missing-no-join-row.md"
+related_tasks:
+  - ".agents/tasks/2026-08-01-space-member-identity-announce-on-connect.md"
+  - ".agents/tasks/2026-08-01-identity-announce-cadence-research.md"
+related_docs:
+  - ".agents/docs/features/identity-resolution-and-profile-sync.md"
+related_tools:
+  - ".agents/tools/dm-debug/06-space-member-sources.js"
+---
+
+# Space sync member reconciliation ignores — and erases — the global identity slot
+
+> ⚠️ **Found by reading code during the identity-cadence research
+> (2026-08-01). NOT reproduced live.** §4 is the verification procedure; run it
+> before acting. Context and the work that consumes this fix:
+> `.agents/tasks/2026-08-01-identity-announce-cadence-research.md` Slice 3.
+
+## §1. Why this matters more than it looks
+
+The space side already ships a **receiver-driven, fingerprint-first member
+identity reconciliation** — `requestSync` fires on every connect
+(`src/components/context/MessageDB.tsx:611-631`), peers exchange `MemberDigest`
+(SHA-256 of name + icon), and the responder returns full `SpaceMember` rows for
+exactly the members the requester lacks or has stale.
+
+That is the mechanism people keep proposing to build. It exists. If it worked on
+the identity that actually renders, spaces would need no periodic announce at all.
+These two defects are why it doesn't.
+
+## §2. Defect 1 — the digest hashes the wrong slot
+
+`computeMemberHash` (`quorum-shared/src/sync/utils.ts:140-147`) hashes:
+
+```ts
+const displayNameHash = computeHash(member.display_name || '');
+const iconHash        = computeHash(member.profile_image || '');
+```
+
+Both are the **per-space OVERRIDE slot**. Desktop's adapter, which builds the
+shared `SpaceMember` from the DB row, drops the global slot entirely
+(`src/adapters/indexedDbAdapter.ts:142-154`) — no `global_display_name`, no
+`global_user_icon`, no `global_bio`, no `bio`, no `profileTimestamp`, no
+`globalProfileTimestamp`.
+
+Since the follow-global work (2026-07-16) deliberately **stopped stamping the
+override fields**, the override slot is empty for most members and the global slot
+is what renders (see the identity-resolution doc, "The TWO-SLOT wire model").
+
+**Consequences:**
+
+1. Two clients holding completely different global identity data for a member
+   produce **identical digests** (`hash('')` on both fields) → `computeMemberDiff`
+   (`sync/utils.ts:364-395`) reports no difference → nothing is transferred.
+2. A member the requester is missing *entirely* IS transferred — as a row with
+   **no identity in any slot**. It then renders as a truncated address while
+   looking "present" to everything downstream, including the `join`-row recovery
+   paths. This matches the symptom in
+   `2026-06-13-space-members-missing-no-join-row.md` (46 of 89 senders with no
+   usable row).
+
+## §3. Defect 2 — applying a member delta erases the global slot
+
+`src/services/MessageService.ts:5645-5669` applies the delta:
+
+```ts
+const dbMember = {
+  ...member,                                    // wire member — no global_* (defect 1)
+  user_address: userAddress,
+  user_icon: member.profile_image || member.user_icon,
+  joinedAt: member.joinedAt ?? existing?.joinedAt,   // ← the ONLY field preserved
+};
+await this.messageDB.saveSpaceMember(spaceId, dbMember);
+```
+
+and `saveSpaceMember` does a **full-row replace** (`src/db/messages.ts:1211`):
+
+```ts
+store.put({ ...userProfile, spaceId });
+```
+
+IndexedDB `put` replaces the whole record. Every field absent from `dbMember` is
+destroyed: `global_display_name`, `global_user_icon`, `global_bio`, `bio`,
+`profileTimestamp`, `globalProfileTimestamp` — all real fields, written by
+`applyGlobalProfileSlots` (`MessageService.ts:222-239`).
+
+So a member whose *override* hash differs (the case that does produce a delta)
+loses their global identity on the receiver, and the staleness guards lose their
+timestamps at the same time.
+
+This is the same **"empty means absent"** rule that `utils/conversationProfile.ts`
+enforces, violated at a different write site — the same shape as the deferred
+Slice 4 in `2026-08-01-dm-partner-identity-lost-on-established-sessions.md`, where
+`db.saveMessage` unconditionally stamps the conversation row.
+
+## §4. How to verify (~20 minutes, two desktop clients)
+
+1. Clients A and B, both members of one space, both with a global display name and
+   avatar set, and **no per-space override** in that space.
+2. On A, confirm B's row carries `global_display_name` / `global_user_icon` —
+   `.agents/tools/dm-debug/06-space-member-sources.js`, or read `space_members`
+   directly in DevTools.
+3. Make the two clients disagree about B's global identity (e.g. B renames while A
+   is offline), then reconnect A. `requestSync` fires on the 10s connect timer.
+4. **Defect 1 is confirmed** if no `memberDelta` is produced for B despite the
+   disagreement. Watch for `[MessageService] sync-delta` logs.
+5. **Defect 2 is confirmed** if, after a delta that *does* include B, B's
+   `global_display_name` / `global_user_icon` / `profileTimestamp` are gone from
+   A's row.
+
+## §5. Fix shape (do not implement before §4)
+
+**Defect 2 first** — it is destructive, smaller, and independent.
+
+- Merge instead of replace: read the existing row and preserve any field the wire
+  member does not carry, exactly as `joinedAt` already is. Preferably fix it in
+  `db.saveSpaceMember` so every caller benefits, but note that is a shared write
+  path and needs its own regression pass.
+
+**Defect 1** — two parts, and they must ship together or the digest lies:
+
+- Carry the global slot through `dbMemberToShared` / `sharedMemberToDb`
+  (`src/adapters/indexedDbAdapter.ts:142-166`), which needs the shared
+  `SpaceMember` type to declare the global fields (still outstanding as
+  `.agents/tasks/.done/2026-07-16-quorum-shared-type-two-slot-global-identity-fields.md`
+  — carried via casts today).
+- Include them in `computeMemberHash`. **This changes the digest for every member
+  on both platforms**, so the first exchange after deploy produces a large delta.
+  Bound it, and check mobile computes the identical hash before shipping either
+  side — a one-sided change makes every member look permanently out of sync.
+
+## §6. Relationship to the announce work
+
+If both defects are fixed, the space side needs only a **bootstrap** announce for
+members nobody has a row for (the sibling task's Slice 1), behind a bounded,
+terminating gate. It does **not** need a periodic cadence, and specifically must
+not copy the DM 24h placeholder — see
+`.agents/tasks/2026-08-01-identity-announce-cadence-research.md` Slice 3.
+
+---
+*Last updated: 2026-08-01*

--- a/.agents/tasks/2026-08-01-dm-partner-identity-lost-on-established-sessions.md
+++ b/.agents/tasks/2026-08-01-dm-partner-identity-lost-on-established-sessions.md
@@ -213,7 +213,26 @@ Clearing the poisoned `"Unknown User"` / `/unknown.png` literals off existing ro
 a name the app does not have. That is cosmetic cleanup, not identity recovery, and it
 belongs with Slice 4 as a one-shot migration rather than a user-facing button.
 
-## §5c. The 24h retry interval is a placeholder — see the cadence research task
+## §5c. The 24h retry interval is a placeholder — ✅ DECIDED
+
+> ✅ **2026-08-01: researched and decided in
+> `.agents/tasks/2026-08-01-identity-announce-cadence-research.md`.**
+>
+> **Keep the 24h interval, cap it at 3 retries** per (partner, identity-version),
+> then stop until the identity changes. ~99% cheaper, same convergence, ~5 lines.
+> The retry is a transitional safety net — with reliable delivery one send is
+> enough. ⚠️ The migration is what bites: stamp legacy records with
+> `at = Date.now()`, **not** the stored value, or the whole fleet fires on the
+> first connect after deploy.
+>
+> **Also relevant to this file: Slice 4 below is promoted, not deferred.** The
+> `db.saveMessage` re-stamp is the mechanism that un-converges an already-fixed
+> row, and it is the reason the retries can safely be capped. It is Slice 2 of
+> that task.
+>
+> The prose below is the original framing; its cost figures omit the per-device
+> fan-out multiplier (a DM send emits one frame **per destination inbox**, ~9 on
+> aged accounts).
 
 `RESEND_INTERVAL_MS` in `src/utils/dmProfileGate.ts` is **24h, chosen to bound
 an anti-loss retry, not researched.** It pays a cost on EVERY pair to fix a

--- a/.agents/tasks/2026-08-01-identity-announce-cadence-research.md
+++ b/.agents/tasks/2026-08-01-identity-announce-cadence-research.md
@@ -1,142 +1,400 @@
 ---
 type: task
-title: "Research: a better rule than 'announce your identity once a day' before the user base grows"
-status: open — research, no implementation authorised
-priority: medium (low urgency, rises sharply with user count)
+title: "Identity announce: cap the retries instead of re-sending forever, and fix what un-converges a row"
+status: open — researched and decided 2026-08-01; implementation NOT started
+priority: medium (Slice 2 is higher — it is a live bug)
 created: 2026-08-01
 updated: 2026-08-01
-severity: none today; a bandwidth and battery problem at scale
-area: identity propagation cadence (DMs and spaces)
-repos: quorum-desktop + quorum-mobile (+ likely a wire-format change, so lead-dev input)
+severity: a bandwidth and battery problem at scale, plus one live correctness bug (Slice 2)
+area: identity propagation (DMs and spaces)
+repos: quorum-desktop + quorum-mobile
 related_tasks:
   - ".agents/tasks/2026-08-01-dm-partner-identity-lost-on-established-sessions.md"
   - ".agents/tasks/2026-08-01-space-member-identity-announce-on-connect.md"
+  - ".agents/tasks/transport/README.md"
+related_bugs:
+  - ".agents/bugs/2026-08-01-space-sync-member-delta-blind-to-and-erases-global-slot.md"
 related_docs:
   - ".agents/docs/features/identity-resolution-and-profile-sync.md"
 ---
 
-# Research: a better identity-announce cadence
+# Identity announce: cap the retries
 
-## §0. The question
+> **One file.** Research, decision and work all live here. The only separate
+> document is a distinct defect this uncovered, with its own repro:
+> `.agents/bugs/2026-08-01-space-sync-member-delta-blind-to-and-erases-global-slot.md`.
 
-The DM identity fix (shipped 2026-08-01) makes each client re-announce its name
-and avatar to every DM partner **once every 24 hours**, even when nothing has
-changed, so that a lost announcement cannot leave a partner stuck on a
-placeholder forever.
+## §0. Doesn't this already work? Yes, almost.
 
-**24h is a placeholder value. Nobody researched it.** It was chosen to bound the
-cost of an anti-loss retry, not because it is right.
+The intended design is the simple one, and both halves work:
 
-This task is to find the right shape. **It is research: produce a recommendation
-and a cost model, do not implement.**
+| # | Path | When | Status |
+|---|---|---|---|
+| 1 | **Session init** — B's first frame carries `user_profile` in the envelope; A stores it in the `conversations` row | once, when the DM session is created | ✅ works |
+| 2 | **`dm-update-profile`** — B edits their profile → pushed to every DM partner | on every change | ✅ works |
 
-## §1. Why it needs replacing — the operator's objection, which is correct
+**One hole, and it is narrow.** Identity rides only on the **init** frame. Once
+the session is established, ordinary messages carry nothing — measured 2026-08-01,
+`hasUserProfile: false` on every observation. So if that init frame is lost, B can
+send a thousand more messages and none re-assert who they are. And path 2 fires
+only on *change*, so if B never edits their profile again it never fires again.
 
-> "if the app gets many thousands of users it can become a big waste of data
-> transfer... reporting name and pfp once a day will be a waste in most cases
-> since a missing pfp and avatar is kinda rare"
+The failure needs **both** conditions: A's row is empty **and** B never changes
+their profile. Then it is permanent. That is the reported bug.
 
-That is the crux: **the cost is paid on every pair, to fix a failure that occurs
-on a small fraction of pairs.** The mechanism does not scale with the problem,
-it scales with the population.
+### The honest bottom line
 
-Order of magnitude for DMs (avatar sizes are real, measured from live logs on
-2026-08-01: 9 KB and 51 KB for the two test accounts):
+> **If messages landed 100% of the time, no retry would be needed at all.**
+> One announce per identity would be enough. The retry exists *only* because a
+> lost frame had no second chance.
 
-| Users | Avg DM partners | Avatar | Announcements/day | Daily bytes |
-|---|---|---|---|---|
-| 100 | 10 | 30 KB | 1,000 | ~30 MB |
-| 10,000 | 20 | 30 KB | 200,000 | **~6 GB** |
-| 100,000 | 20 | 30 KB | 2,000,000 | **~60 GB** |
+That is correct, and it is the frame this whole task should be read in. The
+transport was losing **15–20% of messages** (rounds X/Y/Z/Q/R,
+`.agents/tasks/transport/measurements.md`); **send retention shipped** in
+`quorum-shared` 2.1.0-39 and took rounds Q/R (16-17/20) to S/U and the
+published-build round at **20/20**.
 
-To fix something that likely affects low single-digit percentages of pairs. On
-mobile this is also battery and radio wake-ups, not just bytes.
+Two things are still true, from `transport/README.md`:
+- desktop **does not consume that fix yet** (item **B1**, `READY-TO-BUILD`), so
+  desktop's loss rate is unchanged today;
+- the cause is still upstream (item **U1**) — connections died 9 times in 51
+  seconds during the round that scored 20/20. Retention makes loss survivable,
+  not absent.
 
-**Spaces are far less exposed** (one broadcast per space reaches every member,
-rather than one message per recipient), so the DM side is where this bites. Any
-recommendation should say whether the two should even share a cadence.
+**So: a capped retry is a transitional safety net, not architecture.** As delivery
+is proven, the cap should shrink toward 1 and eventually be removed. Nothing in
+this task should be built as if the retry were permanent.
 
-## §2. Constraints any answer must respect
+### What is actually wrong today: the two platforms sit at opposite extremes
 
-1. **Identity is push-based.** There is no directory to query for a user who has
-   not published a public profile. If nobody announces, nobody can know.
-2. **The transport loses messages.** This is documented and measured, not
-   hypothetical. Any design that assumes one delivery is enough will reproduce
-   the permanent-placeholder bug (see the DM task's §6 trap 2).
-3. **The receiver is the only party that knows there is a problem.** It can see
-   its own row is a placeholder. The sender cannot.
-4. **The avatar is essentially the entire payload.** Name and bio are bytes;
-   the image is tens of kilobytes.
-5. **Cross-platform parity.** Desktop and mobile must agree, and a new message
-   type is a wire change needing lead-dev sign-off.
-6. **Privacy.** Anything that makes a client advertise or request identity must
-   not leak more than the current model does — particularly for users who have
-   deliberately NOT published a public profile.
+Neither is right, and this is the real finding.
 
-## §3. Candidates to evaluate (not exhaustive — better ideas welcome)
+| | Desktop | Mobile |
+|---|---|---|
+| **Trigger** | `setTimeout(…, 10000)` on startup + ~4s after every reconnect (`MessageDB.tsx:558-596`) | 4s after connect, but a per-launch ref (`lastProfileRebroadcastSigRef`) makes it **once per app launch** (`WebSocketContext.tsx:6201-6310`) |
+| **Gate** | localStorage `{sig, at}`, **expires after 24h** (`dmProfileGate.ts:40`) | MMKV **bare signature, no expiry** (`dmProfileService.ts`) |
+| **Net effect** | re-sends to every partner **every day, forever** | sends **once, ever**, per identity |
+| **Failure mode** | pure waste at scale | one lost frame = permanent failure |
 
-### A. Receiver-driven request — most likely the right shape
-The receiver knows its roster/conversation row is a placeholder, so let it ASK
-that specific peer, instead of everyone broadcasting on the off-chance. Cost
-becomes proportional to the actual problem rather than to the population.
-- Needs a new control message (`request-profile` or similar): wire change.
-- Questions: rate-limit it (an attacker could ask repeatedly); what if the peer
-  is offline (retry policy); does asking reveal anything the peer would rather
-  not disclose?
+The answer is a number between 1 and infinity, applied to both. That is the whole
+change.
 
-### B. Fingerprint first, bytes on demand
-Announce a short hash of name+avatar rather than the payload. The peer requests
-the full image only when its hash differs or is absent. ~99% reduction, since
-the avatar dominates.
-- Composes with every other option, including keeping a periodic announce.
-- Questions: where does the hash live on the wire; is it worth doing alone,
-  without A?
+---
 
-### C. Backoff instead of a flat interval
-Retry at 1 day, then 1 week, then stop. Keeps the anti-loss property for the
-window where loss actually matters, kills the steady-state cost.
-- Cheapest to implement — it is a change to one comparison in the existing gate.
-- Good fallback if A is blocked on a wire-format decision.
+## §1. The plan — four steps, in this order
 
-### D. Piggyback on existing traffic
-Attach the fingerprint to messages already being sent rather than generating
-dedicated ones. Near-zero marginal cost between active partners.
-- Does nothing for inactive pairs, which may be exactly the stale ones.
-- Interacts with the DM ack piggybacking already in `MessageService`.
+**The order matters.** Capping the retries is only safe once identity can no
+longer be erased, because today's daily resend is accidentally repairing that
+erasure within 24h.
 
-### E. Do nothing periodic; rely on the per-frame profile
-The decrypt union already exposes `user_profile` on some frames and desktop now
-keeps it. If that fired often enough, no periodic announce would be needed.
-- **Measured 2026-08-01: it does NOT fire on ordinary established-session
-  frames** (`hasUserProfile: false`, every observation). Recorded so nobody
-  re-runs this experiment. Would need an SDK change to be viable.
+| # | Step | Status | Needs the operator? |
+|---|---|---|---|
+| **1** | **Stop identity being erased.** `db.saveMessage` overwrote the conversation row's name/avatar on every save. | ✅ **DONE** — branch `fix/conversation-identity-preserve-on-empty`, 8 tests, 4 of which fail against the old code | no |
+| **2** | **Cap the retries.** Keep the 24h check, add "and fewer than 3 sends". Both platforms, moving in opposite directions. | not started | no |
+| **3** | **Spaces: no cadence.** Verify + fix the digest/apply defects, then add the bootstrap announce behind the same cap. | not started | **yes — the ~20 min check** |
+| **4** | **Prove it.** A diagnostic counting rows with no identity from any source. Run before and after. | not started | no |
 
-## §4. Deliverable
-
-A short recommendation document containing:
-
-- [ ] A cost model with real numbers at 1k / 10k / 100k users, for DMs and
-      spaces separately
-- [ ] An estimate, however rough, of how often identity actually goes missing —
-      this is the denominator the whole argument turns on, and nobody has
-      measured it. The `.agents/tools/dm-debug/06-space-member-sources.js`
-      diagnostic gives a real data point (46 of 89 senders had no row in one
-      test space) but test spaces are not representative.
-- [ ] A recommended option, with the wire change spelled out if there is one
-- [ ] A migration path from the current 24h gate that does not stampede on the
-      first connect after deploy (see the DM task's legacy-record note — the
-      stored value is a bare signature and reads as "absent" if parsed naively)
-- [ ] Whether DMs and spaces should share a cadence or diverge
-
-## §5. Where the current behaviour lives
-
-| Piece | File |
+| Rejected | Why |
 |---|---|
-| The 24h constant | `src/utils/dmProfileGate.ts` (`RESEND_INTERVAL_MS`) |
-| Gate read / claim / record | `src/utils/dmProfileGate.ts` |
-| Send loop that consults it | `src/services/MessageService.ts` (`broadcastProfileToAllDMs`) |
-| On-connect trigger | `src/components/context/MessageDB.tsx` |
-| Mobile equivalent (NO expiry) | `quorum-mobile/services/dm/dmProfileService.ts`, `quorum-mobile/services/space/spaceMessageService.ts` |
+| ~~Cap the encoded avatar size~~ | Rejected by the operator 2026-08-01. Do not re-propose. |
+| ~~Receiver-driven `request-profile`~~ | Not needed once steps 1-3 land. See §4 — recorded so it is not re-derived. |
+
+**Do DMs and spaces share a cadence? No.** Spaces already ship a receiver-driven
+member reconciliation that runs on every connect. The space answer is to repair
+it, not to add traffic. Step 3.
+
+**Outside this task:** desktop still has no send retention (`transport/README.md`
+item **B1**). Until that lands, desktop drops sends and step 2's retries are
+earning their keep. Once it lands the cap can drop toward 1.
+
+---
+
+## §2. Work
+
+### Step 1 — Stop identity being erased ✅ DONE
+
+**User-visible outcome:** a DM partner's name and avatar, once learned, stay.
+They could previously revert to "Unknown User".
+
+**What was wrong.** `db.saveMessage` also upserts the conversation row, and that
+`put` replaces the whole record — it wrote whatever identity the caller passed,
+unconditionally. Both call paths hand it non-identity:
+
+| Path | What it passed | Effect |
+|---|---|---|
+| DM **send** (`MessageService.ts:3269`, `:3464`) | the row as read at the **top** of the send, falling back to `'Unknown User'` / the default icon | a `dm-update-profile` landing mid-send was overwritten by the stale snapshot — a name we had already learned, silently reverted |
+| **Space** paths (`MessageService.ts:5593`, `:5608`, …) | `{}`, which the wrapper turns into `updatedUserProfile.user_icon!` → **`undefined`** | **blanked the channel row's `icon` and `displayName` on every space message saved** |
+
+> 🔴 **The space half was not previously known.** The original Slice 4 note in the
+> DM identity task describes only the DM send path. Found 2026-08-01 while
+> implementing: six `messageDB.saveMessage` call sites, and the space ones pass an
+> empty object through a non-null assertion.
+
+**The fix** (`src/db/messages.ts`, `saveMessage`): a real incoming value always
+wins; otherwise keep what is stored; and only when the row is new do we fall back
+to the incoming placeholder, so a brand-new row keeps the shape `Conversation`
+requires (`icon` and `displayName` are non-optional). Uses the existing,
+locale-aware `isPlaceholderDisplayName` / `isPlaceholderIcon`
+(`src/utils/identityPlaceholder.ts`) rather than a new literal check.
+
+- [x] Preserve-on-placeholder in `db.saveMessage`
+- [x] Tests — `src/dev/tests/db/saveMessageConversationIdentity.test.ts`, 8 cases
+      against the real DB via `fake-indexeddb`. **4 of them fail against the
+      pre-fix code**, including both the DM race and the space blanking.
+- [x] Full suite green (720 tests), `tsc` clean
+- [x] **Mobile checked — it does NOT have this bug.** Its adapter takes
+      `_icon` / `_displayName` and **ignores them**
+      (`services/storage/mmkvAdapter.ts:115-123`); `messagesDb.saveMessage` only
+      writes the message. Its send path re-reads the conversation immediately
+      before writing and touches only timestamp / preview / sender-name, never
+      identity (`hooks/chat/useSendDirectMessage.ts:634-648`). **No mobile work
+      needed** — this is desktop catching up, same shape as the original DM
+      identity parity fix.
+- [ ] One-shot cleanup of rows already holding the `'Unknown User'` /
+      `/unknown.png` literals, so they fall back cleanly to the address render.
+      Deliberately NOT bundled — it is a data migration, not a write-path fix.
+
+> ⚠️ `yarn lint` is currently broken repo-wide by a stale `.worktrees/secondary`
+> directory (eslint cannot resolve `tsconfigRootDir`): 1383 errors on a clean
+> `HEAD`, 1384 with this branch — the +1 is the new test file hitting the same
+> parse error. Unrelated to this work.
+
+### Step 2 — Cap the retries
+
+**User-visible outcome:** a DM partner whose identity never landed still recovers,
+and the app stops emitting a message per partner per day forever. Verifiable in the
+DevTools console: after the cap is reached for a partner, reconnecting no longer
+produces a `[DMProfile]` send for them — today it does every 24 hours indefinitely.
+
+**The change is deliberately small.** Keep `RESEND_INTERVAL_MS = 24h` exactly as
+it is. Add a counter and a cap:
+
+```
+send if:  never sent before
+      OR  the identity changed (signature differs)
+      OR  (24h has passed since the last send  AND  we have sent < 3 times)
+```
+
+- **3 attempts total**, spread over at least 2 days.
+- **Convergence:** residual after k attempts is p^k. At p = 0.15 (desktop today,
+  before B1) three attempts leave **0.34%**; at p = 0.02 (post-B1) they leave
+  **0.0008%**.
+- **Cost:** 3 sends per (pair, identity-version) instead of 365 per year. **~99%
+  cut.**
+- **The cap is the only new concept.** No ladder of intervals, no new scheduling.
+  If a shorter first retry is ever wanted, that is a follow-up, not this change.
+- **3 is a transitional number.** Drop it to 2 once desktop consumes send
+  retention (B1), and consider 1 if U1 is fixed upstream and the miss rate
+  measured in §5 is at zero.
+
+#### How it actually works — no magic, no scheduling
+
+This is the part that sounds more complicated than it is:
+
+1. **Nothing runs while the app is closed.** There is no timer, no background job,
+   no scheduled resend. The whole mechanism is a small record in local storage:
+   `{signature, lastSentAt, attempts}`, one per DM partner.
+2. **The check runs when the app connects.** Desktop: 10s after startup and ~4s
+   after each reconnect. It walks the DM list and asks the question above for each
+   partner. Almost always the answer is no, and nothing goes on the wire.
+3. **The sender must be online; the receiver does not.** Messages go into the
+   receiver's inbox on the relay and are picked up next time *they* connect. So a
+   partner who is offline for a week still gets it.
+4. **The user does nothing and sees nothing.** There is no UI, no prompt, no
+   setting.
+5. **An identity change resets everything.** Changing name or avatar produces a
+   new signature, which resets the counter — correct, because new bytes genuinely
+   have to be pushed.
+
+Worked example. B sets an avatar on Monday and never touches their profile again:
+
+| When | What happens |
+|---|---|
+| Mon, B connects | attempt 1 to each partner. Counter = 1. |
+| Mon-Tue, B reconnects 40 times | nothing — 24h has not passed |
+| Tue, B connects | attempt 2. Counter = 2. |
+| Wed, B connects | attempt 3. Counter = 3. |
+| Thu onwards, forever | **nothing.** Today this would send every single day. |
+
+#### Migration — the part that stampedes if you get it wrong
+
+The gate record has had two shapes (`src/utils/dmProfileGate.ts:76-113`): the
+current `{sig, at}`, and a **bare signature string** from before the expiry
+existed. Note a signature is itself valid JSON, which is why the shape check
+matters more than the try/catch.
+
+Add `attempts`. Migrate **both** legacy shapes to
+`{sig, at: Date.now(), attempts: 2}`:
+
+- **`at = Date.now()`, NOT the stored value.** Keeping the old `at` puts every
+  existing pair instantly past the 24h check, so the entire fleet fires on the
+  first connect after deploy. That is the stampede.
+- **`attempts = 2` leaves exactly one more try** for anything broken right now,
+  then stops. Users do not all connect at the same moment, so it spreads across a
+  day.
+
+- [ ] Add `attempts` to the record + migration for both legacy shapes
+- [ ] The cap in `shouldSendDmProfile`
+- [ ] Tests in `src/dev/tests/utils/dmProfileGate.test.ts`, including both
+      migration paths and the no-stampede property
+- [ ] **Mobile: the same cap, moving in the opposite direction.** Its gate has no
+      expiry at all, so it sends once and never retries. Give it the same
+      `{sig, at, attempts}` record and the same rule — for mobile this is an
+      *increase* from 1 attempt to 3.
+- [ ] `npx tsc --noEmit --jsx react-jsx --skipLibCheck` + `yarn lint` clean
+
+### Step 3 — Spaces: repair the existing mechanism, do not add a cadence
+
+**User-visible outcome:** space members stop rendering as a 6-character address,
+without either user touching settings.
+
+Spaces already have what everyone keeps proposing to build. On every connect,
+`MessageDB.tsx:611-631` calls `requestSync` for every joined space, which drives a
+**receiver-driven, fingerprint-first member identity reconciliation** — already on
+the wire, no new type needed:
+
+| Piece | Location |
+|---|---|
+| `MemberDigest { address, inboxAddress, displayNameHash, iconHash }` | `quorum-shared/src/sync/types.ts:82-91` |
+| digest construction | `quorum-shared/src/sync/utils.ts:140-147`, `:241-249` |
+| diff → missing / outdated | `quorum-shared/src/sync/utils.ts:364-395` |
+| responder ships full rows for exactly those | `quorum-shared/src/sync/utils.ts:486-501` |
+| delta applied on receive | `src/services/MessageService.ts:5645-5669` |
+
+It does not work for identity, for two reasons filed as
+`.agents/bugs/2026-08-01-space-sync-member-delta-blind-to-and-erases-global-slot.md`
+(**unverified — code reading only; that file's §4 is the repro**): the digest
+hashes only the per-space **override** slot, which the follow-global work
+deliberately emptied, so most members hash to `hash('')` on both fields; and
+applying a delta does a full-row `put` that **erases** `global_display_name` /
+`global_user_icon` / the profile timestamps.
+
+- [ ] Verify both defects live (bug file §4, ~20 minutes, two clients)
+- [ ] Fix them (bug file §5 — defect 2 first, it is destructive and independent)
+- [ ] Then ship the sibling task's Slice 1 (announce-on-connect, global slot only)
+      as a **bootstrap** for members nobody has a row for, behind the Step 2 cap
+- [ ] **Do not copy 24h**, and do not give spaces a periodic cadence
+- [ ] Mobile's `spaceMessageService.maybeSendUpdateProfileMessage` gate has no
+      expiry either — same cap
+
+> 🔴 **Corrects `2026-08-01-space-member-identity-announce-on-connect.md` §4.**
+> "Cheaper here than it was for DMs" holds for the *sender's uplink* only. One
+> broadcast is read by **every member**, so total transfer is `spaces × members`.
+> At 5 spaces × 50 members that is **250 payload-deliveries per user per day
+> versus 40 for DMs** — a daily space cadence is ~6× more total transfer than a
+> daily DM one, not less.
+
+### Step 4 — Prove it
+
+**User-visible outcome:** a single number you can read before and after, instead
+of taking anyone's word for it.
+
+Everything above is argued from code reading and small manual rounds. Without a
+measurement, "fixed forever" is a claim rather than a fact — and the cap in Step 2
+is sized from a loss rate nobody has measured in production.
+
+Build a diagnostic that counts, on one client: **how many DM conversation rows and
+space member rows carry no identity from any source** (no real name, no real
+avatar, no public-profile fallback). The per-client logic already exists in
+`.agents/tools/dm-debug/05-profile-sources.js` and `06-space-member-sources.js` —
+the gap is a single headline number and somewhere to record it.
+
+- [ ] One console snippet that prints the count for DMs and spaces
+- [ ] Baseline it before Step 2 and Step 3 land
+- [ ] Re-run after. The number going to near-zero **and staying there across a
+      week** is the acceptance criterion for this whole task
+- [ ] If the number does NOT settle, that is the signal to revisit
+      `request-profile` (§4) — and the only legitimate reason to
+
+---
+
+## §3. Cost model (reference)
+
+Kept so the numbers are not re-derived. **Parameterised** — re-read with real
+values once they exist.
+
+**Fan-out is easy to miss.** `encryptAndSendDm` builds `targetInboxes` from every
+established session inbox for the conversation minus our own device
+(`MessageService.ts:1138-1140`) and emits one sealed frame per inbox (`:1200-1208`).
+So cost is **per destination inbox** — partner devices plus our own other devices,
+ghosts included and never pruned. Bench row B of `transport/index.md` §3.1 measured
+**~9 frames per message** on aged multi-device accounts. Use D = 2 healthy, 9 aged.
+
+Avatars are base64 data URLs, measured at **9 KB and 51 KB** on two real accounts
+(2026-08-01). Use A = 30 KB.
+
+**DMs, today's flat 24h**, per user per day = `P × D × A`. Downstream is the same
+volume again, so relay transfer is ~2× the upstream column.
+
+| Scenario | P | D | Per user/day | 1k users | 10k | 100k |
+|---|---|---|---|---|---|---|
+| conservative | 10 | 2 | 600 KB | 0.6 GB/d | 6 GB/d | 60 GB/d |
+| **central** | 20 | 2 | **1.2 MB** | **1.2 GB/d** | **12 GB/d** | **120 GB/d** |
+| aged accounts | 20 | 9 | 5.4 MB | 5.4 GB/d | 54 GB/d | 540 GB/d |
+
+Central case at 10k users ≈ **4.4 TB/yr upstream, ~8.8 TB/yr total transfer.**
+
+**With Slice 1** (3 sends per identity-version; assume ~2 identity changes per user
+per year → ~9 announces per pair per year instead of 365): 10k users central →
+**~110 GB/yr upstream. A ~97% cut.**
+
+**Spaces:** one Triple-Ratchet hub broadcast regardless of member count
+(`MessageService.ts:1044-1071`), so the sender pays `S × A` but total transfer is
+`S × M × A`. At S = 5, M = 50, 10k users: 150 KB/user/day sender-side, **75 GB/day
+fleet-wide**.
+
+---
+
+## §4. Considered and rejected — do not re-derive
+
+**Receiver-driven `request-profile`** (a new control message: the receiver, which
+is the only party that knows its row is a placeholder, asks that specific peer).
+Structurally the most elegant option — it is the only **closed-loop** design, since
+an announcer can never know whether its send worked, while a receiver can see its
+own row is empty.
+
+**Rejected anyway**, because the two problems it solves are being removed more
+cheaply:
+
+- the transport-loss tail is shrinking on its own as delivery is fixed;
+- the state-loss tail (a converged row going bad) is Slice 2, which fixes the cause
+  rather than adding a mechanism to compensate for it.
+
+A new wire type needs lead-dev sign-off and handlers on both platforms. Not worth
+it for a residual measured in fractions of a percent. **Revisit only if §5's
+measurement shows a real, persistent tail after Slices 1-3 have shipped.**
+
+**Capping the encoded avatar size.** Avatars are uncapped after compression (a
+≤750 KB PNG stays PNG and can reach ~500 KB on the wire, since `isPNGPhoto` only
+converts PNG→JPEG above a 750 KB *input*). **Rejected by the operator 2026-08-01.**
+
+---
+
+## §5. What is still unmeasured
+
+| Question | Why it matters | How |
+|---|---|---|
+| Real per-pair identity-miss rate in production | Sets the cap, and whether it can go to 1 | Ship a counter: at render, how many DM rows and space member rows have no identity from any source. `05-profile-sources.js` / `06-space-member-sources.js` already compute this per client — the gap is aggregation |
+| Whether the space sync defects are live | Decides whether spaces need anything beyond a bootstrap announce | Bug file §4, ~20 min, two clients |
+| Desktop loss rate after send retention | Desktop does not consume the fix | Blocked on `transport/README.md` B1 |
+| Real distribution of P (partners) and S/M (spaces) | Every fleet number scales linearly | Not knowable pre-launch; §3 is parameterised |
+
+---
+
+## §6. Files
+
+| Concern | File |
+|---|---|
+| The 24h constant + the gate | `src/utils/dmProfileGate.ts` |
+| Its tests | `src/dev/tests/utils/dmProfileGate.test.ts` |
+| DM send loop that consults it | `src/services/MessageService.ts:543` (`broadcastProfileToAllDMs`) |
+| Desktop on-connect trigger | `src/components/context/MessageDB.tsx:558-596` |
+| Mobile on-connect trigger (once per launch) | `quorum-mobile/context/WebSocketContext.tsx:6201-6310` |
+| Mobile DM gate (no expiry) | `quorum-mobile/services/dm/dmProfileService.ts` |
+| Mobile space gate (no expiry) | `quorum-mobile/services/space/spaceMessageService.ts` |
+| Placeholder re-stamp (Slice 2) | `src/db/messages.ts:1360-1370`, `src/services/MessageService.ts:3455` |
+| Space digest blindness | `quorum-shared/src/sync/utils.ts:140-147`, `src/adapters/indexedDbAdapter.ts:142-166` |
+| Space delta erasure | `src/services/MessageService.ts:5645-5669`, `src/db/messages.ts:1203-1216` |
 
 ---
 *Last updated: 2026-08-01*

--- a/.agents/tasks/2026-08-01-space-member-identity-announce-on-connect.md
+++ b/.agents/tasks/2026-08-01-space-member-identity-announce-on-connect.md
@@ -215,7 +215,26 @@ Plus one that is space-specific and NOT shared with DMs:
    still stands. Announcing is safe (it is a normal control message through the
    normal handler); inventing rows from message traffic is not.
 
-## §7. Open question inherited from the DM fix — retry cadence
+## §7. Open question inherited from the DM fix — retry cadence ✅ ANSWERED
+
+> ✅ **2026-08-01: answered in
+> `.agents/tasks/2026-08-01-identity-announce-cadence-research.md` Slice 3.**
+>
+> **Spaces should get no cadence at all.** They already ship a receiver-driven,
+> fingerprint-first member reconciliation — `requestSync` fires on every connect
+> (`MessageDB.tsx:611-631`) and exchanges `MemberDigest` → `MemberDelta`. That is
+> candidates A+B from the list below, already on the wire. It is broken in two
+> specific ways, filed as
+> `.agents/bugs/2026-08-01-space-sync-member-delta-blind-to-and-erases-global-slot.md`
+> (digest hashes only the override slot, which is empty post-follow-global; and
+> applying a delta full-row-`put`s away the global slot). **Fix those, and
+> Slice 1 here becomes a bootstrap for members nobody has a row for** — gate it
+> with the same capped retry as DMs (3 attempts, then stop), not a flat interval.
+>
+> 🔴 **§4 above is also corrected there.** "Cheaper here than it was for
+> DMs" is true for the *sender's uplink* only. One broadcast is read by every
+> member, so total transfer is `spaces × members` — at 5 spaces × 50 members
+> that is ~6× the total bytes of a daily DM announce, not less.
 
 The DM gate currently re-sends an unchanged identity **once per 24h per
 partner**. That is a placeholder value, not a researched one, and it is

--- a/src/db/messages.ts
+++ b/src/db/messages.ts
@@ -8,6 +8,10 @@ import type { IconColor } from '../components/space/IconPicker/types';
 import type { IconName } from '../components/primitives';
 import type { QueueTask, TaskStatus, QueueStats } from '../types/actionQueue';
 import { QUORUM_DB_NAME, QUORUM_DB_VERSION } from './dbVersion';
+import {
+  isPlaceholderDisplayName,
+  isPlaceholderIcon,
+} from '../utils/identityPlaceholder';
 import MiniSearch, { type Options } from 'minisearch';
 
 export interface EncryptedMessage {
@@ -1358,12 +1362,32 @@ export class MessageDB {
         // Update lastReadTimestamp if this is our own message (prevents false unread indicators)
         const isOwnMessage =
           currentUserAddress && message.content?.senderId === currentUserAddress;
+        // EMPTY / PLACEHOLDER MEANS ABSENT — saving a message must never
+        // DOWNGRADE the identity already on the row. This `put` replaces the
+        // whole record, and both call paths hand us non-identity here:
+        //
+        //  - the DM SEND path passes the row as it read it at the TOP of the
+        //    send (MessageService.ts ~3269/3464), falling back to the
+        //    'Unknown User' / default-icon placeholders. So a partner's
+        //    `dm-update-profile` landing mid-send was overwritten by that stale
+        //    snapshot, silently reverting a name we had already learned.
+        //  - the SPACE paths pass `{}` and the wrapper asserts
+        //    `updatedUserProfile.user_icon!`, so both arrive `undefined` and
+        //    used to blank the channel row on every space message saved.
+        //
+        // Rule: a real incoming value always wins; otherwise keep what is
+        // stored; and only when there is nothing stored do we fall back to the
+        // incoming placeholder, so a brand-new row keeps today's shape (both
+        // fields are required on `Conversation`).
+        // See .agents/tasks/2026-08-01-identity-announce-cadence-research.md §2.
         const request = conversationStore.put({
           ...existingConv, // Preserve existing fields including isRepudiable
           conversationId,
           address: address,
-          icon: icon,
-          displayName: displayName,
+          icon: isPlaceholderIcon(icon) ? (existingConv?.icon ?? icon) : icon,
+          displayName: isPlaceholderDisplayName(displayName)
+            ? (existingConv?.displayName ?? displayName)
+            : displayName,
           type: conversationType,
           timestamp: message.createdDate,
           lastMessageId: message.messageId, // Track last message for previews

--- a/src/dev/tests/db/saveMessageConversationIdentity.test.ts
+++ b/src/dev/tests/db/saveMessageConversationIdentity.test.ts
@@ -1,0 +1,203 @@
+import 'fake-indexeddb/auto';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { MessageDB } from '../../../db/messages';
+import type { Message } from '@quilibrium/quorum-shared';
+import { DefaultImages } from '../../../utils';
+
+// `db.saveMessage` also upserts the conversation row, and that `put` replaces
+// the whole record. Before this guard it wrote whatever identity the caller
+// happened to pass, which meant:
+//
+//  - the DM SEND path (which reads the row at the TOP of the send and falls
+//    back to the 'Unknown User' / default-icon placeholders) could revert a
+//    name learned mid-send from a `dm-update-profile`; and
+//  - the SPACE paths, which pass `{}` and reach the DB as `undefined`, blanked
+//    the channel row's identity on every single message saved.
+//
+// The rule under test: a REAL incoming value wins; otherwise keep what is
+// stored; and only fall back to the incoming placeholder when the row is new,
+// so a brand-new row keeps the shape `Conversation` requires.
+//
+// See .agents/tasks/2026-08-01-identity-announce-cadence-research.md §2.
+
+const PARTNER = 'QmNSr2YL6iLho1CQfRNikQRs2mBxGQRSL2CXYmtKL5ihUB';
+const REAL_NAME = 'Ada Lovelace';
+const REAL_ICON = 'data:image/jpeg;base64,/9j/REAL';
+
+const message = (overrides: Partial<Message> = {}): Message =>
+  ({
+    messageId: 'msg-1',
+    spaceId: PARTNER,
+    channelId: PARTNER,
+    createdDate: 1000,
+    modifiedDate: 1000,
+    digestAlgorithm: 'SHA-256',
+    nonce: 'nonce-1',
+    lastModifiedHash: '',
+    content: { type: 'post', senderId: PARTNER, text: ['hi'] },
+    reactions: [],
+    mentions: { memberIds: [], roleIds: [], channelIds: [] },
+    ...overrides,
+  }) as unknown as Message;
+
+describe('MessageDB.saveMessage — conversation identity is never downgraded', () => {
+  let db: MessageDB;
+
+  beforeEach(async () => {
+    const FDBFactory = (await import('fake-indexeddb/lib/FDBFactory')).default;
+    globalThis.indexedDB = new FDBFactory();
+    db = new MessageDB();
+    await db.init();
+  });
+
+  const conversationId = `${PARTNER}/${PARTNER}`;
+
+  const seedRealIdentity = async () => {
+    await db.saveMessage(
+      message(),
+      1000,
+      PARTNER,
+      'direct',
+      REAL_ICON,
+      REAL_NAME
+    );
+  };
+
+  it('writes a real incoming identity onto a new row', async () => {
+    await seedRealIdentity();
+    const conv = await db.getConversation({ conversationId }).then((r) => r.conversation);
+    expect(conv?.displayName).toBe(REAL_NAME);
+    expect(conv?.icon).toBe(REAL_ICON);
+  });
+
+  it('THE BUG: a placeholder from the send path no longer overwrites a real name', async () => {
+    await seedRealIdentity();
+
+    // The DM send path's fallback, carrying a stale snapshot of the row.
+    await db.saveMessage(
+      message({ messageId: 'msg-2', createdDate: 2000 }),
+      2000,
+      PARTNER,
+      'direct',
+      DefaultImages.UNKNOWN_USER,
+      'Unknown User'
+    );
+
+    const conv = await db.getConversation({ conversationId }).then((r) => r.conversation);
+    expect(conv?.displayName).toBe(REAL_NAME);
+    expect(conv?.icon).toBe(REAL_ICON);
+  });
+
+  it('THE SPACE BUG: undefined identity no longer blanks the row', async () => {
+    await seedRealIdentity();
+
+    // Space callers pass `{}` and the wrapper asserts `user_icon!`, so both
+    // arrive here as undefined.
+    await db.saveMessage(
+      message({ messageId: 'msg-3', createdDate: 3000 }),
+      3000,
+      PARTNER,
+      'direct',
+      undefined as unknown as string,
+      undefined as unknown as string
+    );
+
+    const conv = await db.getConversation({ conversationId }).then((r) => r.conversation);
+    expect(conv?.displayName).toBe(REAL_NAME);
+    expect(conv?.icon).toBe(REAL_ICON);
+  });
+
+  it('an empty string does not clear a stored identity either', async () => {
+    await seedRealIdentity();
+    await db.saveMessage(
+      message({ messageId: 'msg-4', createdDate: 4000 }),
+      4000,
+      PARTNER,
+      'direct',
+      '',
+      ''
+    );
+    const conv = await db.getConversation({ conversationId }).then((r) => r.conversation);
+    expect(conv?.displayName).toBe(REAL_NAME);
+    expect(conv?.icon).toBe(REAL_ICON);
+  });
+
+  it('a real update still wins over a stored placeholder (recovery still works)', async () => {
+    // Row starts life as a placeholder, as a never-identified partner's does.
+    await db.saveMessage(
+      message(),
+      1000,
+      PARTNER,
+      'direct',
+      DefaultImages.UNKNOWN_USER,
+      'Unknown User'
+    );
+
+    await db.saveMessage(
+      message({ messageId: 'msg-5', createdDate: 5000 }),
+      5000,
+      PARTNER,
+      'direct',
+      REAL_ICON,
+      REAL_NAME
+    );
+
+    const conv = await db.getConversation({ conversationId }).then((r) => r.conversation);
+    expect(conv?.displayName).toBe(REAL_NAME);
+    expect(conv?.icon).toBe(REAL_ICON);
+  });
+
+  it('a real identity change still overwrites an older real identity', async () => {
+    await seedRealIdentity();
+    await db.saveMessage(
+      message({ messageId: 'msg-6', createdDate: 6000 }),
+      6000,
+      PARTNER,
+      'direct',
+      'data:image/jpeg;base64,/9j/NEWER',
+      'Ada L.'
+    );
+    const conv = await db.getConversation({ conversationId }).then((r) => r.conversation);
+    expect(conv?.displayName).toBe('Ada L.');
+    expect(conv?.icon).toBe('data:image/jpeg;base64,/9j/NEWER');
+  });
+
+  it('a brand-new row still gets the placeholder, so its shape is unchanged', async () => {
+    await db.saveMessage(
+      message(),
+      1000,
+      PARTNER,
+      'direct',
+      DefaultImages.UNKNOWN_USER,
+      'Unknown User'
+    );
+    const conv = await db.getConversation({ conversationId }).then((r) => r.conversation);
+    expect(conv?.displayName).toBe('Unknown User');
+    expect(conv?.icon).toBe(DefaultImages.UNKNOWN_USER);
+  });
+
+  it('preserves unrelated fields it has always preserved', async () => {
+    await seedRealIdentity();
+    const seeded = await db.getConversation({ conversationId }).then((r) => r.conversation);
+    await db.saveConversation({
+      ...seeded!,
+      isRepudiable: true,
+      bio: 'mathematician',
+    });
+
+    await db.saveMessage(
+      message({ messageId: 'msg-7', createdDate: 7000 }),
+      7000,
+      PARTNER,
+      'direct',
+      undefined as unknown as string,
+      undefined as unknown as string
+    );
+
+    const conv = await db.getConversation({ conversationId }).then((r) => r.conversation);
+    expect(conv?.isRepudiable).toBe(true);
+    expect(conv?.bio).toBe('mathematician');
+    expect(conv?.displayName).toBe(REAL_NAME);
+    expect(conv?.lastMessageId).toBe('msg-7');
+  });
+});

--- a/src/utils/dmProfileGate.ts
+++ b/src/utils/dmProfileGate.ts
@@ -30,12 +30,32 @@ const GATE_PREFIX = 'quorum:dm-profile-broadcast';
  * Re-send an unchanged identity at most this often, per partner.
  *
  * ⚠️ PLACEHOLDER VALUE — chosen to bound an anti-loss retry, not researched.
- * It pays a cost on EVERY pair to fix a failure that occurs on a small fraction
- * of pairs, so it scales with the user base rather than with the problem
- * (~6 GB/day at 10k users × 20 partners × 30 KB avatars). Better shapes
- * (receiver-driven request, fingerprint-first, backoff) are being evaluated in
- * .agents/tasks/2026-08-01-identity-announce-cadence-research.md — do not treat
- * this constant as settled, and do not copy it into the space implementation.
+ * It scales with the user base rather than with the problem: ~12 GB/day at 10k
+ * users (20 partners × ~2 destination inboxes × 30 KB avatars), forever.
+ *
+ * DECIDED 2026-08-01: keep this interval, but CAP the number of retries — stop
+ * after 3 sends per (partner, identity-version), until the signature changes.
+ * Healing a lost identity is a finite job; repeating it 365×/year per partner is
+ * not. ~99% cheaper, with the same convergence.
+ *
+ * The retry is a TRANSITIONAL SAFETY NET, not architecture. It exists only
+ * because a lost frame had no second chance — with reliable delivery, ONE send
+ * per identity is enough (which is exactly what mobile already does). As
+ * delivery is proven the cap should shrink toward 1. Do not build as if the
+ * retry were permanent.
+ *
+ * Two things not to get wrong:
+ *  - Capping is only safe once db.saveMessage stops re-stamping 'Unknown User'
+ *    onto the row (src/db/messages.ts:1360-1370). That re-stamp is what
+ *    un-converges an already-fixed row. Fix it in the same effort.
+ *  - The MIGRATION stampedes the whole fleet on deploy day if a legacy record is
+ *    stamped with its stored `at` instead of `Date.now()`.
+ *
+ * Both are covered in:
+ *   .agents/tasks/2026-08-01-identity-announce-cadence-research.md
+ *
+ * Do not copy this into the space implementation — spaces already have a
+ * receiver-driven member reconciliation and need no cadence (that task, Slice 3).
  */
 export const RESEND_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24h
 


### PR DESCRIPTION
Saving a message could silently wipe a conversation's stored name and avatar.

## Cause

`db.saveMessage` also upserts the conversation row, and that `put` replaces the
whole record. It wrote whatever identity the caller passed, unconditionally, and
**both** call paths hand it non-identity:

| Path | What it passes | Effect |
|---|---|---|
| DM **send** | the row as read at the **top** of the send, falling back to the `Unknown User` / default-icon placeholders | a partner's `dm-update-profile` landing mid-send was overwritten by that stale snapshot, silently reverting a name already learned |
| **Space** paths | `{}`, which the wrapper turns into `updatedUserProfile.user_icon!` and so arrives `undefined` | **blanked the channel row's `icon` and `displayName` on every space message saved** |

The space half was not previously known; it was found while implementing, by
checking all six `messageDB.saveMessage` call sites.

## Fix

In `db.saveMessage`: a **real incoming value always wins**; otherwise keep what
is stored; and only when the row is new do we fall back to the incoming
placeholder, so a brand-new row keeps the shape `Conversation` requires (`icon`
and `displayName` are both non-optional).

This reuses the existing, locale-aware `isPlaceholderDisplayName` /
`isPlaceholderIcon` rather than matching the literals again — which matters,
because an Italian client persists the placeholder as `Utente sconosciuto`.

## Mobile is not affected

Checked rather than assumed. Mobile's adapter takes `_icon` / `_displayName` and
**ignores them** (`services/storage/mmkvAdapter.ts`), and its send path re-reads
the conversation immediately before writing, touching only timestamp, preview
and sender name, never identity (`hooks/chat/useSendDirectMessage.ts`). This is
desktop catching up, the same shape as the earlier DM identity parity fix.

## Verification

- 8 new tests against the real DB via `fake-indexeddb`
- **4 of them fail against the pre-fix code** (the DM race, the space blanking,
  an empty-string clobber, and field preservation), confirmed by stashing the
  fix and re-running
- Full suite: 720 tests pass
- `tsc` clean

## Also included

Docs: the identity-announce plan, reduced to four ordered steps with this one
done, plus a filed lead on the space member sync (its digest hashes only the
per-space override slot, which the follow-global work deliberately emptied, and
applying a member delta appears to erase the global slot). That lead is marked
**unverified — code reading only**, and carries its own reproduction steps.

Deliberately **not** included: cleaning up rows that already hold the
`Unknown User` literal. That is a data migration with a different risk profile
and belongs in its own change.
