### PR TITLE
fix: cap the identity re-send at 3 attempts instead of repeating it forever

### DIFF
--- a/.agents/tasks/2026-08-01-identity-announce-cadence-research.md
+++ b/.agents/tasks/2026-08-01-identity-announce-cadence-research.md
@@ -89,8 +89,8 @@ erasure within 24h.
 
 | # | Step | Status | Needs the operator? |
 |---|---|---|---|
-| **1** | **Stop identity being erased.** `db.saveMessage` overwrote the conversation row's name/avatar on every save. | ✅ **DONE** — branch `fix/conversation-identity-preserve-on-empty`, 8 tests, 4 of which fail against the old code | no |
-| **2** | **Cap the retries.** Keep the 24h check, add "and fewer than 3 sends". Both platforms, moving in opposite directions. | not started | no |
+| **1** | **Stop identity being erased.** `db.saveMessage` overwrote the conversation row's name/avatar on every save. | ✅ **SHIPPED** — desktop #288 (`19e79da41`). 8 tests, 4 fail against the old code. Mobile was never affected. | no |
+| **2** | **Cap the retries.** Keep the 24h check, add "and fewer than 3 sends". Both platforms, moving in opposite directions. | ✅ **DONE, both repos** — desktop `fix/cap-identity-announce-retries` (24 tests), mobile same branch name (16 tests). Not yet merged. | no |
 | **3** | **Spaces: no cadence.** Verify + fix the digest/apply defects, then add the bootstrap announce behind the same cap. | not started | **yes — the ~20 min check** |
 | **4** | **Prove it.** A diagnostic counting rows with no identity from any source. Run before and after. | not started | no |
 
@@ -233,15 +233,30 @@ Add `attempts`. Migrate **both** legacy shapes to
   then stops. Users do not all connect at the same moment, so it spreads across a
   day.
 
-- [ ] Add `attempts` to the record + migration for both legacy shapes
-- [ ] The cap in `shouldSendDmProfile`
-- [ ] Tests in `src/dev/tests/utils/dmProfileGate.test.ts`, including both
-      migration paths and the no-stampede property
-- [ ] **Mobile: the same cap, moving in the opposite direction.** Its gate has no
-      expiry at all, so it sends once and never retries. Give it the same
-      `{sig, at, attempts}` record and the same rule — for mobile this is an
-      *increase* from 1 attempt to 3.
-- [ ] `npx tsc --noEmit --jsx react-jsx --skipLibCheck` + `yarn lint` clean
+- [x] Add `attempts` to the record + migration for both legacy shapes
+- [x] The cap in `shouldSendDmProfile`
+- [x] Tests — `src/dev/tests/utils/dmProfileGate.test.ts`, 24 total. Verified to
+      fail against the old behaviour: **3 fail with the cap check disabled**, and
+      **5 fail when the migration does not re-anchor the timestamp**.
+- [x] Desktop: 728 tests, `tsc` clean, `eslint` clean
+- [x] **Mobile: the same cap, moving in the opposite direction.** Its gate had no
+      expiry *and* no retry — one send ever, so a lost frame was permanent. Now
+      the same `{sig, at, attempts}` record and the same rule, an *increase* from
+      1 attempt to 3. Constants and migration semantics match desktop exactly.
+      - Decision logic split into `services/dm/dmProfileGate.ts`, free of MMKV so
+        it is unit-testable — importing the MMKV-backed service into a jest test
+        pulls in NitroModules and fails. Mirrors the existing `dmBurstPrefix`
+        pattern, and now mirrors desktop's file name too.
+      - 16 new tests; full mobile suite 204 pass. `tsc` unchanged at 11
+        pre-existing errors (all in `services/calling`, none in these files —
+        confirmed by counting against `master`).
+
+> **A migration asymmetry worth knowing.** Both platforms credit legacy records
+> 2 attempts, so both land on "exactly one more try, then stop". But that is a
+> *reduction* on desktop (from unbounded) and an *increase* on mobile (from
+> zero). Mobile therefore gets a small, bounded, one-time rise in traffic on
+> first deploy — one extra announce per existing pair — which is the price of
+> closing its permanent-failure hole.
 
 ### Step 3 — Spaces: repair the existing mechanism, do not add a cadence
 

--- a/src/dev/tests/db/saveMessageConversationIdentity.test.ts
+++ b/src/dev/tests/db/saveMessageConversationIdentity.test.ts
@@ -176,6 +176,69 @@ describe('MessageDB.saveMessage — conversation identity is never downgraded', 
     expect(conv?.icon).toBe(DefaultImages.UNKNOWN_USER);
   });
 
+  // The two guards are independent ternaries, and a partner with a name but no
+  // avatar (or vice versa) is an ordinary production state — an avatar-only push
+  // and a name-only push are genuinely different messages.
+  it('handles a MIXED update: real icon, placeholder name', async () => {
+    await seedRealIdentity();
+    await db.saveMessage(
+      message({ messageId: 'msg-mix-1', createdDate: 8000 }),
+      8000,
+      PARTNER,
+      'direct',
+      'data:image/jpeg;base64,/9j/NEWER',
+      'Unknown User'
+    );
+    const conv = await db.getConversation({ conversationId }).then((r) => r.conversation);
+    expect(conv?.icon).toBe('data:image/jpeg;base64,/9j/NEWER'); // real wins
+    expect(conv?.displayName).toBe(REAL_NAME); // placeholder preserved the stored one
+  });
+
+  it('handles a MIXED update: real name, placeholder icon', async () => {
+    await seedRealIdentity();
+    await db.saveMessage(
+      message({ messageId: 'msg-mix-2', createdDate: 9000 }),
+      9000,
+      PARTNER,
+      'direct',
+      DefaultImages.UNKNOWN_USER,
+      'Ada L.'
+    );
+    const conv = await db.getConversation({ conversationId }).then((r) => r.conversation);
+    expect(conv?.displayName).toBe('Ada L.');
+    expect(conv?.icon).toBe(REAL_ICON);
+  });
+
+  // The space half of the bug is the one nobody had spotted, and its callers
+  // pass conversationType 'group'. The fix does not branch on type today, so
+  // this pins that it stays that way.
+  it('protects a GROUP (space channel) row the same way', async () => {
+    const spaceId = 'space-1';
+    const channelId = 'channel-1';
+    const groupConversationId = `${spaceId}/${channelId}`;
+    const groupMessage = (id: string, at: number) =>
+      message({ messageId: id, spaceId, channelId, createdDate: at });
+
+    await db.saveMessage(groupMessage('g1', 1000), 1000, spaceId, 'group', REAL_ICON, REAL_NAME);
+
+    // Every space caller passes `{}`, which reaches the DB as undefined.
+    await db.saveMessage(
+      groupMessage('g2', 2000),
+      2000,
+      spaceId,
+      'group',
+      undefined as unknown as string,
+      undefined as unknown as string
+    );
+
+    const conv = await db
+      .getConversation({ conversationId: groupConversationId })
+      .then((r) => r.conversation);
+    expect(conv?.displayName).toBe(REAL_NAME);
+    expect(conv?.icon).toBe(REAL_ICON);
+    expect(conv?.type).toBe('group');
+  });
+
   it('preserves unrelated fields it has always preserved', async () => {
     await seedRealIdentity();
     const seeded = await db.getConversation({ conversationId }).then((r) => r.conversation);

--- a/src/dev/tests/utils/dmProfileGate.test.ts
+++ b/src/dev/tests/utils/dmProfileGate.test.ts
@@ -221,6 +221,34 @@ describe('migration from a pre-cap record', () => {
     expect(shouldSendDmProfile(SELF, PARTNER, SIG, T0 + RESEND_INTERVAL_MS)).toBe(true);
   });
 
+  // A number that is not a usable count. `typeof NaN === 'number'`, so a naive
+  // shape check lets these through — and then `NaN >= MAX` is false, which
+  // defeats the cap silently and sends forever.
+  it.each([
+    ['NaN attempts', { sig: SIG, at: T0, attempts: NaN }],
+    ['Infinity attempts', { sig: SIG, at: T0, attempts: Infinity }],
+    ['negative attempts', { sig: SIG, at: T0, attempts: -5 }],
+    ['fractional attempts', { sig: SIG, at: T0, attempts: 1.5 }],
+    ['NaN at', { sig: SIG, at: NaN, attempts: 1 }],
+  ])('re-migrates a corrupt record rather than trusting it (%s)', (_label, bad) => {
+    localStorage.setItem(KEY, JSON.stringify(bad));
+    // Re-migrated, so it is anchored at now and NOT immediately due...
+    expect(shouldSendDmProfile(SELF, PARTNER, SIG, T0)).toBe(false);
+    const stored = JSON.parse(localStorage.getItem(KEY)!);
+    expect(Number.isInteger(stored.attempts)).toBe(true);
+    expect(Number.isFinite(stored.at)).toBe(true);
+    // ...and the cap still bites rather than sending forever.
+    const sent: number[] = [];
+    for (let day = 0; day < 10; day++) {
+      const at = T0 + day * RESEND_INTERVAL_MS;
+      if (shouldSendDmProfile(SELF, PARTNER, SIG, at)) {
+        recordDmProfileSend(SELF, PARTNER, SIG, at);
+        sent.push(day);
+      }
+    }
+    expect(sent.length).toBeLessThanOrEqual(MAX_SENDS_PER_IDENTITY);
+  });
+
   it('grants exactly ONE more attempt, then closes', () => {
     localStorage.setItem(KEY, JSON.stringify({ sig: SIG, at: T0 - RESEND_INTERVAL_MS }));
     const sent: number[] = [];

--- a/src/dev/tests/utils/dmProfileGate.test.ts
+++ b/src/dev/tests/utils/dmProfileGate.test.ts
@@ -1,9 +1,10 @@
 // The send gate has two opposite failure modes, both bad:
 //   - too loose  → every reconnect re-sends a real DM to every partner
 //   - too strict → a lost frame means the partner NEVER learns our identity
-// These tests pin both edges, including the expiry that bounds the second one.
+// These tests pin both edges: the expiry that bounds the second one, and the
+// CAP that bounds the first one so a converged pair stops paying forever.
 //
-// Context: .agents/tasks/2026-08-01-dm-partner-identity-lost-on-established-sessions.md
+// Context: .agents/tasks/2026-08-01-identity-announce-cadence-research.md (Step 2)
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
@@ -13,6 +14,7 @@ import {
   claimDmProfileSend,
   releaseDmProfileSend,
   RESEND_INTERVAL_MS,
+  MAX_SENDS_PER_IDENTITY,
 } from '../../../utils/dmProfileGate';
 
 const SELF = 'QmSelfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
@@ -133,5 +135,102 @@ describe('shouldSendDmProfile', () => {
     localStorage.setItem(`quorum:dm-profile-broadcast:${SELF}:${PARTNER}`, SIG);
     const renamed = dmProfileSignature({ displayName: 'Roberta' });
     expect(shouldSendDmProfile(SELF, PARTNER, renamed, T0)).toBe(true);
+  });
+});
+
+// The cap is the whole point of this gate's second revision. Without it a
+// converged pair pays RESEND_INTERVAL_MS forever — 365 sends a year, per
+// partner, to say nothing new.
+describe('shouldSendDmProfile — the retry cap', () => {
+  /** Walk the gate the way the send loop does: check, then record if it said yes. */
+  const runConnect = (at: number, sig = SIG): boolean => {
+    const send = shouldSendDmProfile(SELF, PARTNER, sig, at);
+    if (send) recordDmProfileSend(SELF, PARTNER, sig, at);
+    return send;
+  };
+
+  it('sends exactly MAX_SENDS_PER_IDENTITY times, then never again', () => {
+    const sent: number[] = [];
+    // One connect per day for a fortnight — far past the cap.
+    for (let day = 0; day < 14; day++) {
+      if (runConnect(T0 + day * RESEND_INTERVAL_MS)) sent.push(day);
+    }
+    expect(sent).toEqual([0, 1, 2]);
+    expect(sent.length).toBe(MAX_SENDS_PER_IDENTITY);
+  });
+
+  it('a flapping connection cannot burn the attempts in one session', () => {
+    expect(runConnect(T0)).toBe(true);
+    // 200 reconnects inside the interval must all be no-ops.
+    for (let i = 1; i <= 200; i++) {
+      expect(runConnect(T0 + i * 1000)).toBe(false);
+    }
+    // ...and the second real attempt is still available a day later.
+    expect(runConnect(T0 + RESEND_INTERVAL_MS)).toBe(true);
+  });
+
+  it('a rename resets the count and gets its own full set of attempts', () => {
+    for (let day = 0; day < 5; day++) runConnect(T0 + day * RESEND_INTERVAL_MS);
+    expect(runConnect(T0 + 5 * RESEND_INTERVAL_MS)).toBe(false); // exhausted
+
+    const renamed = dmProfileSignature({ displayName: 'Roberta', userIcon: 'icon' });
+    const sent: number[] = [];
+    for (let day = 5; day < 15; day++) {
+      if (runConnect(T0 + day * RESEND_INTERVAL_MS, renamed)) sent.push(day);
+    }
+    expect(sent).toEqual([5, 6, 7]);
+  });
+
+  it('the cap is per-partner — one exhausted partner does not gate another', () => {
+    for (let day = 0; day < 5; day++) runConnect(T0 + day * RESEND_INTERVAL_MS);
+    expect(shouldSendDmProfile(SELF, OTHER_PARTNER, SIG, T0)).toBe(true);
+  });
+});
+
+// Deploy day. Both legacy shapes must land on "one more try, a day from now",
+// never "everyone sends immediately".
+describe('migration from a pre-cap record', () => {
+  const KEY = `quorum:dm-profile-broadcast:${SELF}:${PARTNER}`;
+
+  // The trap: these records carry a timestamp up to 24h old. Keeping it would
+  // put every existing pair instantly past the interval, so the whole fleet
+  // fires on the first connect after deploy.
+  it('re-anchors a {sig, at} record to now instead of firing immediately', () => {
+    const longAgo = T0 - 10 * RESEND_INTERVAL_MS;
+    localStorage.setItem(KEY, JSON.stringify({ sig: SIG, at: longAgo }));
+    expect(shouldSendDmProfile(SELF, PARTNER, SIG, T0)).toBe(false);
+  });
+
+  it('re-anchors a legacy bare-signature record the same way', () => {
+    localStorage.setItem(KEY, SIG);
+    expect(shouldSendDmProfile(SELF, PARTNER, SIG, T0)).toBe(false);
+  });
+
+  // The migration must PERSIST, or `now - at` is recomputed as ~0 on every read
+  // and the record can never age out — which is how the pre-cap code left
+  // bare-signature records permanently shut.
+  it('persists the upgrade, so the record can still age out', () => {
+    localStorage.setItem(KEY, SIG);
+    shouldSendDmProfile(SELF, PARTNER, SIG, T0);
+
+    const stored = JSON.parse(localStorage.getItem(KEY)!);
+    expect(stored).toMatchObject({ sig: SIG, at: T0 });
+    expect(typeof stored.attempts).toBe('number');
+
+    // A day later the one remaining attempt is genuinely due.
+    expect(shouldSendDmProfile(SELF, PARTNER, SIG, T0 + RESEND_INTERVAL_MS)).toBe(true);
+  });
+
+  it('grants exactly ONE more attempt, then closes', () => {
+    localStorage.setItem(KEY, JSON.stringify({ sig: SIG, at: T0 - RESEND_INTERVAL_MS }));
+    const sent: number[] = [];
+    for (let day = 0; day < 10; day++) {
+      const at = T0 + day * RESEND_INTERVAL_MS;
+      if (shouldSendDmProfile(SELF, PARTNER, SIG, at)) {
+        recordDmProfileSend(SELF, PARTNER, SIG, at);
+        sent.push(day);
+      }
+    }
+    expect(sent).toEqual([1]);
   });
 });

--- a/src/utils/dmProfileGate.ts
+++ b/src/utils/dmProfileGate.ts
@@ -12,52 +12,76 @@
 // Observed live on 2026-08-01 — a closed gate on one side while the other side
 // still showed "Unknown User".
 //
-// So the gate EXPIRES. An unchanged identity is re-sent at most once per
-// RESEND_INTERVAL_MS per partner, which bounds the wire cost to ~1 message per
-// partner per day while guaranteeing the identity eventually lands.
+// So the gate EXPIRES — but only a BOUNDED number of times. An unchanged
+// identity is re-sent at most once per RESEND_INTERVAL_MS, at most
+// MAX_SENDS_PER_IDENTITY times, per partner. Healing a lost identity is a
+// finite job; the first version of this gate had no cap and so kept paying 365
+// sends a year per pair to say nothing new.
+//
+// The three states, in the order the predicate checks them:
+//   never sent / identity changed → send (a rename resets the count)
+//   attempts exhausted            → never again, until the identity changes
+//   otherwise                     → send once the interval has elapsed
 //
 // Desktop counterpart of mobile's MMKV gate
-// (quorum-mobile/services/dm/dmProfileService.ts), plus the expiry, which
-// mobile does not have.
+// (quorum-mobile/services/dm/dmProfileService.ts). The two are NOT yet in
+// parity and diverge in opposite directions: mobile has no expiry and no cap,
+// so it sends exactly once ever and a single lost frame is permanent. Bringing
+// mobile to the same rule is tracked, and is deliberately not part of this
+// change.
 //
-// See .agents/tasks/2026-08-01-dm-partner-identity-lost-on-established-sessions.md
+// See .agents/tasks/2026-08-01-identity-announce-cadence-research.md (Step 2)
+// and 2026-08-01-dm-partner-identity-lost-on-established-sessions.md
 
 import { logger } from '@quilibrium/quorum-shared';
 
 const GATE_PREFIX = 'quorum:dm-profile-broadcast';
 
+/** Minimum gap between two sends of the SAME identity to the same partner. */
+export const RESEND_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24h
+
 /**
- * Re-send an unchanged identity at most this often, per partner.
+ * How many times an UNCHANGED identity is ever sent to one partner.
  *
- * ⚠️ PLACEHOLDER VALUE — chosen to bound an anti-loss retry, not researched.
- * It scales with the user base rather than with the problem: ~12 GB/day at 10k
- * users (20 partners × ~2 destination inboxes × 30 KB avatars), forever.
+ * Healing a lost identity is a FINITE job. The interval above used to have no
+ * cap, so a converged pair kept paying 365 sends a year to say nothing new —
+ * cost that scaled with the user base rather than with the problem (~12 GB/day
+ * at 10k users × 20 partners × ~2 destination inboxes × 30 KB avatars).
  *
- * DECIDED 2026-08-01: keep this interval, but CAP the number of retries — stop
- * after 3 sends per (partner, identity-version), until the signature changes.
- * Healing a lost identity is a finite job; repeating it 365×/year per partner is
- * not. ~99% cheaper, with the same convergence.
+ * Three attempts is sized from measured transport loss: residual after k tries
+ * is p^k, so at p≈0.15 (desktop today, before it consumes send retention) three
+ * leaves 0.34%, and at p≈0.02 it leaves 0.0008%. Attempts 4..365 buy nothing.
  *
- * The retry is a TRANSITIONAL SAFETY NET, not architecture. It exists only
- * because a lost frame had no second chance — with reliable delivery, ONE send
- * per identity is enough (which is exactly what mobile already does). As
- * delivery is proven the cap should shrink toward 1. Do not build as if the
- * retry were permanent.
+ * ⚠️ This retry is a TRANSITIONAL SAFETY NET, not architecture. It exists only
+ * because a lost frame had no second chance; with reliable delivery ONE send per
+ * identity is enough. As delivery is proven the cap should shrink toward 1 — a
+ * flat interval is wrong at every loss rate, and MOST wrong once the transport
+ * works. Do not build as if the retry were permanent.
  *
  * Two things not to get wrong:
- *  - Capping is only safe once db.saveMessage stops re-stamping 'Unknown User'
- *    onto the row (src/db/messages.ts:1360-1370). That re-stamp is what
- *    un-converges an already-fixed row. Fix it in the same effort.
- *  - The MIGRATION stampedes the whole fleet on deploy day if a legacy record is
- *    stamped with its stored `at` instead of `Date.now()`.
+ *  - Capping is only safe because db.saveMessage no longer re-stamps
+ *    'Unknown User' over a real name (fixed 2026-08-01). That re-stamp was what
+ *    un-converged an already-healed row; with a cap and no fix, such a row would
+ *    stay broken forever.
+ *  - The MIGRATION stampedes the whole fleet on deploy day if a legacy record
+ *    keeps its stored `at`. See `readRecord`.
  *
- * Both are covered in:
+ * Rationale and the cost model:
  *   .agents/tasks/2026-08-01-identity-announce-cadence-research.md
  *
  * Do not copy this into the space implementation — spaces already have a
- * receiver-driven member reconciliation and need no cadence (that task, Slice 3).
+ * receiver-driven member reconciliation and need no cadence (that task, Step 3).
  */
-export const RESEND_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24h
+export const MAX_SENDS_PER_IDENTITY = 3;
+
+/**
+ * Attempts credited to a record written before this cap existed.
+ *
+ * 2 leaves exactly ONE more try for pairs that are broken right now, then the
+ * cap closes. Going straight to MAX would abandon them; going to 0 would replay
+ * the whole ladder for every pair that is already fine.
+ */
+const MIGRATED_ATTEMPTS = MAX_SENDS_PER_IDENTITY - 1;
 
 /** The identity fields that actually go on the wire. */
 export interface DmProfileWirePayload {
@@ -91,11 +115,54 @@ const gateKey = (selfAddress: string, partnerAddress: string): string =>
 interface GateRecord {
   sig: string;
   at: number;
+  /** Sends of THIS signature to this partner so far. Capped at MAX_SENDS_PER_IDENTITY. */
+  attempts: number;
 }
+
+const writeRecord = (
+  selfAddress: string,
+  partnerAddress: string,
+  record: GateRecord
+): void => {
+  try {
+    localStorage.setItem(
+      gateKey(selfAddress, partnerAddress),
+      JSON.stringify(record)
+    );
+  } catch (err) {
+    logger.warn('[DMProfile] gate write failed — will re-send next connect', { err });
+  }
+};
+
+/**
+ * Upgrade a pre-cap record, and PERSIST the upgrade.
+ *
+ * ⚠️ `at` is re-anchored to NOW, deliberately, never the stored value. Records
+ * carry a timestamp up to 24h old, so keeping it would put every existing pair
+ * instantly past the interval and fire the entire fleet on the first connect
+ * after deploy. Re-anchoring spreads the one remaining attempt across whenever
+ * each user next opens the app.
+ *
+ * The write matters as much as the value: without it the upgrade is recomputed
+ * on every read, so `now - at` is always ~0 and the record can never age out —
+ * which is exactly how the pre-cap code left legacy bare-signature records
+ * permanently gated shut.
+ */
+const migrateRecord = (
+  selfAddress: string,
+  partnerAddress: string,
+  sig: string,
+  now: number
+): GateRecord => {
+  const migrated: GateRecord = { sig, at: now, attempts: MIGRATED_ATTEMPTS };
+  writeRecord(selfAddress, partnerAddress, migrated);
+  return migrated;
+};
 
 const readRecord = (
   selfAddress: string,
-  partnerAddress: string
+  partnerAddress: string,
+  now: number
 ): GateRecord | null => {
   let raw: string | null;
   try {
@@ -116,20 +183,21 @@ const readRecord = (
       typeof (parsed as GateRecord).sig === 'string' &&
       typeof (parsed as GateRecord).at === 'number'
     ) {
-      return {
-        sig: (parsed as GateRecord).sig,
-        at: (parsed as GateRecord).at,
-      };
+      const sig = (parsed as GateRecord).sig;
+      const attempts = (parsed as GateRecord).attempts;
+      // Shape 1 of 2: `{sig, at}` — the pre-cap format, no attempt counter.
+      if (typeof attempts !== 'number') {
+        return migrateRecord(selfAddress, partnerAddress, sig, now);
+      }
+      return { sig, at: (parsed as GateRecord).at, attempts };
     }
   } catch {
     // Not JSON at all — fall through to the legacy branch.
   }
-  // Pre-expiry format stored a BARE SIGNATURE string. Note that a signature is
-  // itself valid JSON (an array), so it parses cleanly — which is exactly why
-  // the shape check above matters more than the try/catch. Stamp it as sent
-  // "now" rather than at epoch 0, so upgrading does not make every partner
-  // instantly due for a resend on the first connect after deploy.
-  return { sig: raw, at: Date.now() };
+  // Shape 2 of 2: the ORIGINAL format stored a BARE SIGNATURE string. Note that
+  // a signature is itself valid JSON (an array), so it parses cleanly — which is
+  // exactly why the shape check above matters more than the try/catch.
+  return migrateRecord(selfAddress, partnerAddress, raw, now);
 };
 
 // In-flight claims, process-local. The persisted record is only written AFTER
@@ -143,11 +211,13 @@ const inFlight = new Set<string>();
 /**
  * Should we send this payload to this partner right now?
  *
- * True when we have never sent to them, when the identity has changed, or when
- * the last send is older than RESEND_INTERVAL_MS (the anti-loss retry) — and
- * only when no equivalent send is already in flight.
+ * True when we have never sent to them, when the identity has CHANGED (which
+ * resets the counter — new bytes genuinely have to be pushed), or when the last
+ * send is older than RESEND_INTERVAL_MS AND we are still under
+ * MAX_SENDS_PER_IDENTITY. Only when no equivalent send is already in flight.
  *
- * `now` is injectable so the expiry is testable without faking the clock.
+ * `now` is injectable so the interval and the cap are testable without faking
+ * the clock.
  */
 export const shouldSendDmProfile = (
   selfAddress: string,
@@ -158,9 +228,15 @@ export const shouldSendDmProfile = (
   if (inFlight.has(`${gateKey(selfAddress, partnerAddress)}|${signature}`)) {
     return false;
   }
-  const record = readRecord(selfAddress, partnerAddress);
+  const record = readRecord(selfAddress, partnerAddress, now);
   if (!record) return true;
+  // A changed identity is not a retry — it is new information, so it ignores
+  // both the interval and the cap, and starts its own count (see record*Send).
   if (record.sig !== signature) return true;
+  // The cap. Checked BEFORE the interval so a converged pair short-circuits
+  // without any arithmetic, and so the intent reads in order: "have we said
+  // this enough times already?" then "has it been long enough?".
+  if (record.attempts >= MAX_SENDS_PER_IDENTITY) return false;
   return now - record.at >= RESEND_INTERVAL_MS;
 };
 
@@ -187,9 +263,13 @@ export const releaseDmProfileSend = (
 };
 
 /**
- * Record a successful send. Call ONLY after the send resolves, so a failure
- * leaves the gate open and the next connect retries.
+ * Record a successful send, advancing the attempt counter. Call ONLY after the
+ * send resolves, so a failure leaves the gate open and the next connect retries.
  * Storage failures are non-fatal (gate simply stays open).
+ *
+ * A send of a DIFFERENT signature restarts the count at 1: the cap is per
+ * identity-version, not per partner for all time, so a rename gets its own full
+ * set of attempts.
  */
 export const recordDmProfileSend = (
   selfAddress: string,
@@ -197,12 +277,8 @@ export const recordDmProfileSend = (
   signature: string,
   now: number = Date.now()
 ): void => {
-  try {
-    localStorage.setItem(
-      gateKey(selfAddress, partnerAddress),
-      JSON.stringify({ sig: signature, at: now } satisfies GateRecord)
-    );
-  } catch (err) {
-    logger.warn('[DMProfile] gate write failed — will re-send next connect', { err });
-  }
+  const previous = readRecord(selfAddress, partnerAddress, now);
+  const attempts =
+    previous && previous.sig === signature ? previous.attempts + 1 : 1;
+  writeRecord(selfAddress, partnerAddress, { sig: signature, at: now, attempts });
 };

--- a/src/utils/dmProfileGate.ts
+++ b/src/utils/dmProfileGate.ts
@@ -180,16 +180,28 @@ const readRecord = (
       parsed !== null &&
       typeof parsed === 'object' &&
       !Array.isArray(parsed) &&
-      typeof (parsed as GateRecord).sig === 'string' &&
-      typeof (parsed as GateRecord).at === 'number'
+      typeof (parsed as GateRecord).sig === 'string'
     ) {
+      // Only `sig` is required to recognise the object form. `at` and
+      // `attempts` are validated below rather than in this guard, so a record
+      // whose numbers are unusable still migrates with its REAL signature
+      // instead of falling through to the bare-signature branch and having the
+      // whole JSON blob mistaken for one.
       const sig = (parsed as GateRecord).sig;
+      const at = (parsed as GateRecord).at;
       const attempts = (parsed as GateRecord).attempts;
       // Shape 1 of 2: `{sig, at}` — the pre-cap format, no attempt counter.
-      if (typeof attempts !== 'number') {
+      //
+      // `Number.isInteger` / `Number.isFinite`, not `typeof === 'number'`: NaN
+      // and Infinity are both numbers, and either breaks the gate silently — a
+      // NaN `attempts` defeats the cap (`NaN >= 3` is false, so it sends
+      // forever) and a NaN `at` wedges the interval shut. Note NaN and Infinity
+      // both serialise to `null` through JSON, so this also covers a record that
+      // was written while one of them was in play.
+      if (!Number.isFinite(at) || !Number.isInteger(attempts) || attempts < 0) {
         return migrateRecord(selfAddress, partnerAddress, sig, now);
       }
-      return { sig, at: (parsed as GateRecord).at, attempts };
+      return { sig, at, attempts };
     }
   } catch {
     // Not JSON at all — fall through to the legacy branch.


### PR DESCRIPTION
The DM identity gate expired every 24h with **no upper bound**, so a pair that
had long since converged kept paying 365 sends a year to say nothing new. That
cost scales with the user base rather than with the problem: roughly **12 GB/day
at 10k users**, at 20 partners x ~2 destination inboxes x 30 KB avatars.

Healing a lost identity is a *finite* job.

## The rule

An unchanged identity is now sent at most `MAX_SENDS_PER_IDENTITY` (3) times per
partner, then never again until the signature changes:

```
send if:  never sent before
      OR  the identity changed        (resets the count — new bytes must go out)
      OR  (24h elapsed  AND  fewer than 3 sends so far)
```

Residual after k attempts is p^k. At the measured per-message loss of ~15%
(desktop today, before it consumes send retention) three attempts leave 0.34%;
at ~2% they leave 0.0008%. Attempts 4..365 bought nothing.

**This retry is a transitional safety net, not architecture.** With reliable
delivery one send is enough, and the cap should shrink toward 1 as the transport
is proven. The comments say so, so the number is not mistaken for permanent.

Capping is only safe because saving a message no longer re-stamps `Unknown User`
over a real name (#288). Without that, a row could be un-converged *after* the
sender had stopped retrying, and stay broken forever.

## Migration — the part that bites

Both pre-cap shapes (`{sig, at}` and the original bare signature string) are
re-anchored to **now**, never to their stored timestamp. Those records are up to
24h old, so keeping the timestamp would put every existing pair instantly past
the interval and fire the whole fleet on the first connect after deploy.

They are credited 2 attempts, leaving exactly **one more try** for anything
broken right now, then the cap closes. The upgrade is persisted rather than
recomputed per read, which additionally fixes a pre-existing quirk where a
bare-signature record could never age out at all.

## Review findings, addressed

An independent review found no bugs in the state machine, and flagged one gap
below its own reporting bar which is fixed here anyway: `typeof NaN === 'number'`,
so a corrupt record passed the shape check — and `NaN >= 3` is `false`, which
silently removes the cap and sends forever. A `NaN` timestamp does the opposite
and wedges the gate shut. Both serialise to `null` through JSON.

Writing that test surfaced something the review did not: such a record fell
through to the bare-signature branch, so **the whole JSON blob was mistaken for a
signature**, losing track of what had already been announced. Recognising the
object form now requires only `sig`, with the numbers validated separately.

Two coverage gaps from the review are also closed (both already handled
correctly, just unpinned): a **mixed** update — real icon with placeholder name
and the reverse, since the two guards are independent ternaries — and a
**group/space channel** row, the half of the original bug nobody had spotted.

## Scope

Desktop only. Mobile diverges in the opposite direction (no expiry *and* no
retry, so it sends exactly once ever and a lost frame is permanent) and gets the
same rule in its own PR. The gate is purely local — the `dm-update-profile`
message is unchanged, only how often it is sent — so there is no wire
compatibility concern and no rollout ordering between the two.

## Verification

- 24 gate tests, verified to fail against the old behaviour: **3 fail with the
  cap check disabled**, **5 fail when the migration does not re-anchor**
- Full suite **736 tests**, `tsc` clean, `eslint` clean
