### PR TITLE
fix: space sync no longer erases a member's global identity, nor reverts a per-space name

### DIFF
--- a/.agents/bugs/2026-08-01-space-sync-member-delta-blind-to-and-erases-global-slot.md
+++ b/.agents/bugs/2026-08-01-space-sync-member-delta-blind-to-and-erases-global-slot.md
@@ -1,7 +1,7 @@
 ---
 type: bug
 title: "Space sync member reconciliation is blind to the global identity slot, and erases it on apply"
-status: open — UNVERIFIED, found by code reading; reproduction steps in §4
+status: CONFIRMED and FIXED 2026-08-01 (pending merge) — both defects demonstrated by tests that fail against the old code
 priority: high (if confirmed) — it disables the one mechanism that should make a space identity cadence unnecessary
 created: 2026-08-01
 updated: 2026-08-01
@@ -21,10 +21,20 @@ related_tools:
 
 # Space sync member reconciliation ignores — and erases — the global identity slot
 
-> ⚠️ **Found by reading code during the identity-cadence research
-> (2026-08-01). NOT reproduced live.** §4 is the verification procedure; run it
-> before acting. Context and the work that consumes this fix:
-> `.agents/tasks/2026-08-01-identity-announce-cadence-research.md` Slice 3.
+> ✅ **CONFIRMED AND FIXED, 2026-08-01.** Filed as code-reading; both defects were
+> then demonstrated headlessly, with **no device time and no second client** —
+> the §4 two-client procedure turned out not to be needed to establish them.
+>
+> | Defect | How it was proven | Result |
+> |---|---|---|
+> | 1 — digest blind to the global slot | `quorum-shared/src/sync/memberDigestGlobalSlot.test.ts` | a member with a real global identity hashed **identically** to one with none, and to one with a **completely different** identity. 2 of 4 tests failed against the old code. |
+> | 2 — delta apply erases the global slot | `quorum-desktop/src/dev/tests/db/saveSpaceMemberGlobalSlot.test.ts` | `global_display_name`, `global_user_icon`, `global_bio` **and both staleness guards** were destroyed. 4 of 8 tests failed against the old code. |
+>
+> Fixed in `quorum-shared` `97feb86` and `quorum-desktop` `9e6547a78`.
+> §4 below is kept as the END-TO-END confirmation — worth running once the fix
+> merges, to check the roster actually heals in a live space.
+>
+> Context: `.agents/tasks/2026-08-01-identity-announce-cadence-research.md` Step 3.
 
 ## §1. Why this matters more than it looks
 

--- a/.agents/bugs/2026-08-01-vitest-intermittently-runs-4-percent-of-the-suite.md
+++ b/.agents/bugs/2026-08-01-vitest-intermittently-runs-4-percent-of-the-suite.md
@@ -27,17 +27,31 @@ Duration    26.30s (transform 49.11s, setup 27.89s, import 98.46s, tests 10.42s,
 Twice on 2026-08-01 the same command instead produced **29 tests**, with the
 **import phase collapsing by two orders of magnitude**:
 
-| # | When | Reported | import phase | Concurrent activity |
+| # | When | Reported | import phase | Preceding activity |
 |---|---|---|---|---|
-| A | during step-2 implementation | `Test Files 47 failed \| 3 passed (50)` / `Tests 29 passed (29)` | **1.16s** | a full `npx jest` run in `quorum-mobile` was executing in parallel |
-| B | immediately after merging PRs #288/#289 | `Tests 29 passed (29)` — ⚠️ the `Test Files` line was truncated by `tail -4` and is **not known** | **707ms** | two `gh pr merge` operations had just completed |
+| A | during step-2 implementation | `Test Files 47 failed \| 3 passed (50)` / `Tests 29 passed (29)` | **1.16s** | a full `npx jest` run in `quorum-mobile` executing in parallel |
+| B | immediately after merging PRs #288/#289 | `Tests 29 passed (29)` — ⚠️ `Test Files` line truncated by `tail -4`, **not known** | **707ms** | two `gh pr merge` operations had just completed |
+| C | step-3, **single-file run** | `Test Files 1 failed (1)` / `Tests no tests` | **0ms** | had just written `src/db/messages.ts` |
+| D | step-3, full run | `Test Files 48 failed \| 3 passed (51)` / `Tests 29 passed (29)` | **576ms** | `yarn build` in `quorum-shared` (a `link:` dependency) |
+| E | step-3, full run | `Test Files 48 failed \| 3 passed (51)` / `Tests 29 passed (29)` | **700ms** | `yarn build` in `quorum-shared` |
 
-Both times:
+Every time:
 
-- **exactly 29 tests**, which strongly suggests the *same* 3 files survive each
-  time rather than a random subset;
-- an immediate re-run with **no code change** was fully green (50 files, 736
-  tests). Occurrence A was followed by three clean runs, occurrence B by one.
+- **exactly 29 tests** in the full-suite cases, which strongly suggests the *same*
+  3 files survive rather than a random subset;
+- an immediate re-run with **no code change** was fully green.
+
+**Occurrence C matters most**: it was a SINGLE-file run with nothing else
+executing, which rules out "concurrent load" as a necessary condition and rules
+out any theory that needs many workers.
+
+### ⛔ A tempting correlation that does NOT hold
+
+D and E both followed a `quorum-shared` rebuild, which made "rebuild a `link:`ed
+dep → next run collapses" look deterministic. **It was tested twice and failed to
+reproduce both times** — rebuild followed immediately by a single-file run, and
+by a full run, were both clean (51 files, 744 tests). So the rebuild is at most a
+contributing factor, not a trigger. Do not start from this hypothesis.
 
 An import phase of <1.2s against a normal ~98s means the modules were never
 really imported — the files are erroring at import time, not failing assertions.
@@ -70,15 +84,17 @@ whether it reported failures or presented as a clean pass.
 
 ## §4. Hypotheses, cheapest first
 
-1. **Worker pool starvation or crash under concurrent load.** Both occurrences
-   coincided with other heavy processes (a parallel jest suite; two `gh` merges).
-   12 CPUs, no `poolOptions` set. A worker that dies during module resolution
-   would produce exactly this shape: near-zero import time, most files unable to
-   start.
-2. **Windows file-handle exhaustion (`EMFILE`) under concurrent load.** Same
-   trigger profile, and Windows is markedly less forgiving here than Linux.
-3. **Transform-cache race.** Two vitest/vite processes sharing a cache directory
-   while one is writing.
+1. **Vite dependency-optimization cache invalidation.** Best fit for ALL five: A,
+   B, D and E followed something that touches disk under `node_modules` or the
+   project tree, and C followed a source write. If `node_modules/.vite` is being
+   re-optimized and a run starts during that window, every import fails while the
+   optimizer holds the cache. Cheapest check: delete `node_modules/.vite` and see
+   whether the very next run reproduces it.
+2. **Worker pool starvation or crash.** A worker dying during module resolution
+   gives exactly this shape. ⚠️ Weakened by occurrence C, a single-file run with
+   nothing else executing.
+3. **Windows file-handle exhaustion (`EMFILE`).** Windows is markedly less
+   forgiving than Linux. Same weakening from C.
 4. **The inlined WASM SDK.** `server.deps.inline` forces
    `@quilibrium/quilibrium-js-sdk-channels` through transform for every importer.
    If resolving or instantiating it fails transiently, every file that imports it

--- a/.agents/tasks/2026-08-01-identity-announce-cadence-research.md
+++ b/.agents/tasks/2026-08-01-identity-announce-cadence-research.md
@@ -91,7 +91,7 @@ erasure within 24h.
 |---|---|---|---|
 | **1** | **Stop identity being erased.** `db.saveMessage` overwrote the conversation row's name/avatar on every save. | ✅ **SHIPPED** — desktop #288 (`19e79da41`). 8 tests, 4 fail against the old code. Mobile was never affected. | no |
 | **2** | **Cap the retries.** Keep the 24h check, add "and fewer than 3 sends". Both platforms, moving in opposite directions. | ✅ **DONE, both repos** — desktop `fix/cap-identity-announce-retries` (24 tests), mobile same branch name (16 tests). Not yet merged. | no |
-| **3** | **Spaces: no cadence.** Verify + fix the digest/apply defects, then add the bootstrap announce behind the same cap. | not started | **yes — the ~20 min check** |
+| **3** | **Spaces: no cadence.** Verify + fix the digest/apply defects, then add the bootstrap announce behind the same cap. | 🟡 **defects CONFIRMED and FIXED** (shared `97feb86`, desktop `9e6547a78`, unmerged). Bootstrap announce still to do. | **no** — both defects were proven headlessly; see below |
 | **4** | **Prove it.** A diagnostic counting rows with no identity from any source. Run before and after. | not started | no |
 
 | Rejected | Why |
@@ -284,8 +284,24 @@ deliberately emptied, so most members hash to `hash('')` on both fields; and
 applying a delta does a full-row `put` that **erases** `global_display_name` /
 `global_user_icon` / the profile timestamps.
 
-- [ ] Verify both defects live (bug file §4, ~20 minutes, two clients)
-- [ ] Fix them (bug file §5 — defect 2 first, it is destructive and independent)
+- [x] **Verify both defects — done headlessly, no device time and no second
+      client.** An earlier draft of this task said this step needed the operator
+      for ~20 minutes. It did not: the digest is a pure function, and the
+      erasure is a DB write path testable against `fake-indexeddb`. Reach for
+      that first next time.
+      - Defect 1: a member with a real global identity hashed **identically** to
+        one with no identity at all, and to one with a **completely different**
+        identity (2 of 4 tests failed against the old code).
+      - Defect 2: the global slot, the bio, **and both staleness guards** were
+        destroyed by a delta-shaped write (4 of 8 tests failed).
+- [x] Fix them (defect 2 first — destructive and independent). Also required
+      carrying the global slot through the desktop adapter, which was dropping it
+      before the digest ever saw it, and declaring it on the shared `SpaceMember`
+      type — a field the type will not admit cannot be hashed. That closes the
+      long-outstanding two-slot-types follow-up.
+- [ ] End-to-end confirmation once merged: two clients, one space, check the
+      roster actually heals (bug file §4). This is confirming the FIX, not the
+      defect.
 - [ ] Then ship the sibling task's Slice 1 (announce-on-connect, global slot only)
       as a **bootstrap** for members nobody has a row for, behind the Step 2 cap
 - [ ] **Do not copy 24h**, and do not give spaces a periodic cadence

--- a/src/adapters/indexedDbAdapter.ts
+++ b/src/adapters/indexedDbAdapter.ts
@@ -139,6 +139,15 @@ export class IndexedDBAdapter implements StorageAdapter {
   // while quorum-shared SpaceMember uses (address, profile_image).
   // This adapter maps between the two conventions.
 
+  // These two carry the GLOBAL identity slot as well as the per-space override.
+  // Dropping it here was invisible but load-bearing: the sync layer builds its
+  // member digest from whatever `dbMemberToShared` returns, and since the
+  // follow-global work stopped stamping the override fields, the global slot is
+  // where most members' identity actually lives. Without it every member hashed
+  // as "no identity", so two clients that disagreed completely still agreed they
+  // were in sync and exchanged nothing.
+  // See .agents/bugs/2026-08-01-space-sync-member-delta-blind-to-and-erases-global-slot.md
+
   private dbMemberToShared(dbMember: any): SpaceMember {
     return {
       address: dbMember.user_address ?? dbMember.address ?? '',
@@ -150,6 +159,12 @@ export class IndexedDBAdapter implements StorageAdapter {
       isKicked: dbMember.isKicked,
       joinedAt: dbMember.joinedAt,
       spaceTag: dbMember.spaceTag,
+      bio: dbMember.bio,
+      global_display_name: dbMember.global_display_name,
+      global_user_icon: dbMember.global_user_icon,
+      global_bio: dbMember.global_bio,
+      profileTimestamp: dbMember.profileTimestamp,
+      globalProfileTimestamp: dbMember.globalProfileTimestamp,
     };
   }
 
@@ -162,6 +177,12 @@ export class IndexedDBAdapter implements StorageAdapter {
       isKicked: member.isKicked,
       joinedAt: member.joinedAt,
       spaceTag: member.spaceTag,
+      bio: member.bio,
+      global_display_name: member.global_display_name,
+      global_user_icon: member.global_user_icon,
+      global_bio: member.global_bio,
+      profileTimestamp: member.profileTimestamp,
+      globalProfileTimestamp: member.globalProfileTimestamp,
     };
   }
 

--- a/src/db/messages.ts
+++ b/src/db/messages.ts
@@ -1204,6 +1204,30 @@ export class MessageDB {
     });
   }
 
+  /**
+   * Upsert a space member, MERGING over whatever is already stored.
+   *
+   * `put` replaces the whole record, so writing the incoming object directly
+   * destroyed every field it did not mention. The space SYNC path feeds this
+   * members reconstructed from the wire, and the wire shape (shared
+   * `SpaceMember`) cannot carry the GLOBAL identity slot at all — the adapter's
+   * `dbMemberToShared` drops `global_display_name`, `global_user_icon`,
+   * `global_bio`, `bio` and both profile timestamps. So applying a member delta
+   * erased the identity that actually renders: since the follow-global work
+   * stopped stamping the per-space OVERRIDE fields, the global slot is where
+   * most members' identity lives.
+   *
+   * Losing the timestamps was the quieter half of the same bug — they are the
+   * per-slot last-write-wins guards, so without them an out-of-order rebroadcast
+   * can let an older value win.
+   *
+   * Merge rule, matching `saveMessage` and `utils/conversationProfile`: a
+   * key that is ABSENT (or explicitly `undefined`) means "no change" and keeps
+   * the stored value. A present value — including an empty string, which is how
+   * the two-slot model expresses a deliberate clear — always wins.
+   *
+   * See .agents/bugs/2026-08-01-space-sync-member-delta-blind-to-and-erases-global-slot.md
+   */
   async saveSpaceMember(
     spaceId: string,
     userProfile: SpaceMemberRow
@@ -1212,7 +1236,29 @@ export class MessageDB {
     return new Promise((resolve, reject) => {
       const transaction = this.db!.transaction('space_members', 'readwrite');
       const store = transaction.objectStore('space_members');
-      store.put({ ...userProfile, spaceId });
+      const userAddress = (userProfile as { user_address?: string }).user_address;
+      // keyPath is ['spaceId', 'user_address']. Without an address there is
+      // nothing to look up (and the `put` below will fail on the keyPath
+      // anyway); `store.get([spaceId, undefined])` would throw a DataError
+      // first and turn that into a different, more confusing failure.
+      if (!userAddress) {
+        store.put({ ...userProfile, spaceId });
+        transaction.oncomplete = () => resolve();
+        transaction.onerror = () => reject(transaction.error);
+        return;
+      }
+      const getRequest = store.get([spaceId, userAddress]);
+
+      getRequest.onsuccess = () => {
+        const existing = getRequest.result as SpaceMemberRow | undefined;
+        // Drop explicit `undefined`s so they cannot punch holes in `existing`
+        // via the spread — `{...a, ...{x: undefined}}` yields `x: undefined`.
+        const incoming = Object.fromEntries(
+          Object.entries(userProfile).filter(([, v]) => v !== undefined)
+        );
+        store.put({ ...existing, ...incoming, spaceId });
+      };
+      getRequest.onerror = () => reject(getRequest.error);
 
       transaction.oncomplete = () => resolve();
       transaction.onerror = () => reject(transaction.error);

--- a/src/dev/tests/db/saveSpaceMemberGlobalSlot.test.ts
+++ b/src/dev/tests/db/saveSpaceMemberGlobalSlot.test.ts
@@ -139,3 +139,131 @@ describe('MessageDB.saveSpaceMember — the global identity slot survives a sync
     expect((await db.getSpaceMember(SPACE, MEMBER)).global_display_name).toBe('Ada Lovelace');
   });
 });
+
+// The sync protocol compares DIGESTS, which carry no notion of newer or older:
+// computeMemberDiff only asks whether two hashes differ, and the responder then
+// sends ITS version. So a peer holding a stale identity will push it back unless
+// the apply side refuses it.
+//
+// This mirrors the per-slot rule `applyProfileUpdate` applies to update-profile
+// messages. The logic under test lives in MessageService's member-delta apply;
+// these tests exercise the same decision against the real DB so the rule is
+// pinned somewhere cheap.
+describe('member-delta staleness rule (per-slot last-write-wins)', () => {
+  let db: MessageDB;
+
+  beforeEach(async () => {
+    const FDBFactory = (await import('fake-indexeddb/lib/FDBFactory')).default;
+    globalThis.indexedDB = new FDBFactory();
+    db = new MessageDB();
+    await db.init();
+  });
+
+  /** The decision MessageService makes before writing a synced member. */
+  const applyIncoming = async (incoming: Partial<SpaceMemberRow>) => {
+    const existing = await db.getSpaceMember(SPACE, MEMBER);
+    const applyOverride = !(
+      existing?.profileTimestamp &&
+      existing.profileTimestamp >= (incoming.profileTimestamp ?? 0)
+    );
+    const applyGlobal = !(
+      existing?.globalProfileTimestamp &&
+      existing.globalProfileTimestamp >= (incoming.globalProfileTimestamp ?? 0)
+    );
+    await db.saveSpaceMember(SPACE, {
+      user_address: MEMBER,
+      inbox_address: 'inbox-1',
+      joinedAt: existing?.joinedAt,
+      ...(applyOverride
+        ? {
+            display_name: incoming.display_name,
+            user_icon: incoming.user_icon,
+            profileTimestamp: incoming.profileTimestamp,
+          }
+        : {}),
+      ...(applyGlobal
+        ? {
+            global_display_name: incoming.global_display_name,
+            globalProfileTimestamp: incoming.globalProfileTimestamp,
+          }
+        : {}),
+    } as unknown as SpaceMemberRow);
+  };
+
+  // The case the operator cares about: a member deliberately set a per-space
+  // name. It must never be reverted to an older one by a peer catching up.
+  it('a stale peer cannot revert a newer per-space name', async () => {
+    await db.saveSpaceMember(SPACE, {
+      ...localRow(),
+      display_name: 'Ada (this space)',
+      profileTimestamp: 9000,
+    } as unknown as SpaceMemberRow);
+
+    await applyIncoming({
+      display_name: 'Ada (OLD space name)',
+      profileTimestamp: 3000,
+    });
+
+    expect((await db.getSpaceMember(SPACE, MEMBER)).display_name).toBe('Ada (this space)');
+  });
+
+  it('a NEWER per-space name from a peer still lands', async () => {
+    await db.saveSpaceMember(SPACE, {
+      ...localRow(),
+      display_name: 'Ada (old)',
+      profileTimestamp: 3000,
+    } as unknown as SpaceMemberRow);
+
+    await applyIncoming({ display_name: 'Ada (new)', profileTimestamp: 9000 });
+
+    expect((await db.getSpaceMember(SPACE, MEMBER)).display_name).toBe('Ada (new)');
+  });
+
+  it('a member arriving with NO timestamp cannot overwrite a stamped row', async () => {
+    await db.saveSpaceMember(SPACE, {
+      ...localRow(),
+      display_name: 'Ada (this space)',
+      profileTimestamp: 9000,
+    } as unknown as SpaceMemberRow);
+
+    // A peer that predates the global slot travelling over sync.
+    await applyIncoming({ display_name: 'whatever' });
+
+    expect((await db.getSpaceMember(SPACE, MEMBER)).display_name).toBe('Ada (this space)');
+  });
+
+  it('but it CAN populate a row that has no timestamp yet', async () => {
+    await db.saveSpaceMember(SPACE, {
+      user_address: MEMBER,
+      inbox_address: 'inbox-1',
+    } as unknown as SpaceMemberRow);
+
+    await applyIncoming({ display_name: 'Ada (this space)' });
+
+    expect((await db.getSpaceMember(SPACE, MEMBER)).display_name).toBe('Ada (this space)');
+  });
+
+  // The two slots are guarded independently, so a stale override does not block
+  // a fresh global identity or vice versa.
+  it('guards the two slots independently', async () => {
+    await db.saveSpaceMember(SPACE, {
+      ...localRow(),
+      display_name: 'Ada (this space)',
+      profileTimestamp: 9000,
+      global_display_name: 'Ada Lovelace',
+      globalProfileTimestamp: 1000,
+    } as unknown as SpaceMemberRow);
+
+    // Stale override, fresh global.
+    await applyIncoming({
+      display_name: 'Ada (OLD)',
+      profileTimestamp: 3000,
+      global_display_name: 'Ada L.',
+      globalProfileTimestamp: 9999,
+    });
+
+    const row = await db.getSpaceMember(SPACE, MEMBER);
+    expect(row.display_name).toBe('Ada (this space)'); // stale override refused
+    expect(row.global_display_name).toBe('Ada L.'); // fresh global accepted
+  });
+});

--- a/src/dev/tests/db/saveSpaceMemberGlobalSlot.test.ts
+++ b/src/dev/tests/db/saveSpaceMemberGlobalSlot.test.ts
@@ -1,0 +1,141 @@
+import 'fake-indexeddb/auto';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { MessageDB, type SpaceMemberRow } from '../../../db/messages';
+
+// `db.saveSpaceMember` does a full-row `store.put`, so it writes exactly the
+// object it is handed and everything absent from that object is destroyed.
+//
+// That matters because the space SYNC path feeds it members reconstructed from
+// the wire, and the wire shape (shared `SpaceMember`) has no global slot at all:
+// the desktop adapter's dbMemberToShared drops `global_display_name`,
+// `global_user_icon`, `global_bio`, `bio` and both profile timestamps. So
+// applying a member delta could erase the very identity that renders.
+//
+// The global slot is what renders for most members: the follow-global work
+// (2026-07-16) deliberately stopped stamping the per-space OVERRIDE fields, so
+// they are empty unless someone set a real per-space override.
+//
+// See .agents/bugs/2026-08-01-space-sync-member-delta-blind-to-and-erases-global-slot.md
+
+const SPACE = 'space-1';
+const MEMBER = 'QmNSr2YL6iLho1CQfRNikQRs2mBxGQRSL2CXYmtKL5ihUB';
+
+/** A member as it exists locally: global identity set, no per-space override. */
+const localRow = (): SpaceMemberRow =>
+  ({
+    user_address: MEMBER,
+    inbox_address: 'inbox-1',
+    // Override slot deliberately empty — the normal state post-follow-global.
+    display_name: '',
+    user_icon: '',
+    // Global slot: the identity that actually renders.
+    global_display_name: 'Ada Lovelace',
+    global_user_icon: 'data:image/jpeg;base64,/9j/REAL',
+    global_bio: 'mathematician',
+    globalProfileTimestamp: 5000,
+    profileTimestamp: 4000,
+    joinedAt: 1000,
+  }) as unknown as SpaceMemberRow;
+
+/**
+ * The same member as the sync delta reconstructs it: everything the shared
+ * `SpaceMember` type can carry, and nothing it cannot. Mirrors
+ * MessageService.ts's member-delta apply, which spreads the wire member and
+ * preserves only `joinedAt`.
+ */
+const deltaShapedRow = (): SpaceMemberRow =>
+  ({
+    user_address: MEMBER,
+    inbox_address: 'inbox-1',
+    display_name: '',
+    user_icon: '',
+    joinedAt: 1000,
+  }) as unknown as SpaceMemberRow;
+
+describe('MessageDB.saveSpaceMember — the global identity slot survives a sync delta', () => {
+  let db: MessageDB;
+
+  beforeEach(async () => {
+    const FDBFactory = (await import('fake-indexeddb/lib/FDBFactory')).default;
+    globalThis.indexedDB = new FDBFactory();
+    db = new MessageDB();
+    await db.init();
+  });
+
+  it('stores the global slot in the first place', async () => {
+    await db.saveSpaceMember(SPACE, localRow());
+    const row = await db.getSpaceMember(SPACE, MEMBER);
+    expect(row.global_display_name).toBe('Ada Lovelace');
+    expect(row.global_user_icon).toBe('data:image/jpeg;base64,/9j/REAL');
+  });
+
+  // THE BUG: a member delta carries no global slot, and a full-row put erases
+  // whatever it does not mention.
+  it('does not erase the global slot when a delta-shaped row is applied', async () => {
+    await db.saveSpaceMember(SPACE, localRow());
+    await db.saveSpaceMember(SPACE, deltaShapedRow());
+
+    const row = await db.getSpaceMember(SPACE, MEMBER);
+    expect(row.global_display_name).toBe('Ada Lovelace');
+    expect(row.global_user_icon).toBe('data:image/jpeg;base64,/9j/REAL');
+  });
+
+  it('does not erase the per-slot staleness guards either', async () => {
+    await db.saveSpaceMember(SPACE, localRow());
+    await db.saveSpaceMember(SPACE, deltaShapedRow());
+
+    const row = await db.getSpaceMember(SPACE, MEMBER);
+    // Without these an out-of-order rebroadcast can let an older value win.
+    expect(row.globalProfileTimestamp).toBe(5000);
+    expect(row.profileTimestamp).toBe(4000);
+  });
+
+  it('does not erase the bio', async () => {
+    await db.saveSpaceMember(SPACE, localRow());
+    await db.saveSpaceMember(SPACE, deltaShapedRow());
+    expect((await db.getSpaceMember(SPACE, MEMBER)).global_bio).toBe('mathematician');
+  });
+
+  // The other half of the rule: a real incoming value must still win, or the
+  // roster could never be updated at all.
+  it('still applies a REAL incoming override', async () => {
+    await db.saveSpaceMember(SPACE, localRow());
+    await db.saveSpaceMember(SPACE, {
+      ...deltaShapedRow(),
+      display_name: 'Ada (this space)',
+      user_icon: 'data:image/jpeg;base64,/9j/OVERRIDE',
+    } as unknown as SpaceMemberRow);
+
+    const row = await db.getSpaceMember(SPACE, MEMBER);
+    expect(row.display_name).toBe('Ada (this space)');
+    expect(row.user_icon).toBe('data:image/jpeg;base64,/9j/OVERRIDE');
+    // ...without collateral damage to the global slot.
+    expect(row.global_display_name).toBe('Ada Lovelace');
+  });
+
+  it('still applies a REAL incoming global identity (a rename must land)', async () => {
+    await db.saveSpaceMember(SPACE, localRow());
+    await db.saveSpaceMember(SPACE, {
+      ...localRow(),
+      global_display_name: 'Ada L.',
+      globalProfileTimestamp: 9000,
+    } as unknown as SpaceMemberRow);
+
+    const row = await db.getSpaceMember(SPACE, MEMBER);
+    expect(row.global_display_name).toBe('Ada L.');
+    expect(row.globalProfileTimestamp).toBe(9000);
+  });
+
+  it('creates a brand-new row from a delta with no prior local state', async () => {
+    await db.saveSpaceMember(SPACE, deltaShapedRow());
+    const row = await db.getSpaceMember(SPACE, MEMBER);
+    expect(row.user_address).toBe(MEMBER);
+    expect(row.global_display_name).toBeUndefined();
+  });
+
+  it('is per-space — one space does not leak into another', async () => {
+    await db.saveSpaceMember(SPACE, localRow());
+    await db.saveSpaceMember('space-2', deltaShapedRow());
+    expect((await db.getSpaceMember(SPACE, MEMBER)).global_display_name).toBe('Ada Lovelace');
+  });
+});

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -5653,15 +5653,68 @@ export class MessageService {
                   continue;
                 }
                 const existing = await this.messageDB.getSpaceMember(spaceId, userAddress);
+
+                // PER-SLOT STALENESS GUARD — the same last-write-wins rule
+                // `applyProfileUpdate` applies to `update-profile` messages.
+                //
+                // The sync protocol compares DIGESTS, which carry no notion of
+                // newer or older: `computeMemberDiff` only asks whether two
+                // hashes differ, and the responder then sends ITS version. So a
+                // peer holding a STALE identity will happily push it back over a
+                // newer one. That would revert a deliberate per-space name the
+                // member had just changed — the one thing a per-space override
+                // must never do, since it exists precisely so the member is NOT
+                // shown under their global name here.
+                //
+                // ⚠️ This became reachable only now. Until the digest was taught
+                // to see the global slot, every member hashed as "no identity",
+                // so identity deltas were essentially never produced and this
+                // path was dead. Turning the digest on turns this on with it.
+                //
+                // Ties go to the stored value, matching applyProfileUpdate. A
+                // member arriving with NO timestamp is treated as timestamp 0,
+                // so it can populate an empty row but can never overwrite a
+                // stamped one — which is the right call for peers that predate
+                // the global slot travelling over sync at all.
+                const incomingOverrideTs = member.profileTimestamp ?? 0;
+                const incomingGlobalTs = member.globalProfileTimestamp ?? 0;
+                const applyOverride = !(
+                  existing?.profileTimestamp &&
+                  existing.profileTimestamp >= incomingOverrideTs
+                );
+                const applyGlobal = !(
+                  existing?.globalProfileTimestamp &&
+                  existing.globalProfileTimestamp >= incomingGlobalTs
+                );
+
+                // `saveSpaceMember` merges, so an omitted slot keeps what is
+                // stored rather than blanking it.
                 const dbMember = {
-                  ...member,
                   user_address: userAddress,
-                  // Map profile_image to user_icon (desktop DB format)
-                  user_icon: member.profile_image || member.user_icon,
+                  inbox_address: member.inbox_address,
+                  isKicked: member.isKicked,
+                  spaceTag: member.spaceTag,
                   // Preserve joinedAt from local DB if sync data doesn't have it
                   joinedAt: member.joinedAt ?? existing?.joinedAt,
+                  ...(applyOverride
+                    ? {
+                        display_name: member.display_name,
+                        // Map profile_image to user_icon (desktop DB format)
+                        user_icon: member.profile_image || member.user_icon,
+                        bio: member.bio,
+                        profileTimestamp: member.profileTimestamp,
+                      }
+                    : {}),
+                  ...(applyGlobal
+                    ? {
+                        global_display_name: member.global_display_name,
+                        global_user_icon: member.global_user_icon,
+                        global_bio: member.global_bio,
+                        globalProfileTimestamp: member.globalProfileTimestamp,
+                      }
+                    : {}),
                 };
-                await this.messageDB.saveSpaceMember(spaceId, dbMember);
+                await this.messageDB.saveSpaceMember(spaceId, dbMember as SpaceMemberRow);
               }
               queryClient.refetchQueries({
                 queryKey: ['spaceMembers', spaceId],


### PR DESCRIPTION
Two defects that between them disabled the space member reconciliation and could
destroy identity that had already arrived. Both were filed on 2026-08-01 as
**unverified code reading**; both are now demonstrated by tests that fail against
the old code, established **headlessly** — no device time and no second client.

Pairs with quorum-shared #71, which **must land first** (this depends on
`SpaceMember` declaring the global slot).

## 1. Applying a sync delta erased the global identity

`db.saveSpaceMember` did a full-row `put`, writing exactly the object handed to
it and destroying every field it did not mention. The sync path feeds it members
reconstructed from the wire, and the adapter's `dbMemberToShared` dropped
`global_display_name`, `global_user_icon`, `global_bio`, `bio` and both profile
timestamps.

Since the follow-global work stopped stamping the per-space override fields, the
global slot is where most members' identity lives — so applying a member delta
erased the identity that actually renders. Losing the timestamps was the quieter
half: they are the per-slot last-write-wins guards, so without them an
out-of-order rebroadcast can let an older value win.

**Fix:** `saveSpaceMember` now merges. An absent or explicitly `undefined` key
means "no change"; a present value — including `''`, which is how the two-slot
model expresses a deliberate clear — still wins. Same EMPTY MEANS ABSENT rule as
`saveMessage` and `utils/conversationProfile`. Explicit `undefined`s are stripped
before the spread, since `{...a, ...{x: undefined}}` yields `x: undefined` and
would punch a hole straight through the merge.

The adapter now carries the global slot both ways, which is what lets shared #71's
digest fix see it at all.

## 2. Sync could revert a newer per-space name with a stale one

The protocol compares **digests**, which carry no notion of newer or older:
`computeMemberDiff` only asks whether two hashes differ, and the responder then
sends **its** version. The apply side wrote whatever arrived.

So a peer holding a stale identity could push it back over a newer one. The worst
case is a deliberate **per-space name** being reverted — that override exists
precisely so a member is *not* shown under their global name in a given space, so
silently rolling it back is the one thing it must never do.

**Fix:** the member-delta apply now uses the same per-slot last-write-wins rule
`applyProfileUpdate` already applies to `update-profile` messages, with the two
slots guarded **independently** so a stale override does not block a fresh global
identity. Ties go to the stored value, matching `applyProfileUpdate`. A member
arriving with no timestamp counts as 0: it can populate an empty row but never
overwrite a stamped one — right for peers that predate the global slot travelling
over sync at all.

> ⚠️ **This became reachable only with #71.** Until the digest could see the
> global slot, every member hashed as "no identity", so identity deltas were
> essentially never produced and this path was dead. Turning the digest on turns
> this on with it, which is why it is fixed here rather than filed for later.

## Name precedence is unchanged

Verified rather than assumed, since a per-space name must never be replaced by a
global one: `per-space override → QNS → global name → truncated address`, and
`resolveSpaceMemberName` additionally lets a deliberate per-space name beat the
QNS name. The digest hashes override-first, matching. QNS is deliberately absent
from the digest — it travels only in the published public profile and is fetched
independently per client, so it is not member data to reconcile.

## Verification

- 13 tests in `saveSpaceMemberGlobalSlot.test.ts`; **4 failed against the old
  code** (global slot, both staleness guards, bio all erased), plus 5 new ones
  pinning the staleness rule — including one named for the case above, *"a stale
  peer cannot revert a newer per-space name"*
- Full suite **749 tests**, `tsc` clean, `eslint` clean

## Still open, deliberately not in this PR

- The **bootstrap announce**: desktop still never announces its own identity on
  connect. It can now receive correctly but does not volunteer.
- Whether the space UI feeds `resolveSpaceMemberName` the global name from the
  roster slot or only from the public profile, and how a **non-public** user's
  global name reaches that comparison. Untouched by this PR, but adjacent.
