### PR TITLE
feat: announce space identity on connect so members stop rendering as an address

### DIFF
--- a/.agents/INDEX.md
+++ b/.agents/INDEX.md
@@ -33,7 +33,7 @@ This is the main index for all documentation, bug reports, and task management.
 - [Delete Confirmation System](docs/features/delete-confirmation-system.md)
 - [Desktop Notifications Feature](docs/features/desktop-notifications.md)
 - [Dropdown Panels](docs/features/dropdown-panels.md)
-- [Identity resolution and profile sync (canonical model)](docs/features/identity-resolution-and-profile-sync.md)
+- [Identity resolution and profile sync (canonical model)](docs/features/identity-resolution-and-profile-sync.md) — **start here for any "member shows as a truncated address" report.** Its "Why a name goes missing, and what repairs it" section holds the convergence model (pull vs push, per-platform matrix, debugging checklist)
 - [Input & Textarea Validation Reference](docs/features/input-validation-reference.md)
 - [Invite System Documentation](docs/features/invite-system-analysis.md)
 - [Kick User System Documentation](docs/features/kick-user-system.md)
@@ -119,7 +119,9 @@ This is the main index for all documentation, bug reports, and task management.
 - [UserSettingsModal fields flash empty on open](bugs/2026-06-08-user-settings-modal-fields-flash-empty-on-open.md)
 - [@everyone owner-bypass is a real propagating bug (send-side-only enforcement)](bugs/2026-06-12-everyone-mention-owner-bypass-send-side-only.md)
 - [Desktop shows stale synced config until restart](bugs/2026-06-13-config-not-refetched-stale-until-restart.md)
-- [Space members show truncated address — no `space_members` row](bugs/2026-06-13-space-members-missing-no-join-row.md)
+- [Space members show truncated address — no `space_members` row](bugs/2026-06-13-space-members-missing-no-join-row.md) — root cause characterised; the convergence model that explains it now lives in the identity-resolution doc
+- [A deleted space tag never disappears from other members' rosters](bugs/2026-08-01-space-tag-can-no-longer-be-cleared-from-a-member-roster.md) — self-inflicted by #290; read §6 before "restoring the old behaviour", the obvious fix is worse
+- [Every logger call is a no-op in production builds](bugs/2026-08-01-every-logger-call-is-a-no-op-in-production-builds.md) — "fail open and log" produces zero signal from real users
 - [Sync path hardcodes `'post'` in the signature messageId recompute → non-post signatures nulled](bugs/2026-06-14-sync-path-hardcodes-post-type-nulls-nonpost-signatures.md)
 - [announce-keys flooding → unbounded per-device admission store](bugs/2026-07-20-announce-keys-flooding-unbounded-admissions.md)
 - [Join-binding hijack: unauthenticated member rebind/blank](bugs/2026-07-20-join-binding-hijack-unauthenticated-member-rebind.md)

--- a/.agents/bugs/2026-08-01-every-logger-call-is-a-no-op-in-production-builds.md
+++ b/.agents/bugs/2026-08-01-every-logger-call-is-a-no-op-in-production-builds.md
@@ -1,0 +1,101 @@
+---
+type: bug
+title: "Every logger call is a no-op in production builds, so 'fail open and log' produces zero signal from real users"
+status: CONFIRMED by reading the logger source and grepping for overrides (not yet fixed)
+priority: high — it does not break behaviour, it breaks our ability to SEE behaviour
+created: 2026-08-01
+updated: 2026-08-01
+severity: silent — nothing fails; we simply learn nothing from any user who is not a developer
+area: observability / logging / quorum-shared
+repos: quorum-shared (cause), quorum-desktop + quorum-mobile (affected)
+related_docs:
+  - ".agents/tasks/transport/README.md"
+---
+
+# Every logger call is a no-op in production builds
+
+## §1. The finding
+
+`quorum-shared/src/utils/logger.ts` decides once, at module load, whether
+logging happens at all:
+
+```ts
+function detectEnvironment(): boolean {
+  if (typeof __DEV__ !== 'undefined') return __DEV__;                    // RN/Expo
+  if (typeof process !== 'undefined' && process.env)
+    return process.env.NODE_ENV !== 'production';                        // Node/Electron
+  if (typeof window !== 'undefined')
+    return window.location?.hostname === 'localhost';                    // browser
+  return true;
+}
+config.enabled = detectEnvironment();
+```
+
+`shouldLog()` returns `false` immediately when `config.enabled` is false, before
+the level is even considered. **In a production build every `logger.debug`,
+`logger.log`, `logger.warn` and `logger.error` call is discarded**, on all three
+branches: `__DEV__` is false in a release RN bundle, Vite statically replaces
+`process.env.NODE_ENV` with `'production'`, and a deployed web app is not on
+`localhost`.
+
+A repo-wide grep for `logger.configure`, `logger.enable` and `setLogLevel` in
+`quorum-desktop/src` and `quorum-desktop/web` finds **no call sites**, so nothing
+re-enables it at runtime. There is no Sentry or other reporting integration in
+the desktop repo.
+
+## §2. Why this matters more than it looks
+
+Large parts of this codebase are deliberately built to **fail open and log** —
+the identity announce gates, the DM profile gate, the sync paths, the transport
+retry logic. That is the right design: a redundant retry is harmless, a
+suppressed one leaves a user rendering as a 6-character address forever. But the
+"and log" half is what makes the failure *diagnosable*, and in production that
+half does not exist.
+
+Concretely, today we cannot answer any of these from a real user's session:
+
+- did the on-connect identity announce run, or silently skip every space?
+- did a space have no signing key, or did the send fail on the wire?
+- how often does a gate read hit a corrupt record?
+- how often does a frame fail to decrypt?
+
+Every one of those has a `logger` call written for it. None of them produce
+anything outside a developer's own machine. This is also why transport
+reliability had to be measured with a hand-built harness rather than read off
+production behaviour.
+
+## §3. What NOT to do
+
+Do **not** simply flip `enabled` to true in production. The reason it is off is
+sound: these logs are chatty, some carry addresses and message ids, and a
+messenger that prints conversation metadata to a shared console is a privacy
+regression. The fix has to be selective.
+
+## §4. Options
+
+1. **Keep `debug`/`log` off, let `warn`/`error` through.** Smallest change: make
+   `shouldLog` consult the level before `config.enabled`, so the two severities
+   that mean "something went wrong" survive a production build. Requires an
+   audit that no `warn`/`error` call site prints message content or a full
+   address — several already truncate (`address.slice(0, 16)`), which suggests
+   the convention is half-established.
+2. **A user-facing "collect diagnostics" toggle**, off by default, that enables
+   logging for that session and writes to a local buffer the user can export.
+   Fits an anonymity-conscious app better than always-on remote reporting, and
+   turns "it does not show my friend's name" into an actionable report.
+3. **Counters instead of logs.** For questions that are statistical rather than
+   forensic ("how many rows have no identity"), a small local counter surfaced
+   in the DB Inspector answers them without printing anything sensitive. This is
+   what the identity work's Step 4 diagnostic actually needs.
+
+Option 1 and option 3 are complementary and neither requires a server.
+
+## §5. How it was found
+
+An error-handling review of the on-connect identity announce
+(`2026-08-01-space-member-identity-announce-on-connect.md`) flagged that the
+change relies on "fail open and log" for observability, then checked whether the
+logs actually reach anywhere. They do not.
+
+---
+*Last updated: 2026-08-01*

--- a/.agents/bugs/2026-08-01-space-tag-can-no-longer-be-cleared-from-a-member-roster.md
+++ b/.agents/bugs/2026-08-01-space-tag-can-no-longer-be-cleared-from-a-member-roster.md
@@ -1,0 +1,132 @@
+---
+type: bug
+title: "A deleted space tag never disappears from other members' rosters — the undefined-stripping merge swallowed the only clear signal"
+status: CONFIRMED by isolated repro (not yet fixed)
+priority: medium — cosmetic but permanent, and self-inflicted 3 commits ago
+created: 2026-08-01
+updated: 2026-08-01
+severity: a tag deleted by the space owner keeps rendering next to every member's name on every other client, forever
+area: space member roster / space tags / IndexedDB merge semantics
+repos: quorum-desktop (mobile unverified — see §5)
+introduced_by: "PR #290 `4be71e3fd` — the saveSpaceMember partial-merge fix"
+related_bugs:
+  - "2026-08-01-space-sync-member-delta-blind-to-and-erases-global-slot.md"
+related_docs:
+  - ".agents/docs/features/space-tags.md"
+  - ".agents/docs/features/identity-resolution-and-profile-sync.md"
+---
+
+# A deleted space tag can no longer be cleared from a member roster
+
+## §1. What happens
+
+A space owner deletes the space's tag. Every member's client is supposed to stop
+rendering that tag next to their name. Instead it renders forever, on every
+client except the one whose own config changed.
+
+## §2. Why — two correct-looking changes that cancel each other out
+
+**Half one, the sender.** `rebroadcastTagIfChanged` (`MessageService.ts` ~872)
+handles deletion by building `resolvedTag = undefined` and then OMITTING
+`spaceTag` from the payload. Deletion is therefore signalled by absence — there
+is no explicit tombstone on the wire.
+
+**Half two, the receiver.** Both `update-profile` receive sites
+(`MessageService.ts:2176` and `:2724`) translate that absence into an explicit
+local clear:
+
+```ts
+participant.spaceTag =
+  inboundTag && validateSpaceTagLetters(...) && isValidSpaceTagUrl(...)
+    ? inboundTag
+    : undefined;          // <- the clear
+await this.messageDB.saveSpaceMember(spaceId, participant);
+```
+
+That worked while `saveSpaceMember` was a full-row `put`. **PR #290 changed it to
+a partial merge that drops explicit `undefined`s**, precisely so a sync delta
+could not punch holes in the global identity slot:
+
+```ts
+const incoming = Object.fromEntries(
+  Object.entries(userProfile).filter(([, v]) => v !== undefined)
+);
+store.put({ ...existing, ...incoming, spaceId });
+```
+
+`spaceTag: undefined` is now filtered out, `{...existing}` restores the old tag,
+and the clear is silently discarded. The two halves are individually right and
+jointly wrong: after #290 the row has **no way to express "remove this field"**.
+
+## §3. Isolated repro (run as-is)
+
+```js
+const existing = { user_address: 'a', spaceTag: { letters: 'QQQ', url: 'u' } };
+const participant = { ...existing };
+participant.spaceTag = undefined;               // what the receive handler does
+const incoming = Object.fromEntries(
+  Object.entries(participant).filter(([, v]) => v !== undefined)
+);
+console.log({ ...existing, ...incoming });
+// → { user_address: 'a', spaceTag: { letters: 'QQQ', url: 'u' } }   ← not cleared
+```
+
+## §4. Scope — what else lost its clear
+
+`spaceTag` is the case found, but the merge is field-agnostic, so **any** field a
+caller clears by assigning `undefined` is now unclearable. Worth auditing before
+fixing:
+
+- `isKicked` — if anything un-kicks by assigning `undefined` rather than `false`
+- the override slot: `applyProfileUpdate` deliberately uses `''` for a clear, not
+  `undefined`, so it is **safe** — and is the pattern the fix should follow
+- the global slot: same, `''`
+
+The override slot getting this right is what makes the fix obvious: the wire
+already distinguishes "omitted = no change" from "`''` = deliberately cleared".
+`spaceTag` is an object, so it has no `''`, which is exactly why it has no
+tombstone.
+
+## §5. Mobile
+
+Unverified. Mobile stores the roster in its own layer and did not receive #290,
+so it is probably unaffected — but its receive handler has the same
+`participant.spaceTag = ... : undefined` shape, so confirm rather than assume.
+
+## §6. Fix options, cheapest first
+
+1. **A `null` tombstone in the merge.** Keep dropping `undefined` (that is the
+   #290 property worth keeping — it is what makes a partial row safe), and let
+   `null` mean "remove this field":
+
+   ```ts
+   const incoming = Object.fromEntries(
+     Object.entries(userProfile)
+       .filter(([, v]) => v !== undefined)
+       .map(([k, v]) => [k, v === null ? undefined : v])
+   );
+   ```
+
+   Then the two receive sites assign `null` instead of `undefined`.
+   `SpaceMemberRow.spaceTag` widens to `BroadcastSpaceTag | null`; renderers
+   already test truthiness. **Preferred** — it restores the lost expressiveness
+   instead of special-casing one field.
+2. **Clear `spaceTag` through a dedicated DB method.** Narrow, no type change,
+   but leaves the general "no field can ever be removed" hole open for the next
+   caller to fall into.
+3. **Put a tombstone on the wire** (`spaceTag: null` from the sender). Correct in
+   the long run and needed for cross-client agreement, but it is a wire change
+   and both apps must understand it, so it is not the first move.
+
+Whichever is chosen: **write the failing test first**. This defect is invisible
+to `tsc` and to every existing test, which is how it shipped.
+
+## §7. How it was found
+
+Reading the receive path while wiring the on-connect identity announce
+(`2026-08-01-space-member-identity-announce-on-connect.md`), to check whether
+omitting `spaceTag` from the announce payload could wipe a member's tag. It
+cannot — omission is now a no-op in every direction, which is the bug.
+
+---
+*Last updated: 2026-08-01*

--- a/.agents/bugs/2026-08-01-space-tag-can-no-longer-be-cleared-from-a-member-roster.md
+++ b/.agents/bugs/2026-08-01-space-tag-can-no-longer-be-cleared-from-a-member-roster.md
@@ -1,7 +1,7 @@
 ---
 type: bug
 title: "A deleted space tag never disappears from other members' rosters — the undefined-stripping merge swallowed the only clear signal"
-status: CONFIRMED by isolated repro (not yet fixed)
+status: FIXED on branch fix/space-tag-clear-survives-partial-merge (awaiting the announce PR to merge first)
 priority: medium — cosmetic but permanent, and self-inflicted 3 commits ago
 created: 2026-08-01
 updated: 2026-08-01
@@ -93,33 +93,46 @@ Unverified. Mobile stores the roster in its own layer and did not receive #290,
 so it is probably unaffected — but its receive handler has the same
 `participant.spaceTag = ... : undefined` shape, so confirm rather than assume.
 
-## §6. Fix options, cheapest first
+## §6. The fix — and the wrong fix that the test suite caught
 
-1. **A `null` tombstone in the merge.** Keep dropping `undefined` (that is the
-   #290 property worth keeping — it is what makes a partial row safe), and let
-   `null` mean "remove this field":
+> ⚠️ **Read this before "restoring the old behaviour".** The obvious fix is to
+> make absence mean "clear" again, the way it did before #290. That is WORSE
+> than the current bug, and it was written, run and reverted on 2026-08-01.
 
-   ```ts
-   const incoming = Object.fromEntries(
-     Object.entries(userProfile)
-       .filter(([, v]) => v !== undefined)
-       .map(([k, v]) => [k, v === null ? undefined : v])
-   );
-   ```
+Most `update-profile` messages carry no tag at all — a global avatar save, and
+now the on-connect identity announce. If absence means "clear", every one of
+those strips every member's tag, and the announce does it on **every
+reconnect**. So the pre-#290 behaviour was not correct-then-broken; it was
+**over-clearing**, and #290 traded it for **under-clearing**. Neither is right,
+because absence genuinely cannot carry both "I have nothing to say about the
+tag" and "the tag is gone".
 
-   Then the two receive sites assign `null` instead of `undefined`.
-   `SpaceMemberRow.spaceTag` widens to `BroadcastSpaceTag | null`; renderers
-   already test truthiness. **Preferred** — it restores the lost expressiveness
-   instead of special-casing one field.
-2. **Clear `spaceTag` through a dedicated DB method.** Narrow, no type change,
-   but leaves the general "no field can ever be removed" hole open for the next
-   caller to fall into.
-3. **Put a tombstone on the wire** (`spaceTag: null` from the sender). Correct in
-   the long run and needed for cross-client agreement, but it is a wire change
-   and both apps must understand it, so it is not the first move.
+The three-state fix:
 
-Whichever is chosen: **write the failing test first**. This defect is invisible
-to `tsc` and to every existing test, which is how it shipped.
+| Wire | Meaning | Why |
+|---|---|---|
+| field absent | no change | the common case: the sender is talking about something else |
+| `spaceTag: null` | **clear** — the tombstone | deletion needs its own signal |
+| a tag object | set it, if it validates | an INVALID tag is REJECTED, not treated as a clear, or a malformed tag becomes a one-message way to blank somebody else's |
+
+Implemented as:
+
+- `resolveInboundSpaceTag` (`MessageService.ts`, exported and unit-tested) —
+  the three-state decision, used by both receive sites.
+- `saveSpaceMember(spaceId, row, { clearFields: ['spaceTag'] })` — carries the
+  clear through the merge. Absence stays the safe default for every partial
+  writer, which is the #290 property worth keeping.
+- `rebroadcastTagIfChanged` sends `spaceTag: null` on deletion instead of
+  omitting the field. It is the ONLY sender entitled to speak about the tag —
+  it fires only when the tag actually changed. Every other sender omits it
+  precisely because it has nothing to say.
+
+Old clients see a falsy value and behave exactly as they did, so the wire change
+is additive.
+
+**Mobile is unverified.** Its receive handler has the same shape and would need
+to learn the tombstone too; until then a mobile client will keep showing a
+deleted tag. Not a regression — that is what it does today.
 
 ## §7. How it was found
 

--- a/.agents/bugs/2026-08-01-vitest-intermittently-runs-4-percent-of-the-suite.md
+++ b/.agents/bugs/2026-08-01-vitest-intermittently-runs-4-percent-of-the-suite.md
@@ -104,6 +104,44 @@ whether it reported failures or presented as a clean pass.
 Hypothesis 4 predicts the surviving 3 files share the property of not importing
 the SDK. That is cheap to check and would discriminate 4 from 1-3.
 
+## §4b. 🔵 STRONGEST LEAD — the same signature reproduced ON DEMAND, from a drive-letter mismatch
+
+Later on 2026-08-01, running vitest from inside the secondary worktree produced
+**exactly this signature deliberately**:
+
+```
+Error: Cannot find module '/@fs/E:/GitHub/Quilibrium/quorum-desktop/.worktrees/secondary/src/dev/tests/setup.ts'
+ Test Files  1 failed (1)
+      Tests  no tests
+   Duration  1.92s (transform 0ms, setup 0ms, import 0ms, ...)
+```
+
+Note `import 0ms` and `Tests no tests` — the collapsed-run fingerprint from §1.
+
+**Cause:** the command was issued with a cwd of `D:/GitHub/.../worktrees/secondary`
+while the file resolved through `E:/GitHub/.../worktrees/secondary`. Both paths
+reach the same directory (one is an NTFS junction), but Vite's `/@fs/` resolution
+and its `server.fs.allow` list compare paths as STRINGS, so the two spellings do
+not match and every module fails to resolve. Re-running the identical command
+from the `E:` spelling passed immediately (2 files, 21 tests).
+
+**Why this is the best lead for §1.** `git worktree list` reports the worktree
+under `D:/`, so any tooling that takes git's word for the path and any human or
+agent that copies it gets the wrong spelling. `.worktrees/` is a cross-drive
+junction sitting INSIDE the project root — which is also exactly what broke
+`yarn lint` for every file until `.worktrees/**` was added to the eslint ignores
+(PR #287). Two separate tools have now mis-walked this directory.
+
+**Cheapest test:** run the full suite from the `E:` spelling and from the `D:`
+spelling and compare. If the flake in the MAIN repo has the same root, expect it
+to correlate with something resolving a path through the junction rather than
+with load or concurrency — which would also explain occurrence C (a single-file
+run with nothing else executing, which no concurrency theory survives).
+
+⚠️ Not yet proven for the MAIN repo: every main-repo run in this session used
+the `E:` spelling and none of them collapsed. So this is a confirmed mechanism
+that produces an identical signature, not yet a confirmed cause of §1.
+
 ## §5. Diagnosis plan
 
 - [ ] **Capture a full flaked run.** Loop `npx vitest run` under artificial load

--- a/.agents/docs/features/identity-resolution-and-profile-sync.md
+++ b/.agents/docs/features/identity-resolution-and-profile-sync.md
@@ -176,6 +176,97 @@ live save still learns the identity on the next reconnect.
 > a member neither side has heard of, and that gap is the only thing the
 > announce exists to close.
 
+## Why a name goes missing, and what repairs it (convergence model)
+
+> Added 2026-08-01. Everything above describes what the data IS. This section
+> describes how it CONVERGES — which is where every "member shows as a
+> 6-character address" report actually comes from. If you read one section
+> before touching this area, read this one.
+
+### The premise that explains every symptom
+
+**A user's name and avatar are not stored anywhere that others look up.** In a
+space, another member has a copy only because somebody's client SENT it while
+that member's client was listening. Miss that moment and you have nothing, and
+for a long time nothing ever said it again.
+
+The single exception is channel B (the published public profile), which IS a
+server-side lookup available at any time to anyone. **It is OFF by default**
+(`config?.isProfilePublic ?? false`, `useUserSettings.ts`). So for most users the
+safety net people assume exists catches nothing, and identity depends entirely
+on peer-to-peer traffic.
+
+### Three mechanisms, and which platform has which
+
+| Mechanism | What it does | Desktop | Mobile |
+|---|---|---|---|
+| **Roster PULL** — `requestSync` → `MemberDigest` → `MemberDelta` | On connect, ask the space "here is a fingerprint of every member I know; what am I missing?" Any online peer replies with the missing rows — **for every member it knows about, not just itself**. One informed peer can populate your whole roster in one exchange, including members who are offline right now. | ✅ | ❌ removed (`WebSocketContext.tsx:1297-1303`) |
+| **Identity PUSH — on change** | A global profile save broadcasts `update-profile` to every joined space immediately. | ✅ | ✅ |
+| **Identity PUSH — on connect (bootstrap)** | Announce our identity on connect, so members who have NO row for us get one. Capped (3 per identity) because it only has to cover what the pull cannot. | ✅ since 2026-08-01 | ⚠️ once ever, no expiry |
+| **Durable replay** | Does a member who was OFFLINE receive it later? | ❌ none for control messages | ✅ hub log replays `update-profile` on reconnect — **but only from their join point**; pre-join history is never delivered |
+
+**The pull is the main mechanism, not the push.** This is the thing most easily
+misread: an announce reaches only whoever is listening at that instant, whereas
+one pull can repair an entire roster. The push exists to cover the one case the
+pull cannot — a member nobody has ever heard of, so there is no row to compare.
+
+### Why it was broken for so long
+
+The pull existed all along and **never worked**. `computeMemberHash` built its
+fingerprint from the OVERRIDE slot only, which the follow-global work (2026-07-16)
+deliberately stopped populating — so nearly every member hashed as "no identity".
+Two clients with completely different rosters therefore always agreed they were
+in sync and exchanged nothing. Fixed 2026-08-01 (shared #71 + desktop #290); see
+`.agents/bugs/2026-08-01-space-sync-member-delta-blind-to-and-erases-global-slot.md`.
+
+So the pull went from "never worked" to "works", and the bootstrap push was added
+on top. Both landed the same day and **neither has been measured on a live space**
+(that is Step 4 of `2026-08-01-identity-announce-cadence-research.md`).
+
+### Where it stands per platform pairing
+
+| Viewer | Looking at a DESKTOP member | Looking at a MOBILE member |
+|---|---|---|
+| **Desktop** | repaired — pull, plus the bootstrap push | **still broken** — that member announced once, long ago, and does not participate in the pull |
+| **Mobile** | repaired — the desktop push reaches it, and mobile's receive/upsert/two-slot merge are all correct | **still broken** — same cause, and mobile cannot pull either |
+
+Mobile's RECEIVE side is not the problem and never was: it upserts a missing row,
+stores both slots with independent timestamp guards, and renders the precedence
+ladder correctly. **Mobile's problem is entirely on the SEND side plus the absent
+pull.**
+
+### What would actually close the gap
+
+1. **Give mobile the roster pull.** The largest single win by a wide margin: any
+   client opening a space would obtain every member's identity from any one
+   online peer. Not a new invention — desktop already has it and it now works.
+2. **Give mobile's announce an expiry.** Smaller, and partly redundant once 1
+   lands. Tracked as §10 of
+   `.agents/tasks/2026-08-01-space-member-identity-announce-on-connect.md`.
+
+Remaining structural limit after both: this is peer-to-peer, so "immediately on
+join" really means "as soon as one other member is online". If nobody else is
+online there is nobody to learn from. Closing THAT needs a server-side roster (or
+defaulting the public profile on for spacemates), which is an architecture call —
+see candidate #32, the hub-log migration.
+
+### Debugging checklist
+
+When someone reports a member rendering as an address:
+
+1. **Which platforms?** Use the matrix above before anything else. A mobile→mobile
+   report is expected today and needs no investigation.
+2. **Was anyone else online?** The pull needs a peer. Nothing repairs in isolation.
+3. **Is the announce gate exhausted?** 3 attempts per identity, then silent until
+   the identity changes (`src/utils/spaceProfileGate.ts`). While testing, having
+   the other user change their name or avatar resets the counter — otherwise you
+   are testing a gate that is already closed.
+4. **Count it.** `.agents/tools/dm-debug/06-space-member-sources.js` →
+   `__spaceMissingSenders(spaceId)`. Baseline from 2026-06-13 on "Quorum Test 2":
+   89 distinct senders, 46 with no member row.
+5. Reload before concluding it worked — the row must PERSIST, not render once
+   from an in-memory fallback.
+
 ## Known limitations (accepted)
 
 - **Channel A has no live cross-device push** — your own second device

--- a/.agents/docs/features/identity-resolution-and-profile-sync.md
+++ b/.agents/docs/features/identity-resolution-and-profile-sync.md
@@ -4,7 +4,7 @@ title: "Identity resolution and profile sync (canonical model)"
 status: done
 ai_generated: true
 created: 2026-07-16
-updated: 2026-07-16
+updated: 2026-08-01
 related_docs:
   - "qns-username-display.md"
   - "user-config-sync.md"
@@ -160,9 +160,21 @@ A per-space override edit (Space Settings → Account) is the ONLY thing that
 writes the OVERRIDE slot: value / `''` (clear = follow global) / omitted (no
 change) per the wire semantics above.
 
-The on-connect / tag-rotation rebroadcasts send the override-or-omit fields AND
-the current global slot, so a spacemate who missed a live save still learns the
-global identity on the next reconnect.
+The on-connect announce and the tag-rotation rebroadcast both send the
+override-or-omit fields AND the current global slot, so a spacemate who missed a
+live save still learns the identity on the next reconnect.
+
+> ⚠️ Until 2026-08-01 desktop had NO on-connect announce — only join and tag
+> rotation, and tag rotation is not connect-triggered despite what an earlier
+> version of the table below claimed. A member who joined while you were offline
+> therefore never got a second chance and rendered as a truncated address
+> indefinitely (46 of 89 senders on one test space). The announce added then is a
+> **bootstrap, not a cadence**: it is capped at 3 attempts per identity
+> (`src/utils/spaceProfileGate.ts`) because past that the receiver-driven member
+> digest exchange (`requestSync` → `MemberDigest` → `MemberDelta`) is the repair
+> path. The digest can reconcile rows two peers disagree about; it cannot invent
+> a member neither side has heard of, and that gap is the only thing the
+> announce exists to close.
 
 ## Known limitations (accepted)
 
@@ -252,10 +264,12 @@ residual: an unregistered key can still set the display name/avatar on a claimed
 | Space editor (override) | `useSpaceProfile.ts` + `SpaceSettingsModal/Account.tsx` | `components/SpaceSettingsModal.tsx` |
 | C receive/upsert (two-slot merge) | `MessageService.ts` (update-profile handlers + `applyGlobalProfileSlots`) | `context/WebSocketContext.tsx` (~2100 JS path, ~3589 batch path) |
 | C wire send (both slots) | `MessageService.ts` rebroadcast + `MessageDB.updateUserProfile` | `services/space/spaceMessageService.ts` (`sendUpdateProfileMessage`) |
-| On-connect rebroadcast (override-or-omit + global slot) | `MessageService.ts` (~595, tag rotation) | `context/WebSocketContext.tsx` (~4783) |
+| Tag-rotation rebroadcast (override-or-omit + global slot) | `MessageService.ts` `rebroadcastTagIfChanged` — fires when an incoming manifest changes the selected TAG, **not** on connect | `context/WebSocketContext.tsx` (~4783) |
+| On-connect announce (override-or-omit + global slot, no tag) | `MessageService.ts` `announceProfileToAllSpacesOnConnect`, fired from `MessageDB.tsx` (startup timer **and** `setResubscribe`). Bounded by `src/utils/spaceProfileGate.ts` — 3 attempts per identity, then silent | `services/space/spaceMessageService.ts` (`maybeSendUpdateProfileMessage`) — gate has NO expiry, see below |
+| Announce payload rule (two-slot) | `src/utils/spaceProfilePayload.ts` (pure, tested) | inline in `spaceMessageService.ts` |
 | Global-save space broadcast (GLOBAL SLOT only) | `MessageDB.tsx` `updateUserProfile` | `UnifiedProfileEditModal.tsx` `saveQuorum` space loop |
 | useChannelData (surfaces global slots) | `src/hooks/business/channels/useChannelData.ts` | (mobile reads slots directly in the fallback hook) |
 | Channel A sync | `src/services/ConfigService.ts` | `services/config/configService.ts` |
 
 ---
-*Last updated: 2026-07-19*
+*Last updated: 2026-08-01*

--- a/.agents/tasks/2026-08-01-identity-announce-cadence-research.md
+++ b/.agents/tasks/2026-08-01-identity-announce-cadence-research.md
@@ -1,7 +1,7 @@
 ---
 type: task
 title: "Identity announce: cap the retries instead of re-sending forever, and fix what un-converges a row"
-status: STEPS 1-3 SHIPPED 2026-08-01 — bootstrap announce + Step 4 remain; see the HANDOVER box
+status: STEPS 1-3 DONE 2026-08-01 (announce implemented, awaiting live verification). Step 4 remains
 priority: medium — the two live bugs it uncovered are fixed and merged
 created: 2026-08-01
 updated: 2026-08-01
@@ -47,15 +47,30 @@ All three repos are on their base branch, clean, nothing unpushed. Desktop
 
 ### What is left, in priority order
 
-**1. The bootstrap announce (finishes Step 3).** Desktop still **never announces
-its own identity on connect**. After the fixes above it RECEIVES correctly but
-does not volunteer, so a member nobody has a row for stays unknown. The spec is
-`.agents/tasks/2026-08-01-space-member-identity-announce-on-connect.md` Slice 1 —
-global slot only, gated by the Step 2 cap (3 attempts), **no periodic cadence**.
-That task's §6 lists three traps already paid for on the DM side; read them.
+**1. ✅ The bootstrap announce — DONE 2026-08-01.** Desktop now announces on
+connect: `MessageService.announceProfileToAllSpacesOnConnect`, fired from
+`MessageDB.tsx` on the startup timer and from `setResubscribe`, bounded by
+`src/utils/spaceProfileGate.ts` (3 attempts per identity, minutes apart, then
+silent — a bootstrap, not a cadence). The DM gate was extracted to
+`src/utils/profileSendGate.ts` and both now sit on it.
 
-**2. Step 4, the diagnostic.** A count of "rows with no identity from any source",
-run before and after. Without it, none of this is measured — see §2 Step 4.
+Two deviations from the spec, both argued in
+`2026-08-01-space-member-identity-announce-on-connect.md`'s status box: the
+announce carries the **override slot as well as** the global one (global-only
+would show a member's global name to anyone bootstrapping a row, breaking the
+"a per-space name is what spacemates see" requirement), and the gate is spaced in
+**minutes rather than 24h** (a bootstrap should finish inside a session; the
+floor exists only so a flapping socket cannot spend the allowance in one outage).
+
+⚠️ **Unit-tested, not yet verified on a real space.** That is item 2.
+
+**2. Step 4, the diagnostic — now the top item.** A count of "rows with no
+identity from any source", run before and after. Without it, none of this is
+measured, and the announce above is the first change whose whole purpose is to
+move that number. Baseline to beat, from the 2026-06-13 run on "Quorum Test 2":
+**46 of 89 distinct senders had no member row at all.** Tool and procedure:
+`.agents/tools/dm-debug/06-space-member-sources.js`, `__spaceMissingSenders(id)`.
+Reload between runs — the point is that the row PERSISTS.
 
 **3. Two things I did NOT verify** and which are adjacent to a question the
 operator raised (does a per-space name always win?):

--- a/.agents/tasks/2026-08-01-space-member-identity-announce-on-connect.md
+++ b/.agents/tasks/2026-08-01-space-member-identity-announce-on-connect.md
@@ -175,9 +175,29 @@ from BEFORE a member's cursor, Cause B mostly self-heals and only Cause A
 matters. If the cursor starts at join/first-connect, Cause B is real and §10 is
 required. **Do not build §10 before answering this.**
 
-- [ ] Read `quorum-mobile` `hubLogSync.ts` + `hubLogCursor.ts`: where does a
-      NEW member's cursor start, and is there a server-side retention window?
-- [ ] Record the answer here, in one paragraph, with file:line
+> ## ✅ ANSWERED 2026-08-01 — replay does NOT rescue Cause B
+>
+> `quorum-mobile/context/WebSocketContext.tsx:1297-1303` and `:6182-6185` say it
+> verbatim, twice: *"No peer-to-peer sync; new joiners only see messages sent
+> after they joined."* Mobile's sync handlers were removed deliberately in
+> favour of the hub log.
+>
+> So the hub log DOES carry `update-profile` and DOES replay it on reconnect —
+> which rescues an **existing** member who was merely offline, and is a genuinely
+> stronger position than desktop, which has no durable replay for control
+> messages at all. But it does nothing for a member who joined LATER, and
+> mobile's announce gate never expires, so nobody will ever say it again.
+>
+> **§10 is therefore required, not optional.** Cause B is confirmed real.
+>
+> One extra finding: `clearProfileBroadcastState`
+> (`services/space/spaceMessageService.ts:963-967`) documents itself as the
+> escape hatch used on leave-space/sign-out so a rejoin re-broadcasts. A
+> repo-wide grep shows it is **never called**. The one escape hatch the comments
+> claim exists does not fire.
+
+- [x] Read `quorum-mobile` `hubLogSync.ts` + `hubLogCursor.ts`
+- [x] Record the answer here
 
 ### Slice 1 — Announce identity to every space on connect
 

--- a/.agents/tasks/2026-08-01-space-member-identity-announce-on-connect.md
+++ b/.agents/tasks/2026-08-01-space-member-identity-announce-on-connect.md
@@ -1,7 +1,7 @@
 ---
 type: task
 title: "Spaces: members render as a truncated address because desktop never re-announces identity on connect"
-status: open — not started; design proven on the DM side 2026-08-01
+status: Slices 1-3 IMPLEMENTED 2026-08-01 (desktop). Slice 0 + §10 (mobile) still open
 priority: high
 created: 2026-08-01
 updated: 2026-08-01
@@ -130,6 +130,41 @@ applies much more weakly here. Still gate it — see §5, Slice 2.
 
 ## §5. Work — vertical slices
 
+> ## ✅ Status 2026-08-01 — Slices 1, 2 and 3 are implemented (desktop)
+>
+> `MessageService.announceProfileToAllSpacesOnConnect`, fired from
+> `MessageDB.tsx` on the startup timer **and** from `setResubscribe` (trap 1).
+> Bounded by `src/utils/spaceProfileGate.ts`. The payload rule is a pure,
+> tested function: `src/utils/spaceProfilePayload.ts`.
+>
+> **Two deliberate deviations from what Slice 1 says below.** Both are argued in
+> the code comments; if you disagree, argue with those, not with this box.
+>
+> 1. **The announce sends the OVERRIDE slot too, not global-only.** Slice 1 says
+>    global-only, on the grounds that sending the override re-introduces roster
+>    stamping. That conflates two different things. The bug was stamping the
+>    *global config value* into an override field; sending a *real* override read
+>    from our own member row is what `rebroadcastTagIfChanged` already does, and
+>    what the identity-resolution doc describes as the model. Global-only would
+>    actively break the operator's requirement that a deliberate per-space name
+>    is what spacemates see: a member bootstrapping a fresh row would get the
+>    global name instead. `spaceProfilePayload.test.ts` pins both directions —
+>    a real override travels, an absent one is omitted rather than filled.
+> 2. **The gate is spaced in MINUTES, not the DM gate's 24h.** Same cap (3), very
+>    different spacing, because a space announce is a bootstrap rather than a
+>    repair mechanism — the member digest exchange repairs rows that exist, so
+>    all this has to do is reach members who have no row at all, and it should
+>    finish inside a session rather than over three days. The 5-minute floor
+>    exists only so a flapping socket cannot spend the whole allowance inside one
+>    outage.
+>
+> **Still open here:** Slice 0 (the hub-log replay question) and §10 (mobile's
+> gate, which has no expiry at all). Both live in `quorum-mobile`.
+>
+> **Not yet verified against the live diagnostic in §8** — the code is
+> unit-tested but the before/after count on a real space has not been run. That
+> is Step 4 of the cadence-research task.
+
 ### Slice 0 — Settle whether hub-log replay already rescues Cause B
 
 **User-visible outcome:** none; this is a 30-minute question whose answer decides
@@ -157,11 +192,11 @@ shape already exists — copy it from `rebroadcastTagIfChanged`
 the per-space OVERRIDE fields; that would re-introduce the roster-stamping
 problem the follow-global work removed (see the identity-resolution doc).
 
-- [ ] Add the broadcast alongside the existing on-connect space loop in
-      `MessageDB.tsx` (the one already doing `requestSync` + `announceDeviceKeys`)
-- [ ] Global slot only — no override fields
-- [ ] Verify against the live diagnostic in §8
-- [ ] `npx tsc --noEmit --jsx react-jsx --skipLibCheck` + `yarn lint` clean
+- [x] Add the broadcast alongside the existing on-connect space loop in
+      `MessageDB.tsx` — plus `setResubscribe`, each with its own cleared timer
+- [x] ~~Global slot only~~ → override-or-omit **and** global slot; see the box above
+- [ ] Verify against the live diagnostic in §8 — NOT DONE, needs a real space
+- [x] `npx tsc --noEmit --jsx react-jsx --skipLibCheck` + `yarn lint` clean
 
 ### Slice 2 — Gate it, and give the gate an expiry
 
@@ -172,17 +207,18 @@ Reuse the DM design (`src/utils/dmProfileGate.ts`) rather than inventing one —
 per-(self, space) signature, persisted, skip an unchanged payload, **with an
 expiry** so a lost broadcast cannot break convergence permanently.
 
-- [ ] Extract/generalise the DM gate rather than copy-pasting it
-- [ ] Claim in-flight synchronously (see §6 trap 3)
-- [ ] Unit tests mirroring `src/dev/tests/utils/dmProfileGate.test.ts`
+- [x] Extracted to `src/utils/profileSendGate.ts`; `dmProfileGate` now sits on
+      it (its 29 tests pass unchanged) and `spaceProfileGate` is the second caller
+- [x] Claim in-flight synchronously (see §6 trap 3)
+- [x] `spaceProfileGate.test.ts` (23) + `spaceProfilePayload.test.ts` (18)
 
 ### Slice 3 — Fix the mislabelled doc
 
 **User-visible outcome:** the next person doesn't lose an hour to it.
 
-- [ ] Correct the "On-connect rebroadcast" row in
-      `.agents/docs/features/identity-resolution-and-profile-sync.md` §"File map"
-- [ ] Note that the space announce is now genuinely on-connect once Slice 1 lands
+- [x] Corrected the "On-connect rebroadcast" row — it is now two rows, one for
+      tag rotation and one for the real on-connect announce
+- [x] Noted, with the bootstrap-not-cadence distinction spelled out
 
 ## §6. The three traps — all three cost a cycle on the DM side
 

--- a/src/components/context/MessageDB.tsx
+++ b/src/components/context/MessageDB.tsx
@@ -290,6 +290,7 @@ const MessageDBProvider: FC<MessageDBContextProps> = ({ children }) => {
   // Pending on-reconnect identity push, so a flapping socket replaces the
   // pending broadcast instead of stacking another one behind it.
   const dmProfilePushTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const spaceProfileAnnounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const invalidateConversation = useInvalidateConversation();
   const navigate = useNavigate();
 
@@ -567,6 +568,21 @@ const MessageDBProvider: FC<MessageDBContextProps> = ({ children }) => {
           );
       };
 
+      // Same idea for spaces, and the same startup race. A space member's name
+      // and avatar exist on your device only because someone announced them,
+      // and desktop announced only at join and on tag rotation — so a member
+      // who joined while you were offline stayed a truncated address forever.
+      // Bounded by its own gate (3 attempts per identity, then silent), because
+      // past the bootstrap the member digest exchange is the repair path.
+      const fireSpaceProfileAnnounce = () => {
+        if (!messageServiceRef.current) return;
+        messageServiceRef.current
+          .announceProfileToAllSpacesOnConnect(selfAddress)
+          .catch((err) =>
+            logger.warn('[SpaceProfile] identity announce failed', { err })
+          );
+      };
+
       setResubscribe(async () => {
         enqueueOutbound(async () => {
           const conversations = await messageDB.getAllEncryptionStates();
@@ -588,6 +604,13 @@ const MessageDBProvider: FC<MessageDBContextProps> = ({ children }) => {
         dmProfilePushTimerRef.current = setTimeout(
           fireDmProfileRebroadcast,
           4000
+        );
+        if (spaceProfileAnnounceTimerRef.current !== null) {
+          clearTimeout(spaceProfileAnnounceTimerRef.current);
+        }
+        spaceProfileAnnounceTimerRef.current = setTimeout(
+          fireSpaceProfileAnnounce,
+          6000
         );
       });
 
@@ -629,6 +652,12 @@ const MessageDBProvider: FC<MessageDBContextProps> = ({ children }) => {
             );
         }
       }, 10000);
+
+      // Startup path for the space announce — see the race note above. Trails
+      // the requestSync block so the digest exchange, which repairs rows that
+      // already exist, gets the quieter moment; the announce only has to reach
+      // members who have no row for us at all.
+      setTimeout(fireSpaceProfileAnnounce, 12000);
     }
   }, [keyset, selfAddress]);
 

--- a/src/components/context/MessageDB.tsx
+++ b/src/components/context/MessageDB.tsx
@@ -575,7 +575,15 @@ const MessageDBProvider: FC<MessageDBContextProps> = ({ children }) => {
       // Bounded by its own gate (3 attempts per identity, then silent), because
       // past the bootstrap the member digest exchange is the repair path.
       const fireSpaceProfileAnnounce = () => {
-        if (!messageServiceRef.current) return;
+        if (!messageServiceRef.current) {
+          // Realistically unreachable today (the service is built
+          // unconditionally in the same render pass), but a silent return here
+          // would disable the announce for the whole session with nothing to
+          // explain why — and "renders as an address" is already a symptom with
+          // no signal of its own.
+          logger.warn('[SpaceProfile] announce skipped — service not ready');
+          return;
+        }
         messageServiceRef.current
           .announceProfileToAllSpacesOnConnect(selfAddress)
           .catch((err) =>

--- a/src/dev/tests/utils/spaceProfileGate.test.ts
+++ b/src/dev/tests/utils/spaceProfileGate.test.ts
@@ -1,0 +1,264 @@
+// The space announce is a BOOTSTRAP, not a cadence, and these tests pin the
+// difference. Its two failure modes are not symmetric with the DM gate's:
+//
+//   too loose  → every reconnect re-broadcasts an avatar to EVERY member of
+//                every space (bytes scale as spaces × members, the most
+//                expensive identity traffic in the app)
+//   too strict → a member nobody holds a row for stays a truncated address,
+//                because the digest exchange can only reconcile rows that
+//                exist and cannot invent one
+//
+// So: capped like the DM gate, but spaced in minutes rather than days, because
+// past the bootstrap the member digest exchange is the repair path.
+//
+// Context: .agents/tasks/2026-08-01-space-member-identity-announce-on-connect.md
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  spaceProfileSignature,
+  shouldAnnounceSpaceProfile,
+  recordSpaceProfileAnnounce,
+  claimSpaceProfileAnnounce,
+  releaseSpaceProfileAnnounce,
+  SPACE_ANNOUNCE_MIN_GAP_MS,
+  MAX_SENDS_PER_SPACE_IDENTITY,
+} from '../../../utils/spaceProfileGate';
+import { shouldSendDmProfile, dmProfileSignature } from '../../../utils/dmProfileGate';
+
+const SELF = 'QmSelfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+const SPACE = 'space-alpha';
+const OTHER_SPACE = 'space-beta';
+
+const T0 = 1_750_000_000_000;
+const SIG = spaceProfileSignature({
+  globalDisplayName: 'Ada',
+  globalUserIcon: 'icon',
+});
+
+beforeEach(() => {
+  localStorage.clear();
+  // In-flight claims live in the gate closure, so they must be cleared between
+  // tests or a claim leaks into the next one.
+  releaseSpaceProfileAnnounce(SELF, SPACE, SIG);
+  releaseSpaceProfileAnnounce(SELF, OTHER_SPACE, SIG);
+});
+
+describe('spaceProfileSignature', () => {
+  it('is stable for the same payload regardless of key order', () => {
+    expect(
+      spaceProfileSignature({ globalDisplayName: 'Ada', globalUserIcon: 'i' })
+    ).toBe(
+      spaceProfileSignature({ globalUserIcon: 'i', globalDisplayName: 'Ada' })
+    );
+  });
+
+  it('changes when a value changes (a rename must re-announce)', () => {
+    expect(spaceProfileSignature({ globalDisplayName: 'Ada' })).not.toBe(
+      spaceProfileSignature({ globalDisplayName: 'Ada L.' })
+    );
+  });
+
+  // The two slots are different information. A per-space override and a global
+  // name that happen to share a value are NOT the same announcement, and one
+  // must not gate the other out.
+  it('distinguishes the override slot from the global slot', () => {
+    expect(spaceProfileSignature({ displayName: 'Ada' })).not.toBe(
+      spaceProfileSignature({ globalDisplayName: 'Ada' })
+    );
+  });
+
+  // `''` is a deliberate CLEAR on this wire (revert to follow-global), which is
+  // a real change and must not read as "field absent".
+  it('distinguishes a cleared override from an omitted one', () => {
+    expect(spaceProfileSignature({ displayName: '' })).not.toBe(
+      spaceProfileSignature({})
+    );
+  });
+
+  // It stores a folded digest rather than the payload: the payload carries a
+  // base64 avatar, and a verbatim per-space record would put tens of kilobytes
+  // of our OWN avatar into localStorage, once per space.
+  it('stays compact even for an avatar-sized payload', () => {
+    const big = 'data:image/jpeg;base64,' + 'A'.repeat(40_000);
+    expect(spaceProfileSignature({ globalUserIcon: big }).length).toBeLessThan(64);
+  });
+
+  it('still separates two different avatar-sized payloads', () => {
+    const a = 'data:image/jpeg;base64,' + 'A'.repeat(40_000);
+    const b = 'data:image/jpeg;base64,' + 'B'.repeat(40_000);
+    expect(spaceProfileSignature({ globalUserIcon: a })).not.toBe(
+      spaceProfileSignature({ globalUserIcon: b })
+    );
+  });
+});
+
+describe('shouldAnnounceSpaceProfile', () => {
+  it('announces when nothing has ever been recorded', () => {
+    expect(shouldAnnounceSpaceProfile(SELF, SPACE, SIG, T0)).toBe(true);
+  });
+
+  it('does not re-announce the same identity immediately', () => {
+    recordSpaceProfileAnnounce(SELF, SPACE, SIG, T0);
+    expect(shouldAnnounceSpaceProfile(SELF, SPACE, SIG, T0 + 1000)).toBe(false);
+  });
+
+  it('re-announces once the minimum gap has elapsed', () => {
+    recordSpaceProfileAnnounce(SELF, SPACE, SIG, T0);
+    expect(
+      shouldAnnounceSpaceProfile(SELF, SPACE, SIG, T0 + SPACE_ANNOUNCE_MIN_GAP_MS)
+    ).toBe(true);
+  });
+
+  // The whole point of the bootstrap: a changed identity is new information,
+  // not a retry, so it ignores both the gap and the cap.
+  it('announces a CHANGED identity immediately, even mid-gap', () => {
+    recordSpaceProfileAnnounce(SELF, SPACE, SIG, T0);
+    const renamed = spaceProfileSignature({
+      globalDisplayName: 'Ada L.',
+      globalUserIcon: 'icon',
+    });
+    expect(shouldAnnounceSpaceProfile(SELF, SPACE, renamed, T0 + 1)).toBe(true);
+  });
+
+  it('is per-space — announcing to one space does not gate another', () => {
+    recordSpaceProfileAnnounce(SELF, SPACE, SIG, T0);
+    expect(shouldAnnounceSpaceProfile(SELF, OTHER_SPACE, SIG, T0 + 1)).toBe(true);
+  });
+});
+
+describe('the cap — an unchanged identity is announced a bounded number of times', () => {
+  const advance = (n: number) => T0 + n * SPACE_ANNOUNCE_MIN_GAP_MS;
+
+  it('allows exactly MAX_SENDS_PER_SPACE_IDENTITY announces', () => {
+    let sent = 0;
+    for (let i = 0; i < 20; i++) {
+      const at = advance(i);
+      if (shouldAnnounceSpaceProfile(SELF, SPACE, SIG, at)) {
+        recordSpaceProfileAnnounce(SELF, SPACE, SIG, at);
+        sent++;
+      }
+    }
+    expect(sent).toBe(MAX_SENDS_PER_SPACE_IDENTITY);
+  });
+
+  it('stays shut however long we wait — this is a cap, not a cadence', () => {
+    for (let i = 0; i < MAX_SENDS_PER_SPACE_IDENTITY; i++) {
+      recordSpaceProfileAnnounce(SELF, SPACE, SIG, advance(i));
+    }
+    const aYear = T0 + 365 * 24 * 60 * 60 * 1000;
+    expect(shouldAnnounceSpaceProfile(SELF, SPACE, SIG, aYear)).toBe(false);
+  });
+
+  // Without this a rename after the cap closes would never reach anybody.
+  it('a rename gets its own full allowance', () => {
+    for (let i = 0; i < MAX_SENDS_PER_SPACE_IDENTITY; i++) {
+      recordSpaceProfileAnnounce(SELF, SPACE, SIG, advance(i));
+    }
+    const renamed = spaceProfileSignature({ globalDisplayName: 'Ada L.' });
+
+    let sent = 0;
+    for (let i = 10; i < 30; i++) {
+      const at = advance(i);
+      if (shouldAnnounceSpaceProfile(SELF, SPACE, renamed, at)) {
+        recordSpaceProfileAnnounce(SELF, SPACE, renamed, at);
+        sent++;
+      }
+    }
+    expect(sent).toBe(MAX_SENDS_PER_SPACE_IDENTITY);
+  });
+
+  // A flapping socket fires the announce repeatedly within seconds. Without the
+  // gap floor the whole allowance would be spent inside one outage — three
+  // frames that all fail together buy nothing over one.
+  it('a reconnect storm cannot burn the allowance in one window', () => {
+    let sent = 0;
+    for (let i = 0; i < 50; i++) {
+      const at = T0 + i * 1000; // 50 reconnects, one second apart
+      if (shouldAnnounceSpaceProfile(SELF, SPACE, SIG, at)) {
+        recordSpaceProfileAnnounce(SELF, SPACE, SIG, at);
+        sent++;
+      }
+    }
+    expect(sent).toBe(1);
+  });
+});
+
+describe('in-flight claims', () => {
+  // The startup timer and a reconnect timer overlap by design, and the record
+  // is written only once the send resolves — so without a synchronous claim
+  // both runs read "not yet announced" and both broadcast.
+  it('a claimed announce blocks a concurrent duplicate', () => {
+    expect(shouldAnnounceSpaceProfile(SELF, SPACE, SIG, T0)).toBe(true);
+    claimSpaceProfileAnnounce(SELF, SPACE, SIG);
+    expect(shouldAnnounceSpaceProfile(SELF, SPACE, SIG, T0)).toBe(false);
+  });
+
+  it('releasing re-opens it, so a FAILED send is retried next connect', () => {
+    claimSpaceProfileAnnounce(SELF, SPACE, SIG);
+    releaseSpaceProfileAnnounce(SELF, SPACE, SIG);
+    expect(shouldAnnounceSpaceProfile(SELF, SPACE, SIG, T0)).toBe(true);
+  });
+
+  it('a claim on one space does not block another', () => {
+    claimSpaceProfileAnnounce(SELF, SPACE, SIG);
+    expect(shouldAnnounceSpaceProfile(SELF, OTHER_SPACE, SIG, T0)).toBe(true);
+  });
+});
+
+describe('corrupt and legacy records', () => {
+  const key = `quorum:space-profile-announce:${SELF}:${SPACE}`;
+
+  it('a record with an unusable timestamp still recognises its signature', () => {
+    localStorage.setItem(key, JSON.stringify({ sig: SIG, at: null, attempts: 0 }));
+    // Migrated with its REAL signature and one attempt left, re-anchored to now
+    // — so it is gated immediately rather than firing on the spot.
+    expect(shouldAnnounceSpaceProfile(SELF, SPACE, SIG, T0)).toBe(false);
+    expect(
+      shouldAnnounceSpaceProfile(SELF, SPACE, SIG, T0 + SPACE_ANNOUNCE_MIN_GAP_MS)
+    ).toBe(true);
+  });
+
+  it('a NaN attempts counter cannot defeat the cap', () => {
+    localStorage.setItem(
+      key,
+      JSON.stringify({ sig: SIG, at: T0, attempts: Number.NaN })
+    );
+    let sent = 0;
+    for (let i = 0; i < 20; i++) {
+      const at = T0 + i * SPACE_ANNOUNCE_MIN_GAP_MS;
+      if (shouldAnnounceSpaceProfile(SELF, SPACE, SIG, at)) {
+        recordSpaceProfileAnnounce(SELF, SPACE, SIG, at);
+        sent++;
+      }
+    }
+    expect(sent).toBeLessThanOrEqual(MAX_SENDS_PER_SPACE_IDENTITY);
+  });
+
+  it('garbage in storage fails OPEN rather than wedging the space shut', () => {
+    localStorage.setItem(key, 'not json at all');
+    // Treated as a legacy bare signature for a DIFFERENT identity, so ours
+    // reads as changed and announces.
+    expect(shouldAnnounceSpaceProfile(SELF, SPACE, SIG, T0)).toBe(true);
+  });
+});
+
+// The two gates share an implementation, so a namespace collision would be
+// invisible until a DM push silently suppressed a space announce.
+describe('isolation from the DM gate', () => {
+  it('a DM send to an address does not gate a space of the same id', () => {
+    const dmSig = dmProfileSignature({ displayName: 'Ada', userIcon: 'icon' });
+    recordSpaceProfileAnnounce(SELF, SPACE, SIG, T0);
+    expect(shouldSendDmProfile(SELF, SPACE, dmSig, T0)).toBe(true);
+  });
+
+  it('the two gates use different storage keys', () => {
+    recordSpaceProfileAnnounce(SELF, SPACE, SIG, T0);
+    const keys = Object.keys(localStorage);
+    expect(keys.some((k) => k.startsWith('quorum:space-profile-announce'))).toBe(
+      true
+    );
+    expect(keys.some((k) => k.startsWith('quorum:dm-profile-broadcast'))).toBe(
+      false
+    );
+  });
+});

--- a/src/dev/tests/utils/spaceProfilePayload.test.ts
+++ b/src/dev/tests/utils/spaceProfilePayload.test.ts
@@ -1,0 +1,192 @@
+// What a device announces about itself to a space.
+//
+// Two rules meet here and they pull in opposite directions, which is why both
+// need pinning:
+//
+//   1. A deliberate per-space name MUST travel, or a member who set one would
+//      be shown under their global name to anybody bootstrapping a fresh row.
+//   2. A global value must NEVER be written into an override field. That was
+//      the historical roster-stamping bug: it froze each space to whatever the
+//      global was at stamp time and made "clear my per-space name"
+//      inexpressible, because clearing it just re-stamped the global back.
+//
+// Rule 2 is why absence is expressed by OMITTING the field rather than sending
+// an empty one — on this wire an omitted field means "no change" and `''` means
+// "deliberately cleared, follow global".
+//
+// See .agents/docs/features/identity-resolution-and-profile-sync.md
+
+import { describe, it, expect } from 'vitest';
+import {
+  buildSpaceProfileWirePayload,
+  hasAnnounceableIdentity,
+} from '../../../utils/spaceProfilePayload';
+
+const SELF = 'QmSelfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+
+const GLOBAL = {
+  name: 'Ada Lovelace',
+  profile_image: 'data:image/jpeg;base64,/9j/GLOBAL',
+  bio: 'mathematician',
+};
+
+describe('the global slot', () => {
+  it('carries the current global identity', () => {
+    const p = buildSpaceProfileWirePayload(SELF, undefined, GLOBAL);
+    expect(p.globalDisplayName).toBe('Ada Lovelace');
+    expect(p.globalUserIcon).toBe('data:image/jpeg;base64,/9j/GLOBAL');
+    expect(p.globalBio).toBe('mathematician');
+  });
+
+  it('identifies the sender', () => {
+    expect(buildSpaceProfileWirePayload(SELF, undefined, GLOBAL).senderId).toBe(
+      SELF
+    );
+    expect(buildSpaceProfileWirePayload(SELF, undefined, GLOBAL).type).toBe(
+      'update-profile'
+    );
+  });
+
+  it('omits a global field the user has not set', () => {
+    const p = buildSpaceProfileWirePayload(SELF, undefined, { name: 'Ada' });
+    expect('globalUserIcon' in p).toBe(false);
+    expect('globalBio' in p).toBe(false);
+  });
+});
+
+describe('the override slot — rule 2, never stamp the global into it', () => {
+  // The normal state post-follow-global: the member row exists but its override
+  // fields are empty, meaning "follow global".
+  it('omits every override field when no override is set', () => {
+    const p = buildSpaceProfileWirePayload(
+      SELF,
+      { display_name: '', user_icon: '', bio: '' },
+      GLOBAL
+    );
+    expect('displayName' in p).toBe(false);
+    expect('userIcon' in p).toBe(false);
+    expect('bio' in p).toBe(false);
+  });
+
+  it('omits them when there is no member row at all', () => {
+    const p = buildSpaceProfileWirePayload(SELF, undefined, GLOBAL);
+    expect('displayName' in p).toBe(false);
+    expect('userIcon' in p).toBe(false);
+  });
+
+  // The regression that would matter most: sending the global name as an
+  // override makes every receiver record a fake deliberate override, which
+  // then wins over the sender's real global name forever.
+  it('does not leak the global name into the override field', () => {
+    const p = buildSpaceProfileWirePayload(SELF, undefined, GLOBAL);
+    expect(p.displayName).toBeUndefined();
+    expect(p.userIcon).toBeUndefined();
+    expect(p.globalDisplayName).toBe('Ada Lovelace');
+  });
+});
+
+describe('the override slot — rule 1, a real per-space identity must travel', () => {
+  it('sends a per-space name alongside the global one', () => {
+    const p = buildSpaceProfileWirePayload(
+      SELF,
+      { display_name: 'Ada (this space)' },
+      GLOBAL
+    );
+    expect(p.displayName).toBe('Ada (this space)');
+    // Both slots go out: the receiver stores them separately and renders
+    // override-else-global, so the global is still learned.
+    expect(p.globalDisplayName).toBe('Ada Lovelace');
+  });
+
+  it('sends a per-space avatar and bio', () => {
+    const p = buildSpaceProfileWirePayload(
+      SELF,
+      { user_icon: 'data:image/jpeg;base64,/9j/SPACE', bio: 'here, I lurk' },
+      GLOBAL
+    );
+    expect(p.userIcon).toBe('data:image/jpeg;base64,/9j/SPACE');
+    expect(p.bio).toBe('here, I lurk');
+  });
+
+  // Rows written by different paths disagree about which field holds the
+  // avatar, and reading only one of them silently drops a real override.
+  it('reads the avatar from profile_image when user_icon is absent', () => {
+    const p = buildSpaceProfileWirePayload(
+      SELF,
+      { profile_image: 'data:image/jpeg;base64,/9j/ALT' },
+      GLOBAL
+    );
+    expect(p.userIcon).toBe('data:image/jpeg;base64,/9j/ALT');
+  });
+
+  it('prefers user_icon when both are present', () => {
+    const p = buildSpaceProfileWirePayload(
+      SELF,
+      { user_icon: 'primary', profile_image: 'secondary' },
+      GLOBAL
+    );
+    expect(p.userIcon).toBe('primary');
+  });
+
+  it('an override on one field does not drag the others along', () => {
+    const p = buildSpaceProfileWirePayload(
+      SELF,
+      { display_name: 'Ada (this space)' },
+      GLOBAL
+    );
+    expect('userIcon' in p).toBe(false);
+    expect('bio' in p).toBe(false);
+  });
+});
+
+describe('the space tag', () => {
+  it('is omitted unless one is supplied', () => {
+    expect(
+      'spaceTag' in buildSpaceProfileWirePayload(SELF, undefined, GLOBAL)
+    ).toBe(false);
+  });
+
+  it('rides along when supplied', () => {
+    const tag = { letters: 'QQQ', url: 'https://example.test/t', spaceId: 's1' };
+    const p = buildSpaceProfileWirePayload(SELF, undefined, GLOBAL, tag);
+    expect(p.spaceTag).toEqual(tag);
+  });
+});
+
+describe('hasAnnounceableIdentity', () => {
+  // A fresh account whose config has not synced would otherwise broadcast an
+  // all-empty payload — a no-op the receiver ignores, which still spends one of
+  // the bootstrap's few attempts.
+  it('is false when there is nothing to say', () => {
+    const p = buildSpaceProfileWirePayload(SELF, undefined, {});
+    expect(hasAnnounceableIdentity(p)).toBe(false);
+  });
+
+  it('is true on a global name alone', () => {
+    const p = buildSpaceProfileWirePayload(SELF, undefined, { name: 'Ada' });
+    expect(hasAnnounceableIdentity(p)).toBe(true);
+  });
+
+  it('is true on an avatar alone', () => {
+    const p = buildSpaceProfileWirePayload(SELF, undefined, {
+      profile_image: 'data:image/jpeg;base64,/9j/X',
+    });
+    expect(hasAnnounceableIdentity(p)).toBe(true);
+  });
+
+  it('is true on a per-space override alone', () => {
+    const p = buildSpaceProfileWirePayload(
+      SELF,
+      { display_name: 'Ada (this space)' },
+      {}
+    );
+    expect(hasAnnounceableIdentity(p)).toBe(true);
+  });
+
+  // A bio with no name or avatar is not an identity anybody renders, and it
+  // would still cost an attempt.
+  it('is false on a bio alone', () => {
+    const p = buildSpaceProfileWirePayload(SELF, undefined, { bio: 'hello' });
+    expect(hasAnnounceableIdentity(p)).toBe(false);
+  });
+});

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -90,6 +90,20 @@ import {
   claimDmProfileSend,
   releaseDmProfileSend,
 } from '../utils/dmProfileGate';
+import {
+  claimSpaceProfileAnnounce,
+  recordSpaceProfileAnnounce,
+  releaseSpaceProfileAnnounce,
+  shouldAnnounceSpaceProfile,
+  spaceProfileSignature,
+} from '../utils/spaceProfileGate';
+import {
+  buildSpaceProfileWirePayload,
+  hasAnnounceableIdentity,
+  type GlobalProfileFields,
+  type OwnSpaceMemberFields,
+  type SpaceProfileWireFields,
+} from '../utils/spaceProfilePayload';
 import { preferIncomingProfileField } from '../utils/conversationProfile';
 import { UndecryptableFrameTracker, frameKey } from '../utils/frameRetry';
 import { ThreadService } from './ThreadService';
@@ -922,89 +936,18 @@ export class MessageService {
 
       for (const s of allSpaces) {
         try {
-          // Per-space profile follows the sender's global value unless a
-          // deliberate OVERRIDE was set in this space. The stored member
-          // row carries an override iff its field is a non-empty value;
-          // empty/absent = follow global. We must NOT stamp the global
-          // config value as a per-space field (that froze the space to a
-          // stale global and broke "clear the override" — the bug this
-          // whole effort removes). So: send the per-space override if one
-          // exists, else OMIT the field so receivers fall back to the
-          // sender's global (public-profile) value via the render fallback.
-          // (See per-space-profile-empty-follows-global design.)
-          const ownMember = await this.messageDB.getSpaceMember(
+          const payload = await this.buildSpaceProfilePayload(
             s.spaceId,
-            selfAddress
+            selfAddress,
+            config,
+            resolvedTag
           );
-          const nameOverride = ownMember?.display_name || undefined;
-          // Member avatar lives on `user_icon` (typed UserProfile field);
-          // some rows also carry `profile_image` from other write paths, so
-          // read both defensively (mirrors the fallback at line ~4479).
-          const iconOverride =
-            ownMember?.user_icon ||
-            (ownMember as { profile_image?: string })?.profile_image ||
-            undefined;
-          const bioOverride = ownMember?.bio || undefined;
-
-          const nonce = crypto.randomUUID();
-          // Current GLOBAL identity from config — carried in the global* slots
-          // so members who missed the global save learn it on our tag-rotation
-          // rebroadcast. Separate from the override fields. (Two-slot design.)
-          const globalName = config.name || undefined;
-          const globalIcon = config.profile_image || undefined;
-          const globalBioVal = config.bio || undefined;
-          const updateProfileMessage = {
-            type: 'update-profile',
-            senderId: selfAddress,
-            // Omit any field with no per-space override — the receiver's
-            // upsert merge treats absent fields as "no change" and its
-            // render fallback surfaces the sender's global value. Only a
-            // real per-space override goes on the wire.
-            ...(nameOverride !== undefined ? { displayName: nameOverride } : {}),
-            ...(iconOverride !== undefined ? { userIcon: iconOverride } : {}),
-            ...(bioOverride !== undefined ? { bio: bioOverride } : {}),
-            ...(globalName !== undefined ? { globalDisplayName: globalName } : {}),
-            ...(globalIcon !== undefined ? { globalUserIcon: globalIcon } : {}),
-            ...(globalBioVal !== undefined ? { globalBio: globalBioVal } : {}),
-            ...(resolvedTag ? { spaceTag: resolvedTag } : {}),
-          } as UpdateProfileMessage;
-
-          const messageId = await crypto.subtle.digest(
-            'SHA-256',
-            Buffer.from(
-              nonce +
-                'update-profile' +
-                selfAddress +
-                canonicalize(updateProfileMessage),
-              'utf-8'
-            )
+          const message = await this.signSpaceProfileMessage(
+            s.spaceId,
+            s.defaultChannelId,
+            selfAddress,
+            payload
           );
-
-          const message = {
-            spaceId: s.spaceId,
-            channelId: s.defaultChannelId,
-            messageId: Buffer.from(messageId).toString('hex'),
-            digestAlgorithm: 'SHA-256',
-            nonce,
-            createdDate: Date.now(),
-            modifiedDate: Date.now(),
-            lastModifiedHash: '',
-            content: updateProfileMessage,
-          } as Message;
-
-          // Sign (non-repudiable — required for profile updates)
-          const inboxKey = await this.getSigningKey(s.spaceId);
-          message.publicKey = inboxKey.publicKey;
-          message.signature = Buffer.from(
-            JSON.parse(
-              ch.js_sign_ed448(
-                Buffer.from(inboxKey.privateKey, 'hex').toString('base64'),
-                Buffer.from(messageId).toString('base64')
-              )
-            ),
-            'base64'
-          ).toString('hex');
-
           outbounds.push(await this.encryptAndSendToSpace(s.spaceId, message));
         } catch (err) {
           logger.error(`Failed to re-broadcast tag to space ${s.spaceId}`, err);
@@ -1028,6 +971,189 @@ export class MessageService {
       buildConfigKey({ userAddress: selfAddress }),
       () => updatedConfig
     );
+  }
+
+  /**
+   * Build the `update-profile` payload this device should announce to a space.
+   *
+   * TWO SLOTS, kept separate (see
+   * `.agents/docs/features/identity-resolution-and-profile-sync.md`):
+   *
+   * - OVERRIDE (`displayName`/`userIcon`/`bio`) — a deliberate per-space
+   *   identity, read from our own member row. Sent only when one really exists;
+   *   otherwise the field is OMITTED and the receiver's merge treats that as "no
+   *   change", falling back to the global slot when it renders. Stamping the
+   *   global config value into these fields is the bug the follow-global work
+   *   removed: it froze each space to a stale global and made "clear my
+   *   per-space name" inexpressible.
+   * - GLOBAL (`global*`) — our current global identity from config, so a member
+   *   who missed the live save still learns it.
+   *
+   * Sending the override slot matters for correctness, not just fidelity: a
+   * member who set a per-space name expects spacemates to see THAT name, and a
+   * bootstrap carrying only the global slot would show the global one to anybody
+   * who had no row for them yet.
+   */
+  private async buildSpaceProfilePayload(
+    spaceId: string,
+    selfAddress: string,
+    config: GlobalProfileFields,
+    resolvedTag?: BroadcastSpaceTag
+  ): Promise<UpdateProfileMessage> {
+    const ownMember = await this.messageDB.getSpaceMember(spaceId, selfAddress);
+    return buildSpaceProfileWirePayload(
+      selfAddress,
+      ownMember as OwnSpaceMemberFields | undefined,
+      config,
+      resolvedTag
+      // Cast: `UpdateProfileMessage` still declares `userIcon` required, which
+      // the omit-the-override rule contradicts by design. Same cast as the
+      // global-save broadcast site in MessageDB.tsx. Tracked by the shared-type
+      // follow-up (2026-07-16-quorum-shared-type-two-slot-global-identity-fields).
+    ) as unknown as UpdateProfileMessage;
+  }
+
+  /**
+   * Wrap an `update-profile` payload in a signed space `Message`.
+   *
+   * Signing is non-repudiable and required for profile updates, so this is not
+   * optional — and it is the expensive half (a key read, a digest and an ed448
+   * signature), which is why callers that gate their sends should decide BEFORE
+   * calling this.
+   */
+  private async signSpaceProfileMessage(
+    spaceId: string,
+    channelId: string,
+    selfAddress: string,
+    payload: UpdateProfileMessage
+  ): Promise<Message> {
+    const nonce = crypto.randomUUID();
+    const messageId = await crypto.subtle.digest(
+      'SHA-256',
+      Buffer.from(
+        nonce + 'update-profile' + selfAddress + canonicalize(payload),
+        'utf-8'
+      )
+    );
+
+    const message = {
+      spaceId,
+      channelId,
+      messageId: Buffer.from(messageId).toString('hex'),
+      digestAlgorithm: 'SHA-256',
+      nonce,
+      createdDate: Date.now(),
+      modifiedDate: Date.now(),
+      lastModifiedHash: '',
+      content: payload,
+    } as Message;
+
+    const inboxKey = await this.getSigningKey(spaceId);
+    message.publicKey = inboxKey.publicKey;
+    message.signature = Buffer.from(
+      JSON.parse(
+        ch.js_sign_ed448(
+          Buffer.from(inboxKey.privateKey, 'hex').toString('base64'),
+          Buffer.from(messageId).toString('base64')
+        )
+      ),
+      'base64'
+    ).toString('hex');
+
+    return message;
+  }
+
+  /**
+   * On-connect space identity announce — the BOOTSTRAP half of space identity.
+   *
+   * Space identity is push-based: a member's name and avatar exist on your
+   * device only because somebody announced them. Desktop announced at join and
+   * on tag rotation and nowhere else, so a member who joined a space while you
+   * were offline had no second chance and rendered as a 6-char address
+   * indefinitely. Measured on the test space "Quorum Test 2": 46 of 89 distinct
+   * senders had no member row at all.
+   *
+   * This complements, and does not duplicate, the member digest exchange that
+   * `requestSync` already drives. That exchange reconciles rows two peers
+   * DISAGREE about; it cannot invent a member neither side has ever heard of.
+   * Hence "bootstrap": the gate closes after a few attempts (see
+   * `spaceProfileGate.ts`) rather than running as a cadence, because past the
+   * bootstrap the digest sync is the repair path.
+   *
+   * The `spaceTag` is deliberately NOT carried here. Reconstructing it would
+   * mean trusting `config.lastBroadcastSpaceTag`, which only the tag-rotation
+   * path maintains, and broadcasting a stale tag is worse than omitting one —
+   * the receiver treats an absent `spaceTag` as "no change", and a member delta
+   * carries the real tag once a digest disagreement surfaces.
+   *
+   * Fire-and-forget: per-space failures are logged and never block anything.
+   */
+  async announceProfileToAllSpacesOnConnect(selfAddress: string): Promise<void> {
+    let spaces: Space[];
+    let config: Awaited<ReturnType<typeof this.messageDB.getUserConfig>>;
+    try {
+      config = await this.messageDB.getUserConfig({ address: selfAddress });
+      if (!config) return;
+      spaces = await this.messageDB.getSpaces();
+    } catch (err) {
+      logger.warn('[SpaceProfile] on-connect announce could not read state', {
+        err,
+      });
+      return;
+    }
+
+    // `spaceIds` is the joined set. A Space row can outlive membership (an
+    // invite preview, a space we left), and announcing into one we are not in
+    // would be rejected by the receiver's authorization check anyway.
+    const joinedIds = config.spaceIds;
+    const joined = Array.isArray(joinedIds)
+      ? spaces.filter((s) => joinedIds.includes(s.spaceId))
+      : spaces;
+
+    for (const space of joined) {
+      try {
+        const payload = await this.buildSpaceProfilePayload(
+          space.spaceId,
+          selfAddress,
+          config
+        );
+
+        // Nothing to advertise yet (fresh account, config not synced). An
+        // all-empty announce is a wire no-op the receiver ignores, and sending
+        // it would burn an attempt from the cap for nothing.
+        const wire = payload as unknown as SpaceProfileWireFields;
+        if (!hasAnnounceableIdentity(wire)) continue;
+
+        const signature = spaceProfileSignature(wire);
+        if (
+          !shouldAnnounceSpaceProfile(selfAddress, space.spaceId, signature)
+        ) {
+          continue;
+        }
+
+        // Claim BEFORE the await, release in `finally` — the startup timer and
+        // a reconnect timer overlap by design, and the record is only written
+        // once the send resolves. See spaceProfileGate.
+        claimSpaceProfileAnnounce(selfAddress, space.spaceId, signature);
+        try {
+          const message = await this.signSpaceProfileMessage(
+            space.spaceId,
+            space.defaultChannelId,
+            selfAddress,
+            payload
+          );
+          await this.encryptAndSendToSpace(space.spaceId, message);
+          recordSpaceProfileAnnounce(selfAddress, space.spaceId, signature);
+        } finally {
+          releaseSpaceProfileAnnounce(selfAddress, space.spaceId, signature);
+        }
+      } catch (err) {
+        logger.warn('[SpaceProfile] announce to space failed', {
+          err,
+          spaceId: space.spaceId,
+        });
+      }
+    }
   }
 
   /**

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -1049,6 +1049,14 @@ export class MessageService {
     } as Message;
 
     const inboxKey = await this.getSigningKey(spaceId);
+    // `getSigningKey` legitimately resolves to undefined when we hold neither a
+    // signing nor an inbox key for this space. Dereferencing it would surface
+    // that as a bare TypeError inside the caller's catch-all, which tells a
+    // future debugger nothing about WHICH precondition failed — and this one is
+    // actionable (broken/missing key material) rather than transient.
+    if (!inboxKey?.publicKey || !inboxKey?.privateKey) {
+      throw new Error(`No signing key for space ${spaceId}`);
+    }
     message.publicKey = inboxKey.publicKey;
     message.signature = Buffer.from(
       JSON.parse(
@@ -1148,7 +1156,19 @@ export class MessageService {
           releaseSpaceProfileAnnounce(selfAddress, space.spaceId, signature);
         }
       } catch (err) {
-        logger.warn('[SpaceProfile] announce to space failed', {
+        // Separate the EXPECTED case from a real fault, mirroring the DM
+        // sibling. A space we hold no key material for is a normal transient
+        // state (mid-join, a space row that arrived before its keys), not
+        // something to investigate — and letting it share the `warn` channel
+        // with genuine failures is how the genuine ones get ignored.
+        const detail = (err as Error)?.message ?? '';
+        if (detail.startsWith('No signing key for space')) {
+          logger.debug('[SpaceProfile] no signing key for space yet — skipping', {
+            spaceId: space.spaceId,
+          });
+          continue;
+        }
+        logger.error('[SpaceProfile] announce to space failed', {
           err,
           spaceId: space.spaceId,
         });

--- a/src/utils/dmProfileGate.ts
+++ b/src/utils/dmProfileGate.ts
@@ -18,22 +18,21 @@
 // finite job; the first version of this gate had no cap and so kept paying 365
 // sends a year per pair to say nothing new.
 //
-// The three states, in the order the predicate checks them:
-//   never sent / identity changed → send (a rename resets the count)
-//   attempts exhausted            → never again, until the identity changes
-//   otherwise                     → send once the interval has elapsed
+// The rules themselves — cap, expiry, legacy-record migration, in-flight claim
+// — live in `profileSendGate.ts` and are shared with the space announce. What
+// stays here is DM-specific: the storage namespace, the interval, and what
+// counts as the payload.
 //
 // Desktop counterpart of mobile's MMKV gate
-// (quorum-mobile/services/dm/dmProfileService.ts). The two are NOT yet in
-// parity and diverge in opposite directions: mobile has no expiry and no cap,
-// so it sends exactly once ever and a single lost frame is permanent. Bringing
-// mobile to the same rule is tracked, and is deliberately not part of this
-// change.
+// (quorum-mobile/services/dm/dmProfileService.ts).
 //
 // See .agents/tasks/2026-08-01-identity-announce-cadence-research.md (Step 2)
 // and 2026-08-01-dm-partner-identity-lost-on-established-sessions.md
 
-import { logger } from '@quilibrium/quorum-shared';
+import {
+  canonicalProfileSignature,
+  createProfileSendGate,
+} from './profileSendGate';
 
 const GATE_PREFIX = 'quorum:dm-profile-broadcast';
 
@@ -64,24 +63,24 @@ export const RESEND_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24h
  *    un-converged an already-healed row; with a cap and no fix, such a row would
  *    stay broken forever.
  *  - The MIGRATION stampedes the whole fleet on deploy day if a legacy record
- *    keeps its stored `at`. See `readRecord`.
+ *    keeps its stored `at`. See `migrateRecord` in `profileSendGate.ts`.
  *
  * Rationale and the cost model:
  *   .agents/tasks/2026-08-01-identity-announce-cadence-research.md
  *
- * Do not copy this into the space implementation — spaces already have a
- * receiver-driven member reconciliation and need no cadence (that task, Step 3).
+ * ⚠️ Do not reuse this INTERVAL for spaces. Spaces already have a
+ * receiver-driven member reconciliation (`MemberDigest` → `MemberDelta`), so
+ * their announce is a bootstrap rather than a cadence and spaces it far more
+ * tightly — see `spaceProfileGate.ts`. The cap is shared; the interval is not.
  */
 export const MAX_SENDS_PER_IDENTITY = 3;
 
-/**
- * Attempts credited to a record written before this cap existed.
- *
- * 2 leaves exactly ONE more try for pairs that are broken right now, then the
- * cap closes. Going straight to MAX would abandon them; going to 0 would replay
- * the whole ladder for every pair that is already fine.
- */
-const MIGRATED_ATTEMPTS = MAX_SENDS_PER_IDENTITY - 1;
+const gate = createProfileSendGate({
+  storagePrefix: GATE_PREFIX,
+  logPrefix: '[DMProfile]',
+  minGapMs: RESEND_INTERVAL_MS,
+  maxSendsPerIdentity: MAX_SENDS_PER_IDENTITY,
+});
 
 /** The identity fields that actually go on the wire. */
 export interface DmProfileWirePayload {
@@ -94,131 +93,19 @@ export interface DmProfileWirePayload {
  * Canonical signature of the exact wire payload.
  *
  * Field PRESENCE matters as well as value: an avatar-only push and a
- * name-only push are different messages and must not gate each other. Built
- * from an explicit sorted key order so it never depends on insertion order.
+ * name-only push are different messages and must not gate each other.
+ *
+ * Note `bio` alone tests `!== undefined` rather than truthiness — an empty bio
+ * is a deliberate CLEAR on the wire, so it has to be distinguishable from an
+ * omitted one. Names and avatars have no such "clear" semantics here.
  */
 export const dmProfileSignature = (payload: DmProfileWirePayload): string => {
   const canonical: Record<string, string> = {};
   if (payload.displayName) canonical.displayName = payload.displayName;
   if (payload.userIcon) canonical.userIcon = payload.userIcon;
   if (payload.bio !== undefined) canonical.bio = payload.bio;
-  return JSON.stringify(
-    Object.keys(canonical)
-      .sort()
-      .map((k) => [k, canonical[k]])
-  );
+  return canonicalProfileSignature(canonical);
 };
-
-const gateKey = (selfAddress: string, partnerAddress: string): string =>
-  `${GATE_PREFIX}:${selfAddress}:${partnerAddress}`;
-
-interface GateRecord {
-  sig: string;
-  at: number;
-  /** Sends of THIS signature to this partner so far. Capped at MAX_SENDS_PER_IDENTITY. */
-  attempts: number;
-}
-
-const writeRecord = (
-  selfAddress: string,
-  partnerAddress: string,
-  record: GateRecord
-): void => {
-  try {
-    localStorage.setItem(
-      gateKey(selfAddress, partnerAddress),
-      JSON.stringify(record)
-    );
-  } catch (err) {
-    logger.warn('[DMProfile] gate write failed — will re-send next connect', { err });
-  }
-};
-
-/**
- * Upgrade a pre-cap record, and PERSIST the upgrade.
- *
- * ⚠️ `at` is re-anchored to NOW, deliberately, never the stored value. Records
- * carry a timestamp up to 24h old, so keeping it would put every existing pair
- * instantly past the interval and fire the entire fleet on the first connect
- * after deploy. Re-anchoring spreads the one remaining attempt across whenever
- * each user next opens the app.
- *
- * The write matters as much as the value: without it the upgrade is recomputed
- * on every read, so `now - at` is always ~0 and the record can never age out —
- * which is exactly how the pre-cap code left legacy bare-signature records
- * permanently gated shut.
- */
-const migrateRecord = (
-  selfAddress: string,
-  partnerAddress: string,
-  sig: string,
-  now: number
-): GateRecord => {
-  const migrated: GateRecord = { sig, at: now, attempts: MIGRATED_ATTEMPTS };
-  writeRecord(selfAddress, partnerAddress, migrated);
-  return migrated;
-};
-
-const readRecord = (
-  selfAddress: string,
-  partnerAddress: string,
-  now: number
-): GateRecord | null => {
-  let raw: string | null;
-  try {
-    raw = localStorage.getItem(gateKey(selfAddress, partnerAddress));
-  } catch (err) {
-    // Storage unavailable — fail OPEN. A redundant identity push is harmless;
-    // a missed one leaves the partner stuck on a placeholder.
-    logger.warn('[DMProfile] gate read failed — treating as not-yet-sent', { err });
-    return null;
-  }
-  if (!raw) return null;
-  try {
-    const parsed = JSON.parse(raw) as unknown;
-    if (
-      parsed !== null &&
-      typeof parsed === 'object' &&
-      !Array.isArray(parsed) &&
-      typeof (parsed as GateRecord).sig === 'string'
-    ) {
-      // Only `sig` is required to recognise the object form. `at` and
-      // `attempts` are validated below rather than in this guard, so a record
-      // whose numbers are unusable still migrates with its REAL signature
-      // instead of falling through to the bare-signature branch and having the
-      // whole JSON blob mistaken for one.
-      const sig = (parsed as GateRecord).sig;
-      const at = (parsed as GateRecord).at;
-      const attempts = (parsed as GateRecord).attempts;
-      // Shape 1 of 2: `{sig, at}` — the pre-cap format, no attempt counter.
-      //
-      // `Number.isInteger` / `Number.isFinite`, not `typeof === 'number'`: NaN
-      // and Infinity are both numbers, and either breaks the gate silently — a
-      // NaN `attempts` defeats the cap (`NaN >= 3` is false, so it sends
-      // forever) and a NaN `at` wedges the interval shut. Note NaN and Infinity
-      // both serialise to `null` through JSON, so this also covers a record that
-      // was written while one of them was in play.
-      if (!Number.isFinite(at) || !Number.isInteger(attempts) || attempts < 0) {
-        return migrateRecord(selfAddress, partnerAddress, sig, now);
-      }
-      return { sig, at, attempts };
-    }
-  } catch {
-    // Not JSON at all — fall through to the legacy branch.
-  }
-  // Shape 2 of 2: the ORIGINAL format stored a BARE SIGNATURE string. Note that
-  // a signature is itself valid JSON (an array), so it parses cleanly — which is
-  // exactly why the shape check above matters more than the try/catch.
-  return migrateRecord(selfAddress, partnerAddress, raw, now);
-};
-
-// In-flight claims, process-local. The persisted record is only written AFTER
-// encryptAndSendDm resolves (a real crypto + network round trip), so two
-// overlapping broadcast runs — the startup timer and a reconnect timer can
-// overlap by design — would both read "not yet sent" and both send a real
-// encrypted DM to the same partner. Claiming synchronously here closes that
-// window. Not persisted: a reload legitimately means nothing is in flight.
-const inFlight = new Set<string>();
 
 /**
  * Should we send this payload to this partner right now?
@@ -236,21 +123,7 @@ export const shouldSendDmProfile = (
   partnerAddress: string,
   signature: string,
   now: number = Date.now()
-): boolean => {
-  if (inFlight.has(`${gateKey(selfAddress, partnerAddress)}|${signature}`)) {
-    return false;
-  }
-  const record = readRecord(selfAddress, partnerAddress, now);
-  if (!record) return true;
-  // A changed identity is not a retry — it is new information, so it ignores
-  // both the interval and the cap, and starts its own count (see record*Send).
-  if (record.sig !== signature) return true;
-  // The cap. Checked BEFORE the interval so a converged pair short-circuits
-  // without any arithmetic, and so the intent reads in order: "have we said
-  // this enough times already?" then "has it been long enough?".
-  if (record.attempts >= MAX_SENDS_PER_IDENTITY) return false;
-  return now - record.at >= RESEND_INTERVAL_MS;
-};
+): boolean => gate.shouldSend(selfAddress, partnerAddress, signature, now);
 
 /**
  * Claim a send synchronously, before awaiting it. Must be paired with
@@ -261,18 +134,14 @@ export const claimDmProfileSend = (
   selfAddress: string,
   partnerAddress: string,
   signature: string
-): void => {
-  inFlight.add(`${gateKey(selfAddress, partnerAddress)}|${signature}`);
-};
+): void => gate.claim(selfAddress, partnerAddress, signature);
 
 /** Release an in-flight claim, whether the send succeeded or threw. */
 export const releaseDmProfileSend = (
   selfAddress: string,
   partnerAddress: string,
   signature: string
-): void => {
-  inFlight.delete(`${gateKey(selfAddress, partnerAddress)}|${signature}`);
-};
+): void => gate.release(selfAddress, partnerAddress, signature);
 
 /**
  * Record a successful send, advancing the attempt counter. Call ONLY after the
@@ -288,9 +157,4 @@ export const recordDmProfileSend = (
   partnerAddress: string,
   signature: string,
   now: number = Date.now()
-): void => {
-  const previous = readRecord(selfAddress, partnerAddress, now);
-  const attempts =
-    previous && previous.sig === signature ? previous.attempts + 1 : 1;
-  writeRecord(selfAddress, partnerAddress, { sig: signature, at: now, attempts });
-};
+): void => gate.record(selfAddress, partnerAddress, signature, now);

--- a/src/utils/profileSendGate.ts
+++ b/src/utils/profileSendGate.ts
@@ -1,0 +1,285 @@
+// Shared send-gate for identity announcements.
+//
+// Two callers today: the per-partner DM push (`dmProfileGate.ts`) and the
+// per-space bootstrap announce (`spaceProfileGate.ts`). They differ only in
+// where the record is keyed and how long they wait between attempts; the rules
+// below — cap, expiry, migration, in-flight claim — are identical and each one
+// was paid for with a live failure on the DM side. Keeping ONE implementation
+// is the point: the three subtleties documented here are exactly the kind that
+// get silently dropped by a copy-paste.
+//
+// The shape of the rule:
+//
+//   never sent / identity changed → send (a rename resets the count)
+//   attempts exhausted            → never again, until the identity changes
+//   otherwise                     → send once the minimum gap has elapsed
+//
+// Healing a lost identity is a FINITE job. An uncapped gate keeps paying to say
+// nothing new, forever, on every pair — cost that scales with the user base
+// rather than with the problem. A gate with no expiry at all is the opposite
+// failure: one lost frame becomes permanent and silent, because the sender
+// recorded a success the receiver never saw.
+//
+// See .agents/tasks/2026-08-01-identity-announce-cadence-research.md
+
+import { logger } from '@quilibrium/quorum-shared';
+
+export interface ProfileSendGateConfig {
+  /** localStorage key namespace. Must be unique per gate. */
+  storagePrefix: string;
+  /** Log tag, e.g. `[DMProfile]`. */
+  logPrefix: string;
+  /**
+   * Minimum gap between two sends of the SAME identity to the same peer.
+   *
+   * A floor, not a cadence: after `maxSendsPerIdentity` the gate closes for
+   * good regardless of how much time passes. Its only job is to stop the
+   * attempts landing inside one bad-network window, which would waste the
+   * whole allowance on a single outage.
+   */
+  minGapMs: number;
+  /** How many times an UNCHANGED identity is ever sent to one peer. */
+  maxSendsPerIdentity: number;
+}
+
+interface GateRecord {
+  sig: string;
+  at: number;
+  /** Sends of THIS signature to this peer so far. Capped at maxSendsPerIdentity. */
+  attempts: number;
+}
+
+/**
+ * Canonical signature of a wire payload: an explicit sorted key order, so it
+ * never depends on insertion order.
+ *
+ * Field PRESENCE matters as well as value — an avatar-only push and a name-only
+ * push are different messages and must not gate each other — so callers decide
+ * which keys to include and this only canonicalises what it is handed.
+ */
+export const canonicalProfileSignature = (
+  fields: Record<string, string>
+): string =>
+  JSON.stringify(
+    Object.keys(fields)
+      .sort()
+      .map((k) => [k, fields[k]])
+  );
+
+/**
+ * Fold a string into a compact hex digest.
+ *
+ * FNV-1a over two offset accumulators. NOT a security boundary — this is a
+ * change detector, and its only failure mode is a collision, which reads as
+ * "the identity did not change" and costs one skipped re-announce. Callers that
+ * cannot tolerate that (no other repair path) should store the full signature
+ * instead; see the note in `spaceProfileGate.ts` for why spaces can.
+ */
+export const compactSignature = (value: string): string => {
+  let a = 0x811c9dc5;
+  let b = 0x01000193;
+  for (let i = 0; i < value.length; i++) {
+    const c = value.charCodeAt(i);
+    a = Math.imul(a ^ c, 0x01000193);
+    b = Math.imul(b + c, 0x85ebca6b) ^ (b >>> 13);
+  }
+  return (
+    (a >>> 0).toString(16).padStart(8, '0') +
+    (b >>> 0).toString(16).padStart(8, '0')
+  );
+};
+
+export interface ProfileSendGate {
+  /**
+   * Should we send this payload to this peer right now?
+   *
+   * `now` is injectable so the gap and the cap are testable without faking the
+   * clock.
+   */
+  shouldSend(
+    selfAddress: string,
+    peerKey: string,
+    signature: string,
+    now?: number
+  ): boolean;
+  /**
+   * Claim a send synchronously, BEFORE awaiting it. Must be paired with
+   * `release` in a `finally` so a failed send does not wedge the peer shut
+   * until reload.
+   */
+  claim(selfAddress: string, peerKey: string, signature: string): void;
+  /** Release an in-flight claim, whether the send succeeded or threw. */
+  release(selfAddress: string, peerKey: string, signature: string): void;
+  /**
+   * Record a successful send, advancing the attempt counter. Call ONLY after
+   * the send resolves, so a failure leaves the gate open and the next connect
+   * retries. Storage failures are non-fatal (the gate simply stays open).
+   *
+   * A send of a DIFFERENT signature restarts the count at 1: the cap is per
+   * identity-version, not per peer for all time, so a rename gets its own full
+   * set of attempts.
+   */
+  record(
+    selfAddress: string,
+    peerKey: string,
+    signature: string,
+    now?: number
+  ): void;
+}
+
+export const createProfileSendGate = (
+  config: ProfileSendGateConfig
+): ProfileSendGate => {
+  const { storagePrefix, logPrefix, minGapMs, maxSendsPerIdentity } = config;
+
+  /**
+   * Attempts credited to a record written before the cap existed.
+   *
+   * One below the cap leaves exactly ONE more try for peers that are broken
+   * right now, then it closes. Going straight to the cap would abandon them;
+   * going to 0 would replay the whole ladder for every peer already fine.
+   */
+  const migratedAttempts = Math.max(0, maxSendsPerIdentity - 1);
+
+  const gateKey = (selfAddress: string, peerKey: string): string =>
+    `${storagePrefix}:${selfAddress}:${peerKey}`;
+
+  const writeRecord = (
+    selfAddress: string,
+    peerKey: string,
+    record: GateRecord
+  ): void => {
+    try {
+      localStorage.setItem(gateKey(selfAddress, peerKey), JSON.stringify(record));
+    } catch (err) {
+      logger.warn(`${logPrefix} gate write failed — will re-send next connect`, {
+        err,
+      });
+    }
+  };
+
+  /**
+   * Upgrade a pre-cap record, and PERSIST the upgrade.
+   *
+   * ⚠️ `at` is re-anchored to NOW, deliberately, never the stored value.
+   * Records carry a timestamp up to a full interval old, so keeping it would
+   * put every existing peer instantly past the gap and fire the entire fleet on
+   * the first connect after deploy. Re-anchoring spreads the one remaining
+   * attempt across whenever each user next opens the app.
+   *
+   * The write matters as much as the value: without it the upgrade is
+   * recomputed on every read, so `now - at` is always ~0 and the record can
+   * never age out — which is exactly how the pre-cap code left legacy
+   * bare-signature records permanently gated shut.
+   */
+  const migrateRecord = (
+    selfAddress: string,
+    peerKey: string,
+    sig: string,
+    now: number
+  ): GateRecord => {
+    const migrated: GateRecord = { sig, at: now, attempts: migratedAttempts };
+    writeRecord(selfAddress, peerKey, migrated);
+    return migrated;
+  };
+
+  const readRecord = (
+    selfAddress: string,
+    peerKey: string,
+    now: number
+  ): GateRecord | null => {
+    let raw: string | null;
+    try {
+      raw = localStorage.getItem(gateKey(selfAddress, peerKey));
+    } catch (err) {
+      // Storage unavailable — fail OPEN. A redundant identity push is harmless;
+      // a missed one leaves the peer stuck on a placeholder.
+      logger.warn(`${logPrefix} gate read failed — treating as not-yet-sent`, {
+        err,
+      });
+      return null;
+    }
+    if (!raw) return null;
+    try {
+      const parsed = JSON.parse(raw) as unknown;
+      if (
+        parsed !== null &&
+        typeof parsed === 'object' &&
+        !Array.isArray(parsed) &&
+        typeof (parsed as GateRecord).sig === 'string'
+      ) {
+        // Only `sig` is required to recognise the object form. `at` and
+        // `attempts` are validated below rather than in this guard, so a record
+        // whose numbers are unusable still migrates with its REAL signature
+        // instead of falling through to the bare-signature branch and having
+        // the whole JSON blob mistaken for one.
+        const sig = (parsed as GateRecord).sig;
+        const at = (parsed as GateRecord).at;
+        const attempts = (parsed as GateRecord).attempts;
+        // Shape 1 of 2: `{sig, at}` — the pre-cap format, no attempt counter.
+        //
+        // `Number.isInteger` / `Number.isFinite`, not `typeof === 'number'`:
+        // NaN and Infinity are both numbers, and either breaks the gate
+        // silently — a NaN `attempts` defeats the cap (`NaN >= 3` is false, so
+        // it sends forever) and a NaN `at` wedges the gap shut. Note NaN and
+        // Infinity both serialise to `null` through JSON, so this also covers a
+        // record that was written while one of them was in play.
+        if (!Number.isFinite(at) || !Number.isInteger(attempts) || attempts < 0) {
+          return migrateRecord(selfAddress, peerKey, sig, now);
+        }
+        return { sig, at, attempts };
+      }
+    } catch {
+      // Not JSON at all — fall through to the legacy branch.
+    }
+    // Shape 2 of 2: the ORIGINAL format stored a BARE SIGNATURE string. Note
+    // that a signature is itself valid JSON (an array), so it parses cleanly —
+    // which is exactly why the shape check above matters more than the
+    // try/catch.
+    return migrateRecord(selfAddress, peerKey, raw, now);
+  };
+
+  // In-flight claims, process-local. The persisted record is only written AFTER
+  // the send resolves (a real crypto + network round trip), so two overlapping
+  // broadcast runs — the startup timer and a reconnect timer can overlap by
+  // design — would both read "not yet sent" and both transmit. Claiming
+  // synchronously here closes that window. Not persisted: a reload legitimately
+  // means nothing is in flight.
+  const inFlight = new Set<string>();
+  const claimKey = (
+    selfAddress: string,
+    peerKey: string,
+    signature: string
+  ): string => `${gateKey(selfAddress, peerKey)}|${signature}`;
+
+  return {
+    shouldSend(selfAddress, peerKey, signature, now = Date.now()) {
+      if (inFlight.has(claimKey(selfAddress, peerKey, signature))) return false;
+      const record = readRecord(selfAddress, peerKey, now);
+      if (!record) return true;
+      // A changed identity is not a retry — it is new information, so it
+      // ignores both the gap and the cap, and starts its own count.
+      if (record.sig !== signature) return true;
+      // The cap. Checked BEFORE the gap so a converged peer short-circuits
+      // without any arithmetic, and so the intent reads in order: "have we said
+      // this enough times already?" then "has it been long enough?".
+      if (record.attempts >= maxSendsPerIdentity) return false;
+      return now - record.at >= minGapMs;
+    },
+
+    claim(selfAddress, peerKey, signature) {
+      inFlight.add(claimKey(selfAddress, peerKey, signature));
+    },
+
+    release(selfAddress, peerKey, signature) {
+      inFlight.delete(claimKey(selfAddress, peerKey, signature));
+    },
+
+    record(selfAddress, peerKey, signature, now = Date.now()) {
+      const previous = readRecord(selfAddress, peerKey, now);
+      const attempts =
+        previous && previous.sig === signature ? previous.attempts + 1 : 1;
+      writeRecord(selfAddress, peerKey, { sig: signature, at: now, attempts });
+    },
+  };
+};

--- a/src/utils/spaceProfileGate.ts
+++ b/src/utils/spaceProfileGate.ts
@@ -1,0 +1,146 @@
+// Per-space send gate for the on-connect identity announce.
+//
+// Space identity is PUSH-based: a member's name and avatar exist on your device
+// only because somebody announced them. Desktop announced at join and on tag
+// rotation and nowhere else, so a member who joined while you were offline never
+// got a second chance and rendered as a 6-char address forever.
+//
+// This gate bounds the fix. It is deliberately NOT the DM gate's shape:
+//
+//   DM     — 3 attempts, 24h apart. A DM has no reconciliation of any kind, so
+//            the retry IS the repair mechanism and is spread over days.
+//   Space  — 3 attempts, minutes apart, then never again. Spaces already run a
+//            receiver-driven reconciliation (`MemberDigest` → `MemberDelta` on
+//            every `requestSync`), so this announce only has to BOOTSTRAP
+//            members nobody holds a row for at all. Once a row exists, the
+//            digest exchange keeps it correct without any announce.
+//
+// That is why there is no cadence here and why the spacing is a floor rather
+// than an interval: its only job is to stop all three attempts landing inside
+// one bad-network window. After the third the gate closes until the identity
+// itself changes.
+//
+// Cost is the reason to care. A space announce is one broadcast for the sender
+// but it is READ by every member, so the bytes are `spaces × members` — at
+// 5 spaces × 50 members that is several times a daily DM announce, not less.
+// An uncapped version would be the most expensive identity traffic in the app.
+//
+// See .agents/tasks/2026-08-01-space-member-identity-announce-on-connect.md
+// and 2026-08-01-identity-announce-cadence-research.md (Step 3).
+
+import {
+  canonicalProfileSignature,
+  compactSignature,
+  createProfileSendGate,
+} from './profileSendGate';
+
+const GATE_PREFIX = 'quorum:space-profile-announce';
+
+/**
+ * Floor between two attempts at the SAME identity in one space.
+ *
+ * Not a cadence — see MAX_SENDS_PER_SPACE_IDENTITY. Five minutes is long enough
+ * that a flapping socket cannot burn the whole allowance during a single
+ * outage, and short enough that all three attempts fit comfortably inside one
+ * ordinary session rather than being spread over days like the DM gate.
+ */
+export const SPACE_ANNOUNCE_MIN_GAP_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * How many times an UNCHANGED identity is ever announced to one space.
+ *
+ * Matches the DM cap and is sized the same way: residual loss after k tries is
+ * p^k, so three leaves 0.34% at p≈0.15 and 0.0008% at p≈0.02. Beyond that the
+ * receiver-driven digest sync is the repair path, not more broadcasts.
+ *
+ * ⚠️ Transitional, like the DM cap. With reliable delivery ONE announce is
+ * enough, and this should shrink toward 1 rather than grow.
+ */
+export const MAX_SENDS_PER_SPACE_IDENTITY = 3;
+
+const gate = createProfileSendGate({
+  storagePrefix: GATE_PREFIX,
+  logPrefix: '[SpaceProfile]',
+  minGapMs: SPACE_ANNOUNCE_MIN_GAP_MS,
+  maxSendsPerIdentity: MAX_SENDS_PER_SPACE_IDENTITY,
+});
+
+/**
+ * Signature of the exact announce payload, folded to a compact digest.
+ *
+ * Signs whatever it is handed rather than a fixed field list, so a field added
+ * to the wire later cannot silently fall outside the change detection — which
+ * would read as "identity unchanged" and never be announced.
+ *
+ * Unlike the DM gate this does NOT store the payload verbatim. The payload
+ * contains a base64 avatar, and a per-space record holding one would put tens of
+ * kilobytes per space into localStorage — for the user's OWN avatar, repeated.
+ *
+ * The cost of folding is a hash collision reading as "identity unchanged", i.e.
+ * one skipped re-announce. Spaces can absorb that where DMs could not: the
+ * member digest exchange repairs a stale row on the next `requestSync`, so a
+ * missed announce is not a permanent failure here.
+ */
+export const spaceProfileSignature = (
+  payload: Record<string, unknown>
+): string => {
+  const canonical: Record<string, string> = {};
+  for (const [key, value] of Object.entries(payload)) {
+    // Present-but-empty is meaningful on this wire (`''` = clear the override),
+    // so the test is `!== undefined`, not truthiness.
+    if (value === undefined) continue;
+    canonical[key] = typeof value === 'string' ? value : JSON.stringify(value);
+  }
+  return compactSignature(canonicalProfileSignature(canonical));
+};
+
+/**
+ * Should we announce this identity to this space right now?
+ *
+ * True when we have never announced there, when the identity has CHANGED (which
+ * resets the counter), or when the last announce is older than
+ * SPACE_ANNOUNCE_MIN_GAP_MS AND we are under MAX_SENDS_PER_SPACE_IDENTITY. Only
+ * when no equivalent announce is already in flight.
+ *
+ * `now` is injectable so the gap and the cap are testable without faking the
+ * clock.
+ */
+export const shouldAnnounceSpaceProfile = (
+  selfAddress: string,
+  spaceId: string,
+  signature: string,
+  now: number = Date.now()
+): boolean => gate.shouldSend(selfAddress, spaceId, signature, now);
+
+/**
+ * Claim an announce synchronously, before awaiting it. Must be paired with
+ * `releaseSpaceProfileAnnounce` in a `finally`.
+ *
+ * The startup timer and the reconnect timer can overlap by design, and the
+ * persisted record is only written once the send resolves — so without this
+ * both runs read "not yet announced" and both broadcast.
+ */
+export const claimSpaceProfileAnnounce = (
+  selfAddress: string,
+  spaceId: string,
+  signature: string
+): void => gate.claim(selfAddress, spaceId, signature);
+
+/** Release an in-flight claim, whether the announce succeeded or threw. */
+export const releaseSpaceProfileAnnounce = (
+  selfAddress: string,
+  spaceId: string,
+  signature: string
+): void => gate.release(selfAddress, spaceId, signature);
+
+/**
+ * Record a successful announce, advancing the attempt counter. Call ONLY after
+ * the send resolves, so a failure leaves the gate open and the next connect
+ * retries.
+ */
+export const recordSpaceProfileAnnounce = (
+  selfAddress: string,
+  spaceId: string,
+  signature: string,
+  now: number = Date.now()
+): void => gate.record(selfAddress, spaceId, signature, now);

--- a/src/utils/spaceProfilePayload.ts
+++ b/src/utils/spaceProfilePayload.ts
@@ -1,0 +1,107 @@
+// Builds the `update-profile` payload a device announces to a space.
+//
+// Pure on purpose: this is where the two-slot rule is actually enforced, and it
+// is the rule most likely to be quietly broken by a later edit. Keeping it out
+// of MessageService means it can be pinned by tests that need no DB, no keys
+// and no network.
+//
+// See .agents/docs/features/identity-resolution-and-profile-sync.md
+
+import type { BroadcastSpaceTag } from '@quilibrium/quorum-shared';
+
+/** The fields of our own member row that decide the override slot. */
+export interface OwnSpaceMemberFields {
+  display_name?: string;
+  user_icon?: string;
+  profile_image?: string;
+  bio?: string;
+}
+
+/** The fields of the global config that decide the global slot. */
+export interface GlobalProfileFields {
+  name?: string;
+  profile_image?: string;
+  bio?: string;
+}
+
+// A type alias rather than an interface, deliberately: only an alias gets an
+// implicit index signature, which is what lets the whole payload be handed to
+// the signature helper as a `Record<string, unknown>` instead of being
+// re-listed field by field (and drifting).
+export type SpaceProfileWireFields = {
+  type: 'update-profile';
+  senderId: string;
+  displayName?: string;
+  userIcon?: string;
+  bio?: string;
+  globalDisplayName?: string;
+  globalUserIcon?: string;
+  globalBio?: string;
+  spaceTag?: BroadcastSpaceTag;
+};
+
+/**
+ * TWO SLOTS, deliberately kept apart.
+ *
+ * - **Override slot** (`displayName`/`userIcon`/`bio`) — a deliberate per-space
+ *   identity, read from our own member row. Sent only when one really exists;
+ *   otherwise OMITTED, which the receiver's merge reads as "no change" and its
+ *   render falls back to the global slot.
+ * - **Global slot** (`global*`) — our current global identity.
+ *
+ * Never stamp a global value into an override field. That was the historical
+ * bug: it froze each space to whatever the global was at stamp time, made
+ * "clear my per-space name" inexpressible, and let a user's own devices race
+ * each other for the roster. An empty override field means FOLLOW GLOBAL, and
+ * that distinction only survives if this function omits rather than fills.
+ *
+ * Conversely, the override IS sent when it exists — a member who set a
+ * per-space name expects spacemates to see that name, so an announce carrying
+ * only the global slot would show the wrong one to anybody bootstrapping a row.
+ */
+export const buildSpaceProfileWirePayload = (
+  selfAddress: string,
+  ownMember: OwnSpaceMemberFields | undefined,
+  config: GlobalProfileFields,
+  resolvedTag?: BroadcastSpaceTag
+): SpaceProfileWireFields => {
+  const nameOverride = ownMember?.display_name || undefined;
+  // The member avatar lives on `user_icon` (the typed UserProfile field), but
+  // some rows also carry `profile_image` from other write paths, so read both.
+  const iconOverride =
+    ownMember?.user_icon || ownMember?.profile_image || undefined;
+  const bioOverride = ownMember?.bio || undefined;
+
+  const globalName = config.name || undefined;
+  const globalIcon = config.profile_image || undefined;
+  const globalBioVal = config.bio || undefined;
+
+  return {
+    type: 'update-profile',
+    senderId: selfAddress,
+    ...(nameOverride !== undefined ? { displayName: nameOverride } : {}),
+    ...(iconOverride !== undefined ? { userIcon: iconOverride } : {}),
+    ...(bioOverride !== undefined ? { bio: bioOverride } : {}),
+    ...(globalName !== undefined ? { globalDisplayName: globalName } : {}),
+    ...(globalIcon !== undefined ? { globalUserIcon: globalIcon } : {}),
+    ...(globalBioVal !== undefined ? { globalBio: globalBioVal } : {}),
+    ...(resolvedTag ? { spaceTag: resolvedTag } : {}),
+  };
+};
+
+/**
+ * Is there anything worth announcing?
+ *
+ * A fresh account whose config has not synced yet would otherwise broadcast an
+ * all-empty payload: a wire no-op the receiver ignores, which still costs one
+ * of the bootstrap's few attempts.
+ */
+export const hasAnnounceableIdentity = (
+  payload: SpaceProfileWireFields
+): boolean =>
+  Boolean(
+    payload.displayName ||
+      payload.userIcon ||
+      payload.globalDisplayName ||
+      payload.globalUserIcon
+  );


### PR DESCRIPTION
Space member identity is push-based: a member's name and avatar exist on your device only because somebody announced them. Desktop announced at join and on tag rotation and nowhere else, so a member who joined a space while you were offline never got a second chance and rendered as a 6-character address indefinitely. Measured on the test space "Quorum Test 2": 46 of 89 distinct senders had no member row at all.

This adds the missing announce, and is the last piece of the identity work that landed in #287-#290.

## The announce

Fired from both the startup timer and `setResubscribe`. On a cold load the socket opens before the resubscribe callback is registered, so wiring only the latter never runs at startup — the DM path already works around the same race.

It is a **bootstrap, not a cadence**. The member digest exchange repaired in #71/#290 reconciles rows two peers disagree about; it cannot invent a member neither side has heard of, and that gap is all this closes. So the gate caps at 3 attempts per identity, spaced in minutes, then goes silent. The DM gate's 24h spacing would be wrong here, where the bytes scale as spaces x members.

## The payload

Carries the override slot as well as the global one, so a deliberate per-space name is what spacemates see even when they are bootstrapping a fresh row. An absent override is OMITTED rather than filled from the global config — filling it is the roster-stamping bug the follow-global work removed. The pure payload builder pins both directions in tests.

## Also here

- The DM gate's cap/expiry/migration/in-flight rules are extracted into a shared factory rather than copied. Its 29 tests pass unchanged.
- `signSpaceProfileMessage` dereferenced a signing key that can legitimately be undefined, so "no key material for this space" surfaced as a bare TypeError. It now throws a named error and the caller treats it as the expected transient case, mirroring the DM sibling's handling of "no established session".
- Corrects the file-map row that labelled the tag-rotation rebroadcast "on-connect". It is not, and disproving that cost real time.
- Documents the convergence model in the canonical identity doc: pull vs push, which platform has which mechanism, a per-platform matrix of what is repaired, and a debugging checklist. The load-bearing point is that the roster PULL is the main mechanism, not the announce.
- Files two bugs found along the way: a deleted space tag can no longer be cleared from a member roster (self-inflicted in #290, fix branch ready), and every logger call is a no-op in production builds.

## Verification

53 files / 790 tests, `tsc` and `eslint` clean. Reviewed independently for correctness and for error handling; the four issues that review raised are fixed here.

Not yet verified on a live space — the before/after count remains open.
