### PR TITLE
fix: a deleted space tag can be cleared again, without wiping every other tag

### DIFF
--- a/.agents/bugs/2026-08-01-space-tag-can-no-longer-be-cleared-from-a-member-roster.md
+++ b/.agents/bugs/2026-08-01-space-tag-can-no-longer-be-cleared-from-a-member-roster.md
@@ -1,7 +1,7 @@
 ---
 type: bug
 title: "A deleted space tag never disappears from other members' rosters — the undefined-stripping merge swallowed the only clear signal"
-status: FIXED on branch fix/space-tag-clear-survives-partial-merge (awaiting the announce PR to merge first)
+status: FIXED 2026-08-01 (desktop). Mobile still needs the tombstone — see §5
 priority: medium — cosmetic but permanent, and self-inflicted 3 commits ago
 created: 2026-08-01
 updated: 2026-08-01
@@ -126,6 +126,11 @@ Implemented as:
   omitting the field. It is the ONLY sender entitled to speak about the tag —
   it fires only when the tag actually changed. Every other sender omits it
   precisely because it has nothing to say.
+- `buildSpaceProfileWirePayload` takes the tag as the SAME three states, so the
+  send and receive halves read identically: `undefined` omits, `null` is the
+  tombstone, an object sets. Note the spread tests `!== undefined` rather than
+  truthiness — a truthiness check silently swallows the tombstone, which is the
+  exact shape of the original bug and would be easy to reintroduce.
 
 Old clients see a falsy value and behave exactly as they did, so the wire change
 is additive.

--- a/src/db/messages.ts
+++ b/src/db/messages.ts
@@ -1226,11 +1226,21 @@ export class MessageDB {
    * the stored value. A present value — including an empty string, which is how
    * the two-slot model expresses a deliberate clear — always wins.
    *
+   * `options.clearFields` is the escape hatch that rule needs. Because absence
+   * means "no change", the row would otherwise have no way to express "remove
+   * this field" — and `spaceTag` needs exactly that, since a tag DELETION is
+   * signalled by absence on the wire and the receive handlers turn that absence
+   * into `undefined`. Without an explicit clear, a tag the owner deleted stays
+   * on every other member's roster forever. Name/avatar/bio do not need this:
+   * the two-slot model clears them with `''`, which is a present value.
+   *
    * See .agents/bugs/2026-08-01-space-sync-member-delta-blind-to-and-erases-global-slot.md
+   * and .agents/bugs/2026-08-01-space-tag-can-no-longer-be-cleared-from-a-member-roster.md
    */
   async saveSpaceMember(
     spaceId: string,
-    userProfile: SpaceMemberRow
+    userProfile: SpaceMemberRow,
+    options?: { clearFields?: (keyof SpaceMemberRow)[] }
   ): Promise<void> {
     await this.init();
     return new Promise((resolve, reject) => {
@@ -1256,7 +1266,18 @@ export class MessageDB {
         const incoming = Object.fromEntries(
           Object.entries(userProfile).filter(([, v]) => v !== undefined)
         );
-        store.put({ ...existing, ...incoming, spaceId });
+        const merged = { ...existing, ...incoming, spaceId } as Record<
+          string,
+          unknown
+        >;
+        // Applied AFTER the merge, so a clear wins over whatever `existing`
+        // held. `delete` rather than assigning `undefined`: the row is read
+        // back with `Object.entries` elsewhere, and a key present with an
+        // undefined value is not the same as an absent one.
+        for (const field of options?.clearFields ?? []) {
+          delete merged[field as string];
+        }
+        store.put(merged);
       };
       getRequest.onerror = () => reject(getRequest.error);
 

--- a/src/dev/tests/db/saveSpaceMemberClearField.test.ts
+++ b/src/dev/tests/db/saveSpaceMemberClearField.test.ts
@@ -1,0 +1,150 @@
+import 'fake-indexeddb/auto';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { MessageDB, type SpaceMemberRow } from '../../../db/messages';
+
+// `saveSpaceMember` merges rather than replaces, and DROPS explicit
+// `undefined`s so a partially-populated row (the shape a sync delta arrives in)
+// cannot punch holes in fields it does not carry. That is deliberate and must
+// stay — it is the 2026-08-01 fix for the delta erasing the global identity
+// slot.
+//
+// The cost, discovered the same day: the row then has NO WAY TO EXPRESS
+// "remove this field". `spaceTag` is the field that needs it, because a tag
+// DELETION is signalled by absence on the wire — the sender omits `spaceTag`
+// entirely — and both update-profile receive handlers translate that absence
+// into `participant.spaceTag = undefined`. After the merge fix that assignment
+// is silently discarded, so an owner-deleted tag renders on every other
+// member's roster forever.
+//
+// Hence an explicit `clearFields`. Absence still means "no change" (the safe
+// default for every partial writer); a caller that genuinely means "remove
+// this" now has to say so.
+//
+// See .agents/bugs/2026-08-01-space-tag-can-no-longer-be-cleared-from-a-member-roster.md
+
+const SPACE = 'space-1';
+const MEMBER = 'QmNSr2YL6iLho1CQfRNikQRs2mBxGQRSL2CXYmtKL5ihUB';
+
+const TAG = { letters: 'QUIL', url: 'https://example.test/tag.png', spaceId: SPACE };
+
+const taggedRow = (): SpaceMemberRow =>
+  ({
+    user_address: MEMBER,
+    inbox_address: 'inbox-1',
+    global_display_name: 'Ada Lovelace',
+    global_user_icon: 'data:image/jpeg;base64,/9j/REAL',
+    globalProfileTimestamp: 5000,
+    spaceTag: TAG,
+    joinedAt: 1000,
+  }) as unknown as SpaceMemberRow;
+
+describe('MessageDB.saveSpaceMember — clearing a field', () => {
+  let db: MessageDB;
+
+  beforeEach(async () => {
+    const FDBFactory = (await import('fake-indexeddb/lib/FDBFactory')).default;
+    globalThis.indexedDB = new FDBFactory();
+    db = new MessageDB();
+    await db.init();
+  });
+
+  it('stores a space tag in the first place', async () => {
+    await db.saveSpaceMember(SPACE, taggedRow());
+    expect((await db.getSpaceMember(SPACE, MEMBER)).spaceTag).toEqual(TAG);
+  });
+
+  // THE REGRESSION: this is exactly what the update-profile receive handler
+  // does when the owner has deleted the tag.
+  it('removes the tag when the caller asks for it explicitly', async () => {
+    await db.saveSpaceMember(SPACE, taggedRow());
+
+    const row = await db.getSpaceMember(SPACE, MEMBER);
+    row.spaceTag = undefined;
+    await db.saveSpaceMember(SPACE, row, { clearFields: ['spaceTag'] });
+
+    expect((await db.getSpaceMember(SPACE, MEMBER)).spaceTag).toBeUndefined();
+  });
+
+  // The property from the earlier fix that must NOT regress: without an
+  // explicit request, an absent field means "no change".
+  it('still preserves an absent field when no clear is requested', async () => {
+    await db.saveSpaceMember(SPACE, taggedRow());
+    await db.saveSpaceMember(SPACE, {
+      user_address: MEMBER,
+      inbox_address: 'inbox-1',
+    } as unknown as SpaceMemberRow);
+
+    const row = await db.getSpaceMember(SPACE, MEMBER);
+    expect(row.spaceTag).toEqual(TAG);
+    expect(row.global_display_name).toBe('Ada Lovelace');
+  });
+
+  it('clears only the named field, leaving the identity slots alone', async () => {
+    await db.saveSpaceMember(SPACE, taggedRow());
+
+    const row = await db.getSpaceMember(SPACE, MEMBER);
+    row.spaceTag = undefined;
+    await db.saveSpaceMember(SPACE, row, { clearFields: ['spaceTag'] });
+
+    const after = await db.getSpaceMember(SPACE, MEMBER);
+    expect(after.global_display_name).toBe('Ada Lovelace');
+    expect(after.global_user_icon).toBe('data:image/jpeg;base64,/9j/REAL');
+    expect(after.globalProfileTimestamp).toBe(5000);
+    expect(after.joinedAt).toBe(1000);
+  });
+
+  it('is a no-op on a field that was never set', async () => {
+    await db.saveSpaceMember(SPACE, {
+      user_address: MEMBER,
+      inbox_address: 'inbox-1',
+      global_display_name: 'Ada Lovelace',
+    } as unknown as SpaceMemberRow);
+
+    await db.saveSpaceMember(
+      SPACE,
+      { user_address: MEMBER, inbox_address: 'inbox-1' } as unknown as SpaceMemberRow,
+      { clearFields: ['spaceTag'] }
+    );
+
+    const row = await db.getSpaceMember(SPACE, MEMBER);
+    expect(row.spaceTag).toBeUndefined();
+    expect(row.global_display_name).toBe('Ada Lovelace');
+  });
+
+  it('creates a brand-new row unharmed when a clear is requested', async () => {
+    await db.saveSpaceMember(
+      SPACE,
+      { user_address: MEMBER, inbox_address: 'inbox-1' } as unknown as SpaceMemberRow,
+      { clearFields: ['spaceTag'] }
+    );
+    expect((await db.getSpaceMember(SPACE, MEMBER)).user_address).toBe(MEMBER);
+  });
+
+  // A clear must not leak across members or spaces — the key is composite and
+  // the merge reads the row back before writing it.
+  it('does not clear the same field on another member', async () => {
+    const OTHER = 'QmOtherMemberBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
+    await db.saveSpaceMember(SPACE, taggedRow());
+    await db.saveSpaceMember(SPACE, {
+      ...taggedRow(),
+      user_address: OTHER,
+    } as unknown as SpaceMemberRow);
+
+    const row = await db.getSpaceMember(SPACE, MEMBER);
+    row.spaceTag = undefined;
+    await db.saveSpaceMember(SPACE, row, { clearFields: ['spaceTag'] });
+
+    expect((await db.getSpaceMember(SPACE, OTHER)).spaceTag).toEqual(TAG);
+  });
+
+  it('does not clear the same member in another space', async () => {
+    await db.saveSpaceMember(SPACE, taggedRow());
+    await db.saveSpaceMember('space-2', taggedRow());
+
+    const row = await db.getSpaceMember(SPACE, MEMBER);
+    row.spaceTag = undefined;
+    await db.saveSpaceMember(SPACE, row, { clearFields: ['spaceTag'] });
+
+    expect((await db.getSpaceMember('space-2', MEMBER)).spaceTag).toEqual(TAG);
+  });
+});

--- a/src/dev/tests/services/MessageService.unit.test.tsx
+++ b/src/dev/tests/services/MessageService.unit.test.tsx
@@ -966,7 +966,11 @@ describe('MessageService - Unit Tests', () => {
       await save(upMsg({ publicKey: freshPub }));
       expect(mockDeps.messageDB.saveSpaceMember).toHaveBeenCalledWith(
         'space',
-        expect.objectContaining({ inbox_address: victimInbox })
+        expect.objectContaining({ inbox_address: victimInbox }),
+        // No spaceTag on this message → no clear requested. Absence must mean
+        // "no change"; treating it as a clear would strip every member's tag on
+        // every global profile save and every on-connect announce.
+        undefined
       );
     });
 
@@ -980,7 +984,8 @@ describe('MessageService - Unit Tests', () => {
       );
       expect(mockDeps.messageDB.saveSpaceMember).toHaveBeenCalledWith(
         'space',
-        expect.objectContaining({ user_address: 'newuser', inbox_address: '' })
+        expect.objectContaining({ user_address: 'newuser', inbox_address: '' }),
+        undefined
       );
     });
 
@@ -997,7 +1002,8 @@ describe('MessageService - Unit Tests', () => {
       await save(upMsg({ publicKey: victimPub }));
       expect(mockDeps.messageDB.saveSpaceMember).toHaveBeenCalledWith(
         'space',
-        expect.objectContaining({ inbox_address: victimInbox })
+        expect.objectContaining({ inbox_address: victimInbox }),
+        undefined
       );
     });
   });

--- a/src/dev/tests/utils/resolveInboundSpaceTag.test.ts
+++ b/src/dev/tests/utils/resolveInboundSpaceTag.test.ts
@@ -1,0 +1,81 @@
+// A space tag has THREE inbound states and the whole bug was conflating two of
+// them.
+//
+//   absent  → no change.  Most update-profile messages carry no tag at all: a
+//             global avatar save, the on-connect identity announce. If absence
+//             meant "clear", every one of those would strip every member's tag,
+//             and the on-connect announce would do it on every reconnect.
+//   null    → clear.      The owner deleted the tag and the sender says so.
+//   object  → set it, if it validates. An INVALID tag is rejected, not treated
+//             as a clear — a malformed tag must not strip a good one.
+//
+// History: absence used to mean "clear", which over-cleared (any tagless
+// profile push wiped the tag). Then the row merge started dropping explicit
+// `undefined`s — correctly, to stop a sync delta erasing the identity slot —
+// and absence became "no change", which under-cleared (a deleted tag never went
+// away). Neither state is right, because absence cannot carry both meanings.
+// Hence the tombstone.
+//
+// See .agents/bugs/2026-08-01-space-tag-can-no-longer-be-cleared-from-a-member-roster.md
+
+import { describe, it, expect } from 'vitest';
+import { resolveInboundSpaceTag } from '../../../services/MessageService';
+
+// The url must be a base64 PNG/JPEG data URI — remote URLs and SVG are both
+// rejected by `isValidSpaceTagUrl` (SVG because it can carry script).
+const VALID = {
+  letters: 'QUIL',
+  url: 'data:image/png;base64,iVBORw0KGgo=',
+  spaceId: 's1',
+};
+
+describe('resolveInboundSpaceTag', () => {
+  it('leaves the tag alone when the message carries none', () => {
+    const r = resolveInboundSpaceTag(undefined);
+    expect(r.write).toBe(false);
+    expect(r.options).toBeUndefined();
+  });
+
+  it('clears the tag on an explicit null tombstone', () => {
+    const r = resolveInboundSpaceTag(null);
+    expect(r.write).toBe(true);
+    expect(r.tag).toBeUndefined();
+    expect(r.options).toEqual({ clearFields: ['spaceTag'] });
+  });
+
+  it('sets a valid tag', () => {
+    const r = resolveInboundSpaceTag(VALID);
+    expect(r.write).toBe(true);
+    expect(r.tag).toEqual(VALID);
+    expect(r.options).toBeUndefined();
+  });
+
+  // Rejection is not deletion. Letting an invalid tag clear a good one would
+  // hand any member a one-message way to blank somebody else's tag.
+  it('rejects a tag with bad letters without clearing the stored one', () => {
+    const r = resolveInboundSpaceTag({ ...VALID, letters: 'WAY-TOO-LONG' });
+    expect(r.write).toBe(false);
+    expect(r.options).toBeUndefined();
+  });
+
+  it('rejects an SVG data URI without clearing the stored one', () => {
+    const r = resolveInboundSpaceTag({
+      ...VALID,
+      url: 'data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=',
+    });
+    expect(r.write).toBe(false);
+    expect(r.options).toBeUndefined();
+  });
+
+  it('rejects a javascript: url', () => {
+    const r = resolveInboundSpaceTag({ ...VALID, url: 'javascript:alert(1)' });
+    expect(r.write).toBe(false);
+  });
+
+  // A remote URL would be a tracking pixel pointed at every member of the
+  // space, so only inline data URIs are accepted.
+  it('rejects a remote https url', () => {
+    const r = resolveInboundSpaceTag({ ...VALID, url: 'https://example.test/t.png' });
+    expect(r.write).toBe(false);
+  });
+});

--- a/src/dev/tests/utils/spaceProfilePayload.test.ts
+++ b/src/dev/tests/utils/spaceProfilePayload.test.ts
@@ -151,6 +151,24 @@ describe('the space tag', () => {
     const p = buildSpaceProfileWirePayload(SELF, undefined, GLOBAL, tag);
     expect(p.spaceTag).toEqual(tag);
   });
+
+  // Three-state, matching the wire semantics the receiver applies. Omitted and
+  // cleared are DIFFERENT messages and conflating them breaks in both
+  // directions: silence-as-clear strips every member's tag on every reconnect,
+  // and no tombstone at all means a deleted tag never disappears.
+  it('carries an explicit null tombstone when the tag was deleted', () => {
+    const p = buildSpaceProfileWirePayload(SELF, undefined, GLOBAL, null);
+    expect('spaceTag' in p).toBe(true);
+    expect(p.spaceTag).toBeNull();
+  });
+
+  // The regression guard that matters most: the on-connect announce passes no
+  // tag, and if that reached the wire as a clear it would wipe every member's
+  // tag every time anybody reconnected.
+  it('a caller with nothing to say about the tag says nothing', () => {
+    const p = buildSpaceProfileWirePayload(SELF, undefined, GLOBAL, undefined);
+    expect('spaceTag' in p).toBe(false);
+  });
 });
 
 describe('hasAnnounceableIdentity', () => {

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -215,6 +215,45 @@ export interface MessageServiceDependencies {
 // That cleanup step belongs to the future hub-log migration, at the transport
 // layer, not here. See project docs / the two-slot task file.
 // Exported for unit testing (pure logic, no dependencies).
+/**
+ * Decide what an inbound `update-profile` means for a member's space tag.
+ *
+ * Three cases, and conflating the first two is a live bug in both directions:
+ *
+ * - **absent (`undefined`) → no change.** Most `update-profile` messages carry
+ *   no tag at all: a global avatar save, the on-connect identity announce. If
+ *   absence meant "clear", every one of those would strip every member's tag,
+ *   and the on-connect announce would do it on every reconnect.
+ * - **`null` → the TOMBSTONE.** The owner deleted the tag and the sender says
+ *   so explicitly. Absence cannot carry that meaning (see above), so deletion
+ *   needs a signal of its own. Older clients see a falsy value and behave as
+ *   they always did, so this is additive on the wire.
+ * - **an object → set it, if it validates.** A tag that FAILS validation is
+ *   REJECTED, not treated as a clear: a malformed tag must not be able to strip
+ *   a good one.
+ *
+ * The clear has to travel to the DB as an explicit `clearFields`, because
+ * `saveSpaceMember` merges and drops `undefined`s — see that method's doc and
+ * .agents/bugs/2026-08-01-space-tag-can-no-longer-be-cleared-from-a-member-roster.md
+ */
+export function resolveInboundSpaceTag(
+  inbound: BroadcastSpaceTag | null | undefined
+): {
+  /** Whether to touch `participant.spaceTag` at all. */
+  write: boolean;
+  tag?: BroadcastSpaceTag;
+  options?: { clearFields: (keyof SpaceMemberRow)[] };
+} {
+  if (inbound === null) {
+    return { write: true, tag: undefined, options: { clearFields: ['spaceTag'] } };
+  }
+  if (!inbound) return { write: false };
+  if (!validateSpaceTagLetters(inbound.letters) || !isValidSpaceTagUrl(inbound.url)) {
+    return { write: false };
+  }
+  return { write: true, tag: inbound };
+}
+
 export function applyProfileUpdate(
   participant: SpaceMemberRow,
   content: UpdateProfileMessage,
@@ -925,9 +964,14 @@ export class MessageService {
     setTimeout(() => this.pendingTagRebroadcast.delete(space.spaceId), 60_000);
 
     // 6. Build the resolved tag (or undefined if owner deleted it)
-    const resolvedTag: BroadcastSpaceTag | undefined = currentTag?.letters
+    // `null`, not `undefined`, when the owner deleted the tag: this is the one
+    // caller that fires BECAUSE the tag changed, so it is the one entitled — and
+    // obliged — to say "it is gone". Omitting the field would read as "no
+    // change" and the deletion would never reach anybody. See
+    // resolveInboundSpaceTag for the receiving half.
+    const resolvedTag: BroadcastSpaceTag | null = currentTag?.letters
       ? { ...currentTag, spaceId: space.spaceId }
-      : undefined;
+      : null;
 
     // 7. Broadcast update-profile to all spaces
     const allSpaces = await this.messageDB.getSpaces();
@@ -998,7 +1042,7 @@ export class MessageService {
     spaceId: string,
     selfAddress: string,
     config: GlobalProfileFields,
-    resolvedTag?: BroadcastSpaceTag
+    resolvedTag?: BroadcastSpaceTag | null
   ): Promise<UpdateProfileMessage> {
     const ownMember = await this.messageDB.getSpaceMember(spaceId, selfAddress);
     return buildSpaceProfileWirePayload(
@@ -2192,14 +2236,9 @@ export class MessageService {
       // here — see the security note above.
       applyProfileUpdate(participant, decryptedContent.content, decryptedContent.createdDate);
       // Validate inbound spaceTag — reject SVG data URIs (XSS) and oversized payloads
-      const inboundTag = decryptedContent.content.spaceTag;
-      participant.spaceTag =
-        inboundTag &&
-        validateSpaceTagLetters(inboundTag.letters) &&
-        isValidSpaceTagUrl(inboundTag.url)
-          ? inboundTag
-          : undefined;
-      await messageDB.saveSpaceMember(spaceId, participant);
+      const tagWrite = resolveInboundSpaceTag(decryptedContent.content.spaceTag);
+      if (tagWrite.write) participant.spaceTag = tagWrite.tag;
+      await messageDB.saveSpaceMember(spaceId, participant, tagWrite.options);
     } else {
       // Read-only enforcement on the durable path, mirroring the live gate so a
       // forged post can't survive on disk and resurface on refetch. Fail-OPEN on
@@ -2739,15 +2778,12 @@ export class MessageService {
       // semantics: omitted = no change, '' = deliberate clear. inbox_address is
       // deliberately NOT touched here — see the security note above.
       applyProfileUpdate(participant, decryptedContent.content, decryptedContent.createdDate);
-      // Validate inbound spaceTag — reject SVG data URIs (XSS) and oversized payloads
-      const inboundTag = decryptedContent.content.spaceTag;
-      participant.spaceTag =
-        inboundTag &&
-        validateSpaceTagLetters(inboundTag.letters) &&
-        isValidSpaceTagUrl(inboundTag.url)
-          ? inboundTag
-          : undefined;
-      await this.messageDB.saveSpaceMember(spaceId, participant);
+      // Validate inbound spaceTag — reject SVG data URIs (XSS) and oversized
+      // payloads. Absent means no change, `null` is the deletion tombstone;
+      // see resolveInboundSpaceTag.
+      const tagWrite = resolveInboundSpaceTag(decryptedContent.content.spaceTag);
+      if (tagWrite.write) participant.spaceTag = tagWrite.tag;
+      await this.messageDB.saveSpaceMember(spaceId, participant, tagWrite.options);
       await queryClient.setQueryData(
         buildSpaceMembersKey({ spaceId }),
         (oldData: secureChannel.UserProfile[]) => {

--- a/src/utils/spaceProfilePayload.ts
+++ b/src/utils/spaceProfilePayload.ts
@@ -37,7 +37,7 @@ export type SpaceProfileWireFields = {
   globalDisplayName?: string;
   globalUserIcon?: string;
   globalBio?: string;
-  spaceTag?: BroadcastSpaceTag;
+  spaceTag?: BroadcastSpaceTag | null;
 };
 
 /**
@@ -58,12 +58,24 @@ export type SpaceProfileWireFields = {
  * Conversely, the override IS sent when it exists — a member who set a
  * per-space name expects spacemates to see that name, so an announce carrying
  * only the global slot would show the wrong one to anybody bootstrapping a row.
+ *
+ * `resolvedTag` is THREE-STATE, matching the wire semantics the receiver applies
+ * (see `resolveInboundSpaceTag`):
+ *
+ * - `undefined` → **omit the field**: "I have nothing to say about the tag".
+ *   What every caller but one passes. The on-connect announce and the global
+ *   profile save are not talking about tags, and if their silence read as a
+ *   clear they would strip every member's tag on every reconnect.
+ * - `null` → **the tombstone**: the tag was deleted and somebody has to say so.
+ *   Only the tag-rotation rebroadcast passes this, because it is the only caller
+ *   that fires *because* the tag changed.
+ * - an object → set it.
  */
 export const buildSpaceProfileWirePayload = (
   selfAddress: string,
   ownMember: OwnSpaceMemberFields | undefined,
   config: GlobalProfileFields,
-  resolvedTag?: BroadcastSpaceTag
+  resolvedTag?: BroadcastSpaceTag | null
 ): SpaceProfileWireFields => {
   const nameOverride = ownMember?.display_name || undefined;
   // The member avatar lives on `user_icon` (the typed UserProfile field), but
@@ -85,7 +97,9 @@ export const buildSpaceProfileWirePayload = (
     ...(globalName !== undefined ? { globalDisplayName: globalName } : {}),
     ...(globalIcon !== undefined ? { globalUserIcon: globalIcon } : {}),
     ...(globalBioVal !== undefined ? { globalBio: globalBioVal } : {}),
-    ...(resolvedTag ? { spaceTag: resolvedTag } : {}),
+    // `!== undefined`, not truthiness: `null` is a deliberate tombstone and has
+    // to reach the wire, where truthiness would silently drop it.
+    ...(resolvedTag !== undefined ? { spaceTag: resolvedTag } : {}),
   };
 };
 


### PR DESCRIPTION
A space tag deleted by the owner never disappeared from anyone else's member roster. Self-inflicted in #290.

## What happened

Deletion is signalled by **absence** on the wire: the sender omits `spaceTag` entirely, and the receive handlers turned that absence into `participant.spaceTag = undefined`.

That worked while the member row was written with a full-row `put`. #290 changed it to a merge that drops explicit `undefined`s — correctly, so a sync delta could not punch holes in the global identity slot. But it also left the row with **no way to express "remove this field"**, so the clear was silently discarded.

## The fix that was written first, and rejected

Restoring "absence means clear" is the obvious move and it is **worse**. Most `update-profile` messages carry no tag at all: a global avatar save, and now the on-connect announce from #291. If absence meant clear, every one of those would strip every member's tag, and the announce would do it on every reconnect. The test suite caught it.

So the pre-#290 behaviour was not correct-then-broken, it was **over-clearing**, and #290 traded it for **under-clearing**. Absence genuinely cannot carry both "I have nothing to say about the tag" and "the tag is gone".

## The fix that shipped

Three states, used identically on both halves of the wire:

| Wire | Meaning |
|---|---|
| field absent | no change — the sender is talking about something else |
| `spaceTag: null` | clear — the tombstone |
| a tag object | set it, if it validates |

- `resolveInboundSpaceTag` — the receive-side decision, exported and unit-tested. An **invalid** tag is rejected rather than treated as a clear; otherwise a malformed tag would be a one-message way to blank somebody else's.
- `buildSpaceProfileWirePayload` takes the same three states. The spread tests `!== undefined`, not truthiness, since a truthiness check swallows the tombstone.
- `rebroadcastTagIfChanged` sends the tombstone on deletion. It is the only caller that fires *because* the tag changed, so it is the only one entitled to speak about it.
- `saveSpaceMember` grows a `clearFields` option to carry the clear through the merge. Absence stays the safe default for every partial writer, which is the #290 property worth keeping.

Old clients see a falsy value and behave exactly as before, so the wire change is additive.

## Verification

55 files / 807 tests, `tsc` and `eslint` clean. The clear was confirmed red-then-green: with the clearing logic disabled the new test fails, with it enabled it passes.

Mobile still needs the tombstone in its own receive handler; until then it keeps showing a deleted tag, which is what it does today.
