### PR TITLE
feat: measure how many people still render as a truncated address

### DIFF
--- a/.agents/INDEX.md
+++ b/.agents/INDEX.md
@@ -24,6 +24,7 @@ This is the main index for all documentation, bug reports, and task management.
 ### Development
 - [Android Build Workflow](docs/development/android-build-workflow.md)
 - [Dependency Upgrade Guide](docs/development/dependency-upgrade-guide.md)
+- [Git Worktrees and Linked Dependencies](docs/development/git-worktrees-and-linked-dependencies.md)
 
 ### Features
 - [Action Queue](docs/features/action-queue.md)

--- a/.agents/docs/development/git-worktrees-and-linked-dependencies.md
+++ b/.agents/docs/development/git-worktrees-and-linked-dependencies.md
@@ -1,0 +1,78 @@
+# Git worktrees and linked dependencies
+
+**Read this before trusting a `tsc` / test result from inside a `git worktree`.**
+
+## The one-paragraph version
+
+Two of this project's dependencies are **linked**, not installed from the
+registry. A linked worktree gets its own `node_modules`, and those links do not
+come along — whatever sits there when the worktree is created is frozen forever.
+The result is a worktree compiling against a months-old build of a package whose
+**version number never changed**, which surfaces as type errors that do not
+reproduce on `main`. That reads as "my branch broke something" rather than "my
+`node_modules` is stale", which is the expensive kind of wrong. Run
+`yarn worktree:doctor` from inside any worktree to detect and repair it.
+
+## The linked dependencies
+
+| Package | Linked from |
+|---|---|
+| `@quilibrium/quorum-shared` | the sibling `quorum-shared` checkout |
+| `@quilibrium/quilibrium-js-sdk-channels` | a `yarn link` target |
+
+Because both are links, an edit to `quorum-shared/src` still needs
+`yarn build` in that repo before the desktop app sees it — the link points at
+the checkout, and the app imports `dist/`.
+
+## The two failure modes
+
+Both were observed in `.worktrees/secondary` on 2026-08-02:
+
+**1. A stale physical copy.** The SDK was a real directory from January, while
+the main worktree's link resolved to a July build. Both `package.json` files said
+`"version": "2.1.1"` — the package had been republished under the same version,
+so nothing in the version string revealed the drift. The stale `index.d.ts` was
+2 KB shorter and missing three exported types, producing three `TS2305 has no
+exported member` errors that were absent on a clean `main`.
+
+**2. A link pointing at a path that no longer exists.** `quorum-shared` pointed
+into a sibling worktree directory that had since been removed, so every import
+from it failed to resolve.
+
+> ⚠️ **Do not "fix" this with `ln -s` in Git Bash.** Creating a native symlink on
+> Windows requires Developer Mode or elevation, and when it cannot, MSYS's `ln
+> -s` **silently falls back to a recursive copy**. That is not a workaround —
+> it manufactures failure mode 1. Use the doctor, which creates a directory
+> junction (no privilege required, resolved identically by Node).
+
+## The fix
+
+```bash
+# from inside the worktree
+yarn worktree:doctor        # detect and repair
+yarn worktree:check         # detect only; exits non-zero if broken
+```
+
+`scripts/worktree-doctor.mjs` reads the **main worktree's** link targets at
+runtime and mirrors them into the current worktree as junctions. No machine
+path is hardcoded, so it stays correct when those paths move and never writes a
+user-profile path into a tracked file. It is idempotent — a healthy worktree is
+left untouched, and running it from the main worktree is a no-op.
+
+## When to run it
+
+- Immediately after `git worktree add`.
+- At the start of any session that resumes work in a long-lived worktree.
+- Any time a worktree behaves differently from `main` for a reason the diff does
+  not explain — especially "a type that obviously exists is not exported".
+
+## Why the version number cannot be trusted
+
+The usual instinct is to compare `package.json` versions across the two
+`node_modules`. That did not work here and will not work next time: the SDK is
+republished under the same version during development. Compare the **build
+artifact** instead — file size or mtime of `dist/index.d.ts` — or just let the
+doctor resolve both to a real path and compare those.
+
+---
+*Last updated: 2026-08-02*

--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
     "electron:build": "yarn build && electron-builder",
     "lint": "eslint .",
     "validate": "tsc --noEmit && eslint .",
+    "worktree:doctor": "node scripts/worktree-doctor.mjs",
+    "worktree:check": "node scripts/worktree-doctor.mjs --check",
     "preview": "vite preview --config web/vite.config.ts",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/scripts/worktree-doctor.mjs
+++ b/scripts/worktree-doctor.mjs
@@ -1,0 +1,233 @@
+#!/usr/bin/env node
+/**
+ * Worktree doctor — repair a linked git worktree's locally-linked dependencies.
+ *
+ * ## The problem this exists for
+ *
+ * Some of this project's dependencies are not installed from the registry, they
+ * are LINKED into `node_modules` from elsewhere on the machine:
+ *
+ *   - `@quilibrium/quorum-shared`            → the sibling checkout
+ *   - `@quilibrium/quilibrium-js-sdk-channels` → a `yarn link` target
+ *
+ * A linked worktree (`git worktree add`) gets its own `node_modules`, and those
+ * links do NOT come along. Whatever is sitting there when the worktree is
+ * created is frozen: a physical copy that never updates, or a symlink pointing
+ * at a path that has since moved. Both fail in the same quiet way — the code
+ * compiles against a months-old build of a package whose version number never
+ * changed, so nothing looks wrong until a type that exists everywhere else is
+ * suddenly "not exported".
+ *
+ * Observed 2026-08-02 in `.worktrees/secondary`: the SDK was a stale physical
+ * copy from January (same "2.1.1" version string as the current one, 2 KB of
+ * missing type declarations), and `quorum-shared` pointed at a worktree path
+ * that no longer existed. `tsc` reported three errors that do not reproduce on
+ * `main`, which reads as "my branch broke something" rather than "my
+ * node_modules is stale" — the expensive kind of wrong.
+ *
+ * ## What it does
+ *
+ * For each linked package, it reads the MAIN worktree's link target at runtime
+ * and mirrors it into the current worktree as a junction. Nothing about any
+ * machine's layout is written down here: the target is whatever the main
+ * worktree already resolves to, so this stays correct when that path changes
+ * and never embeds a user-profile path in a tracked file.
+ *
+ * Junctions rather than symlinks deliberately: creating a symlink on Windows
+ * needs Developer Mode or elevation, and Git Bash's `ln -s` silently degrades
+ * to a recursive COPY when it cannot — which is how a "link" becomes the stale
+ * copy this script exists to clean up. Directory junctions need no privilege
+ * and Node resolves them identically. On Linux and macOS real symlinks are
+ * used, where no such restriction applies.
+ *
+ * ## Usage
+ *
+ *   node scripts/worktree-doctor.mjs          # check, report, and repair
+ *   node scripts/worktree-doctor.mjs --check  # report only, non-zero if broken
+ *
+ * Safe and idempotent: a healthy worktree is left untouched. Run it after
+ * creating a worktree, and any time a worktree behaves differently from `main`
+ * for no reason the diff explains.
+ */
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+/** Packages that are linked rather than installed. Add to this list if another
+ *  local link is ever introduced. */
+const LINKED_PACKAGES = [
+  '@quilibrium/quorum-shared',
+  '@quilibrium/quilibrium-js-sdk-channels',
+];
+
+/** A file every one of these packages ships, used as a cheap "is this actually
+ *  reachable and populated" probe rather than trusting the directory exists. */
+const HEALTH_PROBE = 'package.json';
+
+const checkOnly = process.argv.includes('--check');
+const isWindows = process.platform === 'win32';
+
+function git(args, cwd) {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
+}
+
+/**
+ * The main worktree's root — the one holding the canonical links. `git
+ * rev-parse --git-common-dir` points at the main `.git` even from inside a
+ * linked worktree, so its parent is the main checkout.
+ */
+function findMainWorktree(cwd) {
+  const commonDir = path.resolve(cwd, git(['rev-parse', '--git-common-dir'], cwd));
+  return path.dirname(commonDir);
+}
+
+function describeLink(linkPath) {
+  let stat;
+  try {
+    stat = fs.lstatSync(linkPath);
+  } catch {
+    return { kind: 'missing' };
+  }
+  if (stat.isSymbolicLink()) {
+    let target = null;
+    try {
+      target = fs.readlinkSync(linkPath);
+    } catch {
+      /* dangling */
+    }
+    return { kind: 'link', target };
+  }
+  if (stat.isDirectory()) {
+    // A junction reports as a directory to lstat on Windows, so a plain
+    // directory here is either a junction (fine) or a physical copy (stale).
+    // realpath tells them apart: a junction resolves elsewhere.
+    try {
+      const real = fs.realpathSync(linkPath);
+      if (path.resolve(real) !== path.resolve(linkPath)) {
+        return { kind: 'link', target: real };
+      }
+    } catch {
+      /* fall through */
+    }
+    return { kind: 'copy' };
+  }
+  return { kind: 'other' };
+}
+
+function isHealthy(linkPath, expectedTarget) {
+  const info = describeLink(linkPath);
+  if (info.kind !== 'link') return false;
+  if (!fs.existsSync(path.join(linkPath, HEALTH_PROBE))) return false;
+  if (!expectedTarget) return true;
+  try {
+    return (
+      path.resolve(fs.realpathSync(linkPath)) ===
+      path.resolve(fs.realpathSync(expectedTarget))
+    );
+  } catch {
+    return false;
+  }
+}
+
+function createLink(linkPath, target) {
+  fs.rmSync(linkPath, { recursive: true, force: true });
+  fs.mkdirSync(path.dirname(linkPath), { recursive: true });
+  // 'junction' is Windows-only in Node's API and always uses an absolute
+  // target; elsewhere a plain directory symlink is correct and unprivileged.
+  fs.symlinkSync(path.resolve(target), linkPath, isWindows ? 'junction' : 'dir');
+}
+
+function main() {
+  const cwd = process.cwd();
+
+  let mainWorktree;
+  try {
+    mainWorktree = findMainWorktree(cwd);
+  } catch {
+    console.error('worktree-doctor: not inside a git repository.');
+    process.exit(2);
+  }
+
+  const repoRoot = git(['rev-parse', '--show-toplevel'], cwd);
+
+  if (path.resolve(repoRoot) === path.resolve(mainWorktree)) {
+    console.log(
+      'worktree-doctor: this IS the main worktree — its links are the reference, nothing to repair.'
+    );
+    return;
+  }
+
+  console.log(`worktree-doctor: checking ${path.relative(mainWorktree, repoRoot) || repoRoot}`);
+
+  let broken = 0;
+  let repaired = 0;
+
+  for (const pkg of LINKED_PACKAGES) {
+    const linkPath = path.join(repoRoot, 'node_modules', pkg);
+    const referencePath = path.join(mainWorktree, 'node_modules', pkg);
+
+    let target = null;
+    try {
+      target = fs.realpathSync(referencePath);
+    } catch {
+      console.log(`  SKIP ${pkg} — the main worktree has no such package installed.`);
+      continue;
+    }
+
+    if (isHealthy(linkPath, target)) {
+      console.log(`  ok   ${pkg}`);
+      continue;
+    }
+
+    broken += 1;
+    const { kind } = describeLink(linkPath);
+    const reason =
+      kind === 'copy'
+        ? 'physical copy (will go stale silently)'
+        : kind === 'missing'
+          ? 'absent'
+          : 'link does not resolve to the main worktree target';
+    console.log(`  BAD  ${pkg} — ${reason}`);
+
+    if (checkOnly) continue;
+
+    try {
+      createLink(linkPath, target);
+      if (isHealthy(linkPath, target)) {
+        repaired += 1;
+        console.log(`       repaired — now a ${isWindows ? 'junction' : 'symlink'}`);
+      } else {
+        console.log('       REPAIR FAILED — link created but still unhealthy.');
+      }
+    } catch (err) {
+      console.log(`       REPAIR FAILED — ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  if (broken === 0) {
+    console.log('worktree-doctor: all linked dependencies healthy.');
+    return;
+  }
+
+  if (checkOnly) {
+    console.log(
+      `worktree-doctor: ${broken} linked dependenc${broken === 1 ? 'y' : 'ies'} need repair. ` +
+        'Run `node scripts/worktree-doctor.mjs` (no flag) to fix.'
+    );
+    process.exit(1);
+  }
+
+  if (repaired < broken) {
+    console.log(
+      `worktree-doctor: repaired ${repaired} of ${broken}. Re-run typecheck before trusting the worktree.`
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `worktree-doctor: repaired ${repaired}. Re-run \`npx tsc --noEmit --jsx react-jsx --skipLibCheck\` to confirm.`
+  );
+}
+
+main();

--- a/src/components/Router/Router.web.tsx
+++ b/src/components/Router/Router.web.tsx
@@ -92,6 +92,10 @@ const DmDoctor = lazyDevImport(
   () => import('@/dev/dm-doctor'),
   'DmDoctor'
 );
+const IdentityCoverage = lazyDevImport(
+  () => import('@/dev/identity-coverage'),
+  'IdentityCoverage'
+);
 
 interface RouterProps {
   user: {
@@ -342,6 +346,16 @@ export function Router({ user, setUser }: RouterProps) {
           element={
             <Suspense fallback={<div>Loading DM doctor...</div>}>
               <DmDoctor />
+            </Suspense>
+          }
+        />
+      )}
+      {process.env.NODE_ENV === 'development' && IdentityCoverage && (
+        <Route
+          path="/dev/identity-coverage"
+          element={
+            <Suspense fallback={<div>Loading identity coverage...</div>}>
+              <IdentityCoverage />
             </Suspense>
           }
         />

--- a/src/dev/DevMainPage.tsx
+++ b/src/dev/DevMainPage.tsx
@@ -60,6 +60,13 @@ export const DevMainPage: React.FC = () => {
         'Numbered-burst sequence scan, receive-path warning counters, and ghost-conversation detection for the DM-loss investigation',
       path: '/dev/dm-doctor',
     },
+    {
+      name: 'Identity Coverage',
+      icon: 'id-badge',
+      description:
+        'How many space members and DM partners carry no identity from any source, and therefore render as a truncated address. Take one snapshot before a change and one after',
+      path: '/dev/identity-coverage',
+    },
   ];
 
   const handleNavigate = (path: string) => {

--- a/src/dev/DevNavMenu.tsx
+++ b/src/dev/DevNavMenu.tsx
@@ -53,6 +53,11 @@ const devNavItems: DevNavItem[] = [
     icon: 'bug',
     path: '/dev/dm-doctor',
   },
+  {
+    name: 'Identity Coverage',
+    icon: 'id-badge',
+    path: '/dev/identity-coverage',
+  },
 ];
 
 interface DevNavMenuProps {

--- a/src/dev/identity-coverage/IdentityCoverage.tsx
+++ b/src/dev/identity-coverage/IdentityCoverage.tsx
@@ -1,0 +1,536 @@
+/**
+ * Identity Coverage — the resident panel.
+ *
+ * Step 4 of `.agents/tasks/2026-08-01-identity-announce-cadence-research.md`:
+ * the instrument that turns "we think the identity fixes worked" into a number
+ * you take twice, before and after, in one click.
+ *
+ * Reads straight from IndexedDB, so it measures what PERSISTED — not what
+ * rendered once from an in-memory fallback. Reloading the app and taking a
+ * second snapshot is the point, not a caveat.
+ */
+
+import React, { useCallback, useMemo, useState } from 'react';
+import { usePasskeysContext } from '@quilibrium/quilibrium-js-sdk-channels';
+import { Text, Flex, Button, Icon } from '../../components/primitives';
+import { DevNavMenu } from '../DevNavMenu';
+import {
+  buildIdentityCoverageSnapshot,
+  computeCoverageDelta,
+  formatIdentityCoverageReport,
+  formatSigned,
+  summarisePublicProfileProbe,
+  HISTORICAL_BASELINE,
+  type IdentityCoverageSnapshot,
+} from './identityCoverageCore';
+import {
+  probePublicProfiles,
+  readIdentityCoverageStores,
+} from './identityCoverageDb';
+
+function truncateAddress(address: string): string {
+  if (address.length <= 20) return address;
+  return `${address.slice(0, 10)}…${address.slice(-6)}`;
+}
+
+/** Green when the count is zero, red otherwise — the acceptance criterion for
+ *  the whole task is this number reaching zero and staying there. */
+function countTone(value: number): string {
+  return value === 0 ? 'text-green-500' : 'text-red-500';
+}
+
+interface StatProps {
+  label: string;
+  value: number | string;
+  hint?: string;
+  tone?: string;
+}
+
+const Stat: React.FC<StatProps> = ({ label, value, hint, tone }) => (
+  <div className="min-w-32">
+    <Text variant="subtle" size="xs">
+      {label}
+    </Text>
+    <Text variant="strong" size="xl" className={tone}>
+      {value}
+    </Text>
+    {hint && (
+      <Text variant="subtle" size="xs" className="block">
+        {hint}
+      </Text>
+    )}
+  </div>
+);
+
+export const IdentityCoverage: React.FC = () => {
+  const { currentPasskeyInfo } = usePasskeysContext();
+  const ownAddress = currentPasskeyInfo?.address ?? null;
+
+  const [history, setHistory] = useState<IdentityCoverageSnapshot[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [probing, setProbing] = useState(false);
+  const [probeProgress, setProbeProgress] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [copyStatus, setCopyStatus] = useState<string | null>(null);
+
+  const latest = history[history.length - 1] ?? null;
+  const delta = useMemo(
+    () =>
+      history.length >= 2
+        ? computeCoverageDelta(history[0], history[history.length - 1])
+        : null,
+    [history]
+  );
+
+  const takeSnapshot = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const stores = await readIdentityCoverageStores();
+      const snapshot = buildIdentityCoverageSnapshot({
+        atIso: new Date().toISOString(),
+        ownAddress,
+        spaces: stores.spaces,
+        members: stores.members,
+        messages: stores.messages,
+        conversations: stores.conversations,
+      });
+      setHistory((prev) => [...prev, snapshot]);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Snapshot failed');
+    } finally {
+      setLoading(false);
+    }
+  }, [ownAddress]);
+
+  /**
+   * Probe every address that has no local identity — both the senders with no
+   * member row and the rows carrying nothing — and attach the summary to the
+   * most recent snapshot. Opt-in because it is one network call per address.
+   */
+  const runPublicProfileProbe = useCallback(async () => {
+    if (!latest) return;
+    setProbing(true);
+    setError(null);
+    try {
+      const addresses = new Set<string>();
+      for (const space of latest.spaces) {
+        for (const sender of space.missingSenders) {
+          if (!sender.isSelf) addresses.add(sender.address);
+        }
+        for (const row of space.rowsWithoutIdentity) {
+          addresses.add(row.address);
+        }
+      }
+      for (const row of latest.dms.rowsWithoutIdentity) {
+        addresses.add(row.address);
+      }
+
+      const list = [...addresses];
+      if (list.length === 0) {
+        setProbeProgress('Nothing to probe — no addresses lack local identity.');
+        return;
+      }
+
+      setProbeProgress(`0/${list.length}`);
+      const results = await probePublicProfiles(list, (done, total) =>
+        setProbeProgress(`${done}/${total}`)
+      );
+      const summary = summarisePublicProfileProbe(results);
+
+      setHistory((prev) =>
+        prev.map((snapshot, index) =>
+          index === prev.length - 1
+            ? { ...snapshot, publicProfile: summary }
+            : snapshot
+        )
+      );
+      setProbeProgress(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Public-profile probe failed');
+    } finally {
+      setProbing(false);
+    }
+  }, [latest]);
+
+  const copyReport = useCallback(async () => {
+    try {
+      const report = formatIdentityCoverageReport({
+        generatedAtIso: new Date().toISOString(),
+        history,
+      });
+      await navigator.clipboard.writeText(report);
+      setCopyStatus('Report copied!');
+    } catch {
+      setCopyStatus('Failed to copy');
+    } finally {
+      setTimeout(() => setCopyStatus(null), 2000);
+    }
+  }, [history]);
+
+  const clearHistory = useCallback(() => {
+    setHistory([]);
+    setProbeProgress(null);
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-app">
+      <DevNavMenu currentPath="/dev/identity-coverage" sticky />
+
+      <div className="p-6 mx-auto max-w-5xl">
+        <Flex gap="sm" align="center" className="mb-2">
+          <Icon name="id-badge" size="xl" className="text-accent" />
+          <div>
+            <Text as="h1" variant="strong" size="2xl" weight="bold">
+              Identity Coverage
+            </Text>
+            <Text variant="subtle" size="sm">
+              How many people cannot render as anything but a truncated address.
+              Own address:{' '}
+              {ownAddress ? truncateAddress(ownAddress) : 'unknown (not signed in)'}
+            </Text>
+          </div>
+        </Flex>
+
+        {copyStatus && (
+          <div className="fixed top-4 right-4 bg-surface-2 border border-accent px-4 py-2 rounded-lg shadow-lg z-50">
+            <Text variant="main" size="sm">
+              {copyStatus}
+            </Text>
+          </div>
+        )}
+
+        {/* Controls */}
+        <div className="bg-surface-1 rounded-lg border border-default p-4 mt-6">
+          <Flex gap="md" align="center" className="flex-wrap">
+            <Button variant="primary" onClick={takeSnapshot} disabled={loading}>
+              <Icon
+                name={loading ? 'spinner' : 'search'}
+                size="sm"
+                className={loading ? 'animate-spin' : undefined}
+              />
+              {loading ? 'Reading…' : 'Take snapshot'}
+            </Button>
+            {latest && (
+              <Button
+                variant="secondary"
+                onClick={runPublicProfileProbe}
+                disabled={probing}
+              >
+                <Icon
+                  name={probing ? 'spinner' : 'globe-search'}
+                  size="sm"
+                  className={probing ? 'animate-spin' : undefined}
+                />
+                {probing
+                  ? `Probing ${probeProgress ?? ''}`
+                  : 'Probe public profiles'}
+              </Button>
+            )}
+            {history.length > 0 && (
+              <>
+                <Button variant="primary" onClick={copyReport}>
+                  <Icon name="copy" size="sm" />
+                  Copy report
+                </Button>
+                <Button variant="secondary" onClick={clearHistory}>
+                  Clear ({history.length})
+                </Button>
+              </>
+            )}
+          </Flex>
+          <Text variant="subtle" size="xs" className="mt-2 block">
+            Counts a person as having no identity when the per-space override
+            slot AND the global slot are both empty — the two-slot model the
+            older console probe (06-space-member-sources.js) predates. Read
+            straight from IndexedDB, so this measures what persisted. Take one
+            snapshot, reload the app, take another: the delta is the
+            measurement. Baseline for comparison — {HISTORICAL_BASELINE}
+          </Text>
+        </div>
+
+        {error && (
+          <div className="bg-red-500/10 border border-red-500/30 rounded-lg p-4 mt-6">
+            <Text variant="strong" className="text-red-500">
+              {error}
+            </Text>
+          </div>
+        )}
+
+        {probeProgress && !probing && (
+          <div className="bg-surface-1 border border-default rounded-lg p-3 mt-6">
+            <Text variant="subtle" size="sm">
+              {probeProgress}
+            </Text>
+          </div>
+        )}
+
+        {/* Delta */}
+        {delta && (
+          <div className="bg-surface-1 rounded-lg border border-accent p-4 mt-6">
+            <Text variant="strong" size="lg" className="mb-3">
+              Delta — first snapshot to last (negative is improvement)
+            </Text>
+            <Flex gap="lg" className="flex-wrap">
+              <Stat
+                label="Senders with no member row"
+                value={formatSigned(delta.sendersWithNoRow)}
+                tone={
+                  delta.sendersWithNoRow > 0 ? 'text-red-500' : 'text-green-500'
+                }
+              />
+              <Stat
+                label="Rows with no identity"
+                value={formatSigned(delta.rowsNoIdentity)}
+                tone={
+                  delta.rowsNoIdentity > 0 ? 'text-red-500' : 'text-green-500'
+                }
+              />
+              <Stat
+                label="No-identity total"
+                value={formatSigned(delta.noIdentityTotal)}
+                tone={
+                  delta.noIdentityTotal > 0 ? 'text-red-500' : 'text-green-500'
+                }
+              />
+              <Stat
+                label="DM rows with no identity"
+                value={formatSigned(delta.dmRowsNoIdentity)}
+                tone={
+                  delta.dmRowsNoIdentity > 0 ? 'text-red-500' : 'text-green-500'
+                }
+              />
+            </Flex>
+          </div>
+        )}
+
+        {/* Latest snapshot */}
+        {latest && (
+          <>
+            <div className="bg-surface-1 rounded-lg border border-default p-4 mt-6">
+              <Flex justify="between" align="center" className="mb-4">
+                <Text variant="strong" size="lg">
+                  Latest snapshot — {latest.atIso}
+                </Text>
+                <Text
+                  variant="strong"
+                  size="2xl"
+                  className={countTone(latest.totals.noIdentityTotal)}
+                >
+                  {latest.totals.noIdentityTotal} with no identity
+                </Text>
+              </Flex>
+
+              <Flex gap="lg" className="flex-wrap mb-4">
+                <Stat
+                  label="Senders with no member row"
+                  value={latest.totals.sendersWithNoRow}
+                  hint="their join never arrived"
+                  tone={countTone(latest.totals.sendersWithNoRow)}
+                />
+                <Stat
+                  label="Rows with no identity"
+                  value={latest.totals.rowsNoIdentity}
+                  hint="row arrived carrying nothing"
+                  tone={countTone(latest.totals.rowsNoIdentity)}
+                />
+                <Stat
+                  label="Distinct senders"
+                  value={latest.totals.distinctSenders}
+                />
+                <Stat label="Member rows" value={latest.totals.memberRows} />
+                <Stat
+                  label="Rows with no name"
+                  value={latest.totals.rowsNoName}
+                />
+                <Stat
+                  label="Rows with no avatar"
+                  value={latest.totals.rowsNoIcon}
+                />
+              </Flex>
+
+              <Text variant="subtle" size="xs" className="block">
+                The two headline figures are kept apart because they have
+                different causes and different fixes: a missing row is a
+                join/sync transport gap, an empty row is an announce/digest gap.
+                They are disjoint sets, so the total is their sum. Read from{' '}
+                {latest.messagesScanned} message rows, {latest.memberRowsScanned}{' '}
+                member rows, {latest.conversationsScanned} conversation rows.
+              </Text>
+            </div>
+
+            {/* Public-profile probe */}
+            {latest.publicProfile && (
+              <div className="bg-surface-1 rounded-lg border border-default p-4 mt-6">
+                <Text variant="strong" size="lg" className="mb-3">
+                  Public-profile probe
+                </Text>
+                <Flex gap="lg" className="flex-wrap mb-2">
+                  <Stat label="Probed" value={latest.publicProfile.probed} />
+                  <Stat
+                    label="Recoverable at render"
+                    value={latest.publicProfile.recoverable}
+                    hint="public profile can fill it"
+                    tone="text-yellow-500"
+                  />
+                  <Stat
+                    label="No source anywhere"
+                    value={latest.publicProfile.noSource}
+                    hint="never opted in — irreducible"
+                    tone={countTone(latest.publicProfile.noSource)}
+                  />
+                  <Stat
+                    label="Fetch errors"
+                    value={latest.publicProfile.errors}
+                    hint="not evidence of a missing profile"
+                  />
+                </Flex>
+              </div>
+            )}
+
+            {/* Per space */}
+            <div className="bg-surface-1 rounded-lg border border-default p-4 mt-6">
+              <Text variant="strong" size="lg" className="mb-3">
+                Per space (worst first)
+              </Text>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="text-left border-b border-default">
+                      <th className="py-1 pr-4">Space</th>
+                      <th className="py-1 pr-4">Senders</th>
+                      <th className="py-1 pr-4">No member row</th>
+                      <th className="py-1 pr-4">Rows</th>
+                      <th className="py-1 pr-4">Rows w/o identity</th>
+                      <th className="py-1">Total</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {latest.spaces.map((space) => (
+                      <tr
+                        key={space.spaceId}
+                        className="border-b border-default/50"
+                      >
+                        <td className="py-1 pr-4">
+                          {space.spaceName}
+                          {space.selfMissingRow && (
+                            <span className="ml-2 bg-yellow-500/20 text-yellow-500 text-xs px-2 py-0.5 rounded font-medium">
+                              own row missing
+                            </span>
+                          )}
+                        </td>
+                        <td className="py-1 pr-4">{space.distinctSenders}</td>
+                        <td
+                          className={`py-1 pr-4 ${countTone(space.sendersWithNoRow)}`}
+                        >
+                          {space.sendersWithNoRow}
+                        </td>
+                        <td className="py-1 pr-4">{space.memberRows}</td>
+                        <td
+                          className={`py-1 pr-4 ${countTone(space.rowsNoIdentity)}`}
+                        >
+                          {space.rowsNoIdentity}
+                        </td>
+                        <td
+                          className={`py-1 font-medium ${countTone(space.noIdentityTotal)}`}
+                        >
+                          {space.noIdentityTotal}
+                        </td>
+                      </tr>
+                    ))}
+                    {latest.spaces.length === 0 && (
+                      <tr>
+                        <td colSpan={6} className="py-4 text-center text-subtle">
+                          No spaces in the local database.
+                        </td>
+                      </tr>
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+
+            {/* DMs */}
+            <div className="bg-surface-1 rounded-lg border border-default p-4 mt-6">
+              <Text variant="strong" size="lg" className="mb-3">
+                Direct messages
+              </Text>
+              <Flex gap="lg" className="flex-wrap">
+                <Stat label="Direct rows" value={latest.dms.directRows} />
+                <Stat
+                  label="Rows with no identity"
+                  value={latest.dms.rowsNoIdentity}
+                  tone={countTone(latest.dms.rowsNoIdentity)}
+                />
+                <Stat label="Rows with no name" value={latest.dms.rowsNoName} />
+                <Stat label="Rows with no avatar" value={latest.dms.rowsNoIcon} />
+                {latest.dms.selfRows > 0 && (
+                  <Stat
+                    label="Self-keyed rows"
+                    value={latest.dms.selfRows}
+                    hint="excluded — ghost conversation"
+                    tone="text-yellow-500"
+                  />
+                )}
+              </Flex>
+            </div>
+
+            {/* Snapshot history */}
+            {history.length > 1 && (
+              <div className="bg-surface-1 rounded-lg border border-default p-4 mt-6">
+                <Text variant="strong" size="lg" className="mb-3">
+                  Snapshots this session
+                </Text>
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="text-left border-b border-default">
+                        <th className="py-1 pr-4">#</th>
+                        <th className="py-1 pr-4">Taken at</th>
+                        <th className="py-1 pr-4">No member row</th>
+                        <th className="py-1 pr-4">Rows w/o identity</th>
+                        <th className="py-1">Total</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {history.map((snapshot, index) => (
+                        <tr
+                          key={snapshot.atIso}
+                          className="border-b border-default/50"
+                        >
+                          <td className="py-1 pr-4">{index + 1}</td>
+                          <td className="py-1 pr-4 font-mono text-xs">
+                            {snapshot.atIso}
+                          </td>
+                          <td className="py-1 pr-4">
+                            {snapshot.totals.sendersWithNoRow}
+                          </td>
+                          <td className="py-1 pr-4">
+                            {snapshot.totals.rowsNoIdentity}
+                          </td>
+                          <td
+                            className={`py-1 font-medium ${countTone(snapshot.totals.noIdentityTotal)}`}
+                          >
+                            {snapshot.totals.noIdentityTotal}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            )}
+          </>
+        )}
+
+        {!latest && !loading && (
+          <div className="bg-surface-1 rounded-lg border border-default p-8 mt-6 text-center">
+            <Text variant="subtle">
+              Take a snapshot to read the current identity coverage.
+            </Text>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/dev/identity-coverage/identityCoverageCore.ts
+++ b/src/dev/identity-coverage/identityCoverageCore.ts
@@ -1,0 +1,688 @@
+/**
+ * Identity Coverage — pure core logic.
+ *
+ * The instrument for Step 4 of
+ * `.agents/tasks/2026-08-01-identity-announce-cadence-research.md`: one number
+ * you can read before and after an identity fix, instead of taking anyone's
+ * word for it. Every change in that task exists to move this number down.
+ *
+ * No DOM, no IndexedDB, no network, no clock. Plain rows in, plain data out, so
+ * the whole classification is unit-testable without a browser. IndexedDB reads
+ * live in `identityCoverageDb.ts`; the page that wires it together is
+ * `IdentityCoverage.tsx`. Same three-way split as `dm-doctor/`.
+ *
+ * ## What this counts, and why not what the console probe counted
+ *
+ * Ports the questions encoded in the checked-in probes
+ * `.agents/tools/dm-debug/06-space-member-sources.js` and `05-profile-sources.js`,
+ * with one correction. Those scripts predate the two-slot identity model, so
+ * they read only the per-space OVERRIDE slot (`display_name` / `user_icon`).
+ * The follow-global work deliberately leaves that slot empty for members who
+ * have not set a per-space name, so "override slot is empty" no longer means
+ * "renders as an address" — the GLOBAL slot (`global_display_name` /
+ * `global_user_icon`) may still carry a perfectly good identity.
+ *
+ * What this module counts instead is "lands on the last rung of the precedence
+ * ladder", which is the thing the operator actually sees on screen:
+ *
+ *     per-space override → QNS `.q` → global display name → truncated address
+ *                                                            ^^^^^^^^^^^^^^^^
+ *
+ * The ladder itself is `resolveDisplayName` in quorum-shared (via
+ * `src/utils/resolveMemberName.ts`). Only the last two rungs are decidable from
+ * local storage: QNS `primary_username` is not a field of a stored member row,
+ * it arrives with the public profile. So the local count is deliberately the
+ * pessimistic one, and the optional public-profile probe (see
+ * `summarisePublicProfileProbe`) splits it into "a render-time fetch could
+ * still save this" versus "no source anywhere".
+ *
+ * ## Two figures, never merged
+ *
+ * `sendersWithNoRow` and `rowsNoIdentity` are reported separately because they
+ * have different causes and different fixes: the first is a roster row that
+ * never arrived (a join/sync transport gap), the second is a row that arrived
+ * carrying nothing (an announce/digest gap). Collapsing them into one number
+ * would hide which of the two a change actually moved.
+ */
+
+import {
+  isPlaceholderDisplayName,
+  isPlaceholderIcon,
+} from '../../utils/identityPlaceholder';
+
+// ---------------------------------------------------------------------------
+// Row shapes — the minimal slice of each store this module reads
+// ---------------------------------------------------------------------------
+
+/** Minimal shape of a `space_members` row. Mirrors `SpaceMemberRow` in
+ *  `src/db/messages.ts`; only the identity-bearing fields are needed here. */
+export interface SpaceMemberIdentityRow {
+  spaceId: string;
+  user_address: string;
+  /** Per-space OVERRIDE slot. */
+  display_name?: string;
+  user_icon?: string;
+  /** GLOBAL slot (two-slot model). */
+  global_display_name?: string;
+  global_user_icon?: string;
+  isKicked?: boolean;
+}
+
+/** Minimal shape of a `messages` row — just enough to attribute a sender. */
+export interface IdentityMessageRow {
+  spaceId: string;
+  content?: { senderId?: string | null } | null;
+}
+
+/** Minimal shape of a `spaces` row, for naming the per-space breakdown. */
+export interface IdentitySpaceRow {
+  spaceId: string;
+  name?: string;
+}
+
+/** Minimal shape of a `conversations` row. */
+export interface DirectConversationIdentityRow {
+  conversationId: string;
+  type: 'direct' | 'group';
+  address: string;
+  displayName?: string;
+  icon?: string;
+}
+
+// ---------------------------------------------------------------------------
+// The two predicates everything else is built on
+// ---------------------------------------------------------------------------
+
+/**
+ * True when a stored display name would actually render as a name.
+ *
+ * Mirrors the render path exactly, in both of its steps: the app demotes the
+ * locale-aware `'Unknown User'` placeholder via `realDisplayNameOrUndefined`,
+ * and then quorum-shared's `resolveDisplayName` applies a trim-and-length
+ * check before accepting it. A count that skipped either step would disagree
+ * with the screen, which would make it worthless as a measurement.
+ */
+export function hasRealName(value?: string | null): boolean {
+  if (isPlaceholderDisplayName(value)) return false;
+  return (value ?? '').trim().length > 0;
+}
+
+/**
+ * True when a stored avatar would actually render as an avatar.
+ *
+ * Mirrors `realIconOrUndefined` — empty or the default placeholder image means
+ * `UserAvatar` degrades to address-derived initials.
+ */
+export function hasRealIcon(value?: string | null): boolean {
+  return !isPlaceholderIcon(value);
+}
+
+// ---------------------------------------------------------------------------
+// Per-row classification
+// ---------------------------------------------------------------------------
+
+/** Which of the two local slots supplied a value. */
+export type IdentitySlot = 'override' | 'global';
+
+export interface MemberIdentityVerdict {
+  address: string;
+  /** Slot that supplied a real name, or null. Override wins, per the ladder. */
+  nameFrom: IdentitySlot | null;
+  /** Slot that supplied a real avatar, or null. */
+  iconFrom: IdentitySlot | null;
+  /** The row renders as a truncated address rather than a name. */
+  noName: boolean;
+  /** The row renders address-derived initials rather than an avatar. */
+  noIcon: boolean;
+  /** THE headline predicate: no name AND no avatar, from either slot. */
+  noIdentity: boolean;
+  /** Excluded from every headline count — a kicked member rendering as an
+   *  address is not a coverage failure. Reported so the exclusion is visible. */
+  isKicked: boolean;
+}
+
+/**
+ * Classify one `space_members` row against both identity slots.
+ *
+ * Note the asymmetry with the render ladder: the override slot beats the global
+ * slot for BOTH name and avatar, but a row can legitimately draw its name from
+ * one slot and its avatar from the other (e.g. a per-space nickname with no
+ * per-space picture). `nameFrom` and `iconFrom` are therefore resolved
+ * independently rather than picking one winning slot for the whole row.
+ */
+export function classifyMemberIdentity(
+  row: SpaceMemberIdentityRow
+): MemberIdentityVerdict {
+  const nameFrom: IdentitySlot | null = hasRealName(row.display_name)
+    ? 'override'
+    : hasRealName(row.global_display_name)
+      ? 'global'
+      : null;
+
+  const iconFrom: IdentitySlot | null = hasRealIcon(row.user_icon)
+    ? 'override'
+    : hasRealIcon(row.global_user_icon)
+      ? 'global'
+      : null;
+
+  return {
+    address: row.user_address,
+    nameFrom,
+    iconFrom,
+    noName: nameFrom === null,
+    noIcon: iconFrom === null,
+    noIdentity: nameFrom === null && iconFrom === null,
+    isKicked: Boolean(row.isKicked),
+  };
+}
+
+export interface DmIdentityVerdict {
+  conversationId: string;
+  address: string;
+  noName: boolean;
+  noIcon: boolean;
+  noIdentity: boolean;
+  /** A `direct` row keyed by the account's own address — the ghost-conversation
+   *  artifact `dm-doctor` also flags. Excluded from headline counts. */
+  isSelf: boolean;
+}
+
+/** Classify one `direct` conversation row. A DM row has only one identity slot
+ *  (`displayName` / `icon`) — there is no global slot on the DM side. */
+export function classifyDmIdentity(
+  row: DirectConversationIdentityRow,
+  ownAddress: string | null | undefined
+): DmIdentityVerdict {
+  const noName = !hasRealName(row.displayName);
+  const noIcon = !hasRealIcon(row.icon);
+  return {
+    conversationId: row.conversationId,
+    address: row.address,
+    noName,
+    noIcon,
+    noIdentity: noName && noIcon,
+    isSelf: Boolean(
+      ownAddress &&
+        (row.address === ownAddress || row.conversationId === ownAddress)
+    ),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Senders with no member row at all (bucket A)
+// ---------------------------------------------------------------------------
+
+export interface MissingSenderRow {
+  address: string;
+  messageCount: number;
+  /** The account's own address. Excluded from the headline count: "no member
+   *  row for yourself" is a different and much rarer defect, and letting it sit
+   *  in the coverage number would add a constant that no fix ever moves. */
+  isSelf: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Per-space aggregation
+// ---------------------------------------------------------------------------
+
+export interface SpaceCoverage {
+  spaceId: string;
+  spaceName: string;
+  /** Distinct senders observed in this space's messages, self included. */
+  distinctSenders: number;
+  /** Senders with no `space_members` row at all. Excludes self. */
+  sendersWithNoRow: number;
+  /** True when the account's own address is among the senders with no row. */
+  selfMissingRow: boolean;
+  /** `space_members` rows for this space, excluding kicked members. */
+  memberRows: number;
+  kickedRows: number;
+  /** Rows present but carrying no identity in either slot. */
+  rowsNoIdentity: number;
+  rowsNoName: number;
+  rowsNoIcon: number;
+  /**
+   * People in this space who cannot render as anything but an address:
+   * `sendersWithNoRow + rowsNoIdentity`. The two sets are disjoint by
+   * construction — a sender with no row has no row to classify, and a
+   * classified row is by definition not missing — so the sum double-counts
+   * nobody.
+   */
+  noIdentityTotal: number;
+  missingSenders: MissingSenderRow[];
+  rowsWithoutIdentity: MemberIdentityVerdict[];
+}
+
+/**
+ * Build the coverage picture for one space.
+ *
+ * `messages` is the WHOLE store, not a pre-filtered slice: space traffic is
+ * filed under `spaceId`, so filtering happens here and DM rows (filed under a
+ * peer address) simply never match.
+ */
+export function computeSpaceCoverage(
+  space: IdentitySpaceRow,
+  members: SpaceMemberIdentityRow[],
+  messages: IdentityMessageRow[],
+  ownAddress: string | null | undefined
+): SpaceCoverage {
+  const scopedMembers = members.filter((m) => m.spaceId === space.spaceId);
+  const memberAddresses = new Set(scopedMembers.map((m) => m.user_address));
+
+  const senderCounts = new Map<string, number>();
+  for (const message of messages) {
+    if (message.spaceId !== space.spaceId) continue;
+    const senderId = message.content?.senderId;
+    if (!senderId) continue;
+    senderCounts.set(senderId, (senderCounts.get(senderId) ?? 0) + 1);
+  }
+
+  const missingSenders: MissingSenderRow[] = [];
+  for (const [address, messageCount] of senderCounts.entries()) {
+    if (memberAddresses.has(address)) continue;
+    missingSenders.push({
+      address,
+      messageCount,
+      isSelf: Boolean(ownAddress) && address === ownAddress,
+    });
+  }
+  missingSenders.sort((a, b) => b.messageCount - a.messageCount);
+
+  const verdicts = scopedMembers.map(classifyMemberIdentity);
+  const live = verdicts.filter((v) => !v.isKicked);
+  const rowsWithoutIdentity = live.filter((v) => v.noIdentity);
+
+  const sendersWithNoRow = missingSenders.filter((s) => !s.isSelf).length;
+  const rowsNoIdentity = rowsWithoutIdentity.length;
+
+  return {
+    spaceId: space.spaceId,
+    spaceName: space.name?.trim() || '(unnamed)',
+    distinctSenders: senderCounts.size,
+    sendersWithNoRow,
+    selfMissingRow: missingSenders.some((s) => s.isSelf),
+    memberRows: live.length,
+    kickedRows: verdicts.length - live.length,
+    rowsNoIdentity,
+    rowsNoName: live.filter((v) => v.noName).length,
+    rowsNoIcon: live.filter((v) => v.noIcon).length,
+    noIdentityTotal: sendersWithNoRow + rowsNoIdentity,
+    missingSenders,
+    rowsWithoutIdentity,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// DM aggregation
+// ---------------------------------------------------------------------------
+
+export interface DmCoverage {
+  /** `type: 'direct'` rows, excluding any keyed by the account's own address. */
+  directRows: number;
+  selfRows: number;
+  rowsNoIdentity: number;
+  rowsNoName: number;
+  rowsNoIcon: number;
+  rowsWithoutIdentity: DmIdentityVerdict[];
+}
+
+export function computeDmCoverage(
+  conversations: DirectConversationIdentityRow[],
+  ownAddress: string | null | undefined
+): DmCoverage {
+  const verdicts = conversations
+    .filter((c) => c.type === 'direct')
+    .map((c) => classifyDmIdentity(c, ownAddress));
+
+  const live = verdicts.filter((v) => !v.isSelf);
+  const rowsWithoutIdentity = live.filter((v) => v.noIdentity);
+
+  return {
+    directRows: live.length,
+    selfRows: verdicts.length - live.length,
+    rowsNoIdentity: rowsWithoutIdentity.length,
+    rowsNoName: live.filter((v) => v.noName).length,
+    rowsNoIcon: live.filter((v) => v.noIcon).length,
+    rowsWithoutIdentity,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The snapshot
+// ---------------------------------------------------------------------------
+
+export interface CoverageTotals {
+  distinctSenders: number;
+  sendersWithNoRow: number;
+  memberRows: number;
+  rowsNoIdentity: number;
+  rowsNoName: number;
+  rowsNoIcon: number;
+  /** `sendersWithNoRow + rowsNoIdentity` across every space. THE headline. */
+  noIdentityTotal: number;
+}
+
+export interface IdentityCoverageSnapshot {
+  /** ISO timestamp of the IndexedDB read this snapshot was computed from. */
+  atIso: string;
+  ownAddress: string | null;
+  spaces: SpaceCoverage[];
+  totals: CoverageTotals;
+  dms: DmCoverage;
+  /** Store sizes at read time — a snapshot computed over an empty store is not
+   *  the same claim as one computed over a full one, and must not read as it. */
+  messagesScanned: number;
+  memberRowsScanned: number;
+  conversationsScanned: number;
+  /** null until the (optional, network) public-profile probe has been run. */
+  publicProfile: PublicProfileProbeSummary | null;
+}
+
+export interface BuildSnapshotInput {
+  atIso: string;
+  ownAddress: string | null;
+  spaces: IdentitySpaceRow[];
+  members: SpaceMemberIdentityRow[];
+  messages: IdentityMessageRow[];
+  conversations: DirectConversationIdentityRow[];
+}
+
+/**
+ * Assemble the full snapshot. Deterministic: the caller supplies the timestamp,
+ * nothing here reads the clock.
+ *
+ * Spaces are ordered worst-first (highest `noIdentityTotal`), so the space that
+ * needs attention is the one at the top of the table rather than whichever
+ * happened to be inserted first.
+ */
+export function buildIdentityCoverageSnapshot(
+  input: BuildSnapshotInput
+): IdentityCoverageSnapshot {
+  const spaces = input.spaces
+    .map((space) =>
+      computeSpaceCoverage(space, input.members, input.messages, input.ownAddress)
+    )
+    .sort(
+      (a, b) =>
+        b.noIdentityTotal - a.noIdentityTotal ||
+        a.spaceName.localeCompare(b.spaceName)
+    );
+
+  const sum = (pick: (s: SpaceCoverage) => number): number =>
+    spaces.reduce((acc, space) => acc + pick(space), 0);
+
+  return {
+    atIso: input.atIso,
+    ownAddress: input.ownAddress,
+    spaces,
+    totals: {
+      distinctSenders: sum((s) => s.distinctSenders),
+      sendersWithNoRow: sum((s) => s.sendersWithNoRow),
+      memberRows: sum((s) => s.memberRows),
+      rowsNoIdentity: sum((s) => s.rowsNoIdentity),
+      rowsNoName: sum((s) => s.rowsNoName),
+      rowsNoIcon: sum((s) => s.rowsNoIcon),
+      noIdentityTotal: sum((s) => s.noIdentityTotal),
+    },
+    dms: computeDmCoverage(input.conversations, input.ownAddress),
+    messagesScanned: input.messages.length,
+    memberRowsScanned: input.members.length,
+    conversationsScanned: input.conversations.length,
+    publicProfile: null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Optional public-profile probe (the last leg of "from any source")
+// ---------------------------------------------------------------------------
+
+/**
+ * One public-profile lookup result. The fetching itself lives in
+ * `identityCoverageDb.ts` — this module only reclassifies.
+ */
+export interface PublicProfileResult {
+  address: string;
+  /** HTTP status, or 'error' when the request never completed. */
+  status: number | 'error';
+  hasName: boolean;
+  hasImage: boolean;
+}
+
+export interface PublicProfileProbeSummary {
+  probed: number;
+  /** A render-time public-profile fetch could still put a name or avatar on
+   *  screen. The local row is empty, but the user is not invisible. */
+  recoverable: number;
+  /** No public profile and no local identity: nothing anywhere can render
+   *  these. This is the irreducible core of the problem. */
+  noSource: number;
+  /** Requests that failed outright — counted apart from `noSource`, because a
+   *  network error is not evidence of a missing profile. */
+  errors: number;
+  results: PublicProfileResult[];
+}
+
+export function summarisePublicProfileProbe(
+  results: PublicProfileResult[]
+): PublicProfileProbeSummary {
+  let recoverable = 0;
+  let noSource = 0;
+  let errors = 0;
+
+  for (const result of results) {
+    if (result.status === 'error') {
+      errors += 1;
+    } else if (result.hasName || result.hasImage) {
+      recoverable += 1;
+    } else {
+      noSource += 1;
+    }
+  }
+
+  return { probed: results.length, recoverable, noSource, errors, results };
+}
+
+// ---------------------------------------------------------------------------
+// Before/after delta — the whole point of the instrument
+// ---------------------------------------------------------------------------
+
+export interface CoverageDelta {
+  beforeIso: string;
+  afterIso: string;
+  sendersWithNoRow: number;
+  rowsNoIdentity: number;
+  noIdentityTotal: number;
+  dmRowsNoIdentity: number;
+}
+
+/** Signed differences, after minus before. Negative is improvement. */
+export function computeCoverageDelta(
+  before: IdentityCoverageSnapshot,
+  after: IdentityCoverageSnapshot
+): CoverageDelta {
+  return {
+    beforeIso: before.atIso,
+    afterIso: after.atIso,
+    sendersWithNoRow:
+      after.totals.sendersWithNoRow - before.totals.sendersWithNoRow,
+    rowsNoIdentity: after.totals.rowsNoIdentity - before.totals.rowsNoIdentity,
+    noIdentityTotal:
+      after.totals.noIdentityTotal - before.totals.noIdentityTotal,
+    dmRowsNoIdentity: after.dms.rowsNoIdentity - before.dms.rowsNoIdentity,
+  };
+}
+
+/** `-4`, `+2`, `0` — sign always explicit, so a delta can never be misread as
+ *  an absolute count when it is pasted into a task file. */
+export function formatSigned(value: number): string {
+  return value > 0 ? `+${value}` : String(value);
+}
+
+// ---------------------------------------------------------------------------
+// "Copy report" — the self-contained paste
+// ---------------------------------------------------------------------------
+
+export const IDENTITY_COVERAGE_TASK_POINTER =
+  '.agents/tasks/2026-08-01-identity-announce-cadence-research.md';
+
+/** The 2026-06-13 run on the "Quorum Test 2" space, from the task's Step 4
+ *  brief. Quoted in the report so a fresh reader has something to compare a
+ *  first run against without going hunting. */
+export const HISTORICAL_BASELINE =
+  '2026-06-13, space "Quorum Test 2": 89 distinct senders, 46 with no member row.';
+
+function truncate(address: string): string {
+  return address.length > 20
+    ? `${address.slice(0, 10)}…${address.slice(-6)}`
+    : address;
+}
+
+function formatSpaceSection(space: SpaceCoverage): string {
+  const lines: string[] = [];
+  lines.push(`### ${space.spaceName} (${truncate(space.spaceId)})`);
+  lines.push(`distinct_senders: ${space.distinctSenders}`);
+  lines.push(`senders_with_no_member_row: ${space.sendersWithNoRow}`);
+  lines.push(`self_missing_row: ${space.selfMissingRow}`);
+  lines.push(`member_rows: ${space.memberRows} (kicked, excluded: ${space.kickedRows})`);
+  lines.push(`rows_no_identity: ${space.rowsNoIdentity}`);
+  lines.push(`rows_no_name: ${space.rowsNoName}`);
+  lines.push(`rows_no_icon: ${space.rowsNoIcon}`);
+  lines.push(`no_identity_total: ${space.noIdentityTotal}`);
+
+  lines.push('senders with no member row (address, messages):');
+  if (space.missingSenders.length === 0) {
+    lines.push('  none');
+  } else {
+    for (const sender of space.missingSenders) {
+      lines.push(
+        `  - ${sender.address} messages=${sender.messageCount}${sender.isSelf ? ' (SELF — excluded from count)' : ''}`
+      );
+    }
+  }
+
+  lines.push('rows present but carrying no identity:');
+  if (space.rowsWithoutIdentity.length === 0) {
+    lines.push('  none');
+  } else {
+    for (const row of space.rowsWithoutIdentity) {
+      lines.push(`  - ${row.address}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+function formatSnapshotSection(
+  snapshot: IdentityCoverageSnapshot,
+  index: number,
+  total: number
+): string {
+  const lines: string[] = [];
+  lines.push(`## Snapshot ${index + 1} of ${total} — ${snapshot.atIso}`);
+  lines.push('');
+  lines.push('### Totals (all spaces)');
+  lines.push(`senders_with_no_member_row: ${snapshot.totals.sendersWithNoRow}`);
+  lines.push(`rows_no_identity: ${snapshot.totals.rowsNoIdentity}`);
+  lines.push(`NO_IDENTITY_TOTAL: ${snapshot.totals.noIdentityTotal}`);
+  lines.push(`distinct_senders: ${snapshot.totals.distinctSenders}`);
+  lines.push(`member_rows: ${snapshot.totals.memberRows}`);
+  lines.push(`rows_no_name: ${snapshot.totals.rowsNoName}`);
+  lines.push(`rows_no_icon: ${snapshot.totals.rowsNoIcon}`);
+  lines.push('');
+  lines.push('### DMs');
+  lines.push(`direct_rows: ${snapshot.dms.directRows} (self-keyed, excluded: ${snapshot.dms.selfRows})`);
+  lines.push(`rows_no_identity: ${snapshot.dms.rowsNoIdentity}`);
+  lines.push(`rows_no_name: ${snapshot.dms.rowsNoName}`);
+  lines.push(`rows_no_icon: ${snapshot.dms.rowsNoIcon}`);
+  if (snapshot.dms.rowsWithoutIdentity.length) {
+    lines.push('direct rows carrying no identity:');
+    for (const row of snapshot.dms.rowsWithoutIdentity) {
+      lines.push(`  - ${row.address} conversationId=${row.conversationId}`);
+    }
+  }
+  lines.push('');
+  lines.push('### Store sizes at read time');
+  lines.push(`messages_rows: ${snapshot.messagesScanned}`);
+  lines.push(`space_members_rows: ${snapshot.memberRowsScanned}`);
+  lines.push(`conversations_rows: ${snapshot.conversationsScanned}`);
+  lines.push('');
+  lines.push('### Public-profile probe');
+  if (snapshot.publicProfile === null) {
+    lines.push('not run (local-only counts above)');
+  } else {
+    const probe = snapshot.publicProfile;
+    lines.push(`probed: ${probe.probed}`);
+    lines.push(`recoverable_from_public_profile: ${probe.recoverable}`);
+    lines.push(`no_source_anywhere: ${probe.noSource}`);
+    lines.push(`fetch_errors: ${probe.errors}`);
+  }
+  lines.push('');
+  lines.push('### Per space (worst first)');
+  if (snapshot.spaces.length === 0) {
+    lines.push('no spaces in the local database');
+  } else {
+    for (const space of snapshot.spaces) {
+      lines.push(formatSpaceSection(space));
+      lines.push('');
+    }
+  }
+
+  return lines.join('\n');
+}
+
+export interface CoverageReportInput {
+  generatedAtIso: string;
+  /** Newest last. */
+  history: IdentityCoverageSnapshot[];
+}
+
+/**
+ * Build the complete "Copy report" markdown paste: every snapshot taken this
+ * session, the before/after delta when there is more than one, and the
+ * historical baseline to compare a first run against — so a fresh reader needs
+ * no follow-up questions.
+ *
+ * Pure and deterministic: every timestamp comes from the caller.
+ */
+export function formatIdentityCoverageReport(
+  input: CoverageReportInput
+): string {
+  const sections: string[] = [];
+  const { history } = input;
+
+  sections.push(`# Identity coverage report — ${input.generatedAtIso}`);
+  sections.push(`task: ${IDENTITY_COVERAGE_TASK_POINTER}`);
+  sections.push(`historical baseline: ${HISTORICAL_BASELINE}`);
+  sections.push('');
+  sections.push(
+    'Counts are read straight from IndexedDB, so they measure what PERSISTED, ' +
+      'not what rendered once from an in-memory fallback.'
+  );
+  sections.push('');
+
+  if (history.length === 0) {
+    sections.push('No snapshots taken this session.');
+    return sections.join('\n');
+  }
+
+  if (history.length >= 2) {
+    const delta = computeCoverageDelta(history[0], history[history.length - 1]);
+    sections.push('## Delta — first snapshot to last (negative is improvement)');
+    sections.push(`from: ${delta.beforeIso}`);
+    sections.push(`to:   ${delta.afterIso}`);
+    sections.push(
+      `senders_with_no_member_row: ${formatSigned(delta.sendersWithNoRow)}`
+    );
+    sections.push(`rows_no_identity: ${formatSigned(delta.rowsNoIdentity)}`);
+    sections.push(`NO_IDENTITY_TOTAL: ${formatSigned(delta.noIdentityTotal)}`);
+    sections.push(`dm_rows_no_identity: ${formatSigned(delta.dmRowsNoIdentity)}`);
+    sections.push('');
+  }
+
+  history.forEach((snapshot, index) => {
+    sections.push(formatSnapshotSection(snapshot, index, history.length));
+    sections.push('');
+  });
+
+  return sections.join('\n');
+}

--- a/src/dev/identity-coverage/identityCoverageDb.ts
+++ b/src/dev/identity-coverage/identityCoverageDb.ts
@@ -1,0 +1,141 @@
+/**
+ * Identity Coverage — IndexedDB reads and the optional public-profile probe.
+ *
+ * Thin IO layer, deliberately separate from `identityCoverageCore.ts` so the
+ * classification stays pure and unit-testable without a browser or a network.
+ * Same split as `dm-doctor/`.
+ *
+ * Opens `quorum_db` through the shared `openQuorumDb`, which never passes a
+ * version (so a schema bump can't break the tool) and fails loudly rather than
+ * silently creating an empty v1 database — see that module's header.
+ */
+
+import { QuorumApiClient, isHandledFetchError } from '../../api/baseTypes';
+import { openQuorumDb } from '../openQuorumDb';
+import type {
+  DirectConversationIdentityRow,
+  IdentityMessageRow,
+  IdentitySpaceRow,
+  PublicProfileResult,
+  SpaceMemberIdentityRow,
+} from './identityCoverageCore';
+
+function readAll<T>(db: IDBDatabase, storeName: string): Promise<T[]> {
+  return new Promise((resolve, reject) => {
+    try {
+      const tx = db.transaction(storeName, 'readonly');
+      const request = tx.objectStore(storeName).getAll();
+      request.onsuccess = () => resolve(request.result as T[]);
+      request.onerror = () =>
+        reject(request.error ?? new Error(`Failed to read ${storeName}`));
+    } catch (err) {
+      reject(err instanceof Error ? err : new Error(String(err)));
+    }
+  });
+}
+
+export interface IdentityCoverageStores {
+  spaces: IdentitySpaceRow[];
+  members: SpaceMemberIdentityRow[];
+  messages: IdentityMessageRow[];
+  conversations: DirectConversationIdentityRow[];
+}
+
+/**
+ * Read every store the snapshot needs, on ONE connection.
+ *
+ * Four separate opens would each take their own consistent view, so a write
+ * landing between them could produce a snapshot where a member row exists in
+ * one read and not the other. A single connection makes the four `getAll`s
+ * mutually consistent, which matters because the headline number is a
+ * comparison BETWEEN two of those stores (senders in `messages` versus rows in
+ * `space_members`).
+ */
+export async function readIdentityCoverageStores(): Promise<IdentityCoverageStores> {
+  const db = await openQuorumDb();
+  try {
+    const [spaces, members, messages, conversations] = await Promise.all([
+      readAll<IdentitySpaceRow>(db, 'spaces'),
+      readAll<SpaceMemberIdentityRow>(db, 'space_members'),
+      readAll<IdentityMessageRow>(db, 'messages'),
+      readAll<DirectConversationIdentityRow>(db, 'conversations'),
+    ]);
+    return { spaces, members, messages, conversations };
+  } finally {
+    db.close();
+  }
+}
+
+/** How many public-profile lookups run at once. The probe is opt-in and can
+ *  cover a hundred addresses; unbounded parallelism would hammer the API and
+ *  serial fetching would take minutes. */
+const PROBE_CONCURRENCY = 6;
+
+/**
+ * Look up the public profile for each address, classifying the result.
+ *
+ * This is the last leg of "no identity from ANY source": a member with an empty
+ * local row is still renderable if they published a public profile, because the
+ * render path back-fills from it (`useMembersWithPublicProfileFallback`,
+ * `useConversationsWithProfileBackfill`). A 404 means they never opted in, and
+ * that is the irreducible case nothing can fix at render time.
+ *
+ * Deliberately opt-in and separate from the local snapshot: it is N network
+ * calls, and the local counts must stay fast, deterministic and offline-safe.
+ * A fetch failure is reported as `status: 'error'` and counted apart from a
+ * real 404 — a flaky network is not evidence that a profile is missing.
+ *
+ * `onProgress` is called after each completion so the page can show progress
+ * over a long probe rather than appearing hung.
+ */
+export async function probePublicProfiles(
+  addresses: string[],
+  onProgress?: (done: number, total: number) => void
+): Promise<PublicProfileResult[]> {
+  const client = new QuorumApiClient();
+  const results: PublicProfileResult[] = [];
+  let cursor = 0;
+  let done = 0;
+
+  const runOne = async (address: string): Promise<PublicProfileResult> => {
+    try {
+      const response = await client.getPublicProfile(address);
+      const data = response.data;
+      return {
+        address,
+        status: 200,
+        hasName: Boolean(data?.display_name?.trim()),
+        hasImage: Boolean(data?.profile_image?.trim()),
+      };
+    } catch (error: unknown) {
+      // 404 is the common, expected case: the user never opted in.
+      if (isHandledFetchError(error) && error.status === 404) {
+        return { address, status: 404, hasName: false, hasImage: false };
+      }
+      const status =
+        isHandledFetchError(error) && typeof error.status === 'number'
+          ? error.status
+          : ('error' as const);
+      return { address, status, hasName: false, hasImage: false };
+    }
+  };
+
+  const worker = async (): Promise<void> => {
+    for (;;) {
+      const index = cursor++;
+      if (index >= addresses.length) return;
+      results.push(await runOne(addresses[index]));
+      done += 1;
+      onProgress?.(done, addresses.length);
+    }
+  };
+
+  await Promise.all(
+    Array.from(
+      { length: Math.min(PROBE_CONCURRENCY, addresses.length) },
+      worker
+    )
+  );
+
+  return results;
+}

--- a/src/dev/identity-coverage/index.ts
+++ b/src/dev/identity-coverage/index.ts
@@ -1,0 +1,40 @@
+export { IdentityCoverage } from './IdentityCoverage';
+export {
+  hasRealName,
+  hasRealIcon,
+  classifyMemberIdentity,
+  classifyDmIdentity,
+  computeSpaceCoverage,
+  computeDmCoverage,
+  buildIdentityCoverageSnapshot,
+  summarisePublicProfileProbe,
+  computeCoverageDelta,
+  formatSigned,
+  formatIdentityCoverageReport,
+  IDENTITY_COVERAGE_TASK_POINTER,
+  HISTORICAL_BASELINE,
+} from './identityCoverageCore';
+export type {
+  SpaceMemberIdentityRow,
+  IdentityMessageRow,
+  IdentitySpaceRow,
+  DirectConversationIdentityRow,
+  IdentitySlot,
+  MemberIdentityVerdict,
+  DmIdentityVerdict,
+  MissingSenderRow,
+  SpaceCoverage,
+  DmCoverage,
+  CoverageTotals,
+  IdentityCoverageSnapshot,
+  BuildSnapshotInput,
+  PublicProfileResult,
+  PublicProfileProbeSummary,
+  CoverageDelta,
+  CoverageReportInput,
+} from './identityCoverageCore';
+export {
+  readIdentityCoverageStores,
+  probePublicProfiles,
+} from './identityCoverageDb';
+export type { IdentityCoverageStores } from './identityCoverageDb';

--- a/src/dev/tests/identity-coverage/identityCoverageCore.unit.test.ts
+++ b/src/dev/tests/identity-coverage/identityCoverageCore.unit.test.ts
@@ -1,0 +1,450 @@
+import { describe, expect, it } from 'vitest';
+import {
+  hasRealName,
+  hasRealIcon,
+  classifyMemberIdentity,
+  classifyDmIdentity,
+  computeSpaceCoverage,
+  computeDmCoverage,
+  buildIdentityCoverageSnapshot,
+  summarisePublicProfileProbe,
+  computeCoverageDelta,
+  formatSigned,
+  formatIdentityCoverageReport,
+  type DirectConversationIdentityRow,
+  type IdentityMessageRow,
+  type IdentitySpaceRow,
+  type PublicProfileResult,
+  type SpaceMemberIdentityRow,
+} from '../../identity-coverage/identityCoverageCore';
+import { DefaultImages } from '../../../utils';
+
+const OWN = 'own-address-zzz';
+const SPACE = 'space-alpha';
+const OTHER_SPACE = 'space-beta';
+
+const space = (spaceId = SPACE, name = 'Quorum Test 2'): IdentitySpaceRow => ({
+  spaceId,
+  name,
+});
+
+function member(
+  address: string,
+  fields: Partial<SpaceMemberIdentityRow> = {}
+): SpaceMemberIdentityRow {
+  return { spaceId: SPACE, user_address: address, ...fields };
+}
+
+function message(
+  senderId: string,
+  spaceId = SPACE,
+  count = 1
+): IdentityMessageRow[] {
+  return Array.from({ length: count }, () => ({
+    spaceId,
+    content: { senderId },
+  }));
+}
+
+// ---------------------------------------------------------------------------
+
+describe('hasRealName / hasRealIcon — agreement with the render path', () => {
+  it('treats the "Unknown User" placeholder as no name, not as a name', () => {
+    expect(hasRealName('Unknown User')).toBe(false);
+    expect(hasRealName('Alice')).toBe(true);
+  });
+
+  it('treats empty, missing and whitespace-only names as no name', () => {
+    // The shared resolveDisplayName applies a trim-and-length check, so a
+    // whitespace name falls through to the address. The count must agree.
+    expect(hasRealName(undefined)).toBe(false);
+    expect(hasRealName(null)).toBe(false);
+    expect(hasRealName('')).toBe(false);
+    expect(hasRealName('   ')).toBe(false);
+  });
+
+  it('treats the default avatar as no avatar', () => {
+    expect(hasRealIcon(DefaultImages.UNKNOWN_USER)).toBe(false);
+    expect(hasRealIcon('')).toBe(false);
+    expect(hasRealIcon(undefined)).toBe(false);
+    expect(hasRealIcon('data:image/png;base64,AAAA')).toBe(true);
+  });
+});
+
+describe('classifyMemberIdentity — the two-slot model', () => {
+  it('does NOT count a member whose identity lives only in the global slot', () => {
+    // THE load-bearing case, and the reason this module exists rather than the
+    // console probe. The follow-global work deliberately leaves the per-space
+    // override slot empty; 06-space-member-sources.js reads only that slot and
+    // would report this member as having no identity. They render fine.
+    const verdict = classifyMemberIdentity(
+      member('addr-global-only', {
+        global_display_name: 'Bruno',
+        global_user_icon: 'data:image/png;base64,BBBB',
+      })
+    );
+
+    expect(verdict.nameFrom).toBe('global');
+    expect(verdict.iconFrom).toBe('global');
+    expect(verdict.noIdentity).toBe(false);
+    expect(verdict.noName).toBe(false);
+  });
+
+  it('counts a member with both slots empty', () => {
+    const verdict = classifyMemberIdentity(member('addr-empty'));
+
+    expect(verdict.nameFrom).toBeNull();
+    expect(verdict.iconFrom).toBeNull();
+    expect(verdict.noIdentity).toBe(true);
+  });
+
+  it('counts a member whose only value is the placeholder in both slots', () => {
+    const verdict = classifyMemberIdentity(
+      member('addr-placeholder', {
+        display_name: 'Unknown User',
+        user_icon: DefaultImages.UNKNOWN_USER,
+        global_display_name: 'Unknown User',
+        global_user_icon: DefaultImages.UNKNOWN_USER,
+      })
+    );
+
+    expect(verdict.noIdentity).toBe(true);
+  });
+
+  it('lets the override slot win over the global slot, per the ladder', () => {
+    const verdict = classifyMemberIdentity(
+      member('addr-both', {
+        display_name: 'Per-space name',
+        global_display_name: 'Global name',
+      })
+    );
+
+    expect(verdict.nameFrom).toBe('override');
+  });
+
+  it('resolves name and avatar slots independently', () => {
+    // A per-space nickname with no per-space picture is legitimate: the name
+    // comes from the override slot, the avatar from the global one.
+    const verdict = classifyMemberIdentity(
+      member('addr-mixed', {
+        display_name: 'Nickname',
+        global_user_icon: 'data:image/png;base64,CCCC',
+      })
+    );
+
+    expect(verdict.nameFrom).toBe('override');
+    expect(verdict.iconFrom).toBe('global');
+    expect(verdict.noIdentity).toBe(false);
+  });
+
+  it('falls back to the global slot when the override holds a placeholder', () => {
+    const verdict = classifyMemberIdentity(
+      member('addr-demoted', {
+        display_name: 'Unknown User',
+        global_display_name: 'Real Name',
+      })
+    );
+
+    expect(verdict.nameFrom).toBe('global');
+    expect(verdict.noName).toBe(false);
+  });
+
+  it('reports a name-only member as noName false but noIcon true', () => {
+    const verdict = classifyMemberIdentity(
+      member('addr-name-only', { global_display_name: 'Carla' })
+    );
+
+    expect(verdict.noName).toBe(false);
+    expect(verdict.noIcon).toBe(true);
+    // Not "no identity" — they render as a name with initials, not an address.
+    expect(verdict.noIdentity).toBe(false);
+  });
+});
+
+describe('computeSpaceCoverage', () => {
+  it('finds senders with no member row at all (bucket A)', () => {
+    const coverage = computeSpaceCoverage(
+      space(),
+      [member('has-row', { global_display_name: 'Dora' })],
+      [...message('has-row', SPACE, 2), ...message('no-row', SPACE, 5)],
+      OWN
+    );
+
+    expect(coverage.distinctSenders).toBe(2);
+    expect(coverage.sendersWithNoRow).toBe(1);
+    expect(coverage.missingSenders).toEqual([
+      { address: 'no-row', messageCount: 5, isSelf: false },
+    ]);
+  });
+
+  it('excludes the account\'s own address from the count but flags it', () => {
+    // "No member row for yourself" is a different, rarer defect. Leaving it in
+    // the headline would add a constant that no identity fix ever moves.
+    const coverage = computeSpaceCoverage(
+      space(),
+      [],
+      [...message(OWN, SPACE, 3), ...message('stranger', SPACE, 1)],
+      OWN
+    );
+
+    expect(coverage.sendersWithNoRow).toBe(1);
+    expect(coverage.selfMissingRow).toBe(true);
+    expect(coverage.missingSenders).toHaveLength(2);
+  });
+
+  it('excludes kicked members from every headline count', () => {
+    const coverage = computeSpaceCoverage(
+      space(),
+      [member('kicked-empty', { isKicked: true }), member('live-empty')],
+      [],
+      OWN
+    );
+
+    expect(coverage.memberRows).toBe(1);
+    expect(coverage.kickedRows).toBe(1);
+    expect(coverage.rowsNoIdentity).toBe(1);
+  });
+
+  it('ignores messages filed under a different space', () => {
+    const coverage = computeSpaceCoverage(
+      space(),
+      [],
+      [...message('in-space', SPACE, 1), ...message('elsewhere', OTHER_SPACE, 9)],
+      OWN
+    );
+
+    expect(coverage.distinctSenders).toBe(1);
+    expect(coverage.sendersWithNoRow).toBe(1);
+  });
+
+  it('sums the two disjoint figures into noIdentityTotal without double-counting', () => {
+    const coverage = computeSpaceCoverage(
+      space(),
+      [member('empty-row'), member('good-row', { global_display_name: 'Eve' })],
+      [
+        ...message('empty-row', SPACE, 1),
+        ...message('good-row', SPACE, 1),
+        ...message('missing-row', SPACE, 1),
+      ],
+      OWN
+    );
+
+    expect(coverage.sendersWithNoRow).toBe(1);
+    expect(coverage.rowsNoIdentity).toBe(1);
+    expect(coverage.noIdentityTotal).toBe(2);
+  });
+
+  it('reproduces the 2026-06-13 baseline shape: 89 distinct senders, 46 with no row', () => {
+    // Grounding test against the historical measurement quoted in the task, so
+    // the counting rule cannot silently drift away from the number it is meant
+    // to be compared with.
+    const withRows = Array.from({ length: 43 }, (_, i) => `sender-with-row-${i}`);
+    const withoutRows = Array.from({ length: 46 }, (_, i) => `sender-no-row-${i}`);
+
+    const coverage = computeSpaceCoverage(
+      space(),
+      withRows.map((address) =>
+        member(address, { global_display_name: `Name ${address}` })
+      ),
+      [...withRows, ...withoutRows].flatMap((address) => message(address)),
+      OWN
+    );
+
+    expect(coverage.distinctSenders).toBe(89);
+    expect(coverage.sendersWithNoRow).toBe(46);
+    expect(coverage.rowsNoIdentity).toBe(0);
+    expect(coverage.noIdentityTotal).toBe(46);
+  });
+});
+
+describe('computeDmCoverage', () => {
+  const dm = (
+    address: string,
+    fields: Partial<DirectConversationIdentityRow> = {}
+  ): DirectConversationIdentityRow => ({
+    conversationId: `conv-${address}`,
+    type: 'direct',
+    address,
+    ...fields,
+  });
+
+  it('counts direct rows carrying neither a name nor an avatar', () => {
+    const coverage = computeDmCoverage(
+      [
+        dm('peer-empty'),
+        dm('peer-named', { displayName: 'Frida' }),
+        dm('peer-placeholder', {
+          displayName: 'Unknown User',
+          icon: DefaultImages.UNKNOWN_USER,
+        }),
+      ],
+      OWN
+    );
+
+    expect(coverage.directRows).toBe(3);
+    expect(coverage.rowsNoIdentity).toBe(2);
+    expect(coverage.rowsNoName).toBe(2);
+  });
+
+  it('excludes group rows', () => {
+    const coverage = computeDmCoverage(
+      [dm('peer'), { ...dm('group'), type: 'group' }],
+      OWN
+    );
+
+    expect(coverage.directRows).toBe(1);
+  });
+
+  it('excludes a row keyed by the account\'s own address, and reports it apart', () => {
+    const coverage = computeDmCoverage([dm(OWN), dm('peer')], OWN);
+
+    expect(coverage.directRows).toBe(1);
+    expect(coverage.selfRows).toBe(1);
+  });
+
+  it('flags a self-keyed row through classifyDmIdentity', () => {
+    expect(classifyDmIdentity(dm(OWN), OWN).isSelf).toBe(true);
+    expect(classifyDmIdentity(dm('peer'), OWN).isSelf).toBe(false);
+    // conversationId can carry the own address instead of the address field.
+    expect(
+      classifyDmIdentity({ ...dm('peer'), conversationId: OWN }, OWN).isSelf
+    ).toBe(true);
+  });
+});
+
+describe('buildIdentityCoverageSnapshot', () => {
+  const snapshotInput = {
+    atIso: '2026-08-02T10:00:00.000Z',
+    ownAddress: OWN,
+    spaces: [space(SPACE, 'Alpha'), space(OTHER_SPACE, 'Beta')],
+    members: [
+      member('a-empty'),
+      { ...member('b-good'), spaceId: OTHER_SPACE, global_display_name: 'Gus' },
+    ],
+    messages: [...message('ghost', SPACE, 1), ...message('b-good', OTHER_SPACE, 1)],
+    conversations: [] as DirectConversationIdentityRow[],
+  };
+
+  it('totals across spaces and orders them worst first', () => {
+    const snapshot = buildIdentityCoverageSnapshot(snapshotInput);
+
+    expect(snapshot.spaces[0].spaceName).toBe('Alpha');
+    expect(snapshot.spaces[0].noIdentityTotal).toBe(2); // 1 missing + 1 empty row
+    expect(snapshot.spaces[1].noIdentityTotal).toBe(0);
+    expect(snapshot.totals.noIdentityTotal).toBe(2);
+    expect(snapshot.totals.sendersWithNoRow).toBe(1);
+    expect(snapshot.totals.rowsNoIdentity).toBe(1);
+  });
+
+  it('records store sizes so an empty read cannot read as a clean result', () => {
+    const snapshot = buildIdentityCoverageSnapshot(snapshotInput);
+
+    expect(snapshot.messagesScanned).toBe(2);
+    expect(snapshot.memberRowsScanned).toBe(2);
+    expect(snapshot.conversationsScanned).toBe(0);
+  });
+
+  it('leaves the public-profile probe unset until it is explicitly run', () => {
+    expect(buildIdentityCoverageSnapshot(snapshotInput).publicProfile).toBeNull();
+  });
+});
+
+describe('summarisePublicProfileProbe', () => {
+  const result = (
+    address: string,
+    status: number | 'error',
+    hasName = false,
+    hasImage = false
+  ): PublicProfileResult => ({ address, status, hasName, hasImage });
+
+  it('separates recoverable, no-source and errors', () => {
+    const summary = summarisePublicProfileProbe([
+      result('a', 200, true, false),
+      result('b', 200, false, true),
+      result('c', 404),
+      result('d', 'error'),
+      result('e', 200), // 200 but an empty profile — no source either
+    ]);
+
+    expect(summary.probed).toBe(5);
+    expect(summary.recoverable).toBe(2);
+    expect(summary.noSource).toBe(2);
+    expect(summary.errors).toBe(1);
+  });
+
+  it('never counts a fetch error as evidence of a missing profile', () => {
+    const summary = summarisePublicProfileProbe([result('a', 'error')]);
+
+    expect(summary.errors).toBe(1);
+    expect(summary.noSource).toBe(0);
+  });
+});
+
+describe('delta and report', () => {
+  const snapshotAt = (
+    atIso: string,
+    missing: number,
+    emptyRows: number
+  ) =>
+    buildIdentityCoverageSnapshot({
+      atIso,
+      ownAddress: OWN,
+      spaces: [space()],
+      members: Array.from({ length: emptyRows }, (_, i) => member(`empty-${i}`)),
+      messages: Array.from({ length: missing }, (_, i) =>
+        message(`gone-${i}`)
+      ).flat(),
+      conversations: [],
+    });
+
+  it('reports improvement as a negative delta', () => {
+    const before = snapshotAt('2026-08-02T10:00:00.000Z', 46, 4);
+    const after = snapshotAt('2026-08-02T11:00:00.000Z', 2, 1);
+    const delta = computeCoverageDelta(before, after);
+
+    expect(delta.sendersWithNoRow).toBe(-44);
+    expect(delta.rowsNoIdentity).toBe(-3);
+    expect(delta.noIdentityTotal).toBe(-47);
+  });
+
+  it('always signs a delta explicitly', () => {
+    expect(formatSigned(3)).toBe('+3');
+    expect(formatSigned(-3)).toBe('-3');
+    expect(formatSigned(0)).toBe('0');
+  });
+
+  it('formats a report carrying the headline, the delta and the baseline', () => {
+    const report = formatIdentityCoverageReport({
+      generatedAtIso: '2026-08-02T12:00:00.000Z',
+      history: [
+        snapshotAt('2026-08-02T10:00:00.000Z', 46, 0),
+        snapshotAt('2026-08-02T11:00:00.000Z', 2, 0),
+      ],
+    });
+
+    expect(report).toContain('NO_IDENTITY_TOTAL: -44');
+    expect(report).toContain('senders_with_no_member_row: 46');
+    expect(report).toContain('senders_with_no_member_row: 2');
+    expect(report).toContain('89 distinct senders, 46 with no member row');
+    expect(report).toContain('Snapshot 1 of 2');
+    expect(report).toContain('Snapshot 2 of 2');
+  });
+
+  it('says so plainly when no snapshot has been taken', () => {
+    const report = formatIdentityCoverageReport({
+      generatedAtIso: '2026-08-02T12:00:00.000Z',
+      history: [],
+    });
+
+    expect(report).toContain('No snapshots taken this session.');
+  });
+
+  it('omits the delta section for a single snapshot', () => {
+    const report = formatIdentityCoverageReport({
+      generatedAtIso: '2026-08-02T12:00:00.000Z',
+      history: [snapshotAt('2026-08-02T10:00:00.000Z', 1, 0)],
+    });
+
+    expect(report).not.toContain('## Delta');
+  });
+});


### PR DESCRIPTION
Two dev-only changes, bundled because neither touches production behaviour.

## Identity coverage panel (`/dev/identity-coverage`)

Nothing measured whether the recent identity work moved anything. This is the
instrument: one number, taken before and after, in one click.

A person counts as having no identity only when they land on the last rung of
the precedence ladder (per-space override -> QNS -> global -> truncated
address). This matters, and is why it is not just a port of
`.agents/tools/dm-debug/06-space-member-sources.js`: that probe predates the
two-slot model and reads only the per-space override slot, which the
follow-global work deliberately leaves empty. It reports members who render
perfectly well as missing.

- "senders with no member row" and "rows carrying no identity" stay **separate**
  figures. Different causes (join/sync transport gap vs announce/digest gap),
  different fixes. They are disjoint sets, so the headline total is their sum.
- Reads straight from IndexedDB, so it measures what **persisted**, not what
  rendered once from an in-memory fallback. Snapshot, reload, snapshot again.
- The public-profile probe is opt-in, being one network call per address.
- Same three-way split as the DM doctor: pure core, IndexedDB reader, page.

30 unit tests. Verified to discriminate: mutating the core back to
override-slot-only logic fails 7 of them, including the load-bearing case and
the one that reproduces the historical baseline shape.

## Worktree dependency doctor (`yarn worktree:doctor`)

A linked worktree gets its own `node_modules`, and dependencies that are linked
rather than installed from a registry do not follow it. Whatever sat there when
the worktree was created is frozen.

The failure is silent and expensive: a stale copy keeps the **same version
string** as the current build, so `tsc` reports errors that do not reproduce on
the base branch, and it reads as a broken branch rather than stale
`node_modules`. Hit while writing the panel above: a `yarn link`ed package was a
seven-month-old physical copy still carrying the current version number, and a
sibling-package link pointed at a deleted directory.

The doctor reads the **main worktree's** link targets at runtime and mirrors
them as junctions. No machine path is hardcoded and none is printed, so it stays
correct when those paths move. Idempotent, and a no-op on the main worktree.

> Junctions rather than symlinks deliberately: creating a symlink on Windows
> needs elevation, and Git Bash's `ln -s` **silently falls back to a recursive
> copy** when it cannot, manufacturing the very staleness this repairs.

Background: `.agents/docs/development/git-worktrees-and-linked-dependencies.md`.

## Verification

`tsc` clean, `eslint` 0 errors, full suite **56 files / 837 tests** passing
(+1 file / +30 tests over the 55/807 baseline, so not a collapsed run).
