### PR TITLE
fix: identity coverage reported every space as (unnamed)

### DIFF
--- a/src/dev/identity-coverage/identityCoverageCore.ts
+++ b/src/dev/identity-coverage/identityCoverageCore.ts
@@ -77,6 +77,14 @@ export interface IdentityMessageRow {
 /** Minimal shape of a `spaces` row, for naming the per-space breakdown. */
 export interface IdentitySpaceRow {
   spaceId: string;
+  /**
+   * The shared `Space` type calls this `spaceName`, and that is what desktop
+   * actually persists. `name` is kept as a fallback only because reading the
+   * wrong one of the two is exactly how every space in the first real snapshot
+   * came back as "(unnamed)" — a report you cannot act on, because you cannot
+   * tell which space the bad numbers belong to.
+   */
+  spaceName?: string;
   name?: string;
 }
 
@@ -297,7 +305,7 @@ export function computeSpaceCoverage(
 
   return {
     spaceId: space.spaceId,
-    spaceName: space.name?.trim() || '(unnamed)',
+    spaceName: space.spaceName?.trim() || space.name?.trim() || '(unnamed)',
     distinctSenders: senderCounts.size,
     sendersWithNoRow,
     selfMissingRow: missingSenders.some((s) => s.isSelf),

--- a/src/dev/tests/identity-coverage/identityCoverageCore.unit.test.ts
+++ b/src/dev/tests/identity-coverage/identityCoverageCore.unit.test.ts
@@ -448,3 +448,57 @@ describe('delta and report', () => {
     expect(report).not.toContain('## Delta');
   });
 });
+
+// The first real snapshot (2026-08-02) reported every space as "(unnamed)",
+// because the tool read `space.name` while the shared `Space` type — and what
+// desktop persists — calls it `spaceName`. A report you cannot attribute to a
+// space is a report you cannot act on, so this is pinned in both directions.
+describe('space naming', () => {
+  it('reads the spaceName field the app actually writes', () => {
+    const result = buildIdentityCoverageSnapshot({
+      spaces: [{ spaceId: 's1', spaceName: 'Quorum Test 2' }],
+      members: [],
+      messages: [],
+      conversations: [],
+      ownAddress: 'QmSelf',
+      takenAt: '2026-08-02T00:00:00.000Z',
+    });
+    expect(result.spaces[0].spaceName).toBe('Quorum Test 2');
+  });
+
+  it('still falls back to a legacy `name` field', () => {
+    const result = buildIdentityCoverageSnapshot({
+      spaces: [{ spaceId: 's1', name: 'Legacy Space' }],
+      members: [],
+      messages: [],
+      conversations: [],
+      ownAddress: 'QmSelf',
+      takenAt: '2026-08-02T00:00:00.000Z',
+    });
+    expect(result.spaces[0].spaceName).toBe('Legacy Space');
+  });
+
+  it('prefers spaceName when a row somehow carries both', () => {
+    const result = buildIdentityCoverageSnapshot({
+      spaces: [{ spaceId: 's1', spaceName: 'Current', name: 'Stale' }],
+      members: [],
+      messages: [],
+      conversations: [],
+      ownAddress: 'QmSelf',
+      takenAt: '2026-08-02T00:00:00.000Z',
+    });
+    expect(result.spaces[0].spaceName).toBe('Current');
+  });
+
+  it('says (unnamed) rather than throwing when neither is present', () => {
+    const result = buildIdentityCoverageSnapshot({
+      spaces: [{ spaceId: 's1' }],
+      members: [],
+      messages: [],
+      conversations: [],
+      ownAddress: 'QmSelf',
+      takenAt: '2026-08-02T00:00:00.000Z',
+    });
+    expect(result.spaces[0].spaceName).toBe('(unnamed)');
+  });
+});


### PR DESCRIPTION
The identity-coverage panel reported every space as `(unnamed)`, so the first real snapshot showed that one space had 41 senders with no member row and gave no way to tell **which** space that was.

The tool read `space.name`. The shared `Space` type calls it `spaceName`, and that is what desktop persists.

Reads `spaceName`, with `name` kept as a fallback. Pinned in four directions — the current field, the legacy fallback, both present, and neither present — because silent field-name drift is exactly how this returns.

34 tests, `tsc` and `eslint` clean.
