### PR TITLE
fix: the member list ignored every synced roster update

### DIFF
--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -5923,8 +5923,15 @@ export class MessageService {
                 `[MessageService] sync-delta: saved ${savedMembers} member row(s) for ${spaceId.substring(0, 12)}` +
                   (skippedNoAddress ? `, skipped ${skippedNoAddress} with no address` : '')
               );
+              // Use the SHARED key builder. This was hand-written as
+              // `['spaceMembers', spaceId]` while every subscriber uses
+              // `buildSpaceMembersKey` → `['SpaceMembers', spaceId]`. React Query
+              // keys are case-sensitive, so the refetch targeted a key nobody was
+              // subscribed to: rows landed in IndexedDB and the member list kept
+              // showing the stale roster until the user reloaded, repeatedly.
+              // Measured 2026-08-02 — 72 rows on disk, 1 in the list.
               queryClient.refetchQueries({
-                queryKey: ['spaceMembers', spaceId],
+                queryKey: buildSpaceMembersKey({ spaceId }),
               });
             }
 

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -5824,7 +5824,26 @@ export class MessageService {
             }
 
             // Apply member delta
+            //
+            // Counted on arrival AND after the loop. Without both numbers the
+            // send-side logs prove a delta was built and the receive-side logs
+            // prove a `sync-delta` arrived, while the roster stays empty and
+            // nothing distinguishes "the payload never came", "it came empty"
+            // and "it came full and every row was skipped". That gap cost a
+            // full debugging session on 2026-08-02.
+            // See .agents/bugs/2026-08-02-roster-pull-delivers-nothing-to-a-new-joiner.md
+            logger.log(
+              `[MessageService] sync-delta: memberDelta=${
+                envelope.message.memberDelta
+                  ? `${envelope.message.memberDelta.members?.length ?? 0} members`
+                  : 'ABSENT'
+              }, messageDelta=${envelope.message.messageDelta ? 'present' : 'absent'}, isFinal=${
+                (envelope.message as { isFinal?: boolean }).isFinal
+              }`
+            );
             if (envelope.message.memberDelta) {
+              let savedMembers = 0;
+              let skippedNoAddress = 0;
               for (const member of envelope.message.memberDelta.members || []) {
                 // Map shared SpaceMember type to desktop DB format:
                 // - address -> user_address
@@ -5832,6 +5851,7 @@ export class MessageService {
                 // Handle both shared types and legacy field names
                 const userAddress = member.address || member.user_address;
                 if (!userAddress) {
+                  skippedNoAddress++;
                   continue;
                 }
                 const existing = await this.messageDB.getSpaceMember(spaceId, userAddress);
@@ -5897,7 +5917,12 @@ export class MessageService {
                     : {}),
                 };
                 await this.messageDB.saveSpaceMember(spaceId, dbMember as SpaceMemberRow);
+                savedMembers++;
               }
+              logger.log(
+                `[MessageService] sync-delta: saved ${savedMembers} member row(s) for ${spaceId.substring(0, 12)}` +
+                  (skippedNoAddress ? `, skipped ${skippedNoAddress} with no address` : '')
+              );
               queryClient.refetchQueries({
                 queryKey: ['spaceMembers', spaceId],
               });


### PR DESCRIPTION
**The member list ignored every roster update the sync delivered.**

The `sync-delta` handler refetched a hand-written query key, `['spaceMembers', spaceId]`. Every subscriber builds its key with `buildSpaceMembersKey`, which produces `['SpaceMembers', spaceId]`. React Query keys are case-sensitive, so the refetch targeted a key nobody was subscribed to and the list never learned anything had changed.

## Measured

A client holding **72 member rows in IndexedDB** showed exactly **one person** in the member list, and needed several manual reloads before the roster appeared. The data had been correct the whole time.

## How it was found, and why the logging stays

Every layer looked healthy in isolation — the wire was fine, storage was fine, the apply loop was fine. Nothing pointed at the cache until the delta counts were visible.

So this PR keeps the instrumentation that found it. On arrival it records whether a `memberDelta` was present and how many members it carried, and after the apply loop how many rows were actually written, plus any dropped for having no address (the one silent skip in that loop). The send-side counterpart shipped in shared #72.

`logger` is a no-op in production builds, so this costs nothing at runtime.

## Context

Filed and corrected in `.agents/bugs/2026-08-02-roster-pull-delivers-nothing-to-a-new-joiner.md`. That investigation originally concluded the roster pull was broken; instrumentation disproved it (a joiner went from 1 to 72 rows, and the list now renders them). Two smaller defects remain open there: the exchange is unreliable, and peer selection ignores roster completeness.

## Verification

56 files / 841 tests, `tsc` and `eslint` clean.
