### PR TITLE
fix: the roster pull now notices when it did not converge

### DIFF
--- a/.agents/bugs/2026-08-01-every-logger-call-is-a-no-op-in-production-builds.md
+++ b/.agents/bugs/2026-08-01-every-logger-call-is-a-no-op-in-production-builds.md
@@ -4,7 +4,7 @@ title: "Every logger call is a no-op in production builds, so 'fail open and log
 status: CONFIRMED by reading the logger source and grepping for overrides (not yet fixed)
 priority: high — it does not break behaviour, it breaks our ability to SEE behaviour
 created: 2026-08-01
-updated: 2026-08-01
+updated: 2026-08-02
 severity: silent — nothing fails; we simply learn nothing from any user who is not a developer
 area: observability / logging / quorum-shared
 repos: quorum-shared (cause), quorum-desktop + quorum-mobile (affected)
@@ -64,6 +64,35 @@ anything outside a developer's own machine. This is also why transport
 reliability had to be measured with a hand-built harness rather than read off
 production behaviour.
 
+### §2b. The list keeps growing — a new site, added 2026-08-02
+
+The roster convergence check (`src/utils/rosterConvergence.ts` +
+`MessageService.scheduleRosterConvergenceCheck`) re-broadcasts a `sync-request`
+when a peer advertised more members than we actually received. Its entire
+observable surface is `logger`, so in production it can:
+
+- decide the roster is short and re-ask — invisibly;
+- decide **not** to re-ask because the attempt budget is spent while still 70
+  rows short — invisibly, and this is the single most actionable state it has;
+- throw inside its timer and repair nothing, ever — invisibly.
+
+It was written that way **knowingly**, and the alternative was considered and
+rejected: a bespoke counter for one feature is a band-aid on a systemic problem,
+and building private telemetry per feature is how a codebase ends up with five
+incompatible half-solutions instead of one fix.
+
+⚠️ **The point of recording it here is that the cost of this bug is compounding,
+not static.** Every "fail open and log" feature shipped from now on adds another
+question nobody can answer about a real user's session. The next one that wants
+production visibility should trigger the fix in §4 rather than route around it.
+
+The mitigation actually applied, which is available to any similar feature: the
+decision function returns a **typed reason** rather than a boolean, and the
+caller logs it on every branch. That does nothing in production, but it means a
+developer reproducing the problem locally gets "not asking (cap-reached) — have
+1, best offer 78" instead of silence. Cheap, and it makes the eventual §4 fix a
+matter of changing the sink rather than re-instrumenting the code.
+
 ## §3. What NOT to do
 
 Do **not** simply flip `enabled` to true in production. The reason it is off is
@@ -98,4 +127,4 @@ change relies on "fail open and log" for observability, then checked whether the
 logs actually reach anywhere. They do not.
 
 ---
-*Last updated: 2026-08-01*
+*Last updated: 2026-08-02*

--- a/.agents/bugs/2026-08-01-vitest-intermittently-runs-4-percent-of-the-suite.md
+++ b/.agents/bugs/2026-08-01-vitest-intermittently-runs-4-percent-of-the-suite.md
@@ -1,10 +1,10 @@
 ---
 type: bug
 title: "vitest intermittently runs 29 of 736 tests — the import phase collapses from ~98s to <1.2s"
-status: open — observed twice on 2026-08-01, not yet reproduced on demand
+status: open — mechanism visible and CI-safe (exits non-zero); cause still unproven. Read §0 before proposing a fix
 priority: high (a test suite that under-reports coverage is worse than one that fails)
 created: 2026-08-01
-updated: 2026-08-01
+updated: 2026-08-02
 severity: potentially silent — the first question below decides whether this is an annoyance or a trap
 area: test infrastructure (vitest, desktop unit suite)
 repos: quorum-desktop
@@ -13,6 +13,81 @@ related_docs:
 ---
 
 # vitest intermittently runs 4% of the suite
+
+## §0. 2026-08-02 — the mechanism is now visible, and §2's open question is ANSWERED
+
+Not solved. But three things are now established that were not before, and one
+tempting wrong answer has already been tried and disproven **in this very
+section** — read that part before proposing a fix.
+
+### 1. ✅ It exits NON-ZERO. §2's "annoyance or trap" question is answered.
+
+Every collapsed run observed on 2026-08-02 exited **1** and reported
+`55 failed | 3 passed (58)`. **A collapsed run cannot masquerade as a green
+suite**, so CI would catch it and no past "N tests pass" claim is invalidated by
+it. This downgrades the bug from potential trap to loud annoyance.
+
+### 2. ✅ The error, captured at last
+
+Every earlier observation lost this to a `tail`. All 55 failures were one of:
+
+```
+TypeError: Cannot read properties of undefined (reading 'config')
+TypeError: Cannot read properties of undefined (reading 'MAX_INPUT_SIZE')
+ ❯ src/hooks/business/user/useWebFileUpload.ts:7:39
+```
+
+Both are **reading a property off an import that resolved to `undefined`**. The
+modules are not failing to execute; they are handed *empty bindings*. That is
+the signature of the dependency optimizer serving a bundle that does not match
+what is on disk, and it explains the 100× collapse in the import phase —
+nothing real is being imported. Note `FILE_SIZE_LIMITS` is a **desktop-local**
+module, so this is not confined to the `link:`ed shared package.
+
+### 3. ✅ The practical rule: RE-RUN, and judge by the import phase
+
+| | |
+|---|---|
+| **Fingerprint** | `import` under ~2s (normal is 100-170s) and `Tests 29 passed (29)` |
+| **What to do** | run it again — every collapse so far cleared within one or two runs |
+| **Do NOT** | treat a collapsed run as a real failure, or a real failure as a collapse. Check the import phase before concluding anything |
+
+### ⛔ `rm -rf node_modules/.vite` is NOT the fix — already tried, twice
+
+It looked like the answer: the cache was five days stale while `quorum-shared`'s
+`dist/` had been rebuilt minutes earlier, clearing it produced an immediate
+clean run (58 files, 884 tests, import back to 151s), and it matches
+hypothesis 1 exactly. That is a persuasive amount of evidence.
+
+**It then failed to prevent the next collapse.** A subsequent `yarn build` in
+`quorum-shared` followed by `rm -rf node_modules/.vite` still produced a
+collapsed run (import 1.22s); the run after *that* was clean with no
+intervention at all. So the clean run that followed the first clearing was very
+likely just the ordinary "second run works", and the cache deletion did nothing.
+
+⚠️ **This is the second time this bug has produced a confident wrong answer from
+a correlation** (see §1's note about the rebuild theory). Both times the
+evidence was suggestive and the experiment did not actually isolate the link.
+Whatever the next hypothesis is, test it by making the failure *appear* on
+demand, not by making it *disappear* once — a bug that clears on re-run will
+reward almost any intervention.
+
+### What is still unknown
+
+- Why the collapse survives one re-run sometimes and not others.
+- Whether `quorum-shared` rebuilds matter at all, or merely correlate because
+  they cluster around active development. Timing is suggestive (most
+  observations follow one) and that is *all* it is.
+- Why exactly 3 files survive, and which 3.
+
+### Follow-up worth trying
+
+- [ ] `optimizeDeps.exclude` for `@quilibrium/quorum-shared` — a `link:`ed
+      source dependency arguably has no business in the dep optimizer at all.
+      Cheap to try, and unlike the cache deletion it changes the steady state
+      rather than a one-off.
+- [ ] Capture which 3 files survive. If they are the ones importing nothing from
+      `@quilibrium/*`, that is strong evidence; if not, the theory dies cheaply.
 
 ## §1. The symptom
 
@@ -55,6 +130,38 @@ contributing factor, not a trigger. Do not start from this hypothesis.
 
 An import phase of <1.2s against a normal ~98s means the modules were never
 really imported — the files are erroring at import time, not failing assertions.
+
+## §1b. A possible SECOND variant — one test, not the 29-test collapse (2026-08-02)
+
+Recorded because it shares the trigger and would otherwise be dismissed as an
+ordinary flaky test.
+
+| | |
+|---|---|
+| Reported | `Test Files 1 failed \| 56 passed (57)` / `Tests 1 failed \| 868 passed (869)` |
+| import phase | **130.15s** — NOT collapsed, so this is not the §1 signature |
+| Preceding activity | `yarn build` in `quorum-shared` (a `link:` dependency), minutes earlier |
+| Reproduced? | **No.** Five consecutive full runs immediately afterwards were clean at 57/869. |
+
+⚠️ **The failing test's name was not captured** — the output was tailed and only
+a fragment of the frame survived (`34| });`). That is the single most useful
+thing to grab if this recurs, so capture the full output next time rather than
+`tail`-ing it.
+
+⚠️ **Still NOT explained by §0, and probably a different thing.** The import
+phase here was **normal** (130s), which is the opposite of the stale-cache
+fingerprint — a stale cache collapses it to under 2s. So this is not the same
+failure wearing a smaller hat.
+
+It stays filed here because it is **more dangerous than §1 if it is real**: a
+single failing test among 869 looks like ordinary flake and gets re-run away,
+whereas 55 failing files demand attention. One line of vigilance, not a
+hypothesis.
+
+**Cheap habit, and §0 is the proof it matters:** capture the FULL output of a
+failing suite run, never `tail` it. Every earlier observation of §1 lost its
+error message to a `tail`, and the moment one was finally captured the cause was
+obvious within minutes.
 
 ## §2. The question that decides how bad this is
 
@@ -175,4 +282,4 @@ test count alone. A collapsed run is instantly obvious that way and invisible
 otherwise.
 
 ---
-*Last updated: 2026-08-01*
+*Last updated: 2026-08-02*

--- a/src/components/context/MessageDB.tsx
+++ b/src/components/context/MessageDB.tsx
@@ -245,7 +245,7 @@ type MessageDBContextValue = {
     spaceTag?: BroadcastSpaceTag,
     bio?: string
   ) => Promise<void>;
-  requestSync: (spaceId: string) => Promise<void>;
+  requestSync: (spaceId: string) => Promise<boolean>;
   sendVerifyKickedStatuses: (spaceId: string) => Promise<number>;
   broadcastDeviceRevocations: (deviceInboxAddresses: string[]) => Promise<void>;
   deleteConversation: (
@@ -993,6 +993,7 @@ const MessageDBProvider: FC<MessageDBContextProps> = ({ children }) => {
       synchronizeAll,
       informSyncData,
       initiateSync,
+      requestSync,
       directSync,
       saveConfig,
       sendHubMessage,
@@ -1012,6 +1013,7 @@ const MessageDBProvider: FC<MessageDBContextProps> = ({ children }) => {
     synchronizeAll,
     informSyncData,
     initiateSync,
+    requestSync,
     directSync,
     saveConfig,
     sendHubMessage,
@@ -1454,9 +1456,15 @@ const MessageDBProvider: FC<MessageDBContextProps> = ({ children }) => {
 
   const deleteSpace = React.useCallback(
     async (spaceId: string) => {
+      // Drop the roster-convergence state and cancel any armed check FIRST.
+      // `SpaceService` cannot reach MessageService's tracker, and a check armed
+      // seconds ago would otherwise fire ~20s from now against a space that no
+      // longer exists — popping a "Syncing…" toast and broadcasting a
+      // sync-request into a space the user just left.
+      messageService.forgetRosterConvergence(spaceId);
       return spaceService.deleteSpace(spaceId, queryClient);
     },
-    [spaceService, queryClient]
+    [spaceService, messageService, queryClient]
   );
 
   const kickUser = React.useCallback(

--- a/src/dev/tests/harness/deps.ts
+++ b/src/dev/tests/harness/deps.ts
@@ -122,6 +122,7 @@ export function makeDeps(input: DepsInput) {
     synchronizeAll: noop('synchronizeAll'),
     informSyncData: noop('informSyncData'),
     initiateSync: noop('initiateSync'),
+    requestSync: noop('requestSync'),
     directSync: noop('directSync'),
     saveConfig: noop('saveConfig'),
     sendHubMessage: (async () => '' ) as unknown as (spaceId: string, message: string) => Promise<string>,

--- a/src/dev/tests/services/MessageService.rosterConvergence.unit.test.ts
+++ b/src/dev/tests/services/MessageService.rosterConvergence.unit.test.ts
@@ -1,0 +1,212 @@
+/**
+ * The WIRING: a `sync-info` frame must arm the roster convergence check, and
+ * that check must actually re-broadcast a `sync-request`.
+ *
+ * ── Why this test exists ────────────────────────────────────────────────────
+ *
+ * `rosterConvergence.ts` is a pure decision function with its own 39 tests, and
+ * `selectBestCandidate` has its own 15. Both were green while the feature was
+ * completely unreachable, because everything that makes it reachable is two
+ * lines inside the ~6,000-line `handleNewMessage` switch. Nothing failed if
+ * those two lines were deleted.
+ *
+ * So this test drives the REAL entry point — `handleNewMessage` with a hub
+ * control frame — rather than calling the scheduler directly. It is the only
+ * test in either repo that proves the feature is connected to anything.
+ *
+ * It pins three things:
+ *   1. a `sync-info` advertising more members than we hold leads to a re-ask;
+ *   2. several `sync-info` answers to ONE request collapse into ONE re-ask
+ *      (the debounce — without it every peer that replies arms its own timer);
+ *   3. a client that is already converged asks for nothing.
+ *
+ * See .agents/bugs/2026-08-02-roster-pull-delivers-nothing-to-a-new-joiner.md
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { MessageService } from '../../../services/MessageService';
+
+const SPACE_ID = 'QmSpaceAddressAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+const SPACE_INBOX = 'QmSpaceInboxBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
+const DEVICE_INBOX = 'QmDeviceInboxCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC';
+const SELF = 'QmSelfAddressDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD';
+
+/** Whatever `UnsealHubEnvelope` should decode to on the next call. */
+let unsealedPayload = '';
+
+vi.mock('@quilibrium/quilibrium-js-sdk-channels', () => ({
+  channel: {
+    // The handler does `Buffer.from(new Uint8Array(await UnsealHubEnvelope(...)))`,
+    // so this has to be a byte array, not a string.
+    UnsealHubEnvelope: vi.fn(async () =>
+      Array.from(new TextEncoder().encode(unsealedPayload))
+    ),
+    UnsealSyncEnvelope: vi.fn(async () =>
+      Array.from(new TextEncoder().encode(unsealedPayload))
+    ),
+  },
+  channel_raw: {
+    js_sign_ed448: vi.fn().mockReturnValue(JSON.stringify('mock-signature')),
+    js_verify_ed448: vi.fn().mockReturnValue(true),
+  },
+}));
+
+const keyset = {
+  deviceKeyset: {
+    inbox_keyset: {
+      inbox_address: DEVICE_INBOX,
+      inbox_key: { public_key: [1, 2, 3], private_key: [4, 5, 6] },
+    },
+    identity_key: { public_key: [7, 8, 9] },
+  },
+  userKeyset: {},
+} as any;
+
+const spaceKey = { publicKey: '00'.repeat(57), privateKey: '00'.repeat(57), address: SPACE_INBOX };
+
+/** A `sync-info` from a peer claiming to hold `memberCount` members. */
+function syncInfoFrame(memberCount: number) {
+  unsealedPayload = JSON.stringify({
+    type: 'control',
+    message: {
+      type: 'sync-info',
+      inboxAddress: 'QmPeerInboxEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE',
+      summary: {
+        memberCount,
+        messageCount: 5,
+        newestMessageTimestamp: 0,
+        oldestMessageTimestamp: 0,
+      },
+    },
+  });
+  return {
+    inboxAddress: SPACE_INBOX,
+    // Anything but `type: 'sync'`, so the handler takes the hub-broadcast path.
+    encryptedContent: JSON.stringify({ type: 'group' }),
+    timestamp: 1785323281580,
+  } as any;
+}
+
+describe('sync-info arms the roster convergence check', () => {
+  let messageService: MessageService;
+  let mockDeps: any;
+
+  /** How many member rows this client currently holds for the space. */
+  let localMembers: unknown[] = [];
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    localMembers = [];
+
+    mockDeps = {
+      messageDB: {
+        getAllEncryptionStates: vi.fn().mockResolvedValue([
+          {
+            inboxId: SPACE_INBOX,
+            conversationId: `${SPACE_ID}/${SPACE_ID}`,
+            // No `sending_inbox` — that is what selects the SPACE path over
+            // the DM ratchet path.
+            state: JSON.stringify({}),
+          },
+        ]),
+        getEncryptionStates: vi.fn().mockResolvedValue([]),
+        getConversation: vi.fn().mockResolvedValue({ conversation: null }),
+        getSpaceKey: vi.fn().mockResolvedValue(spaceKey),
+        getSpaceMembers: vi.fn(async () => localMembers),
+        getSpaceMember: vi.fn().mockResolvedValue(null),
+        saveSpaceMember: vi.fn().mockResolvedValue(undefined),
+        saveEncryptionState: vi.fn().mockResolvedValue(undefined),
+        saveMessage: vi.fn().mockResolvedValue(undefined),
+        getMessage: vi.fn().mockResolvedValue(null),
+        getMessages: vi.fn().mockResolvedValue({ messages: [], hasMore: false }),
+        isMessageDeleted: vi.fn().mockResolvedValue(false),
+        updateMessage: vi.fn().mockResolvedValue(undefined),
+        getSpace: vi.fn().mockResolvedValue({ spaceId: SPACE_ID }),
+      },
+      enqueueOutbound: vi.fn(),
+      addOrUpdateConversation: vi.fn(),
+      apiClient: {},
+      deleteEncryptionStates: vi.fn().mockResolvedValue(undefined),
+      deleteInboxMessages: vi.fn().mockResolvedValue(undefined),
+      navigate: vi.fn(),
+      spaceInfo: { current: {} },
+      // An OPEN sync session, which is what lets a `sync-info` be admitted.
+      syncInfo: {
+        current: {
+          [SPACE_ID]: { expiry: Date.now() + 30_000, candidates: [] },
+        },
+      },
+      synchronizeAll: vi.fn().mockResolvedValue(undefined),
+      informSyncData: vi.fn().mockResolvedValue(undefined),
+      initiateSync: vi.fn().mockResolvedValue(undefined),
+      requestSync: vi.fn().mockResolvedValue(true),
+      directSync: vi.fn().mockResolvedValue(undefined),
+      saveConfig: vi.fn().mockResolvedValue(undefined),
+      sendHubMessage: vi.fn().mockResolvedValue('message-id'),
+      handleSyncInitiateV2: vi.fn().mockResolvedValue(undefined),
+      handleSyncManifest: vi.fn().mockResolvedValue(undefined),
+    };
+
+    messageService = new MessageService(mockDeps);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const deliver = (memberCount: number) =>
+    messageService.handleNewMessage(SELF, keyset, syncInfoFrame(memberCount), {
+      refetchQueries: vi.fn(),
+      setQueryData: vi.fn(),
+      invalidateQueries: vi.fn(),
+      getQueryData: vi.fn(),
+    } as any);
+
+  it('re-asks when a peer advertises far more members than we hold', async () => {
+    localMembers = [{ user_address: SELF }]; // just ourselves
+
+    await deliver(90);
+    expect(mockDeps.requestSync).not.toHaveBeenCalled(); // not yet — it is debounced
+
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    expect(mockDeps.requestSync).toHaveBeenCalledWith(SPACE_ID);
+  });
+
+  // Several peers answer ONE `sync-request`. Without the per-space debounce
+  // each of their replies would arm its own timer and we would broadcast a
+  // burst of redundant requests.
+  it('collapses several peer answers into a single re-ask', async () => {
+    localMembers = [{ user_address: SELF }];
+
+    await deliver(72);
+    await deliver(79);
+    await deliver(90);
+
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    expect(mockDeps.requestSync).toHaveBeenCalledTimes(1);
+  });
+
+  it('asks for nothing when the roster is already converged', async () => {
+    localMembers = Array.from({ length: 88 }, (_, i) => ({ user_address: `addr-${i}` }));
+
+    await deliver(90);
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    expect(mockDeps.requestSync).not.toHaveBeenCalled();
+  });
+
+  // Cancelling the timer is the whole point of `forgetRosterConvergence`: a
+  // check armed just before a kick would otherwise fire against a space that no
+  // longer exists and broadcast into a space we were removed from.
+  it('does not re-ask for a space that was left before the check fired', async () => {
+    localMembers = [{ user_address: SELF }];
+
+    await deliver(90);
+    messageService.forgetRosterConvergence(SPACE_ID);
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    expect(mockDeps.requestSync).not.toHaveBeenCalled();
+  });
+});

--- a/src/dev/tests/services/MessageService.unit.test.tsx
+++ b/src/dev/tests/services/MessageService.unit.test.tsx
@@ -110,6 +110,7 @@ describe('MessageService - Unit Tests', () => {
       synchronizeAll: vi.fn().mockResolvedValue(undefined),
       informSyncData: vi.fn().mockResolvedValue(undefined),
       initiateSync: vi.fn().mockResolvedValue(undefined),
+      requestSync: vi.fn().mockResolvedValue(undefined),
       directSync: vi.fn().mockResolvedValue(undefined),
       saveConfig: vi.fn().mockResolvedValue(undefined),
       sendHubMessage: vi.fn().mockResolvedValue('message-id'),

--- a/src/dev/tests/services/MessageService.unknownInbox.unit.test.ts
+++ b/src/dev/tests/services/MessageService.unknownInbox.unit.test.ts
@@ -73,6 +73,7 @@ describe('handleNewMessage — frame for an inbox with no encryption state', () 
       synchronizeAll: vi.fn().mockResolvedValue(undefined),
       informSyncData: vi.fn().mockResolvedValue(undefined),
       initiateSync: vi.fn().mockResolvedValue(undefined),
+      requestSync: vi.fn().mockResolvedValue(undefined),
       directSync: vi.fn().mockResolvedValue(undefined),
       saveConfig: vi.fn().mockResolvedValue(undefined),
       sendHubMessage: vi.fn().mockResolvedValue('message-id'),

--- a/src/dev/tests/utils/rosterConvergence.test.ts
+++ b/src/dev/tests/utils/rosterConvergence.test.ts
@@ -1,0 +1,421 @@
+// Deciding whether the roster pull converged.
+//
+// `requestSync` is fire-once-per-connect and the member half travels as ONE
+// payload, so losing a single frame loses the entire roster with no partial
+// result and no retry until relaunch. Measured 2026-08-02: the same two clients
+// ran the same join twice; the first delivered ZERO member rows, the second
+// delivered 71.
+//
+// Peers already tell us what they hold (`memberCount` on `sync-info`), so this
+// compares that against what we actually persisted and decides whether to ask
+// again. These tests pin both edges:
+//
+//   too eager    → a client that is already converged re-asks forever, and each
+//                  re-ask is a broadcast plus a directed exchange, paid once per
+//                  space
+//   too cautious → the catastrophic case (1 row against an advertised 78) is
+//                  never noticed and the user stares at truncated addresses
+//                  until they relaunch
+//
+// See .agents/bugs/2026-08-02-roster-pull-delivers-nothing-to-a-new-joiner.md
+
+import { describe, it, expect } from 'vitest';
+import {
+  createRosterConvergenceTracker,
+  MIN_ROSTER_SHORTFALL,
+  MAX_ROSTER_REASKS,
+  ROSTER_REASK_COOLDOWN_MS,
+  ROSTER_REASK_WINDOW_MS,
+} from '../../../utils/rosterConvergence';
+
+const SPACE = 'QmZM3AKwKfMp';
+const T0 = 1_750_000_000_000;
+
+const tracker = () => createRosterConvergenceTracker();
+
+describe('noticing a shortfall', () => {
+  // THE case this exists for: the member payload was lost, so we hold only our
+  // own row while a peer advertised a full roster.
+  it('asks again when a whole payload was clearly lost', () => {
+    const t = tracker();
+    t.noteAdvertisedRoster(SPACE, 78, T0);
+
+    expect(t.shouldReAsk(SPACE, 1, T0).ask).toBe(true);
+  });
+
+  it('stays quiet once the roster is close to what was on offer', () => {
+    const t = tracker();
+    t.noteAdvertisedRoster(SPACE, 78, T0);
+
+    expect(t.shouldReAsk(SPACE, 72, T0).ask).toBe(false);
+  });
+
+  // The exact 2026-08-02 numbers: the responder resolved 78 and the receiver
+  // persisted 71. That ~7 gap is structural and has its own causes; re-asking
+  // over it would be a permanent traffic drip against a peer already giving us
+  // everything it has.
+  it('tolerates the known structural gap between resolved and persisted', () => {
+    const t = tracker();
+    t.noteAdvertisedRoster(SPACE, 78, T0);
+
+    expect(t.shouldReAsk(SPACE, 71, T0).ask).toBe(false);
+  });
+
+  it('treats exactly the threshold as worth another ask', () => {
+    const t = tracker();
+    t.noteAdvertisedRoster(SPACE, 100, T0);
+
+    expect(t.shouldReAsk(SPACE, 100 - MIN_ROSTER_SHORTFALL, T0).ask).toBe(true);
+    expect(t.shouldReAsk(SPACE, 100 - MIN_ROSTER_SHORTFALL + 1, T0).ask).toBe(false);
+  });
+
+  it('never asks when we already hold more than anyone offered', () => {
+    const t = tracker();
+    t.noteAdvertisedRoster(SPACE, 72, T0);
+
+    // User A's real case: 79 rows locally, synced against a 72-member peer.
+    expect(t.shouldReAsk(SPACE, 79, T0).ask).toBe(false);
+  });
+
+  // Nothing to fall short of. Asking again would be asking into the void.
+  it('does not ask when no peer ever advertised anything', () => {
+    expect(tracker().shouldReAsk(SPACE, 1, T0).ask).toBe(false);
+  });
+
+  it('does not ask for a space it has never heard of', () => {
+    const t = tracker();
+    t.noteAdvertisedRoster(SPACE, 78, T0);
+
+    expect(t.shouldReAsk('a-different-space', 0, T0).ask).toBe(false);
+  });
+});
+
+// ⚠️ An ABSOLUTE shortfall alone is blind exactly where most spaces begin.
+// Every threshold here was tuned against a ~78-member community; a twelve-member
+// space missing three quarters of its roster produces a shortfall of 9, which
+// slips under a purely absolute rule and is silently declared healthy.
+describe('small spaces', () => {
+  it('asks again when most of a small roster is missing', () => {
+    const t = tracker();
+    t.noteAdvertisedRoster(SPACE, 12, T0);
+
+    // 3 of 12 — the absolute shortfall is only 9, below MIN_ROSTER_SHORTFALL.
+    expect(9).toBeLessThan(MIN_ROSTER_SHORTFALL);
+    expect(t.shouldReAsk(SPACE, 3, T0).ask).toBe(true);
+  });
+
+  it('leaves a small roster alone once it is nearly complete', () => {
+    const t = tracker();
+    t.noteAdvertisedRoster(SPACE, 12, T0);
+
+    expect(t.shouldReAsk(SPACE, 11, T0).ask).toBe(false);
+  });
+
+  it('still tolerates the structural gap at community scale', () => {
+    const t = tracker();
+    t.noteAdvertisedRoster(SPACE, 78, T0);
+
+    // 71 of 78 is 91% held — the proportional rule must NOT drag this back in.
+    expect(t.shouldReAsk(SPACE, 71, T0).ask).toBe(false);
+  });
+
+  it('notices a total loss in a tiny space', () => {
+    const t = tracker();
+    t.noteAdvertisedRoster(SPACE, 4, T0);
+
+    expect(t.shouldReAsk(SPACE, 1, T0).ask).toBe(true);
+  });
+});
+
+// The caller logs this reason on every branch. Four materially different
+// situations used to collapse into one silent `false`, and the most actionable
+// of them ("we know you are short, we are out of budget") was the least visible.
+describe('saying WHY', () => {
+  it('reports no-target when nobody ever answered', () => {
+    expect(tracker().shouldReAsk(SPACE, 1, T0)).toMatchObject({
+      ask: false,
+      reason: 'no-target',
+    });
+  });
+
+  it('reports converged, with the target, when we are close enough', () => {
+    const t = tracker();
+    t.noteAdvertisedRoster(SPACE, 78, T0);
+
+    expect(t.shouldReAsk(SPACE, 72, T0)).toMatchObject({
+      ask: false,
+      reason: 'converged',
+      target: 78,
+    });
+  });
+
+  it('reports cooling-down between attempts', () => {
+    const t = tracker();
+    t.noteAdvertisedRoster(SPACE, 78, T0);
+    t.noteReAsk(SPACE, T0);
+
+    expect(t.shouldReAsk(SPACE, 1, T0 + 1000)).toMatchObject({
+      ask: false,
+      reason: 'cooling-down',
+      target: 78,
+    });
+  });
+
+  // THE one worth logging: still short, but out of attempts.
+  it('reports cap-reached while still short', () => {
+    const t = tracker();
+    t.noteAdvertisedRoster(SPACE, 78, T0);
+    for (let i = 0; i < MAX_ROSTER_REASKS; i++) {
+      t.noteReAsk(SPACE, T0 + i * ROSTER_REASK_COOLDOWN_MS);
+    }
+
+    expect(t.shouldReAsk(SPACE, 1, T0 + ROSTER_REASK_COOLDOWN_MS * 3)).toMatchObject({
+      ask: false,
+      reason: 'cap-reached',
+      target: 78,
+    });
+  });
+
+  it('carries the target and the shortfall when it does ask', () => {
+    const t = tracker();
+    t.noteAdvertisedRoster(SPACE, 78, T0);
+
+    expect(t.shouldReAsk(SPACE, 1, T0)).toMatchObject({
+      ask: true,
+      target: 78,
+      shortfall: 77,
+    });
+  });
+});
+
+describe('which offer we aim at', () => {
+  // Several peers answer one request holding different amounts. The target is
+  // the fullest roster available, not whoever replied last.
+  it('targets the best offer, not the most recent one', () => {
+    const t = tracker();
+    t.noteAdvertisedRoster(SPACE, 90, T0);
+    t.noteAdvertisedRoster(SPACE, 72, T0 + 1);
+
+    expect(t.peek(SPACE)?.bestAdvertised).toBe(90);
+    // 80 is comfortably converged against 72 but 10 short of 90.
+    expect(t.shouldReAsk(SPACE, 80, T0 + 2).ask).toBe(true);
+  });
+
+  it('accepts a better offer arriving later', () => {
+    const t = tracker();
+    t.noteAdvertisedRoster(SPACE, 72, T0);
+    t.noteAdvertisedRoster(SPACE, 90, T0 + 1);
+
+    expect(t.peek(SPACE)?.bestAdvertised).toBe(90);
+  });
+
+  // These arrive from a client we do not control. NaN is the dangerous one:
+  // every comparison against it is false, so a shortfall would silently never
+  // be detected.
+  it.each([
+    ['absent', undefined],
+    ['null', null],
+    ['NaN', NaN],
+    ['Infinity', Infinity],
+    ['negative', -5],
+    ['a string', '78'],
+    ['zero', 0],
+  ])('ignores a %s member count rather than trusting it', (_label, value) => {
+    const t = tracker();
+    t.noteAdvertisedRoster(SPACE, value, T0);
+
+    expect(t.peek(SPACE)).toBeNull();
+    expect(t.shouldReAsk(SPACE, 0, T0).ask).toBe(false);
+  });
+
+  it('keeps a good offer when a garbage one follows it', () => {
+    const t = tracker();
+    t.noteAdvertisedRoster(SPACE, 78, T0);
+    t.noteAdvertisedRoster(SPACE, NaN, T0 + 1);
+
+    expect(t.peek(SPACE)?.bestAdvertised).toBe(78);
+  });
+});
+
+describe('bounding the cost', () => {
+  it('spends at most MAX_ROSTER_REASKS attempts in one window', () => {
+    const t = tracker();
+    t.noteAdvertisedRoster(SPACE, 78, T0);
+
+    let sent = 0;
+    for (let i = 0; i < 20; i++) {
+      const now = T0 + i * ROSTER_REASK_COOLDOWN_MS;
+      // Stay strictly inside ONE window — crossing it legitimately grants a
+      // fresh allowance, which the "later window" test covers separately.
+      if (now - T0 >= ROSTER_REASK_WINDOW_MS) break;
+      // The roster never improves — the peer holding those members is gone.
+      if (t.shouldReAsk(SPACE, 1, now).ask) {
+        t.noteReAsk(SPACE, now);
+        sent++;
+      }
+    }
+
+    expect(sent).toBe(MAX_ROSTER_REASKS);
+  });
+
+  // A reconnect storm must not burn the whole allowance in one bad minute.
+  it('holds the cooldown between attempts', () => {
+    const t = tracker();
+    t.noteAdvertisedRoster(SPACE, 78, T0);
+
+    expect(t.shouldReAsk(SPACE, 1, T0).ask).toBe(true);
+    t.noteReAsk(SPACE, T0);
+
+    expect(t.shouldReAsk(SPACE, 1, T0 + 1000).ask).toBe(false);
+    expect(t.shouldReAsk(SPACE, 1, T0 + ROSTER_REASK_COOLDOWN_MS - 1).ask).toBe(false);
+    expect(t.shouldReAsk(SPACE, 1, T0 + ROSTER_REASK_COOLDOWN_MS).ask).toBe(true);
+  });
+
+  it('a burst of sync-info answers cannot spend more than one attempt', () => {
+    const t = tracker();
+
+    let sent = 0;
+    for (let i = 0; i < 30; i++) {
+      const now = T0 + i * 100;
+      t.noteAdvertisedRoster(SPACE, 78, now);
+      if (t.shouldReAsk(SPACE, 1, now).ask) {
+        t.noteReAsk(SPACE, now);
+        sent++;
+      }
+    }
+
+    expect(sent).toBe(1);
+  });
+
+  // Without this the cap is permanent for the life of the tab, and a client
+  // that could not converge at 09:00 never retries when the peer holding those
+  // members comes back.
+  it('allows a fresh set of attempts in a later window, given a fresh offer', () => {
+    const t = tracker();
+    t.noteAdvertisedRoster(SPACE, 78, T0);
+
+    for (let i = 0; i < MAX_ROSTER_REASKS; i++) {
+      const now = T0 + i * ROSTER_REASK_COOLDOWN_MS;
+      expect(t.shouldReAsk(SPACE, 1, now).ask).toBe(true);
+      t.noteReAsk(SPACE, now);
+    }
+    expect(t.shouldReAsk(SPACE, 1, T0 + ROSTER_REASK_COOLDOWN_MS * 3).ask).toBe(false);
+
+    const later = T0 + ROSTER_REASK_WINDOW_MS;
+    // A peer that is STILL HERE re-advertises, and the allowance is renewed.
+    t.noteAdvertisedRoster(SPACE, 78, later);
+    expect(t.shouldReAsk(SPACE, 1, later).ask).toBe(true);
+  });
+
+  // ⚠️ THE ANTI-DRIP RULE, and the reason the test above needs a fresh offer.
+  //
+  // `bestAdvertised` used to be a monotonic high-water mark. Once any peer had
+  // ever advertised 78, that was the target for the rest of the tab's life — so
+  // if that peer left for good, the shortfall could never close and the client
+  // would spend its whole allowance every 15 minutes, forever, against nobody.
+  it('forgets the old target when the window rolls, so a departed peer stops driving retries', () => {
+    const t = tracker();
+    t.noteAdvertisedRoster(SPACE, 78, T0);
+    expect(t.shouldReAsk(SPACE, 1, T0).ask).toBe(true);
+
+    // The 78-member peer is gone and nobody answers any more.
+    const later = T0 + ROSTER_REASK_WINDOW_MS;
+    const decision = t.shouldReAsk(SPACE, 1, later);
+
+    expect(decision.ask).toBe(false);
+    expect(decision).toMatchObject({ reason: 'no-target' });
+    expect(t.peek(SPACE)?.bestAdvertised).toBe(0);
+  });
+
+  // `now` is supplied by the caller. A machine that adjusts its clock backwards
+  // must not wedge the gate open or shut.
+  it('does not misbehave when the clock goes backwards', () => {
+    const t = tracker();
+    t.noteAdvertisedRoster(SPACE, 78, T0);
+    expect(t.shouldReAsk(SPACE, 1, T0).ask).toBe(true);
+    t.noteReAsk(SPACE, T0);
+
+    // Cooldown has obviously not elapsed if time went the other way.
+    expect(t.shouldReAsk(SPACE, 1, T0 - 60_000).ask).toBe(false);
+    // And the window must not be treated as rolled.
+    expect(t.peek(SPACE)?.bestAdvertised).toBe(78);
+  });
+
+  // A zero-gain round is exactly the failure this exists for — a lost payload —
+  // so it must NOT be treated as evidence that asking again is pointless.
+  it('still retries after a round that gained nothing', () => {
+    const t = tracker();
+    t.noteAdvertisedRoster(SPACE, 78, T0);
+
+    expect(t.shouldReAsk(SPACE, 1, T0).ask).toBe(true);
+    t.noteReAsk(SPACE, T0);
+
+    expect(t.shouldReAsk(SPACE, 1, T0 + ROSTER_REASK_COOLDOWN_MS).ask).toBe(true);
+  });
+
+  it('stops once a re-ask actually worked, without spending the allowance', () => {
+    const t = tracker();
+    t.noteAdvertisedRoster(SPACE, 78, T0);
+
+    expect(t.shouldReAsk(SPACE, 1, T0).ask).toBe(true);
+    t.noteReAsk(SPACE, T0);
+
+    // The retry landed: 1 → 72.
+    expect(t.shouldReAsk(SPACE, 72, T0 + ROSTER_REASK_COOLDOWN_MS).ask).toBe(false);
+    expect(t.peek(SPACE)?.reAsks).toBe(1);
+  });
+
+  it('spends nothing when noteReAsk is not called', () => {
+    const t = tracker();
+    t.noteAdvertisedRoster(SPACE, 78, T0);
+
+    // A caller that decided to ask but failed to send must not be charged.
+    expect(t.shouldReAsk(SPACE, 1, T0).ask).toBe(true);
+    expect(t.shouldReAsk(SPACE, 1, T0).ask).toBe(true);
+    expect(t.peek(SPACE)?.reAsks).toBe(0);
+  });
+
+  it('noteReAsk on an unknown space is a no-op rather than a throw', () => {
+    const t = tracker();
+    expect(() => t.noteReAsk('never-seen', T0)).not.toThrow();
+    expect(t.peek('never-seen')).toBeNull();
+  });
+});
+
+describe('forgetting a space', () => {
+  it('drops its state so a later join starts clean', () => {
+    const t = tracker();
+    t.noteAdvertisedRoster(SPACE, 78, T0);
+    t.noteReAsk(SPACE, T0);
+
+    t.forget(SPACE);
+
+    expect(t.peek(SPACE)).toBeNull();
+    expect(t.shouldReAsk(SPACE, 1, T0).ask).toBe(false);
+  });
+
+  it('leaves other spaces alone', () => {
+    const t = tracker();
+    t.noteAdvertisedRoster(SPACE, 78, T0);
+    t.noteAdvertisedRoster('other', 90, T0);
+
+    t.forget(SPACE);
+
+    expect(t.peek('other')?.bestAdvertised).toBe(90);
+  });
+});
+
+describe('spaces are tracked independently', () => {
+  it('one space exhausting its allowance does not silence another', () => {
+    const t = tracker();
+    t.noteAdvertisedRoster(SPACE, 78, T0);
+    t.noteAdvertisedRoster('other', 78, T0);
+
+    for (let i = 0; i < MAX_ROSTER_REASKS; i++) {
+      t.noteReAsk(SPACE, T0 + i * ROSTER_REASK_COOLDOWN_MS);
+    }
+
+    expect(t.shouldReAsk(SPACE, 1, T0 + ROSTER_REASK_COOLDOWN_MS * 3).ask).toBe(false);
+    expect(t.shouldReAsk('other', 1, T0 + ROSTER_REASK_COOLDOWN_MS * 3).ask).toBe(true);
+  });
+});

--- a/src/services/InvitationService.ts
+++ b/src/services/InvitationService.ts
@@ -51,7 +51,7 @@ export class InvitationService {
   private getConfig: (params: { address: string; userKey: secureChannel.UserKeyset }) => Promise<any>;
   private saveConfig: (params: { config: any; keyset: any }) => Promise<void>;
   private sendHubMessage: (spaceId: string, message: string) => Promise<string>;
-  private requestSync: (spaceId: string) => Promise<void>;
+  private requestSync: (spaceId: string) => Promise<boolean>;
 
   constructor(dependencies: {
     messageDB: MessageDB;
@@ -63,7 +63,7 @@ export class InvitationService {
     getConfig: (params: { address: string; userKey: secureChannel.UserKeyset }) => Promise<any>;
     saveConfig: (params: { config: any; keyset: any }) => Promise<void>;
     sendHubMessage: (spaceId: string, message: string) => Promise<string>;
-    requestSync: (spaceId: string) => Promise<void>;
+    requestSync: (spaceId: string) => Promise<boolean>;
   }) {
     this.messageDB = dependencies.messageDB;
     this.apiClient = dependencies.apiClient;

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -105,6 +105,7 @@ import {
   type SpaceProfileWireFields,
 } from '../utils/spaceProfilePayload';
 import { preferIncomingProfileField } from '../utils/conversationProfile';
+import { createRosterConvergenceTracker } from '../utils/rosterConvergence';
 import { UndecryptableFrameTracker, frameKey } from '../utils/frameRetry';
 import { ThreadService } from './ThreadService';
 import type { Ref } from '../types/ref';
@@ -193,6 +194,17 @@ export interface MessageServiceDependencies {
     theirSummary?: any // New protocol: SyncSummary
   ) => Promise<void>;
   initiateSync: (spaceId: string) => Promise<void>;
+  /**
+   * Re-broadcast a `sync-request` for a space.
+   *
+   * Needed here — not just at connect — because the roster half of a sync is a
+   * single payload with no retry, so a lost frame has to be noticed and asked
+   * for again. See `scheduleRosterConvergenceCheck`.
+   *
+   * Resolves to whether the request was built and queued, so a re-ask that
+   * never left the process is not charged against the retry budget.
+   */
+  requestSync: (spaceId: string) => Promise<boolean>;
   directSync: (spaceId: string, message: any) => Promise<void>;
   saveConfig: (args: { config: any; keyset: any }) => Promise<void>;
   sendHubMessage: (spaceId: string, message: string) => Promise<string>;
@@ -330,6 +342,7 @@ export class MessageService {
     theirSummary?: any
   ) => Promise<void>;
   private initiateSync: (spaceId: string) => Promise<void>;
+  private requestSync: (spaceId: string) => Promise<boolean>;
   private directSync: (spaceId: string, message: any) => Promise<void>;
   private saveConfig: (args: { config: any; keyset: any }) => Promise<void>;
   private sendHubMessage: (spaceId: string, message: string) => Promise<string>;
@@ -337,6 +350,17 @@ export class MessageService {
   private handleSyncManifest: (spaceId: string, targetInbox: string, payload: any) => Promise<void>;
 
   private threadService: ThreadService;
+
+  // Did the roster pull actually deliver? The member half of a sync is one
+  // payload with no retry, so a lost frame silently costs the entire roster.
+  // Peers advertise `memberCount` on `sync-info`; this compares that against
+  // what we hold and asks again when we are obviously short.
+  private rosterConvergence = createRosterConvergenceTracker();
+
+  // One pending convergence check per space. Several peers answer a single
+  // request, so without this every `sync-info` would arm its own timer and the
+  // same check would run N times for one exchange.
+  private rosterConvergenceTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
   // Per-sender rate limiters (receiving-side defense-in-depth)
   private receivingRateLimiters = new Map<string, SimpleRateLimiter>();
@@ -489,6 +513,7 @@ export class MessageService {
     this.synchronizeAll = dependencies.synchronizeAll;
     this.informSyncData = dependencies.informSyncData;
     this.initiateSync = dependencies.initiateSync;
+    this.requestSync = dependencies.requestSync;
     this.directSync = dependencies.directSync;
     this.saveConfig = dependencies.saveConfig;
     this.sendHubMessage = dependencies.sendHubMessage;
@@ -1218,6 +1243,99 @@ export class MessageService {
         });
       }
     }
+  }
+
+  /**
+   * How long to wait after a peer's `sync-info` before checking whether the
+   * roster it advertised actually arrived.
+   *
+   * Long enough for the whole exchange — `sync-initiate`, `sync-manifest`, then
+   * the delta payloads, the member half of which is sent LAST — to complete on
+   * a slow link. Too short and every healthy sync would trigger a pointless
+   * second request; too long and the user is reading truncated addresses in the
+   * meantime.
+   */
+  private static readonly ROSTER_CONVERGENCE_CHECK_DELAY_MS = 20_000;
+
+  /**
+   * Arm a one-shot check that the roster pull actually converged.
+   *
+   * Debounced per space: several peers answer one `sync-request`, and each of
+   * their `sync-info` responses lands here. The LAST one wins, which is what we
+   * want — it pushes the check out until the answers have stopped arriving.
+   *
+   * Deliberately fire-and-forget and deliberately silent on failure. This is a
+   * best-effort repair for a roster that is already incomplete; if it cannot
+   * run, the user is no worse off than before it existed, and throwing out of a
+   * timer would take down nothing useful.
+   */
+  /**
+   * Drop everything the convergence check holds for a space.
+   *
+   * ⚠️ Call this whenever a space stops being ours. A timer armed seconds
+   * before a kick would otherwise still fire, read members for a space that has
+   * just been deleted, and broadcast a `sync-request` into a space we are no
+   * longer a member of.
+   */
+  forgetRosterConvergence(spaceId: string): void {
+    const timer = this.rosterConvergenceTimers.get(spaceId);
+    if (timer) clearTimeout(timer);
+    this.rosterConvergenceTimers.delete(spaceId);
+    this.rosterConvergence.forget(spaceId);
+  }
+
+  private scheduleRosterConvergenceCheck(spaceId: string): void {
+    const existing = this.rosterConvergenceTimers.get(spaceId);
+    if (existing) clearTimeout(existing);
+
+    this.rosterConvergenceTimers.set(
+      spaceId,
+      setTimeout(async () => {
+        this.rosterConvergenceTimers.delete(spaceId);
+        try {
+          const members = await this.messageDB.getSpaceMembers(spaceId);
+          const localCount = members?.length ?? 0;
+          const decision = this.rosterConvergence.shouldReAsk(spaceId, localCount);
+
+          if (!decision.ask) {
+            // Logged on the NEGATIVE branch too. "We know you are 70 rows short
+            // and we are out of attempts" is the most actionable state this
+            // code can be in, and the first version of it printed nothing.
+            logger.log(
+              `[MessageService] roster check for ${spaceId.substring(0, 12)}: ` +
+                `not asking (${decision.reason}) — have ${localCount}` +
+                (decision.target !== undefined ? `, best offer ${decision.target}` : '')
+            );
+            return;
+          }
+
+          logger.log(
+            `[MessageService] roster did not converge for ${spaceId.substring(0, 12)}: ` +
+              `have ${localCount}, best peer advertised ${decision.target} ` +
+              `(short by ${decision.shortfall}) — asking again`
+          );
+          // Charge the attempt ONLY if the request was actually built and
+          // queued. The allowance is two; spending one on a request that threw
+          // inside `requestSync` would silently halve it, and since `logger` is
+          // a no-op in production nobody would ever see why the roster stopped
+          // repairing itself.
+          const sent = await this.requestSync(spaceId);
+          if (sent) {
+            this.rosterConvergence.noteReAsk(spaceId);
+          } else {
+            logger.error(
+              `[MessageService] roster re-ask for ${spaceId.substring(0, 12)} was not sent; ` +
+                `attempt not charged`
+            );
+          }
+        } catch (error) {
+          logger.error(
+            `[MessageService] roster convergence check failed for ${spaceId.substring(0, 12)}:`,
+            error
+          );
+        }
+      }, MessageService.ROSTER_CONVERGENCE_CHECK_DELAY_MS)
+    );
   }
 
   /**
@@ -5375,6 +5493,11 @@ export class MessageService {
                     () => userConfig
                   );
                   await this.messageDB.deleteSpace(spaceId);
+                  // The space is gone from under us. Any armed convergence
+                  // timer would fire ~20s from now against a deleted space and
+                  // broadcast a sync-request into a space we were just removed
+                  // from.
+                  this.forgetRosterConvergence(spaceId);
                   return;
                 }
                 // If someone else was kicked, mark them inactive locally
@@ -5455,6 +5578,16 @@ export class MessageService {
               ) {
                 logger.log(`[MessageService] sync-info: Adding candidate and scheduling sync`);
                 this.syncInfo.current[spaceId].candidates.push(envelope.message);
+                // Remember what this peer says it holds, and arm a check that
+                // we actually received it. The member half of a delta is ONE
+                // payload with no retry, so losing that frame loses the whole
+                // roster silently — measured 2026-08-02, where the same join
+                // delivered 0 rows on one run and 71 on the next.
+                this.rosterConvergence.noteAdvertisedRoster(
+                  spaceId,
+                  envelope.message.memberCount ?? envelope.message.summary?.memberCount
+                );
+                this.scheduleRosterConvergenceCheck(spaceId);
                 // reset the timeout to be 1s to more aggressively grab viable candidates for sync instead of waiting the full 30s
                 clearTimeout(this.syncInfo.current[spaceId].invokable);
                 this.syncInfo.current[spaceId].invokable =

--- a/src/services/SyncService.ts
+++ b/src/services/SyncService.ts
@@ -457,8 +457,18 @@ export class SyncService {
   /**
    * Broadcasts sync request to all members via hub (30s expiry, schedules initiateSync).
    * Uses SharedSyncService for O(1) cached payload generation.
+   *
+   * @returns whether the request was built and QUEUED — not whether it was
+   * delivered. `enqueueOutbound` is deliberately not awaited, so `true` means
+   * "nothing threw while assembling and scheduling it" and nothing more.
+   *
+   * ⚠️ Errors are still swallowed here rather than thrown, because most callers
+   * fire this on connect and have no useful recovery. The boolean exists for
+   * the one caller that does: the roster convergence check spends from a budget
+   * of two attempts per space, and charging one for a request that never got
+   * built would silently halve it. Do NOT go back to returning `void`.
    */
-  async requestSync(spaceId: string): Promise<void> {
+  async requestSync(spaceId: string): Promise<boolean> {
     logger.log(`[SyncService] requestSync called for space ${spaceId}`);
     showSyncToast(t`Syncing...`);
     try {
@@ -519,8 +529,10 @@ export class SyncService {
         logger.log(`[SyncService] requestSync: Sending sync-request for space ${spaceId}`);
         return [JSON.stringify({ type: 'group', ...envelope })];
       });
+      return true;
     } catch (error) {
       logger.error(`[SyncService] requestSync failed for space ${spaceId}:`, error);
+      return false;
     }
   }
 

--- a/src/utils/rosterConvergence.ts
+++ b/src/utils/rosterConvergence.ts
@@ -1,0 +1,263 @@
+// Did the roster pull actually converge? — the DECISION half, kept pure and
+// timer-free so it is directly unit-testable. The scheduling lives in
+// MessageService.
+//
+// THE PROBLEM. `requestSync` is fire-once-per-connect. A peer answers with
+// `sync-info` advertising how many members it holds, we pick one, and it sends
+// the roster as a SINGLE final payload (`quorum-shared/src/sync/service.ts`,
+// message chunks first, members in one last payload). Lose that one frame and
+// the entire roster exchange is lost — no partial result, no error, and nothing
+// tries again until the app is relaunched. The user sits in front of a list of
+// truncated addresses with no way to know a retry would fix it.
+//
+// Measured 2026-08-02: the same two clients, same code, ran the join twice. The
+// first run delivered ZERO member rows. The second delivered 71. Nothing about
+// the sync logic differed between them.
+//
+// THE FIX. The peer already tells us what it has — `memberCount` is on the
+// `sync-info` payload and we already read and log it. So after a sync we can
+// compare that against the rows we actually hold and ask again if we are
+// obviously short. No new message type, no wire change, no dependency on the
+// transport work.
+//
+// ⚠️ This is a MITIGATION, not the repair. The real fix is either chunking the
+// member half or desktop consuming the send-retention fix that shipped in shared
+// 2.1.0-39 (transport item B1). Read `.agents/tasks/transport/README.md` before
+// deciding this is enough.
+//
+// ⚠️ OBSERVABILITY. `shouldReAsk` returns a REASON, not a boolean, and the
+// caller logs it on every branch. That is not gold-plating: `logger` is a no-op
+// in production builds (see
+// .agents/bugs/2026-08-01-every-logger-call-is-a-no-op-in-production-builds.md),
+// so a developer running a dev build is the ONLY audience this code will ever
+// have, and giving them "false" with no reason attached reproduces exactly the
+// blindness that made the original bug take a session to find.
+//
+// See .agents/bugs/2026-08-02-roster-pull-delivers-nothing-to-a-new-joiner.md
+// (NEXT STEP B).
+
+import { advertisedCount } from '@quilibrium/quorum-shared';
+
+/**
+ * How far below a peer's advertised count we tolerate before asking again.
+ *
+ * ⚠️ Deliberately NOT small. A converged client does not match its peer exactly,
+ * and that is expected rather than a bug: in the 2026-08-02 capture the
+ * responder resolved 78 members and the receiver persisted 71, a structural gap
+ * of ~7 that has its own causes (rows arriving with no address, among others).
+ * A threshold under that would re-ask forever against a peer that is already
+ * giving us everything it can.
+ *
+ * Ten sits above the observed noise and still catches what this exists for: the
+ * catastrophic case, where a whole payload was lost and we hold 1 row against an
+ * advertised 78.
+ */
+export const MIN_ROSTER_SHORTFALL = 10;
+
+/**
+ * Fraction of the best offer we must hold before calling ourselves converged.
+ *
+ * ⚠️ An ABSOLUTE shortfall alone is blind in a small space, which is where most
+ * spaces actually start. A twelve-member space where we hold three rows is
+ * missing 75% of its people and renders as a wall of truncated addresses — but
+ * the shortfall is 9, under the threshold, so a purely absolute rule would
+ * decide everything was fine and never retry.
+ *
+ * So the two rules are OR'd: ask again if we are short by a lot OR short by a
+ * large fraction. 0.75 is set to sit comfortably above the structural gap the
+ * absolute threshold was chosen for (71 of 78 is 91% held, well clear) while
+ * still catching 3 of 12 (25% held).
+ */
+export const MIN_ROSTER_COVERAGE = 0.75;
+
+/**
+ * Extra sync rounds allowed per space per window.
+ *
+ * Two, because the cost is not free — each re-ask is a broadcast `sync-request`
+ * plus a directed exchange, and a user in ten spaces pays it ten times over.
+ * Two covers a single lost frame (the failure actually observed) without
+ * turning an unreachable peer into a standing drip of traffic.
+ */
+export const MAX_ROSTER_REASKS = 2;
+
+/** Minimum gap between two re-asks for the same space. */
+export const ROSTER_REASK_COOLDOWN_MS = 60 * 1000;
+
+/**
+ * After this long the attempt count resets and a space may try again.
+ *
+ * Without it the cap would be permanent for the lifetime of the tab: a client
+ * that legitimately could not converge at 09:00 — because the only peer holding
+ * those members was offline — would never retry when that peer came back.
+ */
+export const ROSTER_REASK_WINDOW_MS = 15 * 60 * 1000;
+
+export interface RosterConvergenceConfig {
+  minShortfall: number;
+  minCoverage: number;
+  maxReAsks: number;
+  cooldownMs: number;
+  windowMs: number;
+}
+
+/**
+ * Why we are or are not asking again.
+ *
+ * ⚠️ A bare boolean was the first version and it was a mistake worth not
+ * repeating. Four materially different situations — nobody ever answered, we
+ * converged, we are out of budget, we are cooling down — collapsed into one
+ * silent `false`, and the caller's response was a bare `return` with no log.
+ * The single most actionable case ("we KNOW you are 70 rows short, we are just
+ * out of attempts until the window rolls") was the least visible.
+ *
+ * That is the same shape as the bug this whole module exists to fix: the sync
+ * path logged nothing about what it received, so a full session went into
+ * diagnosing it. Do not flatten this back into a boolean.
+ */
+export type ReAskDecision =
+  | { ask: true; target: number; shortfall: number }
+  | {
+      ask: false;
+      reason: 'no-target' | 'converged' | 'cap-reached' | 'cooling-down';
+      /** Best offer seen, when there was one — for the log line. */
+      target?: number;
+    };
+
+export interface RosterConvergenceState {
+  /** The highest member count any peer advertised for this space. */
+  bestAdvertised: number;
+  /** Re-asks spent in the current window. */
+  reAsks: number;
+  lastReAskAt: number;
+  windowStartedAt: number;
+}
+
+export interface RosterConvergenceTracker {
+  /** Record what a peer says it holds. Ignores absent or nonsensical counts. */
+  noteAdvertisedRoster(spaceId: string, memberCount: unknown, now?: number): void;
+  /** Are we obviously short of the best roster on offer, and allowed to ask again? */
+  shouldReAsk(spaceId: string, localMemberCount: number, now?: number): ReAskDecision;
+  /** Record that a re-ask was sent. Call this ONLY after actually sending one. */
+  noteReAsk(spaceId: string, now?: number): void;
+  /** Drop a space's state — on leave, or when its sync session is torn down. */
+  forget(spaceId: string): void;
+  /** Read-only, for tests and diagnostics. */
+  peek(spaceId: string): Readonly<RosterConvergenceState> | null;
+}
+
+export function createRosterConvergenceTracker(
+  config: RosterConvergenceConfig = {
+    minShortfall: MIN_ROSTER_SHORTFALL,
+    minCoverage: MIN_ROSTER_COVERAGE,
+    maxReAsks: MAX_ROSTER_REASKS,
+    cooldownMs: ROSTER_REASK_COOLDOWN_MS,
+    windowMs: ROSTER_REASK_WINDOW_MS,
+  }
+): RosterConvergenceTracker {
+  const { minShortfall, minCoverage, maxReAsks, cooldownMs, windowMs } = config;
+  const states = new Map<string, RosterConvergenceState>();
+
+  /**
+   * Start a new window: fresh attempts, and — importantly — a fresh TARGET.
+   *
+   * ⚠️ `bestAdvertised` must be cleared here, not carried over. It was a
+   * monotonic high-water mark in the first version, which meant that once any
+   * peer had ever advertised 90 members, 90 was the target for the rest of the
+   * tab's life. If that peer then went offline for good, the shortfall could
+   * never close, and the client would spend its full allowance every window
+   * forever — the exact standing drip of traffic the cap exists to prevent.
+   *
+   * Clearing it makes the target only ever as good as a CURRENT offer: the next
+   * `sync-info` from a peer that is actually here repopulates it, and if nobody
+   * is there to answer, there is correctly nothing to fall short of.
+   */
+  const rollWindow = (state: RosterConvergenceState, now: number): void => {
+    if (now - state.windowStartedAt >= windowMs) {
+      state.windowStartedAt = now;
+      state.reAsks = 0;
+      state.lastReAskAt = 0;
+      state.bestAdvertised = 0;
+    }
+  };
+
+  return {
+    noteAdvertisedRoster(spaceId, memberCount, now = Date.now()) {
+      // Shared with `selectBestCandidate` on purpose: both sides have to apply
+      // the same floor AND the same ceiling to a peer's self-reported count.
+      // An absurd value here would set a target that can never be reached, so
+      // the check below would spend its whole allowance every window forever.
+      const count = advertisedCount(memberCount as number | undefined | null);
+      if (count === 0) return;
+
+      const existing = states.get(spaceId);
+      if (!existing) {
+        states.set(spaceId, {
+          bestAdvertised: count,
+          reAsks: 0,
+          lastReAskAt: 0,
+          windowStartedAt: now,
+        });
+        return;
+      }
+      rollWindow(existing, now);
+      // Keep the BEST offer seen, not the latest. Several peers answer one
+      // request and they hold different amounts; the target is the fullest
+      // roster available, not whichever client happened to reply last.
+      if (count > existing.bestAdvertised) existing.bestAdvertised = count;
+    },
+
+    shouldReAsk(spaceId, localMemberCount, now = Date.now()) {
+      const state = states.get(spaceId);
+      // No peer ever advertised anything, so there is no target to fall short
+      // of. Asking again would be asking into the void.
+      if (!state) return { ask: false, reason: 'no-target' };
+
+      rollWindow(state, now);
+
+      // The window just rolled and cleared the target, or every offer we ever
+      // saw was garbage. Either way there is no CURRENT peer to fall short of.
+      if (state.bestAdvertised === 0) return { ask: false, reason: 'no-target' };
+
+      const target = state.bestAdvertised;
+      const ourCount = Number.isFinite(localMemberCount) ? localMemberCount : 0;
+      const shortfall = target - ourCount;
+
+      // Two rules, OR'd. The absolute one catches a lost payload in a large
+      // space; the proportional one catches the same loss in a small space,
+      // where the absolute gap is tiny but the roster is mostly missing.
+      const shortByALot = shortfall >= minShortfall;
+      const shortByALargeFraction = ourCount < target * minCoverage;
+      if (!shortByALot && !shortByALargeFraction) {
+        return { ask: false, reason: 'converged', target };
+      }
+
+      if (state.reAsks >= maxReAsks) return { ask: false, reason: 'cap-reached', target };
+      if (state.reAsks > 0 && now - state.lastReAskAt < cooldownMs) {
+        return { ask: false, reason: 'cooling-down', target };
+      }
+
+      // ⚠️ There is deliberately NO "did the last re-ask gain anything?" guard.
+      // It is tempting and it is wrong: the failure this exists for is "we
+      // received nothing at all", so a round that gained zero rows is precisely
+      // the case that must be allowed to retry. The cap and the cooldown are
+      // what bound the cost, not a progress check.
+      return { ask: true, target, shortfall };
+    },
+
+    noteReAsk(spaceId, now = Date.now()) {
+      const state = states.get(spaceId);
+      if (!state) return;
+      rollWindow(state, now);
+      state.reAsks += 1;
+      state.lastReAskAt = now;
+    },
+
+    forget(spaceId) {
+      states.delete(spaceId);
+    },
+
+    peek(spaceId) {
+      return states.get(spaceId) ?? null;
+    },
+  };
+}


### PR DESCRIPTION
## The problem

`requestSync` is fire-once-per-connect, and the member half of a sync delta travels as a **single payload**. Lose that one frame and the entire roster exchange is lost — no partial result, no error, and no retry until the app is relaunched.

Measured on 2026-08-02: the same two clients ran the same join twice. The first delivered **zero** member rows; the second delivered **71**. Nothing about the sync logic differed. The user is left reading a list of truncated addresses with no way to know a retry would fix it.

## The fix

Peers already tell us what they hold — `memberCount` arrives on `sync-info` and we already read and log it. So 20 seconds after a peer answers, compare that against the rows we actually persisted and ask again if we are obviously short. No new message type, no wire change, no dependency on the transport work.

**Two rules decide "obviously short", OR'd:**

- an **absolute** shortfall of 10, which catches a lost payload in a large space and sits deliberately above the ~7 structural gap between what a responder resolves and what a receiver persists;
- a **proportional** rule (75% coverage), which catches the same loss in a small space — three rows of twelve is a wall of truncated addresses, but an absolute gap of only 9.

**Bounded:** 2 attempts per space per 15 minutes, 60-second cooldown. The target is cleared when the window rolls; as a monotonic high-water mark, one departed peer's advertised count would have driven retries forever.

There is deliberately **no** "did the last retry gain anything?" guard. The failure this exists for is *"we received nothing at all"*, so a zero-gain round is exactly the case that must retry.

> ⚠️ This is a mitigation, not the repair. The real fix is chunking the member half, or consuming the send-retention fix from shared `2.1.0-39` (transport item B1).

## From review

- `shouldReAsk` returns a typed **reason**, not a boolean, and the caller logs it on every branch. Four materially different situations collapsed into one silent `false`, and the most actionable of them — "still 70 rows short, out of budget" — was the least visible. That is the same blindness that made the original bug take a full session to diagnose.
- `requestSync` reports whether the request was built and queued, so an attempt that never left the process is not charged against a budget of two.
- Convergence state and any armed timer are dropped on **both** space-teardown paths, kick and voluntary leave. A timer armed seconds before leaving would otherwise fire against a deleted space and broadcast into a space the user had just left.
- Peer counts go through the shared `advertisedCount`, which gained a ceiling as well as a floor.

## Tests

**47 new.** 39 cover the decision logic. The other 4 drive the **real** `handleNewMessage` entry point, because everything that makes this feature reachable is two lines inside a ~6,000-line switch, and nothing failed if they were deleted. Those 4 were verified by removing the hook and confirming they go red.

Full suite: **58 files, 884 tests**.

## Also in here

Documentation updates from the same investigation: the identity-resolution doc now states the missing-name problem **per platform** rather than as one sentence (it read as "fixed" when only the desktop→desktop case is), and the vitest flake bug records its error message for the first time — including which of its hypotheses has now been tried and disproven.
