### PR TITLE
test: reproduce the roster failure on demand, and name the step that dies

### DIFF
--- a/src/dev/tests/harness/errorTap.ts
+++ b/src/dev/tests/harness/errorTap.ts
@@ -41,6 +41,18 @@ import { logger } from '@quilibrium/quorum-shared';
 /** Where an attributed failure is recorded. One per in-flight frame. */
 export interface FailureSink {
   record: (message: string) => void;
+  /**
+   * Optional: receive EVERY `logger.log` line emitted while this sink is
+   * current, not only failures.
+   *
+   * This is what turns "the roster did not arrive" into "the handshake died at
+   * step 4, and here is by how many milliseconds". The sync path is already
+   * densely logged by the real services — `sync-request: Expired, ignoring`,
+   * `initiateSync: No suitable candidates`, `member delta: … resolved=N` — and
+   * in a browser those lines are trapped behind DevTools and a human reading
+   * them. In-process they are data.
+   */
+  trace?: (line: string) => void;
 }
 
 const store = new AsyncLocalStorage<FailureSink>();
@@ -89,9 +101,26 @@ export function installErrorTap(): void {
 
   const loggerRef = logger as unknown as {
     error: (...a: unknown[]) => unknown;
+    log: (...a: unknown[]) => unknown;
   };
   loggerRef.error = wrap(loggerRef.error.bind(logger));
   console.error = wrap(console.error.bind(console)) as typeof console.error;
+
+  // The trace tap. Same discipline as above — installed once, never restored,
+  // attributed by async context — because a per-frame patch/restore of a global
+  // is the bug this module exists to avoid.
+  const origLog = loggerRef.log.bind(logger);
+  loggerRef.log = (...args: unknown[]) => {
+    const sink = store.getStore();
+    if (sink?.trace) {
+      sink.trace(
+        args
+          .map((a) => (typeof a === 'string' ? a : JSON.stringify(a)))
+          .join(' ')
+      );
+    }
+    return origLog(...args);
+  };
 }
 
 /** Run `fn` with failures attributed to `sink`. */

--- a/src/dev/tests/harness/space-backlog.scenario.test.ts
+++ b/src/dev/tests/harness/space-backlog.scenario.test.ts
@@ -1,0 +1,237 @@
+// Does a RECONNECT BACKLOG starve the roster handshake?
+//
+//   yarn harness space-backlog
+//   HARNESS_BACKLOG_SIZES=0,50,200 HARNESS_BACKLOG_ITERATIONS=3 yarn harness space-backlog
+//
+// This is the experiment `.agents/bugs/2026-08-02-sync-requests-arrive-four-
+// minutes-late-and-every-peer-rejects-them.md` §5b step 1 asks for, and it is
+// the thing a manual test cannot do: vary the backlog and watch the rate move.
+//
+// ## The field observation being reproduced
+//
+// A joiner that had not opened the app in a long time showed a console dominated
+// by its reconnect backlog — 352 `announce-keys`, 659 decrypt calls, running from
+// log line 245 to 4040. Its three `sync-request`s sat at lines 2211, 2225 and
+// 3998, interleaved in that flood, and every one was read ~210s late against a
+// 30s expiry. It answered NOBODY for four minutes, across all six of its spaces,
+// and stayed at 1 member row.
+//
+// The reading is head-of-line blocking: the frames are not slow to arrive, the
+// client is slow to reach them. Inbound processing is serial (the app's
+// `processInbound`, and `WsTransport.dispatch` here), so a perishable
+// `sync-request` queued behind hundreds of real decrypts is stale by the time it
+// is read. The expiry is doing its job; the scheduling is the bug.
+//
+// ## Why the previous sweep could not see this
+//
+// `space-rate` measured 15/15 at 2, 25 and 79 members — on FRESH accounts with no
+// backlog. That is not a refutation of the field failure; it is the CONTROL ARM
+// of the hypothesis above, and it behaved exactly as predicted. This scenario
+// adds the treatment arm.
+//
+// ## The design
+//
+//   A creates S_backlog, B joins it            → B now has an inbox the relay fills
+//   B goes offline                             → transport closed, frames retain
+//   A posts M messages to S_backlog            → M real frames queue for B
+//   A creates S_target and seeds a roster of N
+//   B comes back online AND joins S_target     → the flood and the handshake race
+//
+// Sweeping M gives a dose-response curve. If the roster rate falls as M grows,
+// the diagnosis is settled with a curve rather than an anecdote — and
+// `announce-keys` flooding, currently rated LOW because it needs an attacker,
+// becomes a no-attacker-needed availability bug.
+//
+// ⚠️ FIDELITY, stated honestly. The field backlog was `announce-keys` control
+// messages; this uses space POSTS. Both enter the same space branch of
+// `handleNewMessage` and both cost a real hub-envelope unseal plus a triple
+// ratchet decrypt, so posts are a faithful proxy for the COST and the SERIAL
+// QUEUE. They are not a proxy for anything specific to announce-keys handling.
+// What this cannot reproduce at all is the socket behaviour that needs real
+// devices — see "Why every bench was green" in tasks/transport/measurements.md.
+import { test, expect } from 'vitest';
+import { createSpaceBot } from './spaceBot';
+import { RunLog } from './log';
+
+const SIZES = (process.env.HARNESS_BACKLOG_SIZES ?? '0,50,200')
+  .split(',')
+  .map((s) => Number(s.trim()))
+  .filter((n) => Number.isFinite(n) && n >= 0);
+const ITERATIONS = Number(process.env.HARNESS_BACKLOG_ITERATIONS ?? 2);
+const ROSTER = Number(process.env.HARNESS_BACKLOG_ROSTER ?? 79);
+const WINDOW_MS = Number(process.env.HARNESS_BACKLOG_WINDOW_MS ?? 180_000);
+const SAMPLE_MS = 2000;
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+interface Trial {
+  backlog: number;
+  iteration: number;
+  ok: boolean;
+  got: number;
+  target: number;
+  /** ms from B rejoining to a complete roster. */
+  ms?: number;
+  /** Frames B's socket actually received during the window. */
+  framesArrived: number;
+  note?: string;
+}
+
+function median(xs: number[]): number | undefined {
+  if (!xs.length) return undefined;
+  const s = [...xs].sort((a, b) => a - b);
+  const mid = Math.floor(s.length / 2);
+  return s.length % 2 ? s[mid] : Math.round((s[mid - 1] + s[mid]) / 2);
+}
+
+test(
+  'space-backlog: does a reconnect backlog starve the roster handshake?',
+  async () => {
+    const startedAt = Date.now();
+    const log = new RunLog('space-backlog', startedAt);
+    const say = (msg: string, fields: Record<string, unknown> = {}) => {
+      console.log(`[space-backlog] ${msg}`);
+      log.add(Date.now(), 'harness', 'note', { msg, ...fields });
+    };
+
+    say(
+      `backlog sweep=[${SIZES.join(', ')}] iterations=${ITERATIONS} roster=${ROSTER} ` +
+        `window=${WINDOW_MS / 1000}s`
+    );
+
+    const trials: Trial[] = [];
+
+    for (const backlog of SIZES) {
+      for (let i = 1; i <= ITERATIONS; i++) {
+        const stamp = String(Date.now()).slice(-7);
+        let a: Awaited<ReturnType<typeof createSpaceBot>> | undefined;
+        let b: Awaited<ReturnType<typeof createSpaceBot>> | undefined;
+        try {
+          [a, b] = await Promise.all([
+            createSpaceBot(`bk-a-${stamp}`),
+            createSpaceBot(`bk-b-${stamp}`),
+          ]);
+          await Promise.all([a.start(), b.start()]);
+
+          // 1. A space B belongs to, so the relay has somewhere to queue for it.
+          const s1 = await a.createSpace(`harness-bk-src-${stamp}`);
+          await b.join(await a.inviteLink(s1.spaceId));
+
+          // 2. B goes offline. Frames posted now are retained for it.
+          b.disconnect();
+          await sleep(1000);
+
+          // 3. Build the backlog.
+          if (backlog > 0) {
+            say(`  building backlog of ${backlog} message(s)…`);
+            await a.postMany(s1.spaceId, s1.channelId, backlog, `bk-${stamp}`);
+          }
+
+          // 4. The space whose roster we actually care about.
+          const s2 = await a.createSpace(`harness-bk-tgt-${stamp}`);
+          const seeded = await a.seedMembers(s2.spaceId, ROSTER - 1);
+          if (seeded !== ROSTER) {
+            throw new Error(`seeding produced ${seeded}, expected ${ROSTER}`);
+          }
+          const link = await a.inviteLink(s2.spaceId);
+
+          // 5. B returns and joins. The retained flood and the roster handshake
+          //    now compete for B's single serial inbound queue — the field
+          //    condition.
+          const framesBefore = b.transport.arrived.length;
+          await b.reconnect();
+          const rejoinedAt = Date.now();
+          await b.join(link);
+
+          const target = ROSTER + 1;
+          let ms: number | undefined;
+          const deadline = Date.now() + WINDOW_MS;
+          while (Date.now() < deadline) {
+            await sleep(SAMPLE_MS);
+            if ((await b.members(s2.spaceId)) >= target) {
+              ms = Date.now() - rejoinedAt;
+              break;
+            }
+          }
+
+          const got = await b.members(s2.spaceId);
+          const trial: Trial = {
+            backlog,
+            iteration: i,
+            ok: got >= target,
+            got,
+            target,
+            ms,
+            framesArrived: b.transport.arrived.length - framesBefore,
+          };
+          trials.push(trial);
+          log.add(Date.now(), 'harness', 'trial', { ...trial });
+          say(
+            `  backlog=${backlog} iter=${i}/${ITERATIONS}  ${trial.ok ? 'OK' : 'MISS'}  ` +
+              `rows=${got}/${target}  framesArrived=${trial.framesArrived}` +
+              (ms ? `  ${(ms / 1000).toFixed(1)}s` : '')
+          );
+        } catch (err) {
+          const note = (err as Error)?.message ?? String(err);
+          trials.push({
+            backlog,
+            iteration: i,
+            ok: false,
+            got: -1,
+            target: ROSTER + 1,
+            framesArrived: 0,
+            note,
+          });
+          say(`  backlog=${backlog} iter=${i}  ERROR (excluded): ${note}`);
+        } finally {
+          a?.stop();
+          b?.stop();
+        }
+      }
+    }
+
+    const valid = trials.filter((t) => t.got >= 0);
+    const errored = trials.filter((t) => t.got < 0);
+
+    say('');
+    say('==== ROSTER DELIVERY vs RECONNECT BACKLOG ====');
+    say(`backlog | trials | delivered | rate  | median lag | median frames`);
+    for (const backlog of SIZES) {
+      const forSize = valid.filter((t) => t.backlog === backlog);
+      if (!forSize.length) continue;
+      const ok = forSize.filter((t) => t.ok);
+      const med = median(ok.map((t) => t.ms!).filter(Boolean));
+      const medFrames = median(forSize.map((t) => t.framesArrived));
+      say(
+        `${String(backlog).padStart(7)} | ${String(forSize.length).padStart(6)} | ` +
+          `${String(ok.length).padStart(9)} | ` +
+          `${((ok.length / forSize.length) * 100).toFixed(0).padStart(4)}% | ` +
+          `${(med ? `${(med / 1000).toFixed(1)}s` : '—').padStart(10)} | ${medFrames ?? '—'}`,
+        {
+          backlog,
+          trials: forSize.length,
+          delivered: ok.length,
+          medianMs: med,
+          medianFrames: medFrames,
+        }
+      );
+    }
+    say('');
+    say(
+      'Read the RATE column top to bottom. A fall as backlog grows is the ' +
+        'head-of-line-blocking diagnosis confirmed; a flat column says the ' +
+        'backlog is not what starves the handshake, and the field cause is ' +
+        'something this harness still cannot host.'
+    );
+    if (errored.length) {
+      say(`⚠️ ${errored.length} trial(s) errored and are EXCLUDED:`);
+      for (const e of errored)
+        say(`   backlog=${e.backlog} iter=${e.iteration}: ${e.note}`);
+    }
+    say(`log: ${log.file}`);
+
+    // Instrument, not regression test — see space-rate for the reasoning.
+    expect(valid.length).toBeGreaterThan(0);
+  },
+  4 * 60 * 60 * 1000
+);

--- a/src/dev/tests/harness/space-backlog.scenario.test.ts
+++ b/src/dev/tests/harness/space-backlog.scenario.test.ts
@@ -165,7 +165,34 @@ test(
             framesArrived: b.transport.arrived.length - framesBefore,
           };
           trials.push(trial);
-          log.add(Date.now(), 'harness', 'trial', { ...trial });
+          log.add(Date.now(), 'harness', 'trial', {
+            ...trial,
+            bTrace: b.syncTrace,
+          });
+
+          // On a MISS, say WHICH step died. Without this the scenario reports
+          // "the roster is short" and the reader is back to guessing — which is
+          // the whole failure mode this investigation keeps repeating.
+          if (!trial.ok) {
+            const step = (needle: string) =>
+              `${needle}=${b!.traceCount(needle)}`;
+            say(
+              `    B handshake: ${[
+                'requestSync',
+                'sync-info',
+                'Adding candidate',
+                'No suitable candidates',
+                'Expired, ignoring',
+                'No active session or expired',
+                'sync-delta',
+                'member delta',
+              ]
+                .map(step)
+                .join('  ')}`
+            );
+            for (const line of b.syncTrace.slice(-6))
+              say(`      | ${line.slice(0, 150)}`);
+          }
           say(
             `  backlog=${backlog} iter=${i}/${ITERATIONS}  ${trial.ok ? 'OK' : 'MISS'}  ` +
               `rows=${got}/${target}  framesArrived=${trial.framesArrived}` +

--- a/src/dev/tests/harness/space-rate.scenario.test.ts
+++ b/src/dev/tests/harness/space-rate.scenario.test.ts
@@ -1,0 +1,242 @@
+// SLICE S2 — the deliverable. How OFTEN does a new joiner get the roster?
+//
+//   yarn harness space-rate
+//   HARNESS_RATE_SIZES=2,25,79 HARNESS_RATE_ITERATIONS=10 yarn harness space-rate
+//
+// S1 proved the exchange CAN work. It ran at two members and passed five times,
+// which says nothing about a failure reported at ~79 members and described as
+// intermittent. This scenario answers the three questions
+// `.agents/bugs/2026-08-02-roster-pull-delivers-nothing-to-a-new-joiner.md`
+// says a manual test cannot:
+//
+//   1. is it 1-in-2 or 1-in-50?
+//   2. does it correlate with roster size?
+//   3. does it ever succeed twice in a row?
+//
+// Each iteration is an independent trial: fresh accounts, a fresh space, a fresh
+// joiner. A creates a space and holds a roster of N; B joins and must converge to
+// N. Success is B's row count reaching N within the window, read from IndexedDB.
+//
+// ⚠️ THIS SCENARIO DOES NOT ASSERT A PASS RATE, deliberately. It is an
+// instrument, not a regression test: it prints a rate and only fails if the
+// instrument itself is broken (no trial completed). Asserting "≥90% must
+// succeed" would convert a measurement into a coin flip that goes red on the
+// days the bug is worst — which is exactly when the number matters most.
+//
+// ⚠️ COST. Every iteration registers two accounts and creates one space on
+// PRODUCTION, and nothing cleans them up. A 3-size × 10-iteration sweep is 60
+// registrations and 30 spaces. Creating throwaway spaces on production is
+// approved (see the spec's operator decisions), but the volume is not
+// incidental — start small and scale deliberately.
+import { test, expect } from 'vitest';
+import { createSpaceBot } from './spaceBot';
+import { RunLog } from './log';
+
+const SIZES = (process.env.HARNESS_RATE_SIZES ?? '2,25,79')
+  .split(',')
+  .map((s) => Number(s.trim()))
+  .filter((n) => Number.isFinite(n) && n >= 2);
+const ITERATIONS = Number(process.env.HARNESS_RATE_ITERATIONS ?? 3);
+const WINDOW_MS = Number(process.env.HARNESS_RATE_WINDOW_MS ?? 90_000);
+const SAMPLE_MS = Number(process.env.HARNESS_RATE_SAMPLE_MS ?? 2000);
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+interface Trial {
+  size: number;
+  iteration: number;
+  ok: boolean;
+  /** Rows B ended with (1 = its own row only, i.e. nothing arrived). */
+  got: number;
+  /** ms from B joining to B reaching the full roster. */
+  ms?: number;
+  novelErrors: number;
+  note?: string;
+}
+
+/** Longest run of consecutive successes — question 3, straight from the data. */
+function longestStreak(trials: Trial[]): number {
+  let best = 0;
+  let cur = 0;
+  for (const t of trials) {
+    cur = t.ok ? cur + 1 : 0;
+    if (cur > best) best = cur;
+  }
+  return best;
+}
+
+function median(xs: number[]): number | undefined {
+  if (!xs.length) return undefined;
+  const s = [...xs].sort((a, b) => a - b);
+  const mid = Math.floor(s.length / 2);
+  return s.length % 2 ? s[mid] : Math.round((s[mid - 1] + s[mid]) / 2);
+}
+
+test(
+  'space-rate: how often does a new joiner receive the full member roster?',
+  async () => {
+    const startedAt = Date.now();
+    const log = new RunLog('space-rate', startedAt);
+    const say = (msg: string, fields: Record<string, unknown> = {}) => {
+      console.log(`[space-rate] ${msg}`);
+      log.add(Date.now(), 'harness', 'note', { msg, ...fields });
+    };
+
+    say(
+      `sweep sizes=[${SIZES.join(', ')}] iterations=${ITERATIONS} window=${WINDOW_MS / 1000}s ` +
+        `(${SIZES.length * ITERATIONS} trials, ${SIZES.length * ITERATIONS * 2} registrations)`
+    );
+
+    const trials: Trial[] = [];
+
+    for (const size of SIZES) {
+      for (let i = 1; i <= ITERATIONS; i++) {
+        const stamp = `${String(Date.now()).slice(-7)}`;
+        let a: Awaited<ReturnType<typeof createSpaceBot>> | undefined;
+        let b: Awaited<ReturnType<typeof createSpaceBot>> | undefined;
+        try {
+          [a, b] = await Promise.all([
+            createSpaceBot(`rate-a-${stamp}`),
+            createSpaceBot(`rate-b-${stamp}`),
+          ]);
+          await Promise.all([a.start(), b.start()]);
+
+          const { spaceId } = await a.createSpace(
+            `harness-s2-${size}-${stamp}`
+          );
+          // A already holds its own row, so seed size-1 to reach `size`.
+          const seeded = await a.seedMembers(spaceId, size - 1);
+          if (seeded !== size) {
+            throw new Error(
+              `seeding produced ${seeded} rows, expected ${size}`
+            );
+          }
+
+          const link = await a.inviteLink(spaceId);
+          const joinedAt = Date.now();
+          await b.join(link);
+
+          // B's join fires requestSync itself, so nothing here has to nudge it.
+          //
+          // Target arithmetic: A's roster is `size` and already counts A. B
+          // writes its own row locally at join, and must then receive A's
+          // `size` rows from the wire — so a complete result is `size + 1`.
+          const target = size + 1;
+          let ms: number | undefined;
+          const deadline = Date.now() + WINDOW_MS;
+          while (Date.now() < deadline) {
+            await sleep(SAMPLE_MS);
+            if ((await b.members(spaceId)) >= target) {
+              ms = Date.now() - joinedAt;
+              break;
+            }
+          }
+
+          const got = await b.members(spaceId);
+          const trial: Trial = {
+            size,
+            iteration: i,
+            ok: got >= target,
+            got,
+            ms,
+            novelErrors: b.novelErrors().length,
+          };
+          trials.push(trial);
+          log.add(Date.now(), 'harness', 'trial', { ...trial });
+          say(
+            `  size=${size} iter=${i}/${ITERATIONS}  ${trial.ok ? 'OK' : 'MISS'}  ` +
+              `rows=${got}/${target}` +
+              (ms ? `  ${(ms / 1000).toFixed(1)}s` : '') +
+              (trial.novelErrors ? `  novelErrors=${trial.novelErrors}` : '')
+          );
+        } catch (err) {
+          // A thrown trial is NOT a delivery failure — it is the harness or the
+          // relay failing, and folding it into the rate would corrupt the very
+          // number this exists to produce. Recorded separately.
+          const note = (err as Error)?.message ?? String(err);
+          trials.push({
+            size,
+            iteration: i,
+            ok: false,
+            got: -1,
+            novelErrors: 0,
+            note,
+          });
+          say(
+            `  size=${size} iter=${i}/${ITERATIONS}  ERROR (excluded from rate): ${note}`
+          );
+        } finally {
+          a?.stop();
+          b?.stop();
+        }
+      }
+    }
+
+    // ── Report ───────────────────────────────────────────────────────────────
+    const valid = trials.filter((t) => t.got >= 0);
+    const errored = trials.filter((t) => t.got < 0);
+
+    say('');
+    say('==== ROSTER DELIVERY RATE ====');
+    say(
+      `roster size | trials | delivered | rate   | median lag | longest streak`
+    );
+    for (const size of SIZES) {
+      const forSize = valid.filter((t) => t.size === size);
+      if (!forSize.length) continue;
+      const ok = forSize.filter((t) => t.ok);
+      const med = median(ok.map((t) => t.ms!).filter(Boolean));
+      say(
+        `${String(size).padStart(11)} | ${String(forSize.length).padStart(6)} | ` +
+          `${String(ok.length).padStart(9)} | ` +
+          `${((ok.length / forSize.length) * 100).toFixed(0).padStart(4)}% | ` +
+          `${(med ? `${(med / 1000).toFixed(1)}s` : '—').padStart(10)} | ` +
+          `${longestStreak(forSize)}`,
+        {
+          size,
+          trials: forSize.length,
+          delivered: ok.length,
+          medianMs: med,
+          longestStreak: longestStreak(forSize),
+        }
+      );
+    }
+
+    const allOk = valid.filter((t) => t.ok);
+    say('');
+    say(
+      `OVERALL ${allOk.length}/${valid.length} delivered` +
+        (valid.length
+          ? ` (${((allOk.length / valid.length) * 100).toFixed(0)}%)`
+          : '') +
+        `, longest success streak ${longestStreak(valid)}`,
+      { delivered: allOk.length, trials: valid.length }
+    );
+    // A partial roster is a DIFFERENT failure from an empty one: empty means the
+    // member payload never arrived, partial means it arrived carrying less than
+    // the peer holds (the peer-selection defect, NEXT STEP A in the bug file).
+    // Reporting one number for both would hide which mechanism is at work.
+    const empty = valid.filter((t) => !t.ok && t.got <= 1).length;
+    const partial = valid.filter((t) => !t.ok && t.got > 1).length;
+    say(
+      `misses: ${empty} EMPTY (nothing arrived), ${partial} PARTIAL (short of the peer)`,
+      {
+        empty,
+        partial,
+      }
+    );
+    if (errored.length) {
+      say(
+        `⚠️ ${errored.length} trial(s) errored and are EXCLUDED from the rate above:`
+      );
+      for (const e of errored)
+        say(`   size=${e.size} iter=${e.iteration}: ${e.note}`);
+    }
+    say(`log: ${log.file}`);
+
+    // The run IS the measurement. Assert only that the instrument produced data —
+    // see the header for why a pass-rate assertion would be wrong here.
+    expect(valid.length).toBeGreaterThan(0);
+  },
+  4 * 60 * 60 * 1000
+);

--- a/src/dev/tests/harness/spaceBot.ts
+++ b/src/dev/tests/harness/spaceBot.ts
@@ -72,6 +72,23 @@ export interface HarnessSpaceBot {
   join(inviteLink: string): Promise<{ spaceId: string; channelId: string }>;
   /** Post a text message to a channel via the real submitChannelMessage path. */
   post(spaceId: string, channelId: string, text: string): Promise<void>;
+  /**
+   * Post `count` messages, draining ONCE at the end rather than per message.
+   *
+   * Same real path as `post`; only the waiting differs. Used to build a relay
+   * backlog for an offline member, where the point is volume and per-message
+   * timing is not the measurement.
+   */
+  postMany(
+    spaceId: string,
+    channelId: string,
+    count: number,
+    prefix: string
+  ): Promise<void>;
+  /** Drop the socket without tearing the bot down — simulates going offline. */
+  disconnect(): void;
+  /** Reopen the socket and re-subscribe — simulates coming back. */
+  reconnect(): Promise<void>;
   /** Ask the space for a roster/message sync (the pull under investigation). */
   requestSync(spaceId: string): Promise<boolean>;
   /** Member rows currently on disk for a space. */
@@ -255,6 +272,39 @@ export async function createSpaceBot(
       // in that order — the handler is what puts frames into the FIFO.
       await mustDrain(drainActionQueue(), 'post action queue');
       await mustDrain(graph.outbound.flush(), 'post outbound');
+    },
+
+    postMany: async (
+      spaceId: string,
+      channelId: string,
+      count: number,
+      prefix: string
+    ) => {
+      for (let i = 1; i <= count; i++) {
+        await graph.messageService.submitChannelMessage(
+          spaceId,
+          channelId,
+          `${prefix} ${i}/${count}`,
+          queryClient,
+          passkeyInfo
+        );
+      }
+      // One drain for the whole batch. Generous timeout: the ActionQueue
+      // encrypts and sends each message serially, so a large batch legitimately
+      // takes minutes, and a premature "wedged" throw here would be wrong.
+      await mustDrain(drainActionQueue(10 * 60_000), 'postMany action queue');
+      await mustDrain(graph.outbound.flush(10 * 60_000), 'postMany outbound');
+    },
+
+    disconnect: () => transport.close(),
+
+    reconnect: async () => {
+      transport.reopen();
+      await transport.connect();
+      // Force a re-listen: the subscription memo still holds the old key, and
+      // the relay only re-pushes a retained backlog in response to a `listen`.
+      subscribed = '';
+      await refreshSubscriptions();
     },
 
     requestSync: (spaceId: string) => graph.syncService.requestSync(spaceId),

--- a/src/dev/tests/harness/spaceBot.ts
+++ b/src/dev/tests/harness/spaceBot.ts
@@ -17,6 +17,7 @@ import { QueryClient } from '@tanstack/react-query';
 import { type Message, type UserRegistration } from '@quilibrium/quorum-shared';
 import type { MessageDB } from '../../../db/messages';
 import type { EncryptedMessage } from '../../../db/messages';
+import { sha256, base58btc } from '../../../utils/crypto';
 import { makeMessageDB } from './storage';
 import { makeApiClient, WsTransport } from './transport';
 import { createSpaceGraph, type SpaceGraph } from './spaceDeps';
@@ -75,6 +76,29 @@ export interface HarnessSpaceBot {
   requestSync(spaceId: string): Promise<boolean>;
   /** Member rows currently on disk for a space. */
   members(spaceId: string): Promise<number>;
+  /**
+   * Add `count` synthetic member rows to this bot's roster for a space.
+   *
+   * ⚠️ READ BEFORE USING — this is a deliberate, load-bearing shortcut and it
+   * bounds what the resulting measurement means.
+   *
+   * The reported roster failure happens at ~79 members. Reaching that with real
+   * clients would cost 79 account registrations and 79 real joins PER
+   * ITERATION, which makes a rate measurement unaffordable. It is unnecessary
+   * because the responder builds its delta from its OWN stored rows and nothing
+   * else: `getPayloadCache` fills `memberMap` from
+   * `storage.getSpaceMembers(spaceId)` (`quorum-shared/src/sync/service.ts:141`),
+   * and the receiver's apply path validates nothing against the manifest or any
+   * registration — it skips rows with no address and writes the rest
+   * (`MessageService.ts:6010-6052`). So seeded rows travel the identical code
+   * path real ones do.
+   *
+   * What this therefore measures: **whether a roster of size N is delivered.**
+   * What it does NOT measure: the behaviour of N live clients — their traffic,
+   * their own sync requests, or peer selection among many candidates. Those are
+   * separate variables and must not be claimed from this.
+   */
+  seedMembers(spaceId: string, count: number): Promise<number>;
   /** Wait until everything enqueued so far has been handed to the socket. */
   flush(timeoutMs?: number): Promise<boolean>;
   /** Fetch + delete queued frames on the device inbox. */
@@ -237,6 +261,41 @@ export async function createSpaceBot(
 
     members: async (spaceId: string) =>
       (await messageDB.getSpaceMembers(spaceId)).length,
+
+    seedMembers: async (spaceId: string, count: number) => {
+      for (let i = 0; i < count; i++) {
+        // Real-shaped addresses (base58btc of a sha256), derived deterministically
+        // from the space + index so two runs at the same size are comparable.
+        const digest = await sha256.digest(
+          Buffer.from(`${spaceId}:seed:${i}`, 'utf-8')
+        );
+        const address = base58btc.baseEncode(digest.bytes);
+        const inboxDigest = await sha256.digest(
+          Buffer.from(`${spaceId}:seed-inbox:${i}`, 'utf-8')
+        );
+        await messageDB.saveSpaceMember(spaceId, {
+          user_address: address,
+          inbox_address: base58btc.baseEncode(inboxDigest.bytes),
+          // A populated GLOBAL slot, because that is what the follow-global work
+          // left real rows carrying — seeding the override slot instead would
+          // exercise a shape production stopped producing in 2026-07.
+          global_display_name: `Seeded Member ${i}`,
+          globalProfileTimestamp: Date.now(),
+          joinedAt: Date.now(),
+        } as Parameters<MessageDB['saveSpaceMember']>[1]);
+      }
+      // The responder caches its payload view; without this the seeded rows are
+      // invisible until something else invalidates it, and the sweep would
+      // silently measure N=1 at every size.
+      (
+        graph.syncService as unknown as {
+          sharedSyncService: {
+            invalidateCache: (s: string, c?: string) => void;
+          };
+        }
+      ).sharedSyncService.invalidateCache(spaceId);
+      return (await messageDB.getSpaceMembers(spaceId)).length;
+    },
 
     flush: (timeoutMs?: number) => graph.outbound.flush(timeoutMs),
 

--- a/src/dev/tests/harness/spaceBot.ts
+++ b/src/dev/tests/harness/spaceBot.ts
@@ -94,6 +94,16 @@ export interface HarnessSpaceBot {
   /** Member rows currently on disk for a space. */
   members(spaceId: string): Promise<number>;
   /**
+   * Sync-handshake log lines this bot emitted, in order.
+   *
+   * The real services log every step; this captures the ones the roster bugs
+   * argue about, so a failing trial can say WHICH step died instead of only
+   * that the roster is short.
+   */
+  syncTrace: string[];
+  /** Count trace lines containing `needle`. */
+  traceCount(needle: string): number;
+  /**
    * Add `count` synthetic member rows to this bot's roster for a space.
    *
    * ⚠️ READ BEFORE USING — this is a deliberate, load-bearing shortcut and it
@@ -170,6 +180,37 @@ export async function createSpaceBot(
   /** Spaces this bot created or joined — needed to clear their timers at stop(). */
   const joinedSpaces = new Set<string>();
 
+  // ── Sync handshake trace ──────────────────────────────────────────────────
+  //
+  // The real services already log every step of the sync handshake. In a browser
+  // those lines are trapped behind DevTools and a human scrolling; in-process
+  // they are data, and they are the difference between "the roster did not
+  // arrive" and "the request was read 210s after it expired".
+  //
+  // Filtered at capture, because an unfiltered trace of a 1200-frame backlog is
+  // tens of thousands of lines. These are the steps the two roster bugs actually
+  // argue about — the chain in `2026-08-02-sync-requests-arrive-four-minutes-
+  // late…` §4, plus the member-delta counters shared #72 added.
+  const TRACE_PATTERNS = [
+    'requestSync',
+    'sync-request',
+    'sync-info',
+    'sync-initiate',
+    'sync-manifest',
+    'sync-delta',
+    'initiateSync',
+    'member delta',
+    'delta payload',
+    'informSyncData',
+  ];
+  const syncTrace: string[] = [];
+  const trace = (line: string) => {
+    if (TRACE_PATTERNS.some((p) => line.includes(p))) syncTrace.push(line);
+  };
+  /** Run a send-side operation with its log lines traced too, not just receives. */
+  const traced = <T>(fn: () => Promise<T>): Promise<T> =>
+    runAttributed({ record: () => {}, trace }, fn);
+
   /**
    * Fail loudly when the send pipeline did not drain.
    *
@@ -245,10 +286,12 @@ export async function createSpaceBot(
       graph.invitationService.constructInviteLink(spaceId),
 
     join: async (link: string) => {
-      const result = await graph.invitationService.joinInviteLink(
-        link,
-        identity.keyset,
-        passkeyInfo
+      const result = await traced(() =>
+        graph.invitationService.joinInviteLink(
+          link,
+          identity.keyset,
+          passkeyInfo
+        )
       );
       if (!result)
         throw new Error('joinInviteLink returned nothing (unparseable link?)');
@@ -307,10 +350,15 @@ export async function createSpaceBot(
       await refreshSubscriptions();
     },
 
-    requestSync: (spaceId: string) => graph.syncService.requestSync(spaceId),
+    requestSync: (spaceId: string) =>
+      traced(() => graph.syncService.requestSync(spaceId)),
 
     members: async (spaceId: string) =>
       (await messageDB.getSpaceMembers(spaceId)).length,
+
+    syncTrace,
+    traceCount: (needle: string) =>
+      syncTrace.filter((l) => l.includes(needle)).length,
 
     seedMembers: async (spaceId: string, count: number) => {
       for (let i = 0; i < count; i++) {
@@ -440,6 +488,7 @@ export async function createSpaceBot(
       record: (m: string) => {
         loggedFailure ??= m;
       },
+      trace,
     };
     try {
       await runAttributed(sink, () =>

--- a/src/dev/tests/harness/transport.ts
+++ b/src/dev/tests/harness/transport.ts
@@ -81,10 +81,16 @@ export const deleteFault = {
 type DeleteInbox = QuorumApiClient['deleteInbox'];
 
 export function makeApiClient(): QuorumApiClient {
-  const client = new QuorumApiClient({ baseUrl: config.apiUrl, wsUrl: config.wsUrl });
+  const client = new QuorumApiClient({
+    baseUrl: config.apiUrl,
+    wsUrl: config.wsUrl,
+  });
   if (deleteFault.delayMs > 0) {
     const original = client.deleteInbox.bind(client) as DeleteInbox;
-    const every = Math.max(1, Math.round(1 / Math.min(1, Math.max(0.0001, deleteFault.rate))));
+    const every = Math.max(
+      1,
+      Math.round(1 / Math.min(1, Math.max(0.0001, deleteFault.rate)))
+    );
     (client as unknown as { deleteInbox: DeleteInbox }).deleteInbox = ((
       ...args: Parameters<DeleteInbox>
     ) => {
@@ -95,7 +101,9 @@ export function makeApiClient(): QuorumApiClient {
       // which is the thing under test; doing it here also keeps the stall exactly
       // as long as configured instead of at the mercy of the client's own
       // timeout/retry arithmetic, so the expected histogram bucket is predictable.
-      return new Promise((r) => setTimeout(r, deleteFault.delayMs)).then(() => original(...args));
+      return new Promise((r) => setTimeout(r, deleteFault.delayMs)).then(() =>
+        original(...args)
+      );
     }) as DeleteInbox;
   }
   return client;
@@ -129,7 +137,10 @@ export class WsTransport {
   /** Inbound dispatch is serialized — see dispatch(). */
   private chain: Promise<void> = Promise.resolve();
   /** Handler invocations started but not yet settled — see stuckFrames(). */
-  private inFlightFrames = new Map<number, { fp: string; inbox: string; at: number }>();
+  private inFlightFrames = new Map<
+    number,
+    { fp: string; inbox: string; at: number }
+  >();
   private dispatchSeq = 0;
 
   constructor(private readonly wsUrl: string = config.wsUrl) {}
@@ -140,7 +151,9 @@ export class WsTransport {
 
   /** Stable id for a frame, so redelivered copies are recognised. */
   static fingerprint(frame: InboundFrame): string {
-    return fnv1a(String((frame as { encryptedContent?: string }).encryptedContent ?? ''));
+    return fnv1a(
+      String((frame as { encryptedContent?: string }).encryptedContent ?? '')
+    );
   }
 
   /**
@@ -155,7 +168,10 @@ export class WsTransport {
       const s =
         typeof rawOrFrame === 'string'
           ? rawOrFrame
-          : String((rawOrFrame as { encryptedContent?: string }).encryptedContent ?? '');
+          : String(
+              (rawOrFrame as { encryptedContent?: string }).encryptedContent ??
+                ''
+            );
       obj = JSON.parse(s) as Record<string, unknown>;
     } catch {
       return undefined;
@@ -165,7 +181,10 @@ export class WsTransport {
       obj && typeof obj.envelope === 'string'
         ? obj
         : (obj?.message as Record<string, unknown> | undefined);
-    const env = sealed && typeof sealed.envelope === 'string' ? sealed.envelope : undefined;
+    const env =
+      sealed && typeof sealed.envelope === 'string'
+        ? sealed.envelope
+        : undefined;
     return env ? fnv1a(env) : undefined;
   }
 
@@ -311,7 +330,8 @@ export class WsTransport {
         });
 
         ws.on('error', (err: Error) => {
-          if (!this.connected) reject(new Error(`WS connect failed: ${err.message}`));
+          if (!this.connected)
+            reject(new Error(`WS connect failed: ${err.message}`));
         });
       };
       open();
@@ -320,27 +340,52 @@ export class WsTransport {
 
   /** Subscribe to inbox addresses. Remembered and re-sent on reconnect. */
   listen(inboxAddresses: string[]): void {
-    this.subscriptions = Array.from(new Set([...this.subscriptions, ...inboxAddresses]));
+    this.subscriptions = Array.from(
+      new Set([...this.subscriptions, ...inboxAddresses])
+    );
     if (this.connected) this.sendListen(this.subscriptions);
   }
 
   private sendListen(inboxAddresses: string[]): void {
-    this.ws?.send(JSON.stringify({ type: 'listen', inbox_addresses: inboxAddresses }));
+    this.ws?.send(
+      JSON.stringify({ type: 'listen', inbox_addresses: inboxAddresses })
+    );
   }
 
   /** Raw send — pushes an outbound sealed frame, and records it for loss counting. */
   send(raw: string): void {
     let target: string | undefined;
     try {
-      const o = JSON.parse(raw) as { inbox_address?: string; message?: { inbox_address?: string } };
+      const o = JSON.parse(raw) as {
+        inbox_address?: string;
+        message?: { inbox_address?: string };
+      };
       target = o.inbox_address ?? o.message?.inbox_address;
-    } catch { /* not JSON — still counted */ }
-    this.sent.push({ t: Date.now(), fp: WsTransport.ciphertextFp(raw), target });
+    } catch {
+      /* not JSON — still counted */
+    }
+    this.sent.push({
+      t: Date.now(),
+      fp: WsTransport.ciphertextFp(raw),
+      target,
+    });
     this.ws?.send(raw);
   }
 
   close(): void {
     this.closed = true;
     this.ws?.close();
+  }
+
+  /**
+   * Undo `close()`'s latch so `connect()` works again.
+   *
+   * `close()` sets `closed = true` specifically to stop the 1s auto-reconnect in
+   * `ws.on('close')`, which is right for teardown and wrong for a scenario that
+   * deliberately takes a client offline and brings it back. Without this a
+   * reconnect silently produces a socket that is immediately abandoned.
+   */
+  reopen(): void {
+    this.closed = false;
   }
 }


### PR DESCRIPTION
Slice S2 of the space harness, plus the two things that turned it from a rate
into a diagnosis. Instrument only — **no fix is attempted here.**

## What it does

| scenario | question it answers |
|---|---|
| `space-rate` | how often does a new joiner receive the full roster, and does it depend on roster size? |
| `space-backlog` | does a reconnect backlog starve the roster handshake? |

Both are instruments, not regression tests: they print a rate and fail only if no
trial completed. Asserting a pass rate would turn a measurement into a coin flip
that goes red exactly on the days the number matters most.

## Results

**Roster size is exonerated.** 15/15 delivered at 2, 25 and 79 members, flat
~4.7 s each. That mattered because `chunkMembers()` is dead code, so the member
delta ships as one unbounded payload at any size — it is built, sent and applied
intact every time.

**Reconnect backlog is the variable, and it has a cliff:**

| backlog | frames received | rate | median lag |
|---|---|---|---|
| 0 | 15 | 100% | 5.1 s |
| 100 | 417 | 100% | 23.0 s |
| 300 | 1201 | **0%** | — (`rows=1/80`) |

`rows=1/80` is the field symptom verbatim. The lag crosses
`DEFAULT_SYNC_EXPIRY_MS` (30 s) exactly where delivery stops.

## And the handshake trace names the failing step

```
requestSync=4   sync-info=12   Adding candidate=0
No suitable candidates=2   sync-delta=0   member delta=0

sync-info from: …, hasSession: true, isExpired: true
sync-info payload: {"messageCount":1,"memberCount":80,"hasSummary":true}
sync-info: No active session or expired, ignoring
```

**Twelve `sync-info` replies arrived, each advertising the full 80-member roster,
and every one was discarded** because the joiner's own 30 s window had closed
before it got round to reading them. Not lost in transit, not a bad digest, not
the member payload going missing — the peer answered, the answer arrived, and the
receiver refused it on its own expiry bookkeeping.

Note `requestSync=4`: it already retried three extra times and each retry failed
identically. "Retry more" is therefore not the fix. The frame **arrives** in time
and is **read** too late — expiry is judged at processing time, not arrival time.

This confirms §5b step 1 of
`bugs/2026-08-02-sync-requests-arrive-four-minutes-late-and-every-peer-rejects-them.md`,
which asked for exactly this before any code was written, and reproduces its §3
stale-answer corollary deterministically.

## Notable implementation points

- **Seeded member rows** let roster size vary without N registrations per trial.
  Sound because the responder builds its delta only from
  `storage.getSpaceMembers` and the receiver validates nothing against the
  manifest. The scope limit is documented on the method: it measures whether a
  roster of size N is *delivered*, not the behaviour of N live clients.
- **Handshake tracing** taps `logger.log` through the same async-context
  attribution used for failures — installed once, never restored, so two bots
  cannot corrupt each other's trace.
- `WsTransport.reopen()` — `close()` latches `closed` to stop the auto-reconnect,
  which is right for teardown and wrong for a scenario that deliberately takes a
  client offline and brings it back.

## What this does NOT establish

That the backlog is the *only* cause in the field. The socket behaviour that
needs real devices remains out of reach — see "Why every bench was green" in
`tasks/transport/measurements.md`. What is established is that a reconnect
backlog is a **sufficient** cause: the symptom can now be produced on demand,
which means a candidate fix can be validated before it ships.

## Verification

`tsc --noEmit` and `eslint` clean. Scenarios verified live against production;
the numbers above are the runs. No CI in this repo, so these are local results.
