### PR TITLE
fix: the roster check now survives a sync window that expired

### DIFF
--- a/src/dev/tests/services/MessageService.rosterConvergence.unit.test.ts
+++ b/src/dev/tests/services/MessageService.rosterConvergence.unit.test.ts
@@ -14,13 +14,19 @@
  * control frame — rather than calling the scheduler directly. It is the only
  * test in either repo that proves the feature is connected to anything.
  *
- * It pins three things:
+ * It pins these things:
  *   1. a `sync-info` advertising more members than we hold leads to a re-ask;
  *   2. several `sync-info` answers to ONE request collapse into ONE re-ask
  *      (the debounce — without it every peer that replies arms its own timer);
- *   3. a client that is already converged asks for nothing.
+ *   3. a client that is already converged asks for nothing;
+ *   4. an EXPIRED or absent sync session still arms the check — see below, this
+ *      is the case the whole mechanism exists for and it was the one case that
+ *      did not work;
+ *   5. arming the check does NOT mean syncing from an offer we are no longer
+ *      entitled to use. The expiry gate is untouched; only the tracker moved
+ *      out from behind it.
  *
- * See .agents/bugs/2026-08-02-roster-pull-delivers-nothing-to-a-new-joiner.md
+ * See .agents/issues/.open/2026-08-02-roster-pull-delivers-nothing-to-a-new-joiner.md
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -192,6 +198,68 @@ describe('sync-info arms the roster convergence check', () => {
     localMembers = Array.from({ length: 88 }, (_, i) => ({ user_address: `addr-${i}` }));
 
     await deliver(90);
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    expect(mockDeps.requestSync).not.toHaveBeenCalled();
+  });
+
+  // ── The case this whole mechanism exists for ─────────────────────────────
+  //
+  // A client reconnecting onto a long backlog drains its inbound queue serially.
+  // Its `sync-request` goes out, peers answer, and by the time those answers are
+  // processed the 30s window has closed. Measured 2026-08-02 at a 300-message
+  // backlog: twelve answers, every one advertising 80 members, every one
+  // discarded on `isExpired: true`.
+  //
+  // The tracker used to live INSIDE that gate, so this exact client — the one
+  // holding 1 row of 80, with no session left and nothing else to try — learned
+  // no target and armed no check. The repair was silent in the only failure it
+  // was written for.
+  it('still arms the check when our request window has already expired', async () => {
+    localMembers = [{ user_address: SELF }]; // 1 row, against an advertised 90
+    // The session exists, but its window closed while we drained the backlog.
+    mockDeps.syncInfo.current[SPACE_ID].expiry = Date.now() - 1;
+
+    await deliver(90);
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    expect(mockDeps.requestSync).toHaveBeenCalledWith(SPACE_ID);
+  });
+
+  // The counterpart to the test above, and the reason it is safe: hoisting the
+  // tracker out of the gate must NOT hoist the gate's actual decision with it.
+  // An offer that arrived after our window closed is still an offer we may not
+  // sync from — we bank what it advertises and ask again, nothing more.
+  it('does not sync from an offer that arrived after the window closed', async () => {
+    localMembers = [{ user_address: SELF }];
+    mockDeps.syncInfo.current[SPACE_ID].expiry = Date.now() - 1;
+
+    await deliver(90);
+
+    expect(mockDeps.syncInfo.current[SPACE_ID].candidates).toHaveLength(0);
+    expect(mockDeps.initiateSync).not.toHaveBeenCalled();
+  });
+
+  // The other half of the gate: no session at all, which is where a client sits
+  // once its sync state has been torn down. A peer's answer is still true.
+  it('still arms the check when there is no sync session at all', async () => {
+    localMembers = [{ user_address: SELF }];
+    delete mockDeps.syncInfo.current[SPACE_ID];
+
+    await deliver(90);
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    expect(mockDeps.requestSync).toHaveBeenCalledWith(SPACE_ID);
+  });
+
+  // A frame that teaches us nothing must not arm anything. Without a target
+  // `shouldReAsk` can only answer `no-target`, so arming would buy a timer and
+  // a database read to reach a foregone conclusion.
+  it('arms nothing when the advertised count is unusable', async () => {
+    localMembers = [{ user_address: SELF }];
+    mockDeps.syncInfo.current[SPACE_ID].expiry = Date.now() - 1;
+
+    await deliver(0);
     await vi.advanceTimersByTimeAsync(20_000);
 
     expect(mockDeps.requestSync).not.toHaveBeenCalled();

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -5571,6 +5571,36 @@ export class MessageService {
               memberCount: envelope.message.memberCount,
               hasSummary: !!envelope.message.summary,
             });
+            // ⚠️ These two calls sit OUTSIDE the session gate below, and that
+            // placement is the entire point of them. They were INSIDE it until
+            // 2026-08-03, which left the convergence check disarmed in exactly
+            // the case it was built to repair.
+            //
+            // What a peer advertises is true whether or not our own request
+            // window is still open. The gate below answers a different
+            // question — "may we sync FROM this offer, in THIS session?" — and
+            // it is still right to answer that with the expiry. But learning
+            // what is out there is not acting on the offer, and it does not
+            // need permission from a window we opened.
+            //
+            // Measured 2026-08-02 against a 300-message reconnect backlog:
+            // twelve `sync-info` frames arrived, every one advertising 80
+            // members, and every one fell to the `else` branch on
+            // `isExpired: true` — the inbound queue took longer to drain than
+            // the 30s window. With these calls inside the gate the tracker
+            // learned nothing, no check was ever armed, and the client sat on
+            // 1 row of 80 with nothing left to try. The roster landed 0/2 that
+            // way, and 2/2 when the same request was simply made again once the
+            // flood had drained. The request was never wrong; only its timing
+            // was, which is why re-asking is the whole repair.
+            //
+            // See .agents/issues/.open/2026-08-02-sync-requests-arrive-four-minutes-late-and-every-peer-rejects-them.md
+            const learnedTarget = this.rosterConvergence.noteAdvertisedRoster(
+              spaceId,
+              envelope.message.memberCount ?? envelope.message.summary?.memberCount
+            );
+            if (learnedTarget) this.scheduleRosterConvergenceCheck(spaceId);
+
             if (hasSession && !isExpired) {
               if (
                 envelope.message.inboxAddress &&
@@ -5578,16 +5608,6 @@ export class MessageService {
               ) {
                 logger.log(`[MessageService] sync-info: Adding candidate and scheduling sync`);
                 this.syncInfo.current[spaceId].candidates.push(envelope.message);
-                // Remember what this peer says it holds, and arm a check that
-                // we actually received it. The member half of a delta is ONE
-                // payload with no retry, so losing that frame loses the whole
-                // roster silently — measured 2026-08-02, where the same join
-                // delivered 0 rows on one run and 71 on the next.
-                this.rosterConvergence.noteAdvertisedRoster(
-                  spaceId,
-                  envelope.message.memberCount ?? envelope.message.summary?.memberCount
-                );
-                this.scheduleRosterConvergenceCheck(spaceId);
                 // reset the timeout to be 1s to more aggressively grab viable candidates for sync instead of waiting the full 30s
                 clearTimeout(this.syncInfo.current[spaceId].invokable);
                 this.syncInfo.current[spaceId].invokable =
@@ -5599,7 +5619,13 @@ export class MessageService {
                 logger.log(`[MessageService] sync-info: Missing inboxAddress or counts, ignoring`);
               }
             } else {
-              logger.log(`[MessageService] sync-info: No active session or expired, ignoring`);
+              // NOT "ignoring" any more, and the wording matters to whoever
+              // reads this log next: we cannot sync from this offer, but we
+              // have banked what it advertised and a re-ask is pending.
+              logger.log(
+                `[MessageService] sync-info: No active session or expired — cannot sync from ` +
+                  `this offer, roster check armed: ${learnedTarget}`
+              );
             }
           } else if (envelope.message.type === 'sync-initiate') {
             logger.log(`[MessageService] sync-initiate received from: ${envelope.message.inboxAddress?.substring(0, 12)}`);

--- a/src/utils/rosterConvergence.ts
+++ b/src/utils/rosterConvergence.ts
@@ -20,20 +20,28 @@
 // obviously short. No new message type, no wire change, no dependency on the
 // transport work.
 //
+// ⚠️ WHERE THIS IS WIRED IN MATTERS AS MUCH AS WHAT IT DECIDES. The two calls
+// that drive it — `noteAdvertisedRoster` and the scheduler — must stay OUTSIDE
+// the sync-session expiry gate in `MessageService`'s `sync-info` handler. They
+// were inside it until 2026-08-03, which meant a client whose request window
+// expired while it drained a reconnect backlog never learned a target and never
+// armed a check: this module was silent in precisely the failure it exists for.
+// Read the comment at that call site before moving either call.
+//
 // ⚠️ This is a MITIGATION, not the repair. The real fix is either chunking the
 // member half or desktop consuming the send-retention fix that shipped in shared
-// 2.1.0-39 (transport item B1). Read `.agents/tasks/transport/README.md` before
+// 2.1.0-39 (transport item B1). Read `.agents/issues/transport/README.md` before
 // deciding this is enough.
 //
 // ⚠️ OBSERVABILITY. `shouldReAsk` returns a REASON, not a boolean, and the
 // caller logs it on every branch. That is not gold-plating: `logger` is a no-op
 // in production builds (see
-// .agents/bugs/2026-08-01-every-logger-call-is-a-no-op-in-production-builds.md),
+// .agents/issues/.open/2026-08-01-every-logger-call-is-a-no-op-in-production-builds.md),
 // so a developer running a dev build is the ONLY audience this code will ever
 // have, and giving them "false" with no reason attached reproduces exactly the
 // blindness that made the original bug take a session to find.
 //
-// See .agents/bugs/2026-08-02-roster-pull-delivers-nothing-to-a-new-joiner.md
+// See .agents/issues/.open/2026-08-02-roster-pull-delivers-nothing-to-a-new-joiner.md
 // (NEXT STEP B).
 
 import { advertisedCount } from '@quilibrium/quorum-shared';
@@ -133,8 +141,15 @@ export interface RosterConvergenceState {
 }
 
 export interface RosterConvergenceTracker {
-  /** Record what a peer says it holds. Ignores absent or nonsensical counts. */
-  noteAdvertisedRoster(spaceId: string, memberCount: unknown, now?: number): void;
+  /**
+   * Record what a peer says it holds. Ignores absent or nonsensical counts.
+   *
+   * Returns whether a usable target was actually recorded. The caller needs
+   * that to decide whether arming a convergence check buys anything: with no
+   * target `shouldReAsk` can only ever answer `no-target`, so arming would
+   * spend a timer and a database read reaching a foregone conclusion.
+   */
+  noteAdvertisedRoster(spaceId: string, memberCount: unknown, now?: number): boolean;
   /** Are we obviously short of the best roster on offer, and allowed to ask again? */
   shouldReAsk(spaceId: string, localMemberCount: number, now?: number): ReAskDecision;
   /** Record that a re-ask was sent. Call this ONLY after actually sending one. */
@@ -187,7 +202,7 @@ export function createRosterConvergenceTracker(
       // An absurd value here would set a target that can never be reached, so
       // the check below would spend its whole allowance every window forever.
       const count = advertisedCount(memberCount as number | undefined | null);
-      if (count === 0) return;
+      if (count === 0) return false;
 
       const existing = states.get(spaceId);
       if (!existing) {
@@ -197,13 +212,14 @@ export function createRosterConvergenceTracker(
           lastReAskAt: 0,
           windowStartedAt: now,
         });
-        return;
+        return true;
       }
       rollWindow(existing, now);
       // Keep the BEST offer seen, not the latest. Several peers answer one
       // request and they hold different amounts; the target is the fullest
       // roster available, not whichever client happened to reply last.
       if (count > existing.bestAdvertised) existing.bestAdvertised = count;
+      return true;
     },
 
     shouldReAsk(spaceId, localMemberCount, now = Date.now()) {


### PR DESCRIPTION
Fixes the roster-delivery failure for a client that reconnects onto a long
backlog. **Three files, and the behaviour change is two calls moving out from
behind a gate.**

## The failure

A client reconnecting onto a backlog drains its inbound queue serially. Its
`sync-request` goes out, peers answer, and by the time those answers are
processed the 30 s window has closed — so every offer is discarded and the
joiner keeps 1 member row out of 80, with nothing left to try.

Measured 2026-08-02 at a 300-message backlog: **twelve** `sync-info` frames
arrived, every one advertising `memberCount: 80`, every one dropped on
`isExpired: true`.

## Why the existing repair could not help

The re-ask machinery for exactly this shipped in #296. But both calls that drive
it — `noteAdvertisedRoster` and the scheduler — sat **inside** the expiry gate.
So the one failure it was written for was also the one case that disarmed it: no
target was ever learned, no check was ever armed, and it went silent precisely
when it was needed.

## The change

Move those two calls out of the gate. What a peer advertises is true whether or
not our request window is still open; the gate answers a different question —
*"may we sync FROM this offer, in this session?"* — and still answers it
unchanged. `noteAdvertisedRoster` now reports whether it recorded a usable
target, so a check is armed only when there is something to converge to.

**No new mechanism and no timing heuristic.** The convergence check is already
debounced per space, so it fires once the answers stop arriving — which is
already the quiet moment a re-ask needs.

## Result

`space-backlog`, with its **simulated late re-ask disabled** so this measures the
product path rather than the scenario's own scaffolding:

| backlog | trials | delivered | rate | median lag |
|---|---|---|---|---|
| 0 | 2 | 2 | 100% | 4.8 s |
| 300 | 2 | 2 | **100%** | 79.5 s |

The 300 row was **0%** before this change. The healthy path is unchanged (4.7 s →
4.8 s), and the two 300 trials landed 79.8 s and 79.3 s — 0.5 s apart, which is a
timer firing rather than luck.

## Cost, stated plainly

Bounds are the existing ones: at most two re-asks per space per 15 minutes, 60 s
cooldown. This does mean a client in many spaces can now send up to two extra
`sync-request` broadcasts per space where it previously sent none. The debounce
places them after each space's flood has drained rather than during it, but it is
more traffic than before in exactly the congested case.

Expiry semantics are untouched, on both platforms. No wire change, no change to
`quorum-shared`.

## Verification

- `yarn test:run` — **58 files, 888 tests, all passing.**
- The two new positive tests were confirmed to **fail** with the fix reverted, so
  they are load-bearing rather than vacuous.
- `tsc --noEmit` clean; `eslint` clean on the changed files (two pre-existing
  warnings elsewhere in `MessageService.ts` are untouched).
- Harness numbers above are live runs against production.

## Scope limit

This fixes the backlog-starvation path, which is the one the harness can host. It
is not a claim about every field report — the socket conditions that need real
devices remain out of reach here, so this wants one real two-client run before it
is trusted in the field.
