### PR TITLE
fix: Space delete no longer promises what it cannot do

### DIFF
--- a/.agents/INDEX.md
+++ b/.agents/INDEX.md
@@ -118,6 +118,7 @@ This is the main index for all documentation, bug reports, and task management.
 - 📋 [Identity announce: cap the retries](issues/2026-08-01-identity-announce-cadence-research.md)
 - 📋 [Spaces: desktop never re-announces identity on connect](issues/2026-08-01-space-member-identity-announce-on-connect.md)
 - 📋 [Promote the identity-announce gate to shared](issues/2026-08-02-promote-identity-announce-gate-to-shared.md)
+- 🐛 ["Delete Space" is Leave with a destructive-sounding label, and the owner must never click it](issues/2026-08-02-delete-space-is-leave-and-can-permanently-brick-a-space.md)
 
 #### Messagedb
 
@@ -295,7 +296,6 @@ This is the main index for all documentation, bug reports, and task management.
 - 🐛 [Space sync member reconciliation ignores — and erases — the global identity slot](issues/.open/2026-08-01-space-sync-member-delta-blind-to-and-erases-global-slot.md)
 - 🐛 [A deleted space tag can no longer be cleared from a member roster](issues/.open/2026-08-01-space-tag-can-no-longer-be-cleared-from-a-member-roster.md)
 - 🐛 [vitest intermittently runs 4% of the suite](issues/.open/2026-08-01-vitest-intermittently-runs-4-percent-of-the-suite.md)
-- 🐛 ["Delete Space" is Leave with a destructive-sounding label, and the owner must never click it](issues/.open/2026-08-02-delete-space-is-leave-and-can-permanently-brick-a-space.md)
 - 🐛 [The roster pull: what it actually does](issues/.open/2026-08-02-roster-pull-delivers-nothing-to-a-new-joiner.md)
 - 🐛 [Sync requests expire unread, behind a reconnect backlog](issues/.open/2026-08-02-sync-requests-arrive-four-minutes-late-and-every-peer-rejects-them.md)
 - 📋 [User Status Feature Implementation Plan](issues/.open/2025-01-20-user-status.md)

--- a/.agents/issues/2026-08-02-delete-space-is-leave-and-can-permanently-brick-a-space.md
+++ b/.agents/issues/2026-08-02-delete-space-is-leave-and-can-permanently-brick-a-space.md
@@ -1,16 +1,42 @@
 ---
 type: bug
 title: "\"Delete Space\" is actually Leave, the dialog promises otherwise, and an owner clicking it permanently bricks the space"
-status: OPEN — found 2026-08-02 during adversarial verification of two space key-management bugs filed in quorum-mobile. Not yet runtime-reproduced.
+status: in-progress
 created: 2026-08-02
-severity: high (UI promises a permanent destructive action and performs a no-op for everyone else; owner use leaves the space permanently un-kickable and un-rotatable, with no recovery path)
+severity: medium — was high. The dangerous half is neutralised in release builds as of 2026-08-03 (see Update): the button is disabled, so an owner can no longer brick a Space with it, and no dialog claims a deletion that does not happen. What remains is the absence of real deletion, which is blocked on a backend endpoint.
 area: space management / space deletion + leaving / ownership
 repo: quorum-desktop
 related:
-  - "quorum-mobile .agents/bugs/2026-08-02-config-key-rotation-on-kick-destroys-space-history.md (ownerless spaces can never receive that fix — see §4)"
-  - "quorum-mobile .agents/bugs/2026-08-02-leaving-a-space-revokes-no-access.md (the leave path this button actually invokes)"
+  - "quorum-mobile .agents/issues/2026-08-02-make-delete-space-actually-delete.md (the cross-repo tracker for the remaining work — read this one first)"
+  - "quorum-mobile .agents/issues/.open/2026-08-02-config-key-rotation-on-kick-destroys-space-history.md (ownerless spaces can never receive that fix — see §4)"
+  - "quorum-mobile .agents/issues/.open/2026-08-02-leaving-a-space-revokes-no-access.md (the leave path this button actually invokes)"
   - "issues/.done/user-kick-role-permission-non-functional.md (independently root-caused the owner-key constraint that makes §3 permanent)"
 ---
+
+> ## Update 2026-08-03 — the lying is fixed, the deletion is not
+>
+> **Landed on desktop** (branch `fix/space-delete-stop-promising-what-it-does-not-do`):
+> the Danger tab no longer claims permanent space-wide deletion, the type-to-confirm
+> and its channel/member counts are gone, the button is **disabled in release builds**
+> with copy explaining why, the tab is labelled "Danger" rather than "Delete Space",
+> and the dead `isOwner = true` stub from §2 is deleted outright (nothing consumed it;
+> `useSpaceOwner` was already the real predicate everywhere that mattered). Dev builds
+> keep the action under the honest label "Leave this Space", because that is what
+> `SpaceService.deleteSpace` actually does. Covered by
+> `src/dev/tests/hooks/spaceOwnerPredicate.unit.test.ts`.
+>
+> **§1 and the §2 stub are therefore resolved. §3 is not reachable in a release build
+> any more** — an owner cannot press the button, so they cannot brick a Space with it.
+>
+> **Still open, and why this stays a bug rather than moving to `.done/`:** there is no
+> way to delete a Space. That needs a server-side purge endpoint that does not exist in
+> any repo this team holds, plus a tombstone so a purged Space cannot be silently
+> re-registered by the client self-heal. Both are specified in the cross-repo tracker
+> above, §4. Do not close this until deletion actually works; the current state is an
+> honest disabled button, not a fixed feature.
+>
+> Note also that §3's premise is narrower than written: the owner key is not confined
+> to the creating device once cross-device sync is on. See §4B finding 2 of the tracker.
 
 # "Delete Space" is Leave with a destructive-sounding label, and the owner must never click it
 

--- a/src/components/modals/SpaceSettingsModal/Danger.tsx
+++ b/src/components/modals/SpaceSettingsModal/Danger.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
-import { Button, Callout, Input, Icon } from '../../primitives';
+import { Button, Callout, Icon } from '../../primitives';
 import { Trans } from '@lingui/react/macro';
-import { t } from '@lingui/core/macro';
-import { useSpaceMembers } from '../../../hooks';
 
 interface DangerProps {
   space: any;
@@ -11,62 +9,65 @@ interface DangerProps {
   clearDeleteError: () => void;
 }
 
+// Deleting a Space for real needs a server-side purge that does not exist yet: no
+// endpoint removes a Space's registration, manifest, hub log or invite evals, and the
+// existing ones cannot be composed into one.
+//
+// What this button actually calls is the LEAVE flow. SpaceService.deleteSpace
+// broadcasts a `leave`, calls postHubDelete for the caller's own inbox, and erases the
+// caller's local copy. Every other member keeps the Space, its channels and all its
+// messages — so the old copy ("will permanently delete this Space and all of its
+// channels and messages") was false for everyone except the clicker.
+//
+// It is worse than a mislabel for the owner, and this tab is owner-only (Navigation
+// gates `danger` behind useSpaceOwner). Ownership is possession of the `owner` key
+// slot, there is no transfer and no second copy, and the wipe takes it. An owner who
+// used this kept the Space running for everyone while destroying their own ability to
+// kick, rekey or ever delete it.
+//
+// So: release builds disable it and say why. Dev builds keep it, because a tester
+// needs disposable Spaces gone, under a label that names what it does.
+const IS_DEV = process.env.NODE_ENV === 'development';
+
 const Danger: React.FunctionComponent<DangerProps> = ({
   space,
   handleDeleteSpace,
   deleteError,
   clearDeleteError,
 }) => {
-  const [confirmInput, setConfirmInput] = React.useState('');
-  const isConfirmed = confirmInput.trim().toLowerCase() === 'delete';
-
-  const { data: members } = useSpaceMembers({ spaceId: space?.spaceId });
-
-  const channelCount = React.useMemo(
-    () =>
-      space?.groups?.reduce(
-        (total: number, group: any) => total + (group.channels?.length || 0),
-        0
-      ) ?? 0,
-    [space?.groups]
-  );
-  const memberCount = members?.length ?? 0;
-
   return (
     <>
       <div className="modal-content-header">
         <div className="modal-text-section">
           <div className="text-title text-danger flex items-center gap-2">
             <Icon name="warning" size="lg" />
-            <Trans>Delete this Space</Trans>
+            {IS_DEV ? (
+              <Trans>Leave this Space (dev build)</Trans>
+            ) : (
+              <Trans>Delete this Space</Trans>
+            )}
           </div>
           <div className="pt-2 text-body">
-            <Trans>
-              This action cannot be undone and will permanently delete this Space and
-              all of its channels and messages.
-            </Trans>
+            {IS_DEV ? (
+              <Trans>
+                Dev builds only. This does not delete the Space. It announces that you
+                have left, removes your inbox from the hub, and erases your local copy.
+                Every other member keeps the Space, its channels and all of its
+                messages, and you lose the ability to manage it for good.
+              </Trans>
+            ) : (
+              <Trans>
+                Deleting a Space is not available yet. Today this would only remove your
+                own copy: everyone else would keep the Space, its channels and all of
+                its messages, and you would permanently lose the ability to manage it.
+              </Trans>
+            )}
           </div>
 
           {space && (
             <div className="mt-6 border border-default rounded-md">
               <div className="p-3 bg-chat rounded">
-                <div className="flex flex-col gap-2">
-                  <div className="text-label-strong font-bold">
-                    {space.spaceName}
-                  </div>
-                  <div className="flex items-center gap-1.5">
-                    <Icon name="hashtag" size="xs" />
-                    <span className="text-label-strong">
-                      {channelCount} {channelCount === 1 ? 'channel' : 'channels'}
-                    </span>
-                  </div>
-                  <div className="flex items-center gap-1.5">
-                    <Icon name="users" size="xs" />
-                    <span className="text-label-strong">
-                      {memberCount} {memberCount === 1 ? 'member' : 'members'}
-                    </span>
-                  </div>
-                </div>
+                <div className="text-label-strong font-bold">{space.spaceName}</div>
               </div>
             </div>
           )}
@@ -79,26 +80,24 @@ const Danger: React.FunctionComponent<DangerProps> = ({
                 dismissible
                 onClose={clearDeleteError}
               >
-                <Trans>An error occurred while deleting the Space. Please try again.</Trans>
+                <Trans>An error occurred. Please try again.</Trans>
               </Callout>
             </div>
           )}
+
+          {/* The type-to-confirm input and the channel/member counts were removed
+              rather than disabled. Typing a keyword beside "N channels, N members" is
+              the strongest "you are destroying something shared" signal this app has,
+              and it sat on an action that only ever affected the person clicking it.
+              A real delete needs a confirmation written against what that does. */}
           <div className="pt-6">
-            <Input
-              value={confirmInput}
-              onChange={setConfirmInput}
-              placeholder={t`Type DELETE to confirm`}
-              variant="bordered"
-            />
-          </div>
-          <div className="pt-4">
             <Button
               type="danger"
               className="!w-auto !inline-flex"
-              disabled={!isConfirmed}
+              disabled={!IS_DEV}
               onClick={handleDeleteSpace}
             >
-              <Trans>Delete Space</Trans>
+              {IS_DEV ? <Trans>Leave Space</Trans> : <Trans>Delete Space</Trans>}
             </Button>
           </div>
         </div>

--- a/src/components/modals/SpaceSettingsModal/Navigation.tsx
+++ b/src/components/modals/SpaceSettingsModal/Navigation.tsx
@@ -41,7 +41,10 @@ const Navigation: React.FunctionComponent<NavigationProps> = ({
     { id: 'emojis', icon: 'smile', label: t`Emojis`, className: '' },
     { id: 'stickers', icon: 'image', label: t`Stickers`, className: '' },
     { id: 'invites', icon: 'user-plus', label: t`Invites`, className: '' },
-    { id: 'danger', icon: 'warning', label: t`Delete Space`, className: 'text-danger' },
+    // Labelled "Danger", not "Delete Space": deleting is not available yet, and a tab
+    // named after a capability the app does not have is the same overpromise the tab's
+    // own copy was fixed for. Matches mobile's Danger tab.
+    { id: 'danger', icon: 'warning', label: t`Danger`, className: 'text-danger' },
   ];
 
   // Owners see everything. Non-owners see Account always + Invites only when

--- a/src/dev/tests/hooks/spaceOwnerPredicate.unit.test.ts
+++ b/src/dev/tests/hooks/spaceOwnerPredicate.unit.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from 'vitest';
+import { buildSpaceOwnerFetcher } from '@/hooks/queries/spaceOwner/buildSpaceOwnerFetcher';
+import type { MessageDB } from '@/db/messages';
+
+/**
+ * Ownership is possession of the `owner` key slot, and nothing else.
+ *
+ * There is no ownership flag on the Space record, no server-side owner lookup a client
+ * can ask, and no ownership transfer. This fetcher is therefore the single gate in
+ * front of every owner-only surface: the Space settings tabs, the owner entries in the
+ * Space context menu, and the withholding of "Leave" from owners.
+ *
+ * It is pinned because the wrong answer shipped for a long time right next to it —
+ * `useSpaceManagement` returned a hardcoded `const isOwner = true`, which would grant
+ * owner UI to every member. That stub is now deleted, and these tests exist so the
+ * surviving implementation cannot drift into the same shape unnoticed.
+ */
+
+const dbWithKeys = (keys: Record<string, unknown>) =>
+  ({
+    getSpaceKey: vi.fn(async (spaceId: string, keyId: string) => keys[`${spaceId}:${keyId}`]),
+  }) as unknown as MessageDB;
+
+const SPACE_ID = 'space-under-test';
+
+describe('buildSpaceOwnerFetcher', () => {
+  it('is false when this device holds no owner key for the Space', async () => {
+    const messageDB = dbWithKeys({});
+
+    await expect(buildSpaceOwnerFetcher({ messageDB, spaceId: SPACE_ID })()).resolves.toBe(
+      false
+    );
+  });
+
+  it('is false on a member device that holds every other key for the Space', async () => {
+    // A joined member legitimately holds the space, config, hub and inbox keys. Only
+    // the owner slot is absent, and only that slot decides ownership.
+    const messageDB = dbWithKeys({
+      [`${SPACE_ID}:${SPACE_ID}`]: { privateKey: 'x' },
+      [`${SPACE_ID}:config`]: { privateKey: 'x' },
+      [`${SPACE_ID}:hub`]: { privateKey: 'x' },
+      [`${SPACE_ID}:inbox`]: { privateKey: 'x' },
+    });
+
+    await expect(buildSpaceOwnerFetcher({ messageDB, spaceId: SPACE_ID })()).resolves.toBe(
+      false
+    );
+  });
+
+  it('is true once the owner key is present', async () => {
+    const messageDB = dbWithKeys({ [`${SPACE_ID}:owner`]: { privateKey: 'x' } });
+
+    await expect(buildSpaceOwnerFetcher({ messageDB, spaceId: SPACE_ID })()).resolves.toBe(
+      true
+    );
+  });
+
+  it('asks for the owner slot of the requested Space, not another key or another Space', async () => {
+    // Pins both arguments. Querying the wrong slot would answer a different question
+    // entirely while still returning a plausible boolean.
+    const messageDB = dbWithKeys({ [`${SPACE_ID}:owner`]: { privateKey: 'x' } });
+
+    await buildSpaceOwnerFetcher({ messageDB, spaceId: SPACE_ID })();
+
+    expect(messageDB.getSpaceKey).toHaveBeenCalledWith(SPACE_ID, 'owner');
+  });
+
+  it('does not treat another Space’s owner key as ownership of this one', async () => {
+    const messageDB = dbWithKeys({ 'a-different-space:owner': { privateKey: 'x' } });
+
+    await expect(buildSpaceOwnerFetcher({ messageDB, spaceId: SPACE_ID })()).resolves.toBe(
+      false
+    );
+  });
+});

--- a/src/hooks/business/channels/useSpacePermissions.ts
+++ b/src/hooks/business/channels/useSpacePermissions.ts
@@ -8,7 +8,12 @@ import { useModalContext } from '../../../components/context/ModalProvider';
  */
 export const useSpacePermissions = (spaceId: string) => {
   const { data: isSpaceOwner } = useSpaceOwner({ spaceId });
-  const { openSpaceEditor, openLeaveSpace } = useModalContext();
+  // `openLeaveSpace` was destructured here and never called. Dropped rather than
+  // wired up: leaving is offered through the Space context menu, which correctly
+  // withholds it from owners, and an unused handle here reads like a second entry
+  // point that exists. LeaveSpaceModal itself is currently unreachable — nothing in
+  // the app calls openLeaveSpace — and is left alone for a separate cleanup.
+  const { openSpaceEditor } = useModalContext();
 
   const handleSpaceContextAction = useCallback(() => {
     // Always open Space Settings - Account tab for members, all tabs for owners

--- a/src/hooks/business/spaces/useSpaceManagement.ts
+++ b/src/hooks/business/spaces/useSpaceManagement.ts
@@ -33,7 +33,6 @@ export interface UseSpaceManagementReturn {
     currentBannerFile?: File
   ) => Promise<void>;
   handleDeleteSpace: () => Promise<void>;
-  isOwner: boolean;
   currentPasskeyInfo: any;
   deleteError: string | null;
   clearDeleteError: () => void;
@@ -161,8 +160,12 @@ export const useSpaceManagement = (
     setDeleteError(null);
   }, []);
 
-  // Determine if current user is owner (simplified logic)
-  const isOwner = true; // For now, assume user is owner - would need proper implementation
+  // Ownership deliberately NOT computed here. This used to return a hardcoded
+  // `isOwner = true`, which is wrong for every member who is not the owner, and it
+  // was never read — SpaceSettingsModal and Navigation both use `useSpaceOwner`,
+  // which resolves ownership properly as possession of the `owner` key slot.
+  // Removed rather than fixed: a second source of truth for the same question is
+  // how the hardcoded value survived unnoticed in the first place.
 
   return {
     spaceName,
@@ -179,7 +182,6 @@ export const useSpaceManagement = (
     setSelectedCategory,
     saveChanges,
     handleDeleteSpace,
-    isOwner,
     currentPasskeyInfo,
     deleteError,
     clearDeleteError,


### PR DESCRIPTION
Desktop counterpart to quorum-mobile #219.

## What was wrong

The danger zone claimed permanent, space-wide deletion. What the button calls is the leave flow: `SpaceService.deleteSpace` broadcasts a `leave`, calls `postHubDelete` for the caller's own inbox, and erases the caller's local copy. Every other member keeps the Space, its channels and all of its messages.

The tab is owner-only, which makes the mislabel worse rather than safer. Ownership is possession of the `owner` key slot, there is no transfer and no second copy, and the wipe takes it. An owner who used this kept the Space running for everyone while destroying their own ability to kick, rekey or ever delete it.

## Changes

- Release builds disable the button and explain why. Dev builds keep it under the label "Leave this Space", which is what the code does, so a tester can still clear disposable Spaces.
- The type-to-confirm and its channel and member counts are removed. Typing a keyword beside "N members" is the strongest "you are destroying something shared" signal in the app, and it sat on an action that only ever affected the person clicking it.
- The settings tab is labelled "Danger" rather than "Delete Space", for the same reason the copy changed.
- `const isOwner = true` is deleted from `useSpaceManagement`, interface field included. Nothing consumed it — `useSpaceOwner` already resolves ownership properly everywhere it is actually asked. Removed rather than fixed: a second source of truth is how a hardcoded answer survived unnoticed.
- Drops an unused `openLeaveSpace` handle that made `LeaveSpaceModal` look reachable. It is not; nothing in the app calls it. The modal itself is left for a separate cleanup.

No change for non-owners: Leave is still offered through the Space context menu, which already withheld it from owners.

## Tests

`src/dev/tests/hooks/spaceOwnerPredicate.unit.test.ts`, 5 cases pinning `buildSpaceOwnerFetcher`. The ones worth naming:

- *is false on a member device that holds every other key for the Space* — a joined member legitimately holds the space, config, hub and inbox keys, and must still not be treated as owner
- *asks for the owner slot of the requested Space, not another key or another Space* — querying the wrong slot would answer a different question while still returning a plausible boolean

Full suite: 893 passed, 59 files. Typecheck clean. Lint clean with no new warnings; the two `react-hooks/exhaustive-deps` warnings in `useSpaceManagement` pre-date this branch.

## Not in this PR

Real deletion needs a server-side purge endpoint that does not exist yet, plus a tombstone so a purged Space cannot be silently re-registered by the client self-heal. The tracking issue is updated rather than closed, with severity downgraded from high to medium: an owner can no longer brick a Space through this button, but deletion still does not exist.
