### PR TITLE
fix(harness): the roster re-ask was invisible to the trace

### DIFF
--- a/src/dev/tests/harness/space-backlog.scenario.test.ts
+++ b/src/dev/tests/harness/space-backlog.scenario.test.ts
@@ -228,10 +228,24 @@ test(
                 'No active session or expired',
                 'sync-delta',
                 'member delta',
+                // The repair path (desktop #300). `asking again` = a re-ask
+                // actually fired; `not asking` = the check ran and DECLINED,
+                // and the line itself carries the reason (cap-reached,
+                // cooling-down, converged, no-target). Both zero means the
+                // debounced check never fired at all — a third state entirely,
+                // and the one that is invisible without this counter.
+                'asking again',
+                'not asking',
               ]
                 .map(step)
                 .join('  ')}`
             );
+            // Every roster-check decision, in full. These are few (the check is
+            // debounced and capped) and they are the difference between "the
+            // ladder ran out" and "the ladder never started" — a distinction
+            // that was guessed wrong once already.
+            for (const line of b.syncTrace.filter((l) => l.includes('roster')))
+              say(`      | ${line.slice(0, 200)}`);
             for (const line of b.syncTrace.slice(-6))
               say(`      | ${line.slice(0, 150)}`);
           }

--- a/src/dev/tests/harness/spaceBot.ts
+++ b/src/dev/tests/harness/spaceBot.ts
@@ -202,6 +202,19 @@ export async function createSpaceBot(
     'member delta',
     'delta payload',
     'informSyncData',
+    // ⚠️ Added 2026-08-03, and its absence had already cost a wrong conclusion.
+    // Desktop #300 made the roster re-ask the mechanism that repairs a starved
+    // handshake — but every line that mechanism emits ("roster did not converge
+    // … asking again", "roster check for X: not asking (cap-reached)") starts
+    // with "roster" and matched none of the patterns above. So the harness could
+    // measure that a run FAILED while being structurally unable to show WHY, and
+    // a 0/2 result at 1200 backlog was read as "the re-ask ladder is exhausted"
+    // on no evidence at all.
+    //
+    // `shouldReAsk` deliberately returns a REASON rather than a boolean, and the
+    // caller logs it on every branch (see rosterConvergence.ts). Capturing it is
+    // the entire point of that design.
+    'roster',
   ];
   const syncTrace: string[] = [];
   const trace = (line: string) => {


### PR DESCRIPTION
The harness could measure that a roster run **failed** while being structurally
unable to show **why**. Test-only change; no product code.

## The gap

Desktop #300 made the roster re-ask the mechanism that repairs a starved
handshake. Every line that mechanism emits begins with `roster` — and `roster`
matched none of the harness's `TRACE_PATTERNS`. So the repair's own decisions
were never captured at all.

## It cost a wrong conclusion the same day

A 1200-message sweep returned **0/2** and was read as *"the re-ask ladder is
exhausted"*. That was a mechanism asserted with no evidence, and there was
nothing in the trace to check it against.

Re-run with a **900s** window instead of 360s, the same load delivers **100%** at
~456s. The trials had been cut off shortly before converging. The ladder was
never the problem.

| backlog | frames | median lag | rate |
|---|---|---|---|
| 300 | 1203 | 79.5 s | 100% |
| 600 | 2410 | 182 s | 100% |
| 1200 | 4806 | 456.5 s | 100% |

## The change

Capture `roster`, and report both halves of the decision as counters on a MISS:

| counter | meaning |
|---|---|
| `asking again=N` | a re-ask actually fired |
| `not asking=N` | the check ran and **declined** — the line carries the reason (`cap-reached`, `cooling-down`, `converged`, `no-target`) |
| **both zero** | the check **never fired at all** |

That third state is the one that was invisible, and it is the one that was
actually happening. `shouldReAsk` already returns a reason rather than a boolean
and the caller already logs it on every branch — capturing it is the entire point
of that design.

Also dumps every roster decision line in full on a MISS. They are few (the check
is debounced and capped) and they separate "the ladder ran out" from "the ladder
never started".

## Verification

Forced a MISS with a window shorter than the 20s debounce. Output:

```
B handshake: requestSync=4  sync-info=8  Adding candidate=0  No suitable candidates=1
             Expired, ignoring=0  No active session or expired=2  sync-delta=0
             member delta=0  asking again=0  not asking=0
```

Both counters `0` is the **correct** reading there — the window ended before the
debounced check could fire. Had this existed earlier, the 1200 misreading would
have been caught on sight instead of becoming a stated conclusion.

`tsc --noEmit` and `eslint` clean.
