### PR TITLE
docs: reference issues by filename, so refiling does not break the link

### DIFF
--- a/src/dev/tests/harness/README.md
+++ b/src/dev/tests/harness/README.md
@@ -9,7 +9,8 @@ Two halves, sharing identity/transport/storage:
 - **DM** — `bot.ts` + `deps.ts` + `dm-*.scenario.test.ts`. Complete through slice 4.
 - **SPACES** — `spaceBot.ts` + `spaceDeps.ts` + `outbound.ts` + `space-*.scenario.test.ts`.
   Slices S0-S1 done. Built to characterise the intermittent roster-pull failure
-  (`.agents/issues/.open/2026-08-02-roster-pull-delivers-nothing-to-a-new-joiner.md`).
+  (`2026-08-02-roster-pull-delivers-nothing-to-a-new-joiner.md` under
+  `.agents/issues/` — issues are filed by state and move, so grep the filename).
 
 It is **not** a reimplementation of the protocol. It re-hosts the real client:
 the SDK wasm crypto core, `fake-indexeddb` for storage, Node's native `fetch` +

--- a/src/dev/tests/services/MessageService.rosterConvergence.unit.test.ts
+++ b/src/dev/tests/services/MessageService.rosterConvergence.unit.test.ts
@@ -26,7 +26,8 @@
  *      entitled to use. The expiry gate is untouched; only the tracker moved
  *      out from behind it.
  *
- * See .agents/issues/.open/2026-08-02-roster-pull-delivers-nothing-to-a-new-joiner.md
+ * See 2026-08-02-roster-pull-delivers-nothing-to-a-new-joiner.md under
+ * .agents/issues/ — issues are filed by state and move, so grep the filename.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -5594,7 +5594,8 @@ export class MessageService {
             // flood had drained. The request was never wrong; only its timing
             // was, which is why re-asking is the whole repair.
             //
-            // See .agents/issues/.open/2026-08-02-sync-requests-arrive-four-minutes-late-and-every-peer-rejects-them.md
+            // See 2026-08-02-sync-requests-arrive-four-minutes-late-and-every-peer-rejects-them.md
+            // under .agents/issues/ (filed by state, so grep the name — it moves).
             const learnedTarget = this.rosterConvergence.noteAdvertisedRoster(
               spaceId,
               envelope.message.memberCount ?? envelope.message.summary?.memberCount

--- a/src/utils/rosterConvergence.ts
+++ b/src/utils/rosterConvergence.ts
@@ -41,8 +41,9 @@
 // have, and giving them "false" with no reason attached reproduces exactly the
 // blindness that made the original bug take a session to find.
 //
-// See .agents/issues/.open/2026-08-02-roster-pull-delivers-nothing-to-a-new-joiner.md
-// (NEXT STEP B).
+// See 2026-08-02-roster-pull-delivers-nothing-to-a-new-joiner.md under
+// .agents/issues/ (NEXT STEP B). Issues are filed by state and move between
+// .open/, the root and .done/, so grep the filename rather than trusting a path.
 
 import { advertisedCount } from '@quilibrium/quorum-shared';
 


### PR DESCRIPTION
Four comment references in `src/` pointed at `.agents/issues/.open/...` and broke
when the two roster issues were refiled to in-progress.

Issues are filed **by state**, so they move between `.open/`, the root and
`.done/` over their lifetime. Any path-based reference to one is therefore
guaranteed to go stale — it is a question of when, not whether.

Reference the **filename** instead, and say where to grep:

```diff
-// See .agents/issues/.open/2026-08-02-sync-requests-…-reject-them.md
+// See 2026-08-02-sync-requests-…-reject-them.md
+// under .agents/issues/ (filed by state, so grep the name — it moves).
```

The date-prefixed filename is unique and stable; the folder is not.

Files: `MessageService.ts`, `rosterConvergence.ts`,
`MessageService.rosterConvergence.unit.test.ts`, `harness/README.md`.

Comments only — no behaviour change. `tsc --noEmit` clean, and a grep confirms no
`issues/.open/` references remain under `src/`.
