### PR TITLE
fix: keep a space frame we could not open, instead of deleting the only copy

### DIFF
--- a/src/dev/tests/services/MessageService.spaceFrameRetention.unit.test.ts
+++ b/src/dev/tests/services/MessageService.spaceFrameRetention.unit.test.ts
@@ -1,0 +1,211 @@
+/**
+ * A space frame we could not OPEN must stay on the relay.
+ *
+ * ── Why this test exists ────────────────────────────────────────────────────
+ *
+ * The relay holds a frame until the client deletes it, and that delete IS the
+ * ack. So deleting a frame we never opened destroys the only copy — permanently,
+ * and silently, because the error goes to `console.error` which is a no-op in
+ * production builds.
+ *
+ * The space path did exactly that: its whole unseal/dispatch block is wrapped in
+ * `try { … } catch (e) { console.error(…) }` with no `return`, and execution then
+ * fell through to an unconditional `dispatchInboxDelete`. The DM path has had the
+ * opposite discipline since 2026-07-25, when replaying real captured frames
+ * proved 5 of 6 frames desktop had deleted were decryptable against a state
+ * desktop itself held ~35 s later.
+ *
+ * ⚠️ The assertion that matters is `deleteInboxMessages` NOT being called.
+ * "It didn't crash" is not the property — a frame can be lost with no error at
+ * all, which is precisely how this survived.
+ *
+ * See issues/.open/2026-08-03-a-space-frame-that-fails-to-decrypt-is-deleted-from-the-relay.md
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MessageService } from '../../../services/MessageService';
+import { FRAME_RETRY_MAX_ATTEMPTS } from '../../../utils/frameRetry';
+
+const SPACE_ID = 'QmSpaceAddressAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+const SPACE_INBOX = 'QmSpaceInboxBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
+const DEVICE_INBOX = 'QmDeviceInboxCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC';
+const SELF = 'QmSelfAddressDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD';
+
+/** Flip to make the envelope refuse to open, as a rotated/absent key would. */
+let unsealThrows = false;
+/** What a SUCCESSFUL unseal decodes to. */
+let unsealedPayload = '';
+
+vi.mock('@quilibrium/quilibrium-js-sdk-channels', () => ({
+  channel: {
+    UnsealHubEnvelope: vi.fn(async () => {
+      if (unsealThrows) throw new Error('aead::Error: decryption failed');
+      return Array.from(new TextEncoder().encode(unsealedPayload));
+    }),
+    UnsealSyncEnvelope: vi.fn(async () => {
+      if (unsealThrows) throw new Error('aead::Error: decryption failed');
+      return Array.from(new TextEncoder().encode(unsealedPayload));
+    }),
+  },
+  channel_raw: {
+    js_sign_ed448: vi.fn().mockReturnValue(JSON.stringify('mock-signature')),
+    js_verify_ed448: vi.fn().mockReturnValue(true),
+  },
+}));
+
+const keyset = {
+  deviceKeyset: {
+    inbox_keyset: {
+      inbox_address: DEVICE_INBOX,
+      inbox_key: { public_key: [1, 2, 3], private_key: [4, 5, 6] },
+    },
+    identity_key: { public_key: [7, 8, 9] },
+  },
+  userKeyset: {},
+} as any;
+
+const spaceKey = {
+  publicKey: '00'.repeat(57),
+  privateKey: '00'.repeat(57),
+  address: SPACE_INBOX,
+};
+
+/**
+ * A hub-broadcast space frame. `encryptedContent` is deliberately anything but
+ * `type: 'sync'`, so the handler takes the hub path.
+ *
+ * `ts` distinguishes frames: the retry tracker keys off inbox + content, so two
+ * frames with different content are tracked independently.
+ */
+function spaceFrame(ts: number, marker = 'x') {
+  return {
+    inboxAddress: SPACE_INBOX,
+    encryptedContent: JSON.stringify({ type: 'group', marker }),
+    timestamp: ts,
+  } as any;
+}
+
+describe('a space frame that cannot be opened is kept on the relay', () => {
+  let messageService: MessageService;
+  let mockDeps: any;
+
+  beforeEach(() => {
+    unsealThrows = false;
+    unsealedPayload = JSON.stringify({
+      type: 'control',
+      message: { type: 'sync-info' },
+    });
+
+    mockDeps = {
+      messageDB: {
+        getAllEncryptionStates: vi.fn().mockResolvedValue([
+          {
+            inboxId: SPACE_INBOX,
+            conversationId: `${SPACE_ID}/${SPACE_ID}`,
+            // No `sending_inbox` — this is what selects the SPACE path.
+            state: JSON.stringify({}),
+          },
+        ]),
+        getEncryptionStates: vi.fn().mockResolvedValue([]),
+        getConversation: vi.fn().mockResolvedValue({ conversation: null }),
+        getSpaceKey: vi.fn().mockResolvedValue(spaceKey),
+        getSpaceMembers: vi.fn().mockResolvedValue([]),
+        getSpaceMember: vi.fn().mockResolvedValue(null),
+        saveSpaceMember: vi.fn().mockResolvedValue(undefined),
+        saveEncryptionState: vi.fn().mockResolvedValue(undefined),
+        saveMessage: vi.fn().mockResolvedValue(undefined),
+        getMessage: vi.fn().mockResolvedValue(null),
+        getMessages: vi.fn().mockResolvedValue({ messages: [], hasMore: false }),
+        isMessageDeleted: vi.fn().mockResolvedValue(false),
+        updateMessage: vi.fn().mockResolvedValue(undefined),
+        getSpace: vi.fn().mockResolvedValue({ spaceId: SPACE_ID }),
+      },
+      enqueueOutbound: vi.fn(),
+      addOrUpdateConversation: vi.fn(),
+      apiClient: {},
+      deleteEncryptionStates: vi.fn().mockResolvedValue(undefined),
+      deleteInboxMessages: vi.fn().mockResolvedValue(undefined),
+      navigate: vi.fn(),
+      spaceInfo: { current: {} },
+      syncInfo: { current: {} },
+      synchronizeAll: vi.fn().mockResolvedValue(undefined),
+      informSyncData: vi.fn().mockResolvedValue(undefined),
+      initiateSync: vi.fn().mockResolvedValue(undefined),
+      requestSync: vi.fn().mockResolvedValue(true),
+      directSync: vi.fn().mockResolvedValue(undefined),
+      saveConfig: vi.fn().mockResolvedValue(undefined),
+      sendHubMessage: vi.fn().mockResolvedValue('message-id'),
+      handleSyncInitiateV2: vi.fn().mockResolvedValue(undefined),
+      handleSyncManifest: vi.fn().mockResolvedValue(undefined),
+    };
+
+    messageService = new MessageService(mockDeps);
+  });
+
+  const deliver = (frame: any) =>
+    messageService.handleNewMessage(SELF, keyset, frame, {
+      refetchQueries: vi.fn(),
+      setQueryData: vi.fn(),
+      invalidateQueries: vi.fn(),
+      getQueryData: vi.fn(),
+    } as any);
+
+  /** `dispatchInboxDelete` defers through a resolved promise. */
+  const settle = () => new Promise((r) => setTimeout(r, 0));
+
+  it('does NOT delete a frame it could not open', async () => {
+    unsealThrows = true;
+
+    await deliver(spaceFrame(1111));
+    await settle();
+
+    expect(mockDeps.deleteInboxMessages).not.toHaveBeenCalled();
+  });
+
+  // The counterpart, and the reason the test above is not just "deletes are
+  // broken": a frame that opens normally must still be acked, or every processed
+  // frame would be redelivered forever.
+  it('still deletes a frame that opened normally', async () => {
+    unsealThrows = false;
+
+    await deliver(spaceFrame(2222));
+    await settle();
+
+    expect(mockDeps.deleteInboxMessages).toHaveBeenCalled();
+  });
+
+  // Retention must be bounded. A frame that can NEVER open would otherwise be
+  // redelivered on every reconnect for the lifetime of the account — its own
+  // denial of service, and the reason the original unconditional delete existed.
+  it('gives up and deletes once the retry budget is exhausted', async () => {
+    unsealThrows = true;
+    const frame = spaceFrame(3333, 'poison');
+
+    // One short of the ceiling: still retained.
+    for (let i = 0; i < FRAME_RETRY_MAX_ATTEMPTS - 1; i++) {
+      await deliver(frame);
+    }
+    await settle();
+    expect(mockDeps.deleteInboxMessages).not.toHaveBeenCalled();
+
+    // The attempt that spends the budget.
+    await deliver(frame);
+    await settle();
+    expect(mockDeps.deleteInboxMessages).toHaveBeenCalled();
+  });
+
+  // The budget is per frame, not global — one poisonous frame must not spend
+  // another frame's allowance.
+  it('tracks frames independently', async () => {
+    unsealThrows = true;
+
+    for (let i = 0; i < FRAME_RETRY_MAX_ATTEMPTS - 1; i++) {
+      await deliver(spaceFrame(4444, 'first'));
+    }
+    // A DIFFERENT frame, arriving with the other one's budget nearly spent.
+    await deliver(spaceFrame(5555, 'second'));
+    await settle();
+
+    expect(mockDeps.deleteInboxMessages).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -4307,6 +4307,14 @@ export class MessageService {
 
     let decryptedContent: Message | null = null;
     let newState: string | null = null;
+    /**
+     * A space frame we could not OPEN, and are keeping on the relay to retry.
+     *
+     * Declared out here because the decision is made in the space branch's catch
+     * but acted on much later, at the inbox-cleanup tail — those are different
+     * block scopes in the same very long function.
+     */
+    let retainUnopenedSpaceFrame = false;
 
     const keys = JSON.parse(found.state);
     let updatedUserProfile: secureChannel.UserProfile | undefined;
@@ -4585,6 +4593,17 @@ export class MessageService {
       // State already persisted inside the locked section — `newState` stays
       // null so the deferred tail save (space path) does not run for DMs.
     } else {
+      const spaceFrameKey = frameKey(
+        message.inboxAddress,
+        message.encryptedContent
+      );
+      /**
+       * Did we get the envelope OPEN? Everything after that point is
+       * application handling, and a failure there will fail identically on a
+       * retry — so only a failure BEFORE this flips is worth keeping the frame
+       * for. See the catch at the end of this block.
+       */
+      let opened = false;
       try {
         const spaceId = conversationId.split('/')[0];
         const hub_key = await this.messageDB.getSpaceKey(spaceId, 'hub');
@@ -4638,6 +4657,13 @@ export class MessageService {
             )
           ).toString('utf-8');
         }
+
+        // The envelope is open. From here on a failure is an application bug,
+        // not a "we could not decrypt it yet" — retrying would fail the same
+        // way, so the frame stops being a retry candidate and the tail cleanup
+        // deletes it exactly as it always did.
+        opened = true;
+        this.undecryptableFrames.clear(spaceFrameKey);
 
         const envelope = JSON.parse(result);
         if (envelope.type === 'message') {
@@ -6134,7 +6160,40 @@ export class MessageService {
             );
           }
         }
-      } catch (e) { console.error('[MessageService] Error processing hub/sync message:', e); }
+      } catch (e) {
+        console.error('[MessageService] Error processing hub/sync message:', e);
+        // ⚠️ THE RELAY IS THE ONLY COPY. It holds a frame until we delete it,
+        // and that delete IS the ack — so deleting a frame we never opened
+        // destroys the message permanently, silently (this log is a no-op in
+        // production builds), with no retry and nothing shown to the user.
+        //
+        // A space frame can fail to open for reasons that are transient by
+        // nature: the config key rotated and the frame predates the rotation,
+        // or the key that opens it has not arrived yet. Those decrypt fine
+        // later, and the relay will redeliver anything we have not acked.
+        //
+        // Same discipline the DM path has had since 2026-07-25, where replaying
+        // real captured frames proved 5 of 6 deleted frames were decryptable
+        // against a state the client itself held ~35s later. The budget
+        // (40 attempts / 5 min TTL) is what stops a genuinely poisonous frame
+        // lingering forever.
+        //
+        // See issues/.open/2026-08-03-a-space-frame-that-fails-to-decrypt-is-deleted-from-the-relay.md
+        if (!opened) {
+          retainUnopenedSpaceFrame = !this.undecryptableFrames.recordFailure(
+            spaceFrameKey
+          );
+          if (!retainUnopenedSpaceFrame) {
+            logger.warn(
+              '[MessageService] giving up on an unopenable space frame after the retry budget — deleting',
+              {
+                inbox: message.inboxAddress?.slice(0, 16),
+                frameTimestamp: message.timestamp,
+              }
+            );
+          }
+        }
+      }
     }
 
     if (newState) {
@@ -6359,6 +6418,18 @@ export class MessageService {
         // Space was deleted, silently skip cleanup
         logger.debug(
           `Skipping inbox cleanup for deleted space: ${conversationId.split('/')[0]}`
+        );
+        return;
+      }
+
+      // We could not open this frame and its retry budget is not spent. Do NOT
+      // delete it: the delete is the ack, and the relay is the only copy.
+      // Leaving it means the relay redelivers it on the next `listen`, by which
+      // time the key that opens it may have arrived.
+      if (retainUnopenedSpaceFrame) {
+        logger.log(
+          `[MessageService] keeping an unopenable space frame for retry: ` +
+            `${conversationId.split('/')[0].substring(0, 12)} ts=${message.timestamp}`
         );
         return;
       }


### PR DESCRIPTION
**Silent, permanent message loss on the space receive path.** Found during an
independent security review of an unrelated design; it exists on `main` today and
is not caused by that proposal.

## The defect

The relay holds a frame until the client deletes it, and **that delete is the
ack**. So deleting a frame we never opened destroys the only copy.

The space branch wraps its entire unseal/dispatch block in
`try { … } catch (e) { console.error(…) }` with no `return`, then falls through
to an unconditional `dispatchInboxDelete`. On any failure to open:

1. the error goes to `console.error` — **invisible in production**, where
   `logger` is a no-op, and
2. the frame is deleted from the relay in the same pass.

No redelivery, no retry, nothing shown to the user. The message is simply gone.

## Why it happens in practice

A space frame can fail to open for reasons that are **transient by nature**:

- the space config key rotated (a kick triggers this) and the frame predates the
  rotation
- the key that opens it has not arrived yet

Both decrypt fine slightly later — and the relay redelivers anything not acked.

## The fix

Keep the frame, reusing the DM path's existing budget (`UndecryptableFrameTracker`,
40 attempts / 5-minute TTL, already pure and unit-tested).

That discipline was added to the DM path on 2026-07-25 after replaying real
captured frames proved **5 of 6 frames desktop had deleted were decryptable
against a state desktop itself held ~35 s later**. The space path was simply
never given it. This is an asymmetry, not a deliberate difference.

**Retention is deliberately narrow.** An `opened` flag flips the moment the
envelope is unsealed, and only failures *before* that point retain the frame.
Anything throwing during application handling would throw identically on a
retry, so those frames are still deleted exactly as before.

## Tests

The assertion that matters is **`deleteInboxMessages` NOT being called** — not
"it didn't crash". A frame can be lost with no error at all, which is precisely
how this survived.

| test | asserts |
|---|---|
| does not delete a frame it could not open | the fix |
| still deletes a frame that opened normally | no regression — frames must still be acked |
| gives up once the retry budget is exhausted | retention is bounded; a poison frame can't be redelivered forever |
| tracks frames independently | one bad frame can't spend another's allowance |

**Confirmed load-bearing:** with the fix reverted, 3 of the 4 fail and the old
code deletes on **all 40** delivery attempts. The fourth passes either way by
design — it is the regression guard.

## Verification

- `yarn test:run` — **61 files, 924 tests, all passing**
- `yarn harness space-basic` — passes live against production, so the real space
  receive path still works end to end
- `tsc --noEmit` clean; `eslint` clean on the changed file (two pre-existing
  warnings elsewhere untouched)
