### PR TITLE
feat: show every field an issue carries, and stop pointing at folders that moved

### DIFF
--- a/src/adapters/indexedDbAdapter.ts
+++ b/src/adapters/indexedDbAdapter.ts
@@ -146,7 +146,7 @@ export class IndexedDBAdapter implements StorageAdapter {
   // where most members' identity actually lives. Without it every member hashed
   // as "no identity", so two clients that disagreed completely still agreed they
   // were in sync and exchanged nothing.
-  // See .agents/bugs/2026-08-01-space-sync-member-delta-blind-to-and-erases-global-slot.md
+  // See 2026-08-01-space-sync-member-delta-blind-to-and-erases-global-slot.md under .agents/issues/
 
   private dbMemberToShared(dbMember: any): SpaceMember {
     return {

--- a/src/components/context/ActionQueueContext.tsx
+++ b/src/components/context/ActionQueueContext.tsx
@@ -8,9 +8,9 @@
  *
  * Online detection uses WebSocket connection state as primary signal
  * because navigator.onLine is unreliable on Wi-Fi disconnect in Chromium
- * browsers. See: .agents/tasks/offline-detection-and-optimistic-message-reliability.md
+ * browsers. See: offline-detection-and-optimistic-message-reliability.md under .agents/issues/
  *
- * See: .agents/tasks/background-action-queue.md
+ * See: background-action-queue.md under .agents/issues/
  */
 
 import React, {

--- a/src/components/discover-page/DiscoverPage.tsx
+++ b/src/components/discover-page/DiscoverPage.tsx
@@ -106,7 +106,7 @@ const SpacesEmpty: React.FC = () => {
  *
  * A People tab previously lived at `/discover/people`; removed 2026-06-08
  * after verification that no profile-enumeration backend endpoint exists.
- * See `.agents/tasks/port-from-mobile/candidates.md` #6.
+ * See `port-from-mobile/candidates.md` under .agents/issues/ #6.
  */
 export const DiscoverPage: React.FC<{ mode?: 'discover' | 'spaces-empty' }> = ({
   mode = 'discover',

--- a/src/components/modals/UserSettingsModal/General.tsx
+++ b/src/components/modals/UserSettingsModal/General.tsx
@@ -146,7 +146,7 @@ const General: React.FunctionComponent<GeneralProps> = ({
         <div className="text-subtitle-2">
           <Trans>Bio</Trans>
         </div>
-        {/* Bio is local-only for now - not synced across devices. See .agents/tasks/add-user-bio-field.md for future sync work */}
+        {/* Bio is local-only for now - not synced across devices. See 2025-01-06-add-user-bio-field.md under .agents/issues/ for future sync work */}
         <div className="pt-2 text-label mb-4">
           <Trans>
             This bio will be visible to others when they view your profile.

--- a/src/components/ui/OfflineBanner.tsx
+++ b/src/components/ui/OfflineBanner.tsx
@@ -14,7 +14,7 @@
  *
  * Adds 'offline-banner-visible' class to body to push layout down.
  *
- * See: .agents/tasks/background-action-queue.md
+ * See: background-action-queue.md under .agents/issues/
  */
 
 import React, { useEffect, useState } from 'react';

--- a/src/components/user/UserOnlineStateIndicator.tsx
+++ b/src/components/user/UserOnlineStateIndicator.tsx
@@ -12,7 +12,7 @@ import { t } from '@lingui/core/macro';
  * - UserProfile users: Have state/status from authentication flow
  * - Message users: Only have displayName/userIcon from space members
  *
- * IMPLEMENTATION PLAN: See .agents/tasks/todo/user-status.md
+ * IMPLEMENTATION PLAN: See 2025-01-20-user-status.md under .agents/issues/
  * - Phase 1: Show current user's WebSocket connection state (online/offline)
  * - Phase 2: Full presence system for all users (requires server changes)
  */

--- a/src/components/user/UserProfile.tsx
+++ b/src/components/user/UserProfile.tsx
@@ -309,7 +309,7 @@ const UserProfile: React.FunctionComponent<{
             </Flex>
             <div className="user-profile-state">
               {/* TODO: Re-enable when online/offline status is implemented
-                  See .agents/tasks/todo/user-status.md for implementation plan
+                  See 2025-01-20-user-status.md under .agents/issues/ for implementation plan
                   Phase 1: Show current user's connection state
                   Phase 2: Show all users' online/offline status via presence system
               <UserOnlineStateIndicator user={props.user} />

--- a/src/db/messages.ts
+++ b/src/db/messages.ts
@@ -1234,8 +1234,8 @@ export class MessageDB {
    * on every other member's roster forever. Name/avatar/bio do not need this:
    * the two-slot model clears them with `''`, which is a present value.
    *
-   * See .agents/bugs/2026-08-01-space-sync-member-delta-blind-to-and-erases-global-slot.md
-   * and .agents/bugs/2026-08-01-space-tag-can-no-longer-be-cleared-from-a-member-roster.md
+   * See 2026-08-01-space-sync-member-delta-blind-to-and-erases-global-slot.md under .agents/issues/
+   * and 2026-08-01-space-tag-can-no-longer-be-cleared-from-a-member-roster.md under .agents/issues/
    */
   async saveSpaceMember(
     spaceId: string,
@@ -1446,7 +1446,7 @@ export class MessageDB {
         // stored; and only when there is nothing stored do we fall back to the
         // incoming placeholder, so a brand-new row keeps today's shape (both
         // fields are required on `Conversation`).
-        // See .agents/tasks/2026-08-01-identity-announce-cadence-research.md §2.
+        // See 2026-08-01-identity-announce-cadence-research.md under .agents/issues/ §2.
         const request = conversationStore.put({
           ...existingConv, // Preserve existing fields including isRepudiable
           conversationId,
@@ -1840,7 +1840,7 @@ export class MessageDB {
    *
    * Storage-adapter-shaped: this is the IndexedDB implementation of what
    * will become a SearchAdapter method once quorum-shared migration unblocks.
-   * Per `.agents/tasks/search-optimization/decisions.md` decision #9.
+   * Per `search-optimization/decisions.md` under .agents/issues/ decision #9.
    */
   async ensureIndexReady(context: SearchContext): Promise<void> {
     const indexKey = this.getIndexKey(context);
@@ -2842,7 +2842,7 @@ export class MessageDB {
   // ============================================
   // DEBUG UTILITIES FOR ENCRYPTION STATE ANALYSIS
   // ============================================
-  // See: .agents/bugs/encryption-state-evals-bloat.md
+  // See: 2025-12-09-encryption-state-evals-bloat.md under .agents/issues/
   //
   // Usage (browser console):
   //   await window.__messageDB.analyzeEncryptionStates()

--- a/src/dev/README.md
+++ b/src/dev/README.md
@@ -18,13 +18,20 @@ Comprehensive development suite for building and managing cross-platform compone
 
 **Path**: `docs/` folder  
 **Access**: `/dev` route during development  
-**Purpose**: Interactive frontend for browsing project documentation, tasks, and bug reports
+**Purpose**: Interactive frontend for browsing project documentation, issues, and reports
 
 - Browse all documentation files from `.agents/docs/`
-- View task management files from `.agents/tasks/` (pending, ongoing, completed)
-- Access bug reports from `.agents/bugs/` (active and solved)
+- Browse issues — bugs and tasks together — from `.agents/issues/`, filtered by
+  type, state and priority. State comes from the folder an issue sits in
+  (`.open/`, `.deferred/`, `.done/`, `.archived/`, or the root for in-progress),
+  not from its `status:` field, which routinely goes stale when a file is refiled
 - Browse reports and audits from `.agents/reports/` (security audits, research, analysis)
 - Features search functionality and categorization
+
+The file list is a build artifact: run `yarn scan-docs` after adding or moving
+markdown under `.agents/`, or the viewer keeps showing the previous tree. The
+scan also reports any file whose YAML frontmatter fails to parse — those render
+without metadata until the YAML is fixed.
 - Full markdown rendering with syntax highlighting
 - Organized by folder structure (e.g., mobile-dev/docs, features/primitives)
 

--- a/src/dev/dm-doctor/dmDoctorCore.ts
+++ b/src/dev/dm-doctor/dmDoctorCore.ts
@@ -11,7 +11,7 @@
  * (`.agents/tools/dm-debug/07-receiver-probe.js`) so the same numbers a manual
  * probe run would produce come out of the resident dev panel, plus the two
  * misfiling/ghost-conversation checks from
- * `.agents/bugs/2026-07-29-stale-returning-device-dm-sends-vanish-and-misfile.md`.
+ * `transport/2026-07-29-stale-returning-device-dm-sends-vanish-and-misfile.md` under .agents/issues/.
  *
  * Also formats the "Copy full report" clipboard block: a self-contained
  * markdown paste designed for a fresh agent to read with no follow-up
@@ -518,7 +518,7 @@ export interface FullReportInput {
   warningState: DmWarningCounterState | null;
 }
 
-export const DM_DOCTOR_RUNBOOK_POINTER = '.agents/tasks/2026-07-29-manual-round-runbook.md';
+export const DM_DOCTOR_RUNBOOK_POINTER = 'transport/runbook.md under .agents/issues/';
 
 function formatDistributionLines(
   scanResult: ScanResult,

--- a/src/dev/docs/MarkdownViewer.tsx
+++ b/src/dev/docs/MarkdownViewer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import {
   Text,
   Flex,
@@ -6,6 +6,7 @@ import {
   Icon,
 } from '../../components/primitives';
 import { DevNavMenu } from '../DevNavMenu';
+import { FrontmatterPanel } from './components/FrontmatterPanel';
 import { useMarkdownContent, MarkdownFile } from './hooks/useMarkdownFiles';
 import Prism from 'prismjs';
 import 'prismjs/themes/prism-dark.css';
@@ -31,20 +32,6 @@ export const MarkdownViewer: React.FC<MarkdownViewerProps> = ({
   file,
 }) => {
   const { content, loading, error } = useMarkdownContent(filePath);
-
-  // Format date to human-readable format
-  const formatDate = (dateString: string): string => {
-    try {
-      const date = new Date(dateString);
-      return date.toLocaleDateString('en-US', {
-        year: 'numeric',
-        month: 'short',
-        day: 'numeric'
-      });
-    } catch {
-      return dateString;
-    }
-  };
 
   // Strip YAML frontmatter from content
   const stripFrontmatter = (markdown: string): string => {
@@ -290,64 +277,7 @@ export const MarkdownViewer: React.FC<MarkdownViewerProps> = ({
         {!loading && content && (
           <div className="bg-surface-1 rounded-lg border border-default p-6">
             {/* Frontmatter Metadata Box - Inside main content */}
-            {file && (
-              <div className="bg-surface-2 rounded-lg border border-default p-3 mb-6">
-                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-6 gap-y-2 text-xs">
-                  {file.frontmatter?.type && (
-                    <div className="flex items-center gap-2">
-                      <Text variant="subtle" size="sm">Type:</Text>
-                      <Text variant="main" size="sm" weight="medium" className="capitalize">{file.frontmatter.type}</Text>
-                    </div>
-                  )}
-                  {file.status && (
-                    <div className="flex items-center gap-2">
-                      <Text variant="subtle" size="sm">Status:</Text>
-                      <Text variant="main" size="sm" weight="medium" className="capitalize">{file.status.replace(/-/g, ' ')}</Text>
-                    </div>
-                  )}
-                  {file.complexity && (
-                    <div className="flex items-center gap-2">
-                      <Text variant="subtle" size="sm">Complexity:</Text>
-                      <Text variant="main" size="sm" weight="medium" className="capitalize">{file.complexity.replace(/-/g, ' ')}</Text>
-                    </div>
-                  )}
-                  {file.created && (
-                    <div className="flex items-center gap-2">
-                      <Text variant="subtle" size="sm">Created:</Text>
-                      <Text variant="main" size="sm">{formatDate(file.created)}</Text>
-                    </div>
-                  )}
-                  {file.updated && (
-                    <div className="flex items-center gap-2">
-                      <Text variant="subtle" size="sm">Updated:</Text>
-                      <Text variant="main" size="sm">{formatDate(file.updated)}</Text>
-                    </div>
-                  )}
-                  {file.ai_generated && (
-                    <div className="flex items-center gap-2">
-                      <Text variant="subtle" size="sm">AI Generated:</Text>
-                      <Text variant="main" size="sm">Yes</Text>
-                    </div>
-                  )}
-                  {file.reviewed_by && (
-                    <div className="flex items-center gap-2">
-                      <Text variant="subtle" size="sm">Reviewed By:</Text>
-                      <Text variant="main" size="sm" className="capitalize">{file.reviewed_by}</Text>
-                    </div>
-                  )}
-                  {file.related_issues && file.related_issues.length > 0 && (
-                    <div className="flex items-center gap-2 sm:col-span-2 lg:col-span-3">
-                      <Text variant="subtle" size="sm">Related Issues:</Text>
-                      <div className="flex flex-wrap gap-1">
-                        {file.related_issues.map((issue) => (
-                          <Text key={issue} variant="main" size="sm" className="bg-surface-3 px-1.5 py-0.5 rounded">{issue}</Text>
-                        ))}
-                      </div>
-                    </div>
-                  )}
-                </div>
-              </div>
-            )}
+            {file && <FrontmatterPanel file={file} />}
 
             {/* Markdown Content */}
             <div

--- a/src/dev/docs/components/FrontmatterPanel.tsx
+++ b/src/dev/docs/components/FrontmatterPanel.tsx
@@ -1,0 +1,146 @@
+import React from 'react';
+import { Flex, Text, Icon } from '../../../components/primitives';
+import { type MarkdownFile } from '../hooks/useMarkdownFiles';
+import {
+  asList,
+  formatFieldValue,
+  partitionFrontmatter,
+} from '../utils/frontmatterDisplay';
+
+/**
+ * The metadata box above a document's body.
+ *
+ * Shows every frontmatter field the file carries, not a curated subset — see
+ * `frontmatterDisplay.ts` for why. Recognised fields come first, anything
+ * pointing at other work is grouped, and the long tail of one-off keys lands in
+ * a final section instead of vanishing.
+ */
+
+const formatDate = (value: string): string => {
+  try {
+    return new Date(value).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+  } catch {
+    return value;
+  }
+};
+
+const DATE_FIELDS = new Set(['created', 'updated', 'completed']);
+
+const Entry: React.FC<{ label: string; children: React.ReactNode }> = ({
+  label,
+  children,
+}) => (
+  <div className="flex gap-2">
+    <Text variant="subtle" size="sm" className="shrink-0">
+      {label}:
+    </Text>
+    {children}
+  </div>
+);
+
+export const FrontmatterPanel: React.FC<{ file: MarkdownFile }> = ({ file }) => {
+  const { primary, relations, other } = partitionFrontmatter(
+    file.frontmatter as Record<string, unknown> | undefined
+  );
+
+  const hasAnything =
+    file.status || primary.length > 0 || relations.length > 0 || other.length > 0;
+
+  if (!hasAnything && !file.parseError) return null;
+
+  return (
+    <div className="bg-surface-2 rounded-lg border border-default p-3 mb-6">
+      {/* A file whose YAML threw has no metadata at all — say so, rather than
+          rendering an empty box that looks like an issue with nothing to show. */}
+      {file.parseError && (
+        <div className="bg-danger/10 border border-danger/30 rounded-md p-3 mb-3">
+          <Flex gap="sm" align="center" className="mb-1">
+            <Icon name="warning" size="sm" className="text-danger" />
+            <Text variant="strong" size="sm" className="text-danger">
+              Frontmatter could not be parsed
+            </Text>
+          </Flex>
+          <Text variant="subtle" size="sm">
+            {file.parseError}
+          </Text>
+          <Text variant="muted" size="sm" className="mt-1">
+            Everything below is missing because of it. Fix the YAML at the top of
+            the file, then re-run <code>yarn scan-docs</code>.
+          </Text>
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-6 gap-y-2">
+        {/* State comes from the folder, not from `status:` — see deriveState. */}
+        {file.status && (
+          <Entry label="State">
+            <Text
+              variant="main"
+              size="sm"
+              weight="medium"
+              className="capitalize"
+            >
+              {file.status.replace(/-/g, ' ')}
+            </Text>
+          </Entry>
+        )}
+
+        {primary.map((field) => (
+          <Entry key={field.key} label={field.label}>
+            <Text variant="main" size="sm" weight="medium">
+              {DATE_FIELDS.has(field.key)
+                ? formatDate(formatFieldValue(field.value))
+                : formatFieldValue(field.value)}
+            </Text>
+          </Entry>
+        ))}
+      </div>
+
+      {relations.length > 0 && (
+        <div className="mt-3 pt-3 border-t border-default space-y-2">
+          {relations.map((field) => (
+            <div key={field.key} className="flex flex-wrap gap-2 items-baseline">
+              <Text variant="subtle" size="sm" className="shrink-0">
+                {field.label}:
+              </Text>
+              <div className="flex flex-wrap gap-1">
+                {asList(field.value).map((entry, index) => (
+                  <Text
+                    key={`${entry}-${index}`}
+                    variant="main"
+                    size="sm"
+                    className="bg-surface-3 px-1.5 py-0.5 rounded font-mono"
+                  >
+                    {entry}
+                  </Text>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {other.length > 0 && (
+        <div className="mt-3 pt-3 border-t border-default space-y-2">
+          <Text variant="muted" size="sm" weight="medium">
+            Other fields
+          </Text>
+          {other.map((field) => (
+            <div key={field.key} className="flex flex-wrap gap-2 items-baseline">
+              <Text variant="subtle" size="sm" className="shrink-0">
+                {field.label}:
+              </Text>
+              <Text variant="main" size="sm">
+                {formatFieldValue(field.value)}
+              </Text>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/dev/docs/utils/frontmatterDisplay.ts
+++ b/src/dev/docs/utils/frontmatterDisplay.ts
@@ -1,0 +1,154 @@
+/**
+ * Frontmatter display — deciding what an issue's metadata box shows.
+ *
+ * The `.agents/` convention names a handful of fields, but agents write far
+ * more than that: a survey of the 517 issues found ~90 distinct keys, most used
+ * once (`root-cause`, `verified-by`, `spans-repos`, `is-real-root-cause-of`,
+ * `surfaced-by`). Hardcoding a list of fields to render would mean every new
+ * key is silently invisible until someone notices and edits this file — and
+ * nobody notices, because invisible is invisible.
+ *
+ * So the panel renders *everything* and only decides where. Recognised fields
+ * get a place and a label, relations get grouped, and the long tail falls into
+ * a generic section rather than off the page. Misclassifying a rare key costs
+ * nothing; dropping it costs the whole point of opening the file.
+ *
+ * Pure string work — no React, no I/O — so the partitioning can be tested
+ * directly.
+ */
+
+/** Rendered as the page heading, so showing it again would be duplication. */
+const HIDDEN_KEYS = new Set(['title']);
+
+/**
+ * Shown first, in this order.
+ *
+ * `status` is deliberately absent: for issues the frontmatter's copy routinely
+ * contradicts the folder (26 `.done/` files still say `in-progress`), so the
+ * panel takes the derived state from the file record instead. The raw field is
+ * treated as noise and dropped.
+ */
+const PRIMARY_ORDER = [
+  'type',
+  'priority',
+  'complexity',
+  'severity',
+  'area',
+  'scope',
+  'repo',
+  'repos',
+  'created',
+  'updated',
+  'completed',
+  'ai_generated',
+  'reviewed_by',
+];
+
+/** Keys whose values point at other work; grouped so links read together. */
+const RELATION_KEYS = new Set([
+  'depends_on',
+  'depends-on',
+  'blocked_by',
+  'blocked-by',
+  'supersedes',
+  'superseded_by',
+  'spans-repos',
+  'parent-task',
+  'builds_on',
+  'builds-on',
+]);
+
+/** Acronyms mechanical capitalisation would otherwise mangle. */
+const ACRONYMS = new Set(['ai', 'dm', 'ui', 'api', 'db', 'url', 'pr', 'qns', 'id']);
+
+export interface FrontmatterField {
+  key: string;
+  label: string;
+  value: unknown;
+}
+
+export interface FrontmatterPartition {
+  primary: FrontmatterField[];
+  relations: FrontmatterField[];
+  other: FrontmatterField[];
+}
+
+const isRelationKey = (key: string): boolean =>
+  key.startsWith('related') || RELATION_KEYS.has(key);
+
+/** `ai_generated` → `AI generated`, `spans-repos` → `Spans repos`. */
+export function formatFieldLabel(key: string): string {
+  const words = key.split(/[-_\s]+/).filter(Boolean);
+  return words
+    .map((word, index) => {
+      if (ACRONYMS.has(word.toLowerCase())) return word.toUpperCase();
+      if (index === 0) return word.charAt(0).toUpperCase() + word.slice(1);
+      return word;
+    })
+    .join(' ');
+}
+
+/**
+ * A value as text.
+ *
+ * Dates arrive as ISO strings because the manifest is JSON — unquoted YAML
+ * dates become `Date` objects at scan time and serialise on the way through —
+ * so a bare day is pulled back out of the timestamp rather than shown as
+ * `2026-08-01T00:00:00.000Z`.
+ */
+export function formatFieldValue(value: unknown): string {
+  if (value == null) return '—';
+  if (typeof value === 'boolean') return value ? 'Yes' : 'No';
+  if (Array.isArray(value)) return value.map(formatFieldValue).join(', ');
+  if (typeof value === 'object') return JSON.stringify(value);
+
+  const text = String(value);
+  const isoDay = text.match(/^(\d{4}-\d{2}-\d{2})T[\d:.]+Z?$/);
+  return isoDay ? isoDay[1] : text;
+}
+
+/** Values that render as a list of chips rather than one string. */
+export function asList(value: unknown): string[] {
+  if (Array.isArray(value)) return value.map(formatFieldValue).filter(Boolean);
+  const text = formatFieldValue(value);
+  return text === '—' ? [] : [text];
+}
+
+/**
+ * Split frontmatter into the three sections the panel renders. Every key ends
+ * up in exactly one of them, except the ones rendered elsewhere on the page.
+ */
+export function partitionFrontmatter(
+  frontmatter: Record<string, unknown> | undefined | null
+): FrontmatterPartition {
+  const result: FrontmatterPartition = { primary: [], relations: [], other: [] };
+  if (!frontmatter) return result;
+
+  const field = (key: string): FrontmatterField => ({
+    key,
+    label: formatFieldLabel(key),
+    value: frontmatter[key],
+  });
+
+  const seen = new Set<string>(HIDDEN_KEYS);
+
+  // The frontmatter `status` is superseded by the folder-derived state, which
+  // the panel renders from the file record instead.
+  seen.add('status');
+
+  PRIMARY_ORDER.forEach((key) => {
+    if (key in frontmatter && frontmatter[key] != null) {
+      result.primary.push(field(key));
+      seen.add(key);
+    }
+  });
+
+  Object.keys(frontmatter)
+    .filter((key) => !seen.has(key))
+    .forEach((key) => {
+      if (isRelationKey(key)) result.relations.push(field(key));
+      else result.other.push(field(key));
+    });
+
+  return result;
+}

--- a/src/dev/identity-coverage/IdentityCoverage.tsx
+++ b/src/dev/identity-coverage/IdentityCoverage.tsx
@@ -1,7 +1,7 @@
 /**
  * Identity Coverage — the resident panel.
  *
- * Step 4 of `.agents/tasks/2026-08-01-identity-announce-cadence-research.md`:
+ * Step 4 of `2026-08-01-identity-announce-cadence-research.md` under .agents/issues/:
  * the instrument that turns "we think the identity fixes worked" into a number
  * you take twice, before and after, in one click.
  *

--- a/src/dev/identity-coverage/identityCoverageCore.ts
+++ b/src/dev/identity-coverage/identityCoverageCore.ts
@@ -2,7 +2,7 @@
  * Identity Coverage — pure core logic.
  *
  * The instrument for Step 4 of
- * `.agents/tasks/2026-08-01-identity-announce-cadence-research.md`: one number
+ * `2026-08-01-identity-announce-cadence-research.md` under .agents/issues/: one number
  * you can read before and after an identity fix, instead of taking anyone's
  * word for it. Every change in that task exists to move this number down.
  *
@@ -531,7 +531,7 @@ export function formatSigned(value: number): string {
 // ---------------------------------------------------------------------------
 
 export const IDENTITY_COVERAGE_TASK_POINTER =
-  '.agents/tasks/2026-08-01-identity-announce-cadence-research.md';
+  '2026-08-01-identity-announce-cadence-research.md under .agents/issues/';
 
 /** The 2026-06-13 run on the "Quorum Test 2" space, from the task's Step 4
  *  brief. Quoted in the report so a fresh reader has something to compare a

--- a/src/dev/scrollDebug.ts
+++ b/src/dev/scrollDebug.ts
@@ -28,7 +28,7 @@
  * SessionStorage persistence across page reloads.
  *
  * Built during the investigation documented in
- * .agents/bugs/2026-05-24-virtuoso-measurement-scroll-reset.md. Architecture
+ * 2026-05-24-virtuoso-measurement-scroll-reset.md under .agents/issues/. Architecture
  * reference: .agents/docs/features/messages/scroll-anchoring.md.
  *
  * API surface (via window.__scrollDebug):

--- a/src/dev/tests/db/saveMessageConversationIdentity.test.ts
+++ b/src/dev/tests/db/saveMessageConversationIdentity.test.ts
@@ -18,7 +18,7 @@ import { DefaultImages } from '../../../utils';
 // stored; and only fall back to the incoming placeholder when the row is new,
 // so a brand-new row keeps the shape `Conversation` requires.
 //
-// See .agents/tasks/2026-08-01-identity-announce-cadence-research.md §2.
+// See 2026-08-01-identity-announce-cadence-research.md under .agents/issues/ §2.
 
 const PARTNER = 'QmNSr2YL6iLho1CQfRNikQRs2mBxGQRSL2CXYmtKL5ihUB';
 const REAL_NAME = 'Ada Lovelace';

--- a/src/dev/tests/db/saveSpaceMemberClearField.test.ts
+++ b/src/dev/tests/db/saveSpaceMemberClearField.test.ts
@@ -20,7 +20,7 @@ import { MessageDB, type SpaceMemberRow } from '../../../db/messages';
 // default for every partial writer); a caller that genuinely means "remove
 // this" now has to say so.
 //
-// See .agents/bugs/2026-08-01-space-tag-can-no-longer-be-cleared-from-a-member-roster.md
+// See 2026-08-01-space-tag-can-no-longer-be-cleared-from-a-member-roster.md under .agents/issues/
 
 const SPACE = 'space-1';
 const MEMBER = 'QmNSr2YL6iLho1CQfRNikQRs2mBxGQRSL2CXYmtKL5ihUB';

--- a/src/dev/tests/db/saveSpaceMemberGlobalSlot.test.ts
+++ b/src/dev/tests/db/saveSpaceMemberGlobalSlot.test.ts
@@ -15,7 +15,7 @@ import { MessageDB, type SpaceMemberRow } from '../../../db/messages';
 // (2026-07-16) deliberately stopped stamping the per-space OVERRIDE fields, so
 // they are empty unless someone set a real per-space override.
 //
-// See .agents/bugs/2026-08-01-space-sync-member-delta-blind-to-and-erases-global-slot.md
+// See 2026-08-01-space-sync-member-delta-blind-to-and-erases-global-slot.md under .agents/issues/
 
 const SPACE = 'space-1';
 const MEMBER = 'QmNSr2YL6iLho1CQfRNikQRs2mBxGQRSL2CXYmtKL5ihUB';

--- a/src/dev/tests/docs/frontmatterDisplay.unit.test.ts
+++ b/src/dev/tests/docs/frontmatterDisplay.unit.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest';
+import {
+  asList,
+  formatFieldLabel,
+  formatFieldValue,
+  partitionFrontmatter,
+} from '../../docs/utils/frontmatterDisplay';
+
+describe('formatFieldLabel', () => {
+  it('reads a snake_case or kebab-case key as words', () => {
+    expect(formatFieldLabel('related_docs')).toBe('Related docs');
+    expect(formatFieldLabel('spans-repos')).toBe('Spans repos');
+    expect(formatFieldLabel('is-real-root-cause-of')).toBe('Is real root cause of');
+  });
+
+  it('does not mangle acronyms', () => {
+    expect(formatFieldLabel('ai_generated')).toBe('AI generated');
+    expect(formatFieldLabel('related_pr')).toBe('Related PR');
+  });
+
+  it('leaves a single plain word alone but capitalised', () => {
+    expect(formatFieldLabel('severity')).toBe('Severity');
+  });
+});
+
+describe('formatFieldValue', () => {
+  it('renders booleans as words', () => {
+    expect(formatFieldValue(true)).toBe('Yes');
+    expect(formatFieldValue(false)).toBe('No');
+  });
+
+  it('renders a missing value as a dash', () => {
+    expect(formatFieldValue(null)).toBe('—');
+    expect(formatFieldValue(undefined)).toBe('—');
+  });
+
+  it('pulls the day back out of a serialised YAML date', () => {
+    // Unquoted YAML dates become Date objects at scan time and reach the
+    // browser as ISO timestamps once the manifest is JSON.
+    expect(formatFieldValue('2026-08-01T00:00:00.000Z')).toBe('2026-08-01');
+    expect(formatFieldValue('2026-08-01')).toBe('2026-08-01');
+  });
+
+  it('joins arrays', () => {
+    expect(formatFieldValue(['a.md', 'b.md'])).toBe('a.md, b.md');
+  });
+
+  it('keeps prose intact', () => {
+    expect(
+      formatFieldValue('HIGH (authorization bypass / integrity)')
+    ).toBe('HIGH (authorization bypass / integrity)');
+  });
+});
+
+describe('asList', () => {
+  it('splits an array into entries', () => {
+    expect(asList(['one', 'two'])).toEqual(['one', 'two']);
+  });
+
+  it('wraps a lone string', () => {
+    expect(asList('issues/transport/index.md')).toEqual([
+      'issues/transport/index.md',
+    ]);
+  });
+
+  it('is empty when there is no value', () => {
+    expect(asList(null)).toEqual([]);
+    expect(asList(undefined)).toEqual([]);
+  });
+});
+
+describe('partitionFrontmatter', () => {
+  it('is empty for a file whose YAML did not parse', () => {
+    expect(partitionFrontmatter(undefined)).toEqual({
+      primary: [],
+      relations: [],
+      other: [],
+    });
+  });
+
+  it('orders the recognised fields, regardless of the order written', () => {
+    const partition = partitionFrontmatter({
+      created: '2026-08-01',
+      severity: 'high',
+      type: 'bug',
+      priority: 'high',
+    });
+    expect(partition.primary.map((f) => f.key)).toEqual([
+      'type',
+      'priority',
+      'severity',
+      'created',
+    ]);
+  });
+
+  it('drops title and status — both are rendered elsewhere', () => {
+    const partition = partitionFrontmatter({
+      title: 'Something',
+      status: 'in-progress',
+      type: 'task',
+    });
+    const allKeys = [
+      ...partition.primary,
+      ...partition.relations,
+      ...partition.other,
+    ].map((f) => f.key);
+    expect(allKeys).not.toContain('title');
+    // The folder is the source of truth for state, so a stale `status:` would
+    // contradict the badge right next to it.
+    expect(allKeys).not.toContain('status');
+    expect(allKeys).toContain('type');
+  });
+
+  it('groups anything that points at other work', () => {
+    const partition = partitionFrontmatter({
+      related_docs: ['a.md'],
+      related_bugs: ['b.md'],
+      related: ['c.md'],
+      depends_on: ['d.md'],
+      'spans-repos': ['quorum-desktop'],
+      superseded_by: 'e.md',
+    });
+    expect(partition.relations.map((f) => f.key).sort()).toEqual([
+      'depends_on',
+      'related',
+      'related_bugs',
+      'related_docs',
+      'spans-repos',
+      'superseded_by',
+    ]);
+    expect(partition.other).toEqual([]);
+  });
+
+  it('keeps every unrecognised key instead of dropping it', () => {
+    // ~90 one-off keys exist across the tree; the panel must not hide them.
+    const partition = partitionFrontmatter({
+      'is-real-root-cause-of': 'x.md',
+      'runtime-test': 'passed',
+      'found_via': 'sync testing',
+      github: 'https://example.invalid/1',
+    });
+    expect(partition.other.map((f) => f.key).sort()).toEqual([
+      'found_via',
+      'github',
+      'is-real-root-cause-of',
+      'runtime-test',
+    ]);
+    expect(partition.relations).toEqual([]);
+  });
+
+  it('skips a recognised field that is present but empty', () => {
+    const partition = partitionFrontmatter({ type: 'bug', priority: null });
+    expect(partition.primary.map((f) => f.key)).toEqual(['type']);
+  });
+});

--- a/src/dev/tests/harness/README.md
+++ b/src/dev/tests/harness/README.md
@@ -247,7 +247,7 @@ copy was defeated by the relay.
 - Slice S2 (delivery rate + lag at volume, and roster size as the first swept
   variable) — NEXT. This is the one that turns the anecdote into a number.
 
-See `.agents/issues/.done/2026-07-27-headless-dm-harness.md` for the DM slice plan,
+See `2026-07-27-headless-dm-harness.md` under .agents/issues/ for the DM slice plan,
 `.agents/issues/transport/2026-07-27-headless-space-harness.md` for the space one,
 and `.agents/issues/transport/2026-07-26-dm-desktop-to-desktop-resurfaced.md` §1 for the DM
 findings.

--- a/src/dev/tests/harness/space-backlog.scenario.test.ts
+++ b/src/dev/tests/harness/space-backlog.scenario.test.ts
@@ -3,9 +3,9 @@
 //   yarn harness space-backlog
 //   HARNESS_BACKLOG_SIZES=0,50,200 HARNESS_BACKLOG_ITERATIONS=3 yarn harness space-backlog
 //
-// This is the experiment `.agents/bugs/2026-08-02-sync-requests-arrive-four-
-// minutes-late-and-every-peer-rejects-them.md` §5b step 1 asks for, and it is
-// the thing a manual test cannot do: vary the backlog and watch the rate move.
+// This is the experiment `2026-08-02-sync-requests-arrive-four-minutes-late-and-
+// every-peer-rejects-them.md` under .agents/issues/ §5b step 1 asks for, and it
+// is the thing a manual test cannot do: vary the backlog and watch the rate move.
 //
 // ## The field observation being reproduced
 //

--- a/src/dev/tests/harness/space-basic.scenario.test.ts
+++ b/src/dev/tests/harness/space-basic.scenario.test.ts
@@ -9,8 +9,8 @@
 //   2. A's member row        — the ROSTER half, one payload, no retry
 //
 // The second one is why this scenario exists in this shape. The spec's S1 asked
-// only for the post; `.agents/bugs/2026-08-02-roster-pull-delivers-nothing-to-a-
-// new-joiner.md` is about the roster, and its §0 says the exchange is
+// only for the post; `2026-08-02-roster-pull-delivers-nothing-to-a-new-joiner.md`
+// under .agents/issues/ is about the roster, and its §0 says the exchange is
 // INTERMITTENT — it worked once (`memberDelta=71 members → saved 71 member
 // row(s)`) and failed repeatedly around it. A joiner with 2 members is the
 // smallest possible instance of "78 rows on one side, 1 on the other".

--- a/src/dev/tests/harness/space-rate.scenario.test.ts
+++ b/src/dev/tests/harness/space-rate.scenario.test.ts
@@ -6,7 +6,7 @@
 // S1 proved the exchange CAN work. It ran at two members and passed five times,
 // which says nothing about a failure reported at ~79 members and described as
 // intermittent. This scenario answers the three questions
-// `.agents/bugs/2026-08-02-roster-pull-delivers-nothing-to-a-new-joiner.md`
+// `2026-08-02-roster-pull-delivers-nothing-to-a-new-joiner.md` under .agents/issues/
 // says a manual test cannot:
 //
 //   1. is it 1-in-2 or 1-in-50?

--- a/src/dev/tests/services/ConfigService.unit.test.tsx
+++ b/src/dev/tests/services/ConfigService.unit.test.tsx
@@ -6,7 +6,7 @@
  *
  * APPROACH: Unit tests with vi.fn() mocks - NOT integration tests
  *
- * KNOWN GAPS (see .agents/tasks/2026-05-19-test-suite-review.md):
+ * KNOWN GAPS (see 2026-05-19-test-suite-review.md under .agents/issues/):
  * - getConfig newer-remote-timestamp branch (the 60-line decrypt-and-verify path)
  * - getConfig equal-timestamp / stale-remote branches
  * - getConfig bookmark merge, user notes merge, tombstone application paths

--- a/src/dev/tests/services/EncryptionService.unit.test.tsx
+++ b/src/dev/tests/services/EncryptionService.unit.test.tsx
@@ -6,7 +6,7 @@
  *
  * APPROACH: Unit tests with vi.fn() mocks - NOT integration tests
  *
- * KNOWN GAPS (see .agents/tasks/2026-05-19-test-suite-review.md):
+ * KNOWN GAPS (see 2026-05-19-test-suite-review.md under .agents/issues/):
  * - ensureKeyForSpace migration path — the 80-line key-rotation operation
  *   (re-ID conversations, copy messages, migrate members, post API, update
  *   config) is the most destructive operation in the service and is

--- a/src/dev/tests/services/MessageService.unit.test.tsx
+++ b/src/dev/tests/services/MessageService.unit.test.tsx
@@ -12,7 +12,7 @@
  * - saveMessage (database persistence for reaction/remove paths)
  * - encryptAndSendToSpace (hub message helper)
  *
- * KNOWN GAPS (see .agents/tasks/2026-05-19-test-suite-review.md):
+ * KNOWN GAPS (see 2026-05-19-test-suite-review.md under .agents/issues/):
  * - handleNewMessage routing (inbox-match branch and 7 message types)
  * - updateMessageStatus, encryptAndSendDm, sendEphemeralDM/SpaceControl
  * - deleteConversation, submitChannelMessage actual side effects
@@ -442,7 +442,7 @@ describe('MessageService - Unit Tests', () => {
   // SECURITY: DM control-message authorization must anchor to the session-
   // authenticated sender (the conversation owner == spaceId for a DM), NOT the
   // spoofable plaintext content.senderId. See
-  // .agents/tasks/2026-06-25-MASTER-RECAP-control-message-auth.md
+  // 2026-06-25-MASTER-RECAP-control-message-auth.md under .agents/issues/
   describe('3b. saveMessage() - DM remove-message authorization (anti-spoofing)', () => {
     // For a DM, spaceId === channelId === the proven conversation partner address.
     const PEER = 'peer-address';

--- a/src/dev/tests/services/MessageService.unknownInbox.unit.test.ts
+++ b/src/dev/tests/services/MessageService.unknownInbox.unit.test.ts
@@ -24,7 +24,7 @@
  * So the correct behaviour is to retain, and this test pins it. If someone later
  * "restores" a delete here, this fails.
  *
- * Full analysis: `.agents/bugs/.solved/2026-07-29-session-replacement-strands-in-flight-frames.md`
+ * Full analysis: `2026-07-29-session-replacement-strands-in-flight-frames.md` under .agents/issues/
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MessageService } from '../../../services/MessageService';

--- a/src/dev/tests/services/SpaceService.unit.test.tsx
+++ b/src/dev/tests/services/SpaceService.unit.test.tsx
@@ -6,7 +6,7 @@
  *
  * APPROACH: Unit tests with vi.fn() mocks - NOT integration tests
  *
- * KNOWN GAPS (see .agents/tasks/2026-05-19-test-suite-review.md):
+ * KNOWN GAPS (see 2026-05-19-test-suite-review.md under .agents/issues/):
  * - kickUser happy path: the bulk of the kick work (ratchet rekey, member filtering,
  *   SealSyncEnvelope loop) runs inside the enqueueOutbound callback which is fire-and-
  *   forget. EstablishTripleRatchetSessionForSpace returns a complex session object with

--- a/src/dev/tests/services/SyncService.unit.test.tsx
+++ b/src/dev/tests/services/SyncService.unit.test.tsx
@@ -6,7 +6,7 @@
  *
  * APPROACH: Unit tests with vi.fn() mocks - NOT integration tests
  *
- * KNOWN GAPS (see .agents/tasks/2026-05-19-test-suite-review.md):
+ * KNOWN GAPS (see 2026-05-19-test-suite-review.md under .agents/issues/):
  * 9 of 12 public methods have zero coverage: handleSyncInitiateV2,
  * handleSyncManifest, requestSync, directSync, synchronizeAll,
  * updateCacheWithMessage, updateCacheWithMember, removeCacheMessage,

--- a/src/dev/tests/utils/conversationProfile.test.ts
+++ b/src/dev/tests/utils/conversationProfile.test.ts
@@ -3,7 +3,7 @@
 // these tests is that flipping `||` back to `??` (which reads as an equivalent
 // tidy-up) turns a blank avatar into silent data loss.
 //
-// Context: .agents/tasks/2026-08-01-dm-partner-identity-lost-on-established-sessions.md
+// Context: 2026-08-01-dm-partner-identity-lost-on-established-sessions.md under .agents/issues/
 
 import { describe, it, expect } from 'vitest';
 import {

--- a/src/dev/tests/utils/dmProfileGate.test.ts
+++ b/src/dev/tests/utils/dmProfileGate.test.ts
@@ -4,7 +4,7 @@
 // These tests pin both edges: the expiry that bounds the second one, and the
 // CAP that bounds the first one so a converged pair stops paying forever.
 //
-// Context: .agents/tasks/2026-08-01-identity-announce-cadence-research.md (Step 2)
+// Context: 2026-08-01-identity-announce-cadence-research.md under .agents/issues/ (Step 2)
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import {

--- a/src/dev/tests/utils/identityPlaceholder.test.ts
+++ b/src/dev/tests/utils/identityPlaceholder.test.ts
@@ -3,7 +3,7 @@
 // "Unknown User" with a "?" avatar while the header showed "QmYVto…LjDd" with
 // a "Q" avatar for the SAME row.
 //
-// Context: .agents/tasks/2026-08-01-dm-partner-identity-lost-on-established-sessions.md
+// Context: 2026-08-01-dm-partner-identity-lost-on-established-sessions.md under .agents/issues/
 
 import { describe, it, expect } from 'vitest';
 import {

--- a/src/dev/tests/utils/mentionPillDom.unit.test.ts
+++ b/src/dev/tests/utils/mentionPillDom.unit.test.ts
@@ -6,7 +6,7 @@
  * flattened to a single line because the walker ignored block elements and
  * <br>). Browsers represent contentEditable line breaks as either <br> nodes or
  * by wrapping each line after the first in its own <div>/<p>; both shapes are
- * exercised here. See .agents/bugs/2026-06-25-composer-paste-strips-newlines.md.
+ * exercised here. See 2026-06-25-composer-paste-strips-newlines.md under .agents/issues/.
  *
  * @vitest-environment jsdom
  */

--- a/src/dev/tests/utils/resolveInboundSpaceTag.test.ts
+++ b/src/dev/tests/utils/resolveInboundSpaceTag.test.ts
@@ -16,7 +16,7 @@
 // away). Neither state is right, because absence cannot carry both meanings.
 // Hence the tombstone.
 //
-// See .agents/bugs/2026-08-01-space-tag-can-no-longer-be-cleared-from-a-member-roster.md
+// See 2026-08-01-space-tag-can-no-longer-be-cleared-from-a-member-roster.md under .agents/issues/
 
 import { describe, it, expect } from 'vitest';
 import { resolveInboundSpaceTag } from '../../../services/MessageService';

--- a/src/dev/tests/utils/rosterConvergence.test.ts
+++ b/src/dev/tests/utils/rosterConvergence.test.ts
@@ -17,7 +17,7 @@
 //                  never noticed and the user stares at truncated addresses
 //                  until they relaunch
 //
-// See .agents/bugs/2026-08-02-roster-pull-delivers-nothing-to-a-new-joiner.md
+// See 2026-08-02-roster-pull-delivers-nothing-to-a-new-joiner.md under .agents/issues/
 
 import { describe, it, expect } from 'vitest';
 import {

--- a/src/dev/tests/utils/spaceProfileGate.test.ts
+++ b/src/dev/tests/utils/spaceProfileGate.test.ts
@@ -11,7 +11,7 @@
 // So: capped like the DM gate, but spaced in minutes rather than days, because
 // past the bootstrap the member digest exchange is the repair path.
 //
-// Context: .agents/tasks/2026-08-01-space-member-identity-announce-on-connect.md
+// Context: 2026-08-01-space-member-identity-announce-on-connect.md under .agents/issues/
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import {

--- a/src/hooks/business/mentions/useChannelMentionCounts.ts
+++ b/src/hooks/business/mentions/useChannelMentionCounts.ts
@@ -30,7 +30,7 @@ const DISPLAY_THRESHOLD = 10;
  * Uses React Query with 30s stale time for performance while maintaining
  * reasonable real-time updates when invalidated.
  *
- * @see .agents/tasks/mention-notification-settings-phase4.md
+ * @see mention-notification-settings-phase4.md under .agents/issues/
  */
 export function useChannelMentionCounts({
   spaceId,

--- a/src/hooks/business/mentions/useMentionNotificationSettings.ts
+++ b/src/hooks/business/mentions/useMentionNotificationSettings.ts
@@ -5,8 +5,8 @@
  * Settings are stored in IndexedDB user_config.notificationSettings[spaceId] and sync across devices.
  *
  * Part of Phase 4: Mention Notification Settings & Reply Notification System
- * @see .agents/tasks/mention-notification-settings-phase4.md
- * @see .agents/tasks/reply-notification-system.md
+ * @see mention-notification-settings-phase4.md under .agents/issues/
+ * @see reply-notification-system.md under .agents/issues/
  */
 
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
@@ -83,7 +83,7 @@ export function useMentionNotificationSettings({
   // read that could capture desktop's stale local default before a cross-device
   // config sync had landed in IndexedDB — making the modal display (and worse,
   // a no-op Save) clobber a value another device had already set.
-  // See .agents/tasks/.todo/2026-06-23-notification-settings-stale-read-and-clobber.md
+  // See 2026-06-23-notification-settings-stale-read-and-clobber.md under .agents/issues/
   const { data: config } = useConfig({ userAddress: userAddress || '' });
 
   // The persisted settings for this space, derived from the live config.

--- a/src/hooks/business/replies/useAllReplies.ts
+++ b/src/hooks/business/replies/useAllReplies.ts
@@ -29,7 +29,7 @@ interface UseAllRepliesProps {
  *   enabled: selectedTypes.includes('reply')
  * });
  *
- * @see .agents/tasks/reply-notification-system.md
+ * @see reply-notification-system.md under .agents/issues/
  */
 export function useAllReplies({
   spaceId,

--- a/src/hooks/business/replies/useReplyNotificationCounts.ts
+++ b/src/hooks/business/replies/useReplyNotificationCounts.ts
@@ -30,7 +30,7 @@ const DISPLAY_THRESHOLD = 10;
  * Uses React Query with 30s stale time for performance while maintaining
  * reasonable real-time updates when invalidated.
  *
- * @see .agents/tasks/reply-notification-system.md
+ * @see reply-notification-system.md under .agents/issues/
  */
 export function useReplyNotificationCounts({
   spaceId,

--- a/src/services/ActionQueueHandlers.ts
+++ b/src/services/ActionQueueHandlers.ts
@@ -12,7 +12,7 @@
  * - Space updates show success/failure
  * - Moderation shows success/failure
  *
- * See: .agents/tasks/background-action-queue.md
+ * See: background-action-queue.md under .agents/issues/
  */
 
 import { logger } from '@quilibrium/quorum-shared';

--- a/src/services/ActionQueueService.ts
+++ b/src/services/ActionQueueService.ts
@@ -7,7 +7,7 @@
  * - Space settings updates
  * - Moderation actions (kick, mute)
  *
- * See: .agents/tasks/background-action-queue.md
+ * See: background-action-queue.md under .agents/issues/
  */
 
 import { logger } from '@quilibrium/quorum-shared';
@@ -32,7 +32,7 @@ export class ActionQueueService {
 
   // Callback to check online status from ActionQueueContext
   // Uses WebSocket state instead of unreliable navigator.onLine
-  // See: .agents/tasks/offline-detection-and-optimistic-message-reliability.md
+  // See: offline-detection-and-optimistic-message-reliability.md under .agents/issues/
   private isOnlineCallback?: () => boolean;
 
   // Debounced queue update event

--- a/src/services/ConfigService.ts
+++ b/src/services/ConfigService.ts
@@ -474,7 +474,7 @@ export class ConfigService {
       // momentarily incomplete, which is how a device silently wipes its own
       // Space list. Note the copies below: folder items are cloned rather than
       // mutated, because a shallow spread still shares those nested objects.
-      // See .agents/bugs/2026-01-09-config-sync-space-loss-race-condition.md
+      // See 2026-01-09-config-sync-space-loss-race-condition.md under .agents/issues/
       const uploadConfig: UserConfig = { ...config };
       const validSpaceIds = new Set(config.spaceKeys.map(sk => sk.spaceId));
       uploadConfig.spaceIds = config.spaceIds.filter(id => validSpaceIds.has(id));
@@ -508,7 +508,7 @@ export class ConfigService {
       // getConfig applies a remote Space list verbatim, so every other device
       // adopts the shorter list. Hold the upload and let a later save publish
       // the full list once the missing Spaces have synced.
-      // See .agents/bugs/2026-01-09-config-sync-space-loss-race-condition.md
+      // See 2026-01-09-config-sync-space-loss-race-condition.md under .agents/issues/
       const droppedSpaceIds = config.spaceIds.filter(id => !finalSpaceIds.has(id));
 
       if (droppedSpaceIds.length > 0) {

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -246,7 +246,7 @@ export interface MessageServiceDependencies {
  *
  * The clear has to travel to the DB as an explicit `clearFields`, because
  * `saveSpaceMember` merges and drops `undefined`s — see that method's doc and
- * .agents/bugs/2026-08-01-space-tag-can-no-longer-be-cleared-from-a-member-roster.md
+ * 2026-08-01-space-tag-can-no-longer-be-cleared-from-a-member-roster.md under .agents/issues/
  */
 export function resolveInboundSpaceTag(
   inbound: BroadcastSpaceTag | null | undefined
@@ -2073,7 +2073,7 @@ export class MessageService {
       // fully and tolerate a cosmetic self-sync lag, because desktop's JS SDK does
       // not expose the per-message authenticated sender that would let us tell a
       // genuine self-echo from a peer spoofing your address. See
-      // .agents/tasks/2026-06-25-MASTER-RECAP-control-message-auth.md.
+      // 2026-06-25-MASTER-RECAP-control-message-auth.md under .agents/issues/.
       const isDM = spaceId === channelId;
       if (isDM) {
         const authorized =
@@ -4788,7 +4788,7 @@ export class MessageService {
               const isUpdateProfile = decryptedContent.content.type === 'update-profile';
               // participant may be null: the sender's join broadcast never
               // reached us, so there is no space_members row yet (common — see
-              // .agents/bugs/2026-06-13-space-members-missing-no-join-row.md).
+              // 2026-06-13-space-members-missing-no-join-row.md under .agents/issues/).
               // Optional-chain the deref; a missing inbox_address means we have
               // nothing to compare against, so there is no mismatch to flag and
               // the signature is verified below as normal. Without the guard
@@ -6017,7 +6017,7 @@ export class MessageService {
             // nothing distinguishes "the payload never came", "it came empty"
             // and "it came full and every row was skipped". That gap cost a
             // full debugging session on 2026-08-02.
-            // See .agents/bugs/2026-08-02-roster-pull-delivers-nothing-to-a-new-joiner.md
+            // See 2026-08-02-roster-pull-delivers-nothing-to-a-new-joiner.md under .agents/issues/
             logger.log(
               `[MessageService] sync-delta: memberDelta=${
                 envelope.message.memberDelta

--- a/src/shims/quilibrium-sdk-channels.native.tsx
+++ b/src/shims/quilibrium-sdk-channels.native.tsx
@@ -16,7 +16,7 @@
  * IMPORTANT: All methods currently return mock data or no-ops.
  * Passkey functionality is NOT available on mobile until properly implemented.
  *
- * See: .agents/tasks/todo/mobile-sdk-integration-issue.md for full details
+ * See: mobile-dev/2025-08-08-mobile-sdk-integration-issue.md under .agents/issues/ for full details
  */
 
 import { logger } from '@quilibrium/quorum-shared';

--- a/src/types/actionQueue.ts
+++ b/src/types/actionQueue.ts
@@ -2,7 +2,7 @@
  * Action Queue Types
  *
  * Types for the persistent background action queue system.
- * See: .agents/tasks/background-action-queue.md
+ * See: background-action-queue.md under .agents/issues/
  */
 
 export type ActionType =

--- a/src/utils/conversationProfile.ts
+++ b/src/utils/conversationProfile.ts
@@ -16,7 +16,7 @@
 // applies the same `||` semantics on its equivalent merge
 // (quorum-mobile context/WebSocketContext.tsx ~4740).
 //
-// See .agents/tasks/2026-08-01-dm-partner-identity-lost-on-established-sessions.md
+// See 2026-08-01-dm-partner-identity-lost-on-established-sessions.md under .agents/issues/
 
 /** The identity fields carried on a decrypted frame / SDK `UserProfile`. */
 export interface IncomingPartnerProfile {

--- a/src/utils/dmProfileGate.ts
+++ b/src/utils/dmProfileGate.ts
@@ -26,7 +26,7 @@
 // Desktop counterpart of mobile's MMKV gate
 // (quorum-mobile/services/dm/dmProfileService.ts).
 //
-// See .agents/tasks/2026-08-01-identity-announce-cadence-research.md (Step 2)
+// See 2026-08-01-identity-announce-cadence-research.md under .agents/issues/ (Step 2)
 // and 2026-08-01-dm-partner-identity-lost-on-established-sessions.md
 
 import {
@@ -66,7 +66,7 @@ export const RESEND_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24h
  *    keeps its stored `at`. See `migrateRecord` in `profileSendGate.ts`.
  *
  * Rationale and the cost model:
- *   .agents/tasks/2026-08-01-identity-announce-cadence-research.md
+ *   2026-08-01-identity-announce-cadence-research.md under .agents/issues/
  *
  * ⚠️ Do not reuse this INTERVAL for spaces. Spaces already have a
  * receiver-driven member reconciliation (`MemberDigest` → `MemberDelta`), so

--- a/src/utils/dmStaleBucketRetry.ts
+++ b/src/utils/dmStaleBucketRetry.ts
@@ -1,6 +1,6 @@
 /**
  * Mitigation for the upstream skipped-key lookup defect (quorum-mobile#183 item
- * 1a; bug doc `.agents/bugs/2026-07-26-dm-desktop-to-desktop-resurfaced.md` §5-B1).
+ * 1a; bug doc `transport/2026-07-26-dm-desktop-to-desktop-resurfaced.md` under .agents/issues/ §5-B1).
  *
  * THE UPSTREAM DEFECT, as measured. A receiver files the message keys of frames
  * it had to skip into `skipped_keys_map`, keyed by the header key of the sending

--- a/src/utils/identityPlaceholder.ts
+++ b/src/utils/identityPlaceholder.ts
@@ -21,7 +21,7 @@
 // active when it was written, which can differ from the one active now.
 //
 // Spaces have the same class of placeholder problem (see
-// .agents/bugs/2026-06-13-space-members-missing-no-join-row.md); this module is
+// 2026-06-13-space-members-missing-no-join-row.md under .agents/issues/); this module is
 // the intended home for that rule too if it is fixed the same way.
 
 import { t } from '@lingui/core/macro';

--- a/src/utils/profileSendGate.ts
+++ b/src/utils/profileSendGate.ts
@@ -20,7 +20,7 @@
 // failure: one lost frame becomes permanent and silent, because the sender
 // recorded a success the receiver never saw.
 //
-// See .agents/tasks/2026-08-01-identity-announce-cadence-research.md
+// See 2026-08-01-identity-announce-cadence-research.md under .agents/issues/
 
 import { logger } from '@quilibrium/quorum-shared';
 

--- a/src/utils/rosterConvergence.ts
+++ b/src/utils/rosterConvergence.ts
@@ -36,7 +36,7 @@
 // ⚠️ OBSERVABILITY. `shouldReAsk` returns a REASON, not a boolean, and the
 // caller logs it on every branch. That is not gold-plating: `logger` is a no-op
 // in production builds (see
-// .agents/issues/.open/2026-08-01-every-logger-call-is-a-no-op-in-production-builds.md),
+// 2026-08-01-every-logger-call-is-a-no-op-in-production-builds.md under .agents/issues/),
 // so a developer running a dev build is the ONLY audience this code will ever
 // have, and giving them "false" with no reason attached reproduces exactly the
 // blindness that made the original bug take a session to find.

--- a/src/utils/spaceProfileGate.ts
+++ b/src/utils/spaceProfileGate.ts
@@ -25,7 +25,7 @@
 // 5 spaces × 50 members that is several times a daily DM announce, not less.
 // An uncapped version would be the most expensive identity traffic in the app.
 //
-// See .agents/tasks/2026-08-01-space-member-identity-announce-on-connect.md
+// See 2026-08-01-space-member-identity-announce-on-connect.md under .agents/issues/
 // and 2026-08-01-identity-announce-cadence-research.md (Step 3).
 
 import {


### PR DESCRIPTION
Two things, both fallout from the `issues/` merge.

### The metadata box showed eight fields out of ~90

A survey of the 517 issues found ~90 distinct frontmatter keys, most used once — `root-cause`, `verified-by`, `spans-repos`, `surfaced-by`, `is-real-root-cause-of`. Everything outside the hardcoded eight was invisible, **including `priority` and `severity`**, the two an operator most wants when triaging.

The panel now renders everything and only decides *where*: recognised fields first, anything pointing at other work grouped together, the long tail in a generic "Other fields" section. A new key needs no code change to become visible — which matters, because the alternative is noticing it is missing, and nobody notices invisible.

Two deliberate calls:

- **The frontmatter `status:` is not shown.** State is derived from the folder; rendering the raw field beside it would put a stale value next to the correct one on 42 of 517 files.
- **A file whose YAML failed to parse now says so**, with the parser's own message and what to do about it, instead of an empty box that looks like an issue with nothing to record.

### 65 references pointed at folders that no longer exist

`src/` still referenced `.agents/tasks/` and `.agents/bugs/`, plus a few `.agents/issues/.open/` and `.done/` paths. Both break the same way — an issue is filed by state, so it moves. That is the problem #303 fixed for four references; this applies the same convention to the rest: name the file, say to look under `.agents/issues/`, and keep the epic folder where the bare name is not unique (`search-optimization/decisions.md`, `port-from-mobile/candidates.md`).

**Seven had already gone stale beyond the folder rename** and were resolved against the tree rather than rewritten mechanically: five documents gained a date prefix at some point (`add-user-bio-field.md` → `2025-01-06-add-user-bio-field.md`), one was renamed outright (the DM doctor's runbook pointer, now `transport/runbook.md`), and `candidates.md` exists twice under different epics.

The dev README described a Tasks page and a Bugs page that no longer exist, and never mentioned that the file list is a build artifact — so a doc added after the last `yarn scan-docs` looks like it simply is not there.

### Testing

17 new unit tests on the partitioning and formatting logic. `tsc --noEmit` and `eslint` clean (no new warnings); full suite **941/941**.

### Still to come

The data pass: 8 files with unparseable YAML, 13 prose priorities, 42 issues whose `status:` contradicts their folder, and the priority backfill on the 125 actionable issues. Those are `.md` edits, not code.
