### PR TITLE
fix: ack a typing indicator, so the relay stops re-pushing it forever

### DIFF
--- a/src/dev/tests/harness/space-typing.scenario.test.ts
+++ b/src/dev/tests/harness/space-typing.scenario.test.ts
@@ -1,0 +1,190 @@
+// Are typing frames redelivered on every reconnect, forever?
+//
+//   yarn harness space-typing
+//
+// ## Why this exists
+//
+// The relay retains a frame until the client deletes it, and that delete IS the
+// ack. The space receive path acks exactly once, in the tail of
+// `handleNewMessage`. But a typing frame returns BEFORE that tail
+// (`MessageService.ts`, the `isTypingMessage` branch), so it is processed and
+// never acked.
+//
+// If that reading is right, every typing indicator ever sent to you stays on the
+// relay and is redelivered on every `listen` — each time costing a full unseal
+// and a trip through the inbound queue. `TypingService`'s 30s freshness filter
+// hides the UI symptom, but it runs AFTER the frame has been received and
+// decrypted, so it does nothing for the cost.
+//
+// That matters more than it sounds. Queue DEPTH is the variable that decides
+// whether a perishable control frame (a `sync-info` reply, valid 30s) is read in
+// time — see the FALSIFIED section of
+// `2026-08-02-sync-requests-arrive-four-minutes-late-…`: the wait is the number
+// of frames AHEAD, and no scheduling change alters that. A permanent,
+// ever-growing source of queue depth beats every scheduling fix on the table.
+//
+// ⚠️ The team's own doc already records the replay:
+// `.agents/docs/features/messages/typing-indicators.md` describes the freshness
+// filter as defending against "hub-replay on subscribe-join, which would
+// otherwise flood the receive path with ancient typing-starts". So the replay is
+// known. What has not been established is that it is UNBOUNDED — that these
+// frames are never acked and therefore accumulate for the life of the account.
+//
+// ## What this measures
+//
+// A controlled two-arm comparison inside one run:
+//
+//   POST    — an ordinary message. Acked in the tail. Should NOT come back.
+//   TYPING  — a typing indicator. Never acked. Should come back.
+//
+// The post is the control arm. If BOTH come back, the harness is wrong about
+// acking generally and this scenario proves nothing about typing specifically.
+// If NEITHER comes back, the diagnosis is wrong and that is worth knowing.
+import { test, expect } from 'vitest';
+import { createSpaceBot } from './spaceBot';
+import { WsTransport } from './transport';
+import { RunLog } from './log';
+
+const WINDOW_MS = Number(process.env.HARNESS_TYPING_WINDOW_MS ?? 60_000);
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/** How many times each fingerprint appears in a bot's arrival log. */
+function fingerprintCounts(transport: WsTransport): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const f of transport.arrived) {
+    const fp = WsTransport.fingerprint(f);
+    counts.set(fp, (counts.get(fp) ?? 0) + 1);
+  }
+  return counts;
+}
+
+/** Wait until `transport.arrived` stops growing, or the deadline passes. */
+async function settle(transport: WsTransport, quietMs = 3000): Promise<void> {
+  let last = -1;
+  const deadline = Date.now() + 25_000;
+  while (Date.now() < deadline) {
+    const now = transport.arrived.length;
+    if (now === last) return;
+    last = now;
+    await sleep(quietMs);
+  }
+}
+
+test(
+  'space-typing: is a typing frame redelivered after a reconnect?',
+  async () => {
+    const startedAt = Date.now();
+    const log = new RunLog('space-typing', startedAt);
+    const say = (msg: string, fields: Record<string, unknown> = {}) => {
+      console.log(`[space-typing] ${msg}`);
+      log.add(Date.now(), 'harness', 'note', { msg, ...fields });
+    };
+
+    const stamp = String(Date.now()).slice(-7);
+    let a: Awaited<ReturnType<typeof createSpaceBot>> | undefined;
+    let b: Awaited<ReturnType<typeof createSpaceBot>> | undefined;
+
+    try {
+      [a, b] = await Promise.all([
+        createSpaceBot(`ty-a-${stamp}`),
+        createSpaceBot(`ty-b-${stamp}`),
+      ]);
+      await Promise.all([a.start(), b.start()]);
+
+      const { spaceId, channelId } = await a.createSpace(`harness-ty-${stamp}`);
+      const link = await a.inviteLink(spaceId);
+      await b.join(link);
+      await settle(b.transport);
+      say(`joined; B has seen ${b.transport.arrived.length} frame(s)`);
+
+      // ── Control arm: an ordinary post, which the tail acks ──────────────────
+      await a.post(spaceId, channelId, `control-post-${stamp}`);
+      await settle(b.transport);
+      const afterPost = b.transport.arrived.length;
+      const postFp =
+        afterPost > 0
+          ? WsTransport.fingerprint(b.transport.arrived[afterPost - 1])
+          : undefined;
+      say(`after POST: ${afterPost} frame(s), newest fp=${postFp}`);
+
+      // ── Treatment arm: a typing indicator, which returns before the ack ─────
+      await a.graph.messageService.sendEphemeralSpaceControl(spaceId, {
+        type: 'typing-start',
+        senderId: a.identity.userAddress ?? 'unknown',
+        scope: 'space',
+        spaceId,
+        channelId,
+        timestamp: Date.now(),
+      });
+      await settle(b.transport);
+      const afterTyping = b.transport.arrived.length;
+      const typingFp =
+        afterTyping > afterPost
+          ? WsTransport.fingerprint(b.transport.arrived[afterTyping - 1])
+          : undefined;
+      say(`after TYPING: ${afterTyping} frame(s), newest fp=${typingFp}`);
+
+      if (!typingFp || typingFp === postFp) {
+        say(
+          `⚠️ INCONCLUSIVE: the typing frame did not arrive as a distinct new ` +
+            `frame (postFp=${postFp} typingFp=${typingFp}). Nothing can be ` +
+            `concluded about redelivery from this run.`
+        );
+      }
+
+      const before = fingerprintCounts(b.transport);
+
+      // ── Reconnect: the relay re-pushes whatever B never acked ──────────────
+      say('B disconnecting…');
+      b.disconnect();
+      await sleep(2000);
+      await b.reconnect();
+      await settle(b.transport);
+      const after = fingerprintCounts(b.transport);
+      say(`after RECONNECT: ${b.transport.arrived.length} frame(s) total`);
+
+      const redelivered = (fp: string | undefined) =>
+        fp ? (after.get(fp) ?? 0) - (before.get(fp) ?? 0) : -1;
+
+      const postRedelivered = redelivered(postFp);
+      const typingRedelivered = redelivered(typingFp);
+
+      // Everything that came back, not just the two we are tracking — a
+      // permanently un-acked frame class would show up here as a population,
+      // and that is the finding that would matter most.
+      const allRedelivered = [...after.entries()].filter(
+        ([fp, n]) => n > (before.get(fp) ?? 0)
+      );
+
+      say('');
+      say('==== REDELIVERY AFTER RECONNECT ====');
+      say(`  POST   (acked in the tail)      redelivered ${postRedelivered}x`);
+      say(`  TYPING (returns before the ack) redelivered ${typingRedelivered}x`);
+      say(`  frames redelivered in total: ${allRedelivered.length}`);
+      say('');
+      say(
+        'Expected if the diagnosis holds: POST 0, TYPING 1. ' +
+          'If BOTH are 0 the diagnosis is WRONG. If BOTH are 1 the harness is ' +
+          'not modelling acks and the run proves nothing about typing.'
+      );
+      say(`log: ${log.file}`);
+
+      log.add(Date.now(), 'harness', 'result', {
+        postFp,
+        typingFp,
+        postRedelivered,
+        typingRedelivered,
+        totalRedelivered: allRedelivered.length,
+        arrived: b.transport.arrived.length,
+      });
+
+      // Instrument, not a regression gate — it reports a number. The only hard
+      // assertion is that the run actually happened.
+      expect(b.transport.arrived.length).toBeGreaterThan(0);
+    } finally {
+      a?.stop();
+      b?.stop();
+    }
+  },
+  10 * 60 * 1000
+);

--- a/src/dev/tests/services/MessageService.spaceFrameRetention.unit.test.ts
+++ b/src/dev/tests/services/MessageService.spaceFrameRetention.unit.test.ts
@@ -194,6 +194,42 @@ describe('a space frame that cannot be opened is kept on the relay', () => {
     expect(mockDeps.deleteInboxMessages).toHaveBeenCalled();
   });
 
+  // ── The other half of the ack contract ──────────────────────────────────
+  //
+  // The tests above are about NOT deleting a frame we could not open. This one
+  // is the opposite failure, and it was live: a frame we DID process, and never
+  // acked.
+  //
+  // A typing indicator returns early from `handleNewMessage`, and that return
+  // used to skip the tail — the only place a space frame is acked. So every
+  // typing indicator ever received stayed on the relay and was re-pushed on
+  // every `listen`, forever.
+  //
+  // MEASURED (`yarn harness space-typing`), same run, same reconnect:
+  //   before the fix — post redelivered 0x, typing redelivered 2x
+  //   after  the fix — post redelivered 0x, typing redelivered 0x
+  //
+  // This is the cheap guard for that; the harness scenario is the real proof.
+  it('acks a typing indicator, which is processed and then returned from early', async () => {
+    unsealThrows = false;
+    unsealedPayload = JSON.stringify({
+      type: 'message',
+      message: {
+        type: 'typing-start',
+        senderId: 'QmSomeoneElse',
+        scope: 'space',
+        spaceId: SPACE_ID,
+        channelId: SPACE_ID,
+        timestamp: Date.now(),
+      },
+    });
+
+    await deliver(spaceFrame(6666, 'typing'));
+    await settle();
+
+    expect(mockDeps.deleteInboxMessages).toHaveBeenCalled();
+  });
+
   // The budget is per frame, not global — one poisonous frame must not spend
   // another frame's allowance.
   it('tracks frames independently', async () => {

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -4679,6 +4679,39 @@ export class MessageService {
             if (this.typingService) {
               this.typingService.onTypingReceived(innerMsg as TypingMessage);
             }
+            // ⚠️ ACK BEFORE RETURNING. This early return used to skip the tail,
+            // which is the ONLY place a space frame is acked — so every typing
+            // indicator ever received stayed on the relay and was re-pushed on
+            // every `listen`, forever.
+            //
+            // MEASURED (`yarn harness space-typing`): after one reconnect, an
+            // ordinary post was redelivered 0x and a typing frame 2x, in the
+            // same run.
+            //
+            // `TypingService`'s 30s freshness filter already defends the UI
+            // against this replay (see
+            // `.agents/docs/features/messages/typing-indicators.md`), but it runs
+            // AFTER the frame has been received and unsealed, so it does nothing
+            // for the cost. And that cost is the thing that matters: queue DEPTH
+            // is what decides whether a perishable control frame — a `sync-info`
+            // reply, valid 30s — is read before it expires.
+            //
+            // Typing is high volume by design (one `typing-start` per 5s per
+            // scope while composing), so an unbounded, ever-growing accumulation
+            // of them is plausibly the largest single source of reconnect
+            // backlog. See
+            // `issues/.open/2026-08-03-a-typing-frame-is-never-acked-…`.
+            const typingInboxKey = await this.messageDB.getSpaceKey(
+              conversationId.split('/')[0],
+              'inbox'
+            );
+            if (typingInboxKey) {
+              this.ackSpaceFrame(
+                typingInboxKey,
+                message.timestamp,
+                'processed typing indicator'
+              );
+            }
             return;
           }
 
@@ -6434,20 +6467,48 @@ export class MessageService {
         return;
       }
 
-      this.dispatchInboxDelete(
-        {
-          inbox_address: inbox_key.address!,
-          inbox_encryption_key: {} as never,
-          inbox_key: {
-            type: 'ed448',
-            public_key: hexToSpreadArray(inbox_key.publicKey),
-            private_key: hexToSpreadArray(inbox_key.privateKey),
-          },
-        },
-        [message.timestamp],
+      this.ackSpaceFrame(
+        inbox_key,
+        message.timestamp,
         'post-processing cleanup (space inbox)'
       );
     }
+  }
+
+  /**
+   * Tell the relay we are finished with a space frame.
+   *
+   * ⚠️ The delete IS the ack, and the relay is the only copy — it retains a
+   * frame until we delete it and re-pushes anything un-acked on every `listen`.
+   * So a frame we process and never ack is not merely untidy: it comes back on
+   * every reconnect, forever, each time costing a full unseal and a slot in the
+   * inbound queue.
+   *
+   * That is why this is a named helper rather than inline code. It had exactly
+   * one call site — the tail of `handleNewMessage` — and every path that
+   * returned before reaching it leaked a frame permanently. Typing indicators
+   * did (MEASURED: an ordinary post was redelivered 0x after a reconnect, a
+   * typing frame 2x; `yarn harness space-typing`). If you add an early return to
+   * the space path, call this first.
+   */
+  private ackSpaceFrame(
+    inboxKey: { address?: string; publicKey: string; privateKey: string },
+    timestamp: number,
+    context: string
+  ): void {
+    this.dispatchInboxDelete(
+      {
+        inbox_address: inboxKey.address!,
+        inbox_encryption_key: {} as never,
+        inbox_key: {
+          type: 'ed448',
+          public_key: hexToSpreadArray(inboxKey.publicKey),
+          private_key: hexToSpreadArray(inboxKey.privateKey),
+        },
+      },
+      [timestamp],
+      context
+    );
   }
 
   /**


### PR DESCRIPTION
A typing indicator was processed and **never acked**, so the relay re-pushed it
on every reconnect for the life of the account.

## The defect

The relay retains a frame until the client deletes it, and **that delete is the
ack**. The space receive path acks in exactly one place — the tail of
`handleNewMessage`. A typing indicator returns *before* that tail.

## Measured, with a control arm

New harness scenario (`yarn harness space-typing`). One run, one reconnect, an
ordinary post alongside the typing frame:

| | POST (control) | TYPING | frames redelivered |
|---|---|---|---|
| **before** | 0x | **2x** | 1 |
| **after** | 0x | **0x** | **0** |

The post is what makes this conclusive: it proves the harness models acking
correctly, so the typing result isn't an artefact.

## Why it matters more than "an untidy frame"

`TypingService`'s 30s freshness filter **already defends the UI** against this
replay — [the feature doc](.agents/docs/features/messages/typing-indicators.md)
describes it as guarding against *"hub-replay on subscribe-join, which would
otherwise flood the receive path with ancient typing-starts"*. So the replay was
known and the symptom was handled.

But that filter runs **after** the frame is received and unsealed. It does
nothing for the cost, and the frame is still never acked — so it comes back
again next time.

And the cost is the whole point. **Queue depth** is what decides whether a
perishable control frame (a `sync-info` reply, valid 30s) is read before it
expires — the wait is simply the number of frames ahead of it. Typing is high
volume *by design* (one `typing-start` per 5s per scope while composing), so an
unbounded, permanently growing accumulation of un-acked typing frames is
plausibly the **largest single source of reconnect backlog**.

## The change

Extracts `ackSpaceFrame` rather than duplicating the delete. It had exactly one
call site, and every early return past it leaked a frame permanently — which is
precisely how this survived. It is now a named helper whose doc comment says so,
so the next early return added to the space path has a chance of calling it.

## Tests

- **Unit guard** asserting the ack fires for a typing frame. **Confirmed
  load-bearing** — it fails with the fix reverted.
- **Harness scenario**, which produced the numbers above and doubles as the
  before/after proof. Written to be falsifiable: it states in its own output that
  if *both* arms come back the harness isn't modelling acks, and if *neither*
  does the diagnosis is wrong.

`yarn test:run` — **63 files, 943 tests, all passing.** `tsc --noEmit` clean;
`eslint` clean on the changed files (two pre-existing warnings elsewhere
untouched).
