### PR TITLE
fix(identity): thread and reaction author names no longer lose their .q name

### DIFF
--- a/.agents/INDEX.md
+++ b/.agents/INDEX.md
@@ -108,9 +108,11 @@ This is the main index for all documentation, bug reports, and task management.
 - 🐛 ["Delete Space" is Leave with a destructive-sounding label, and the owner must never click it](issues/2026-08-02-delete-space-is-leave-and-can-permanently-brick-a-space.md)
 - 🐛 [The roster pull: what it actually does](issues/2026-08-02-roster-pull-delivers-nothing-to-a-new-joiner.md)
 - 🐛 [Sync requests expire unread, behind a reconnect backlog](issues/2026-08-02-sync-requests-arrive-four-minutes-late-and-every-peer-rejects-them.md)
+- 🐛 [A fallback string is fed INTO the resolver, so the resolver returns it](issues/2026-08-04-desktop-screens-inject-an-address-as-a-display-name-and-defeat-the-resolver.md)
 - 📋 [Durable multi-device: per-device signing keys via master-signed device statements](issues/2026-07-19-per-device-signing-keys-registration-anchored.md)
 - 📋 [DM partner identity never recovers on an established session](issues/2026-08-01-dm-partner-identity-lost-on-established-sessions.md)
 - 📋 [Spaces: desktop never re-announces identity on connect](issues/2026-08-01-space-member-identity-announce-on-connect.md)
+- 📋 [The dangerous branch is off everywhere. Delete it so it stays off.](issues/2026-08-04-remove-the-dead-bare-name-mention-branch-from-shared.md)
 
 #### Messagedb
 
@@ -737,4 +739,4 @@ This is the main index for all documentation, bug reports, and task management.
 
 ---
 
-**Last Updated**: 2026-08-04 11:12:29
+**Last Updated**: 2026-08-04 13:50:49

--- a/.agents/issues/2026-08-04-desktop-screens-inject-an-address-as-a-display-name-and-defeat-the-resolver.md
+++ b/.agents/issues/2026-08-04-desktop-screens-inject-an-address-as-a-display-name-and-defeat-the-resolver.md
@@ -1,0 +1,216 @@
+---
+type: bug
+title: "Several desktop surfaces inject a truncated address AS the display name before calling the resolver, so it outranks the global name and the .q name"
+status: in-progress
+priority: medium
+created: 2026-08-04
+updated: 2026-08-04
+area: identity resolution / mention rendering / desktop-mobile parity
+source: found 2026-08-04 while adopting the shared resolver on mobile (quorum-mobile branch `one-identity-rule`); every mobile defect fixed there was then checked against desktop, per the standing rule that a bug found in one client is checked in the other
+related:
+  - ".agents/docs/features/identity-resolution-and-profile-sync.md (the canonical model — read §'The precedence ladder' and §'Why a name goes missing')"
+  - ".agents/docs/features/qns-username-display.md"
+  - "quorum-mobile .agents/issues/.open/2026-08-04-one-identity-resolver-so-names-and-avatars-match-everywhere.md (the mobile side of the same work)"
+---
+
+# A fallback string is fed INTO the resolver, so the resolver returns it
+
+## Status
+
+Fixed on branch `fix/identity-resolver-and-mention-cleanup`. Every §3 site is
+addressed, plus one the original write-up missed (§3-A). Two of the original
+three findings did not survive verification and are corrected in §3-B — read
+that section before trusting the original table.
+
+Verification is behavioural, not by reading: a new component test renders the
+reaction list and asserts the `.q` name appears. It was confirmed to go RED with
+the defect reintroduced and GREEN with the fix, so it could genuinely have
+failed. Desktop: 953 tests pass, typecheck and lint clean.
+
+## 1. The defect in one sentence
+
+Several desktop call sites compute `member.displayName || <some truncated address>`
+and pass the **result** into `resolveSpaceMemberName` / `resolveMemberName`. When
+a member has no per-space override, the resolver therefore receives an address
+string in the `displayName` slot, treats it as a deliberate per-space name, and
+returns it — outranking both the member's global name and their QNS `.q` name,
+which are sitting in the very same object.
+
+This is not "a tier was skipped". The fallback **defeats** the resolver. Adding
+more tiers upstream cannot fix it, because the poisoned value wins at the top of
+the ladder.
+
+## 2. Why it matters more than it looks
+
+An empty per-space override is the **default** state. Since the follow-global
+work (2026-07-16) the override slot is deliberately not stamped at join, so most
+members legitimately have an empty `displayName` and a populated
+`globalDisplayName`. Every one of them hits this path.
+
+## 3. Sites named in the original write-up
+
+| Where | The line | Original verdict | Held up? |
+|---|---|---|---|
+| `src/components/modals/ReactionsModal.tsx:53` | `displayName: member?.displayName \|\| memberId.slice(0, 8) + '...'` | Live; a follow-global member renders as `QmXoypiz...` in the reaction list | **Yes.** Confirmed by a failing test before the fix |
+| `src/hooks/business/channels/useChannelMessages.ts:162-174` | `displayName: member.displayName \|\| formatAddress(senderId)` | Live, same shape | **No** — unreachable, see §3-B |
+| `src/components/message/MessageList.tsx:306-318` | `displayName: member.displayName \|\| formatAddress(senderId)` | "Lower severity, if that path is ever taken" | **Understated** — it was the live, full-severity one, see §3-A |
+
+Trace `resolveSpaceMemberName` with `displayName = "QmXoypiz..."`,
+`globalDisplayName = "Alice"`, `primaryUsername = "alice"`:
+
+```
+roster = "QmXoypiz..."   global = "Alice"   qns = "alice"
+qns && roster && roster !== global   →  true
+→ returns { name: "QmXoypiz...", isQnsVerified: false }
+```
+
+The `.q` name loses to a string the UI invented three lines earlier.
+
+## 3-A. The site this write-up missed — ThreadPanel never passed the mapper
+
+`src/components/thread/ThreadPanel.tsx:399` rendered `<MessageList>` **without
+`mapSenderToUser`**, so the thread list silently fell back to MessageList's
+internal mapper — the third row above, the one dismissed as "lower severity, if
+that path is ever taken". It was taken, on every thread.
+
+What makes it worse than the table suggested:
+
+- Threads are a **space** context (`spaceId !== channelId`), so
+  `resolveSpaceMemberName` runs and the substituted address outranks the `.q`
+  name. This is the full-severity form of the bug, not a cosmetic one.
+- The panel was **internally inconsistent**. `channelProps.mapSenderToUser` was
+  already available and already used correctly at ThreadPanel.tsx:180 (thread
+  starter) and :439 (participants), which pass `displayName` through untouched.
+  Only the message list was wired wrong, so the same person could appear under
+  two different names in one panel.
+
+Fixed by passing `mapSenderToUser={channelProps.mapSenderToUser}`.
+
+**Lesson for the next write-up.** The original analysis traced each *poisoning
+line* to a resolver, but never asked *which components actually reach that line*.
+That is how it rated the live, full-severity site lowest and a dead one highest.
+
+## 3-B. Corrections — two of the three original findings do not hold
+
+Recorded rather than quietly rewritten, because the analysis error is repeatable.
+
+**`useChannelMessages.ts:162-174` was not reachable.** `Channel.tsx:282` is its
+only consumer, and `Channel.tsx:307-322` wraps the returned mapper, consulting
+`effectiveMembers` first and falling through to the base mapper only when the
+sender is absent from it. `effectiveMembers` is built as `{...members}`
+(`useMembersWithPublicProfileFallback.ts:126`, and identity when there is nothing
+to fetch), so its key set is always a superset of `members`. The `if (member)`
+branch — the poisoning one — therefore could not execute. Fixed anyway, since
+correctness should not depend on a wrapper two files away, but it was never
+causing a user-visible defect.
+
+**The DM path could not lose a `.q` name.** `Message.tsx:444` routes
+`spaceId === channelId` through `resolveMemberName`, whose ladder is
+`override → QNS → displayName → address`. QNS is checked *above* `displayName`,
+so a poisoned `displayName` cannot beat it — unlike `resolveSpaceMemberName`,
+where a per-space name sits above QNS. The DM impact was limited to a member with
+no `.q` name at all, where the visible difference is which truncation format
+appears (`formatAddress`'s 6+6 vs the resolver's `6…4`). Cosmetic, not identity
+loss.
+
+The generalisable point: **the ladder's shape decides the blast radius.** The
+same poisoned input is fatal above QNS and harmless below it. "Passes a fallback
+into a resolver" is not by itself a severity.
+
+## 3-C. New finding — `globalDisplayName` is a comparator, not a tier
+
+Turned up by a test written for this fix, and it is worth its own item rather
+than a silent fix here.
+
+`resolveSpaceMemberName` reads `globalDisplayName` **only** to compare it against
+the roster name and decide whether that roster name was deliberately set. It is
+never returned. So a member with an empty override, a populated
+`globalDisplayName` and no QNS name resolves to the **truncated address**, with a
+perfectly good global name in the object.
+
+This is **latent, not live**: `useMembersWithPublicProfileFallback.ts:147` merges
+the global name INTO `displayName` before any render path sees it, so no current
+caller reaches the resolver in that shape. It is pinned by a test
+(`ReactionsModal.test.tsx`, "pins that globalDisplayName is a COMPARATOR") so the
+behaviour is documented rather than assumed, and so the test changes
+deliberately if a tier is ever added.
+
+Not fixed here: adding a tier changes resolver semantics shared with every name
+surface, which is a bigger blast radius than this bug warrants.
+
+## 4. The fix shape
+
+**Never pass a fallback into the resolver. Let the resolver produce the
+fallback.** The pattern that works, already used correctly at
+`src/components/space/Channel.tsx:1831`:
+
+```ts
+// wrong — the fallback is an INPUT
+displayName: member?.displayName || truncate(address)
+
+// right — the fallback is an OUTPUT
+resolveSpaceMemberName({
+  address,
+  displayName: member?.displayName,        // may be empty; that is meaningful
+  primaryUsername: member?.primaryUsername,
+  globalDisplayName: member?.globalDisplayName,
+})
+```
+
+Empty must reach the resolver as empty. That is the whole contract of the
+two-slot model: empty override means "follow global", and a call site that
+substitutes something for empty destroys that signal before the rule can read
+it.
+
+Where a caller genuinely has no member record, it now hands the resolver an
+address-only object rather than a pre-truncated string, so every surface
+truncates identically.
+
+## 5. Also worth fixing while in here
+
+**There is no avatar resolver on desktop.** `resolveDisplayName` in
+`quorum-shared` covers names only, and desktop has no `resolveAvatar` /
+`resolveMemberIcon` equivalent — grep for one returns nothing. So every avatar
+call site picks its own source, exactly the situation the name resolver was
+built to end. Mobile hit the same wall (see the linked mobile issue) and solved
+it with a local `resolveMemberAvatar` implementing `override → global → self`,
+with no QNS step because a `.q` name carries no picture. Deciding whether that
+belongs in `quorum-shared` is a cross-client call, not a desktop one.
+
+NOT done on this branch — still open, and still a cross-client decision. One
+narrow related change was made: `ReactionsModal` now derives its avatar initials
+from the **resolved** name, so the avatar and the label beside it cannot disagree.
+
+## 6. Definition of done
+
+- [x] No call site passes a computed fallback into `resolveMemberName` / `resolveSpaceMemberName`; the three sites in §3 are fixed
+- [x] `globalDisplayName` and `primaryUsername` are passed wherever they are available, so the resolver has the tiers it needs (with §3-C noting that `globalDisplayName` is not itself a tier)
+- [x] A follow-global member with a `.q` name renders as their `.q` name in the reaction list, not as an address — proven by `src/dev/tests/components/ReactionsModal.test.tsx`, verified red-before-green
+- [x] Grep for the pattern `displayName ||` / `userIcon ||` across `src/` (excluding `src/dev/`) is reviewed, and every remaining hit is either fixed or recorded as legitimately not an identity ladder — see §7
+- [ ] Avatar resolution has a single home on desktop, or the shared-package decision is filed as its own item — **still open**, see §5
+- [ ] Checked against mobile: the same surface resolves identically on both clients
+
+## 7. Remaining `displayName ||` hits, reviewed
+
+Every hit outside `src/dev/`, with a verdict. None feed a name resolver.
+
+| Site | Verdict |
+|---|---|
+| `MentionDropdown.tsx:134`, `MessageEditTextarea.tsx:187,578,582,588` | Placeholder text for a picker/preview label, not a resolver input |
+| `DirectMessageContactsList.tsx:45` | Reads the placeholder to DETECT a missing name — the opposite of substituting one |
+| `SpaceSettingsModal.tsx:102`, `useUserSettings.ts:72`, `spaceProfilePayload.ts:117` | Form/payload defaults for the LOCAL user's own profile |
+| `NavRail.tsx:94`, `useBatchSearchResultsDisplay.ts:141` | Local user's own name |
+| `ContextMenu.tsx:122`, `SearchResultItem.tsx:106`, `useMessageActions.ts:482`, `useMessageFormatting.ts:161` | Display-only strings that never reach a resolver |
+| `useMembersWithPublicProfileFallback.ts:147-148` | The per-field merge itself (override → roster global → public profile). Deliberate, and it also emits `globalDisplayName` separately so the comparison still works |
+| `shims/quilibrium-sdk-channels.native.tsx:241` | Mock data |
+
+## 8. Guard against recurrence
+
+`src/dev/tests/components/messageListSenderMapper.contract.test.ts` asserts every
+`<MessageList>` render site passes `mapSenderToUser`, with a documented exemption
+for `DirectMessage.tsx` (no space roster, no override slot, and DM senders
+resolve through the QNS-first ladder, so there is nothing to enrich). The test
+was confirmed to fail when the ThreadPanel prop is removed. A stale-exemption
+check keeps the allowlist honest.
+
+*Last updated: 2026-08-04*

--- a/.agents/issues/2026-08-04-remove-the-dead-bare-name-mention-branch-from-shared.md
+++ b/.agents/issues/2026-08-04-remove-the-dead-bare-name-mention-branch-from-shared.md
@@ -1,0 +1,151 @@
+---
+type: task
+title: "quorum-shared's bare-@name mention branch is now dead code on both clients — remove it before something switches it back on"
+status: in-progress
+priority: low
+created: 2026-08-04
+updated: 2026-08-04
+area: mentions / quorum-shared cleanup
+source: filed 2026-08-04 as a desktop BUG, then corrected the same day — see §0. Desktop was never affected; mobile was, and has been fixed
+related:
+  - "quorum-shared src/utils/messagePreprocessing.ts (`processMentions`, `buildMemberKeyMap`)"
+  - "quorum-shared src/utils/mentions.ts (`extractMentionsFromText`) — the notification-side extractor"
+  - "quorum-mobile components/Chat/MessageRenderer.tsx and components/Chat/MentionableText.tsx (the mobile fix)"
+---
+
+# The dangerous branch is off everywhere. Delete it so it stays off.
+
+## Status
+
+Done on `quorum-shared` branch `fix/identity-resolver-and-mention-cleanup`, with
+the matching desktop call-site update on the same branch name in `quorum-desktop`.
+
+§3's "breaking signature change" concern was resolved by taking the breakage
+**deliberately and loudly** rather than avoiding it — see §5.
+
+Verified, not argued: the regression test was run against the OLD implementation
+and fails there, then passes with the branch removed. quorum-shared 585 tests
+pass; quorum-desktop 953 tests pass with typecheck and lint clean against the
+rebuilt `dist`.
+
+## 0. Correction — the original version of this issue was wrong about desktop
+
+> This was first filed as a bug affecting **both** clients, claiming a hand-typed
+> `@Name` renders as a real mention pill on desktop too. **That is false.** It was
+> written from the shared implementation without checking desktop's call site.
+>
+> `src/components/message/MessageMarkdownRenderer.tsx:184-187` already passes an
+> empty member array:
+>
+> ```ts
+> // Desktop never produced legacy bare-`@name` mentions, so it passes no members.
+> return sharedProcessMentions(text, [], hasEveryoneMention);
+> ```
+>
+> and desktop has exactly one mention render path (`MessageMarkdownRenderer`, via
+> react-markdown) with no second plain-text renderer and no name-keyed member map
+> outside role handling. So desktop has always been strict. The observed defect was
+> mobile-only and is fixed there.
+>
+> Recording this rather than quietly rewriting, because the mistake is instructive:
+> the shared implementation told you what was *possible*, not what each client
+> actually *does*. Check the call site.
+
+## 1. What is actually left
+
+`processMentions` in `quorum-shared` still contains a legacy branch that turns a
+bare `@Name` into a user mention token whenever the text matches an entry in
+`buildMemberKeyMap` (keyed on `display_name`, `name`, `address`). It is gated on
+`members.length > 0`.
+
+Both clients now pass an empty array, so the branch never executes:
+
+| Client | Call site | Passes |
+|---|---|---|
+| Desktop | `src/components/message/MessageMarkdownRenderer.tsx:186` | `[]` (always did) |
+| Mobile | `components/Chat/MessageRenderer.tsx` | omits `members` (fixed 2026-08-04) |
+
+## 2. Why bother removing dead code
+
+Because the gate is the *only* thing holding it off, and the gate is a caller's
+argument rather than a property of the function. `PreprocessOptions` still
+advertises `members?: SpaceMember[]`, so any future caller that passes a member
+list silently re-enables it, and what it re-enables is genuinely harmful:
+
+- **The pill lies.** `extractMentionsFromText` extracts `@<address>` only, so a
+  bare `@Name` pill is styled, tappable, opens a profile, and notifies nobody.
+  The sender cannot tell.
+- **It can point at the wrong person.** Display names are not unique.
+  `buildMemberKeyMap` is a plain object, so on a collision the later member in
+  the array silently overwrites the earlier one.
+
+The same pipeline already applies the correct rule to `@everyone`, and says so:
+
+> An unauthorized/spoofed @everyone renders as plain text, matching how the
+> notification path already refuses to honor it.
+
+Names were simply never brought in line. Removing the branch makes "render only
+what the notifier honours" structural instead of a convention two callers happen
+to follow.
+
+## 3. Scope
+
+- Roles are NOT affected and must not change: bare `@roleTag` IS honoured by
+  `extractMentionsFromText` (validated against the space's real roles), so role
+  pills are truthful. Same for channels and `@everyone`.
+- Removing `members` from `PreprocessOptions` is a breaking signature change for
+  a published package. Either drop the parameter in a version both clients move
+  to together, or keep the parameter and delete only the branch body.
+
+## 4. Definition of done
+
+- [x] The bare-name branch and `buildMemberKeyMap` are removed from `processMentions`
+- [x] Role, channel and `@everyone` tokenization unchanged, with tests proving it
+- [x] `members` is removed from `PreprocessOptions` (removed outright, not documented as ignored)
+- [x] Both clients build against the version that drops it
+- [x] A test asserts a bare `@Name` does NOT tokenize even when a matching member is supplied
+
+## 5. How the signature change was made safe
+
+§3 flagged the choice: drop the parameter (breaking) or keep it and empty the
+body (safe but leaves the footgun). Neither, quite — the parameter was dropped in
+a way that **cannot break silently**.
+
+`processMentions(text, members, everyoneAuthorized)` became
+`processMentions(text, everyoneAuthorized)`. The danger with a positional
+removal is the silent shift: `processMentions(text, [], true)` would have passed
+`[]` as `everyoneAuthorized`, and `[]` is falsy, so authorized `@everyone`
+mentions would have quietly stopped rendering. That is exactly the class of
+failure that runs for months undetected.
+
+It cannot happen here, because `SpaceMember[]` is not assignable to `boolean`:
+any surviving caller is a **compile error**, not a behaviour change. That made
+the breakage a one-line fix at desktop's single call site
+(`MessageMarkdownRenderer.tsx:186`), found by the typechecker rather than by a
+user. Mobile passes an options object with no `members` key and needed no change.
+
+Keeping a dead parameter was rejected precisely because it preserves the thing
+§2 objects to: a slot that invites a future caller to fill it.
+
+## 6. Two tests, doing different jobs
+
+- **Type-level**: `Parameters<typeof processMentions>[1]` must be a boolean.
+  Re-adding a members parameter stops the suite compiling.
+- **Runtime**: a member list is forced past the type system with a cast, and the
+  bare name must still not tokenize. This is the one that matters — it proves a
+  plain-JS caller, or a stale bundled `dist`, cannot resurrect the branch either.
+
+The runtime test was checked against the old implementation and **fails** there
+(returning `hi <<<MENTION_USER:Qm…>>>`), so it is a test that could genuinely
+have failed rather than one that passes either way.
+
+## 7. Follow-up in quorum-mobile (not done here)
+
+`components/Chat/MessageRenderer.tsx:80-97` carries a ~20-line comment explaining
+that `members` is deliberately not passed because the branch is "gated on
+`members.length > 0`, so omitting it is the supported way to switch that branch
+off". That gate no longer exists — the branch is gone and the parameter with it.
+The code is still correct; the comment now describes a mechanism that isn't
+there. Worth trimming to a sentence on the next mobile touch.
+
+*Last updated: 2026-08-04*

--- a/src/components/message/MessageList.tsx
+++ b/src/components/message/MessageList.tsx
@@ -24,7 +24,7 @@ import type { VirtuosoHandle } from 'react-virtuoso';
 import React from 'react';
 import { DefaultImages } from '../../utils';
 import { useMessageHighlight } from '../../hooks/business/messages/useMessageHighlight';
-import { shouldShowDateSeparator, shouldShowCompactHeader, formatAddress } from '@quilibrium/quorum-shared';
+import { shouldShowDateSeparator, shouldShowCompactHeader } from '@quilibrium/quorum-shared';
 import { useScrollTracking } from '../../hooks/ui/useScrollTracking';
 import { Button as ButtonBase } from '../primitives';
 // Cast to work around React type version mismatch between quorum-shared and quorum-desktop
@@ -299,21 +299,25 @@ export const MessageList = forwardRef<MessageListRef, MessageListProps>(
       },
     }));
 
-    // Internal resolver from the raw `members` map — used only when the caller
-    // doesn't supply its own mapper. Space channels and DMs both pass an
-    // enriched mapper (with public-profile fallback) via the prop; this is the
-    // bare fallback for any caller that doesn't.
+    // Internal resolver from the `members` map — used only when the caller
+    // doesn't supply its own mapper.
+    //
+    // An empty `displayName` is passed through UNCHANGED and that is the whole
+    // point: empty means "no per-space override, follow the global identity",
+    // and the name resolvers read that. Substituting a truncated address here
+    // would look like a deliberate per-space name, and `resolveSpaceMemberName`
+    // ranks a per-space name ABOVE the QNS `.q` name — so the fallback invented
+    // on this line would beat the real name sitting in the same object. The
+    // fallback belongs to the resolver (its output), never to the caller (its
+    // input). Matches the enriched mapper in Channel.tsx.
     const mapSenderToUserInternal = useCallback(
       (senderId: string) => {
         const member = members[senderId];
-        if (member) {
-          return {
-            ...member,
-            displayName: member.displayName || formatAddress(senderId),
-          };
-        }
+        if (member) return member;
+        // Sender isn't in the roster at all: no name to resolve, so hand the
+        // resolver an address-only record and let it produce the truncation.
         return {
-          displayName: senderId ? formatAddress(senderId) : 'Unknown User',
+          address: senderId,
           userIcon: DefaultImages.UNKNOWN_USER,
         };
       },

--- a/src/components/message/MessageMarkdownRenderer.tsx
+++ b/src/components/message/MessageMarkdownRenderer.tsx
@@ -178,12 +178,13 @@ export const MessageMarkdownRenderer: React.FC<MessageMarkdownRendererProps> = (
   // Process mentions → tokens. Delegates to the shared pipeline; the desktop
   // wrapper keeps the `!mapSenderToUser` guard so contexts without a user
   // resolver (e.g. some bookmark/preview surfaces) leave `@<address>` as plain
-  // text instead of emitting a raw token that wouldn't be rendered. Desktop
-  // never produced legacy bare-`@name` mentions, so it passes no members.
+  // text instead of emitting a raw token that wouldn't be rendered.
   // `hasEveryoneMention` is desktop's authorization signal → `everyoneAuthorized`.
+  // Only the canonical `@<address>` form becomes a pill; a bare `@Name` stays
+  // plain text (the shared pipeline no longer accepts a member list at all).
   const processMentions = useCallback((text: string): string => {
     if (!mapSenderToUser) return text;
-    return sharedProcessMentions(text, [], hasEveryoneMention);
+    return sharedProcessMentions(text, hasEveryoneMention);
   }, [mapSenderToUser, hasEveryoneMention]);
 
   // Role mentions → tokens. Resolves directly from spaceRoles (option B —

--- a/src/components/modals/ReactionsModal.tsx
+++ b/src/components/modals/ReactionsModal.tsx
@@ -4,7 +4,7 @@ import { parse as parseEmoji } from '@twemoji/parser';
 import { Modal, Flex, ScrollContainer } from '../primitives';
 import { UserAvatar } from '../user/UserAvatar';
 import { ResolvedName } from '../user/ResolvedName';
-import { resolveSpaceMemberName } from '../../utils/resolveMemberName';
+import { resolveSpaceMemberName, formatResolvedName } from '../../utils/resolveMemberName';
 import { emojiToUnified } from '../../utils/remarkTwemoji';
 import type { Reaction } from '@quilibrium/quorum-shared';
 import type { CustomEmoji } from '../emoji-picker/types';
@@ -46,22 +46,30 @@ export const ReactionsModal: React.FC<ReactionsModalProps> = ({
     return reactions.find((r) => r.emojiId === activeEmojiId);
   }, [reactions, activeEmojiId]);
 
-  // Helper to get user info from member ID
-  const getUserInfo = (memberId: string): MemberInfo => {
-    const member = members[memberId];
-    return {
-      displayName: member?.displayName || memberId.slice(0, 8) + '...',
-      primaryUsername: member?.primaryUsername,
-      globalDisplayName: member?.globalDisplayName,
-      userIcon: member?.userIcon,
-      address: memberId,
-    };
-  };
-
-  // Map member IDs to user data
+  // Map member IDs to user data, resolving each name once.
+  //
+  // `displayName` is passed to the resolver EXACTLY as stored, empty included.
+  // Empty means "no per-space override, follow the global identity". This used
+  // to substitute a truncated address for an empty one, which the resolver then
+  // read as a deliberate per-space name — and a per-space name outranks the QNS
+  // `.q` name, so a follow-global member appeared here as `QmXoypiz...` while
+  // their `.q` name sat unused in the very same object. The resolver produces
+  // the address fallback itself; a caller must never feed it one.
   const reactionUsers = useMemo(() => {
     if (!selectedReaction) return [];
-    return selectedReaction.memberIds.map((memberId) => getUserInfo(memberId));
+    return selectedReaction.memberIds.map((memberId) => {
+      const member = members[memberId];
+      return {
+        address: memberId,
+        userIcon: member?.userIcon,
+        resolved: resolveSpaceMemberName({
+          address: memberId,
+          displayName: member?.displayName,
+          primaryUsername: member?.primaryUsername,
+          globalDisplayName: member?.globalDisplayName,
+        }),
+      };
+    });
   }, [selectedReaction, members]);
 
   // Render emoji as Twemoji image or custom emoji
@@ -133,17 +141,14 @@ export const ReactionsModal: React.FC<ReactionsModalProps> = ({
               >
                 <UserAvatar
                   userIcon={user.userIcon}
-                  displayName={user.displayName || ''}
+                  // Initials come from the RESOLVED name so the avatar and the
+                  // label next to it can never disagree.
+                  displayName={formatResolvedName(user.resolved)}
                   address={user.address}
                   size={24}
                 />
                 <ResolvedName
-                  resolved={resolveSpaceMemberName({
-                    address: user.address,
-                    displayName: user.displayName,
-                    primaryUsername: user.primaryUsername,
-                    globalDisplayName: user.globalDisplayName,
-                  })}
+                  resolved={user.resolved}
                   className="truncate-user-name flex-1 min-w-0"
                 />
               </Flex>

--- a/src/components/thread/ThreadPanel.tsx
+++ b/src/components/thread/ThreadPanel.tsx
@@ -409,6 +409,13 @@ export const ThreadPanel: React.FC = () => {
             setInReplyTo={composer.setInReplyTo}
             customEmoji={channelProps.customEmoji}
             members={channelProps.members}
+            // Same enriched mapper the channel view uses. Without it MessageList
+            // falls back to its internal mapper, and thread author names lose
+            // their QNS `.q` name to a truncated address — while this very
+            // panel's other surfaces (thread header, participant list) already
+            // used the enriched mapper. Threads are a space context, so the
+            // override-aware resolver runs and a substituted address wins.
+            mapSenderToUser={channelProps.mapSenderToUser}
             submitMessage={handleSubmitMessage}
             onUserClick={channelProps.onUserClick}
             lastReadTimestamp={undefined}

--- a/src/dev/tests/components/ReactionsModal.test.tsx
+++ b/src/dev/tests/components/ReactionsModal.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * ReactionsModal — the reaction list must show a member's REAL name.
+ *
+ * Regression cover for the "fallback fed INTO the resolver" defect: the modal
+ * used to compute `member?.displayName || memberId.slice(0, 8) + '...'` and pass
+ * the RESULT to `resolveSpaceMemberName`. For a follow-global member — the
+ * DEFAULT state since the follow-global work, where the per-space override slot
+ * is deliberately left empty — that handed the resolver an address in the
+ * `displayName` slot. The resolver reads a present `displayName` as a deliberate
+ * per-space name, and a per-space name outranks the QNS `.q` name, so the pill
+ * showed `QmV5xWMo...` while the member's `.q` name sat unused in the very same
+ * object.
+ *
+ * The load-bearing case is `follow-global member with a .q name`. Delete the
+ * `displayName` line from ReactionsModal's memo and that test must go red.
+ */
+
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { i18n } from '@lingui/core';
+import { messages } from '@/i18n/en/messages';
+import { ReactionsModal } from '@/components/modals/ReactionsModal';
+import type { MemberInfo } from '@/components/modals/ReactionsModal';
+
+beforeAll(() => {
+  i18n.load('en', messages);
+  i18n.activate('en');
+});
+
+// Render the modal body inline — we're asserting on names, not on portals.
+vi.mock('@/components/primitives/Modal/ModalContainer', () => ({
+  ModalContainer: ({
+    visible,
+    children,
+  }: {
+    visible: boolean;
+    children: React.ReactNode;
+  }) => (visible ? <div data-testid="modal-container">{children}</div> : null),
+}));
+
+vi.mock('@/components/primitives/Icon', () => ({
+  Icon: ({ name }: { name: string }) => <span data-testid={`icon-${name}`} />,
+}));
+
+const ADDR = 'QmV5xWMo5CYSxgAAy6emKFZZPCKwCsBZKZxXD3mCUZF2nX';
+
+const reactions = [{ emojiId: 'e1', emojiName: '👍', count: 1, memberIds: [ADDR] }];
+
+function renderWith(member: Partial<MemberInfo>) {
+  return render(
+    <ReactionsModal
+      visible
+      onClose={() => {}}
+      reactions={reactions as never}
+      customEmojis={[]}
+      members={{ [ADDR]: { address: ADDR, ...member } as MemberInfo }}
+    />,
+  );
+}
+
+describe('ReactionsModal — name resolution', () => {
+  it('shows the .q name for a follow-global member (empty per-space override)', () => {
+    // The default state: no per-space override, a global name, and a QNS name.
+    renderWith({
+      displayName: undefined,
+      globalDisplayName: 'Alice',
+      primaryUsername: 'alice',
+    });
+
+    // `.q` is rendered as a sibling text node, so match the whole label.
+    expect(screen.getByText('alice.q')).toBeInTheDocument();
+    // The exact defect: an address stood in for the name.
+    expect(screen.queryByText(/^QmV5xWMo/)).not.toBeInTheDocument();
+  });
+
+  it('shows the .q name when the roster echoes the global name at join', () => {
+    // roster === global means "not deliberately set for this space", so the
+    // QNS name still wins. Same outcome, different storage shape.
+    renderWith({
+      displayName: 'Alice',
+      globalDisplayName: 'Alice',
+      primaryUsername: 'alice',
+    });
+
+    expect(screen.getByText('alice.q')).toBeInTheDocument();
+    expect(screen.queryByText('Alice')).not.toBeInTheDocument();
+  });
+
+  it('still lets a DELIBERATE per-space name outrank the .q name', () => {
+    // The tier that must NOT regress: a real override differs from the global
+    // name and is the whole point of the two-slot model.
+    renderWith({
+      displayName: 'Alice (mod)',
+      globalDisplayName: 'Alice',
+      primaryUsername: 'alice',
+    });
+
+    expect(screen.getByText('Alice (mod)')).toBeInTheDocument();
+    expect(screen.queryByText('alice.q')).not.toBeInTheDocument();
+  });
+
+  it('pins that globalDisplayName is a COMPARATOR, not a resolver tier', () => {
+    // Documenting real current behaviour, not endorsing it. `globalDisplayName`
+    // exists only so resolveSpaceMemberName can tell a deliberate per-space name
+    // from the global name echoed at join; it is never itself rendered. With an
+    // empty override, no QNS name, and a global name present, the ladder falls
+    // through to the address.
+    //
+    // Latent, not live: the enricher (useMembersWithPublicProfileFallback)
+    // already merges the global name INTO `displayName`, so no production path
+    // reaches the modal in this shape. If a future caller supplies the two slots
+    // separately, this test is the one that will change — deliberately.
+    renderWith({ displayName: undefined, globalDisplayName: 'Alice' });
+    expect(screen.queryByText('Alice')).not.toBeInTheDocument();
+    expect(screen.getByText(/QmV5xW/)).toBeInTheDocument();
+  });
+
+  it('renders the merged global name when the enricher has filled displayName', () => {
+    // How the global name ACTUALLY reaches this surface in production.
+    renderWith({ displayName: 'Alice', globalDisplayName: 'Alice' });
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+  });
+
+  it('falls back to a truncated address when the member has no name at all', () => {
+    // The fallback is legitimate HERE — produced by the resolver, as output.
+    renderWith({});
+    expect(screen.getByText(/QmV5xW/)).toBeInTheDocument();
+  });
+
+  it('does not render a member entirely absent from the members map as blank', () => {
+    render(
+      <ReactionsModal
+        visible
+        onClose={() => {}}
+        reactions={reactions as never}
+        customEmojis={[]}
+        members={{}}
+      />,
+    );
+    expect(screen.getByText(/QmV5xW/)).toBeInTheDocument();
+  });
+});

--- a/src/dev/tests/components/messageListSenderMapper.contract.test.ts
+++ b/src/dev/tests/components/messageListSenderMapper.contract.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Source-level contract: every <MessageList> render site must pass
+ * `mapSenderToUser`.
+ *
+ * This exists because of a bug the issue write-up missed entirely. ThreadPanel
+ * rendered <MessageList> WITHOUT the prop, so the list silently fell back to
+ * MessageList's internal mapper — which substituted a truncated address for an
+ * empty `displayName`. Threads are a space context, so `resolveSpaceMemberName`
+ * ran, read that substituted address as a deliberate per-space name, and ranked
+ * it ABOVE the member's QNS `.q` name. Thread authors rendered as addresses
+ * while the same panel's header and participant list, which DID use the
+ * enriched mapper, rendered the real names.
+ *
+ * A behaviour test for that would have to mount ThreadPanel with a thread
+ * context, a composer and a virtualized list. The defect is a missing prop, so
+ * assert on the missing prop: this is cheap, and it fails on the exact mistake.
+ *
+ * The internal mapper no longer poisons anything, so a missing prop is no
+ * longer a correctness bug on its own — it now means the list resolves from the
+ * RAW roster instead of the public-profile-enriched map, and loses `.q` names
+ * and avatars for senders whose roster row is thin. Still a defect, still worth
+ * pinning.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+const SRC = join(process.cwd(), 'src');
+
+function tsxFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      if (entry === 'node_modules' || entry === 'dev') continue;
+      tsxFiles(full, out);
+    } else if (entry.endsWith('.tsx')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+interface Site {
+  file: string;
+  line: number;
+  body: string;
+}
+
+function findMessageListSites(): Site[] {
+  const sites: Site[] = [];
+  for (const file of tsxFiles(SRC)) {
+    const source = readFileSync(file, 'utf8');
+    // `<MessageList` followed by whitespace or `>` — excludes the type-only
+    // `useRef<MessageListRef>` occurrences.
+    const re = /<MessageList[\s>]/g;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(source)) !== null) {
+      const end = source.indexOf('/>', m.index);
+      sites.push({
+        file: relative(process.cwd(), file).replace(/\\/g, '/'),
+        line: source.slice(0, m.index).split('\n').length,
+        body: source.slice(m.index, end === -1 ? source.length : end),
+      });
+    }
+  }
+  return sites;
+}
+
+/**
+ * Sites that may legitimately omit the prop, with the reason. An entry here is
+ * a claim that the site has nothing to enrich — NOT a licence to skip it.
+ */
+const EXEMPT: Record<string, string> = {
+  'src/components/direct/DirectMessage.tsx':
+    'DMs are not a space context: there is no roster, no per-space override, ' +
+    'and no public-profile back-fill map. DirectMessage builds its own members ' +
+    'record already carrying primaryUsername, and Message routes DM senders ' +
+    'through resolveMemberName (QNS above displayName), so the internal ' +
+    'pass-through mapper is correct here.',
+};
+
+describe('<MessageList> sender-mapper contract', () => {
+  const sites = findMessageListSites();
+
+  // Guard against a vacuous pass: if the regex or the traversal breaks, this
+  // suite would otherwise "pass" while checking nothing at all.
+  it('finds the known render sites', () => {
+    expect(sites.length).toBeGreaterThanOrEqual(3);
+    const files = sites.map((s) => s.file);
+    expect(files).toContain('src/components/space/Channel.tsx');
+    expect(files).toContain('src/components/thread/ThreadPanel.tsx');
+    expect(files).toContain('src/components/direct/DirectMessage.tsx');
+  });
+
+  it('every non-exempt render site passes mapSenderToUser', () => {
+    const missing = sites
+      .filter((s) => !s.body.includes('mapSenderToUser') && !EXEMPT[s.file])
+      .map((s) => `${s.file}:${s.line}`);
+
+    expect(
+      missing,
+      'These <MessageList> sites resolve sender names from the raw roster ' +
+        'instead of the enriched mapper, so `.q` names and public-profile ' +
+        'avatars go missing. Pass mapSenderToUser, or add an EXEMPT entry ' +
+        'stating why the site has nothing to enrich',
+    ).toEqual([]);
+  });
+
+  it('has no stale exemptions', () => {
+    // An exemption that no longer matches a real site is dead weight that
+    // makes the contract look narrower than it is.
+    const files = new Set(sites.map((s) => s.file));
+    const stale = Object.keys(EXEMPT).filter((f) => !files.has(f));
+    expect(stale, 'EXEMPT names a file with no <MessageList> site').toEqual([]);
+
+    const unnecessary = Object.keys(EXEMPT).filter((f) =>
+      sites.some((s) => s.file === f && s.body.includes('mapSenderToUser')),
+    );
+    expect(
+      unnecessary,
+      'This site now passes mapSenderToUser — drop its EXEMPT entry',
+    ).toEqual([]);
+  });
+});

--- a/src/hooks/business/channels/useChannelMessages.ts
+++ b/src/hooks/business/channels/useChannelMessages.ts
@@ -3,9 +3,8 @@ import { useMessages } from '../../queries/messages/useMessages';
 import { useSpaceOwner } from '../../queries/spaceOwner/useSpaceOwner';
 import { useSpace } from '../../queries/space/useSpace';
 import { usePasskeysContext } from '@quilibrium/quilibrium-js-sdk-channels';
-import { hasPermission, formatAddress } from '@quilibrium/quorum-shared';
+import { hasPermission } from '@quilibrium/quorum-shared';
 import type { Message as MessageType, Channel, Role } from '@quilibrium/quorum-shared';
-import { t } from '@lingui/core/macro';
 import { DefaultImages } from '../../../utils';
 import { useBlockUser } from '../user/useBlockUser';
 
@@ -159,17 +158,24 @@ export function useChannelMessages({
     [roles, user.currentPasskeyInfo, channel, space]
   );
 
+  // Base sender lookup. Channel.tsx wraps this with a public-profile-enriched
+  // map and only falls through to it for senders missing from the roster, so
+  // the `member` branch is not currently reachable — it is written correctly
+  // anyway so that a future direct consumer can't reintroduce the defect.
+  //
+  // A member is returned UNCHANGED, empty `displayName` included. Empty means
+  // "no per-space override, follow the global identity"; substituting a
+  // truncated address here reads as a deliberate per-space name, which
+  // `resolveSpaceMemberName` ranks above the QNS `.q` name. The resolver owns
+  // the fallback, so a caller must never supply one.
   const mapSenderToUser = useCallback(
     (senderId: string) => {
       const member = members[senderId];
-      if (member) {
-        return {
-          ...member,
-          displayName: member.displayName || formatAddress(senderId),
-        };
-      }
+      if (member) return member;
+      // Not in the roster: address-only, so the resolver produces the
+      // truncation itself and every surface truncates the same way.
       return {
-        displayName: senderId ? formatAddress(senderId) : t`Unknown User`,
+        address: senderId,
         userIcon: DefaultImages.UNKNOWN_USER,
       };
     },


### PR DESCRIPTION
Fixes two `.agents/issues/` items. Pairs with **quorum-shared #74** — merge that first, since this branch updates the call site its signature change breaks.

## The defect

Several surfaces computed `member.displayName || <truncated address>` and passed the **result** into `resolveSpaceMemberName`.

An empty per-space override is the **default** state since the follow-global work (2026-07-16), so the resolver routinely received an address in the `displayName` slot, read it as a deliberate per-space name, and returned it. A per-space name outranks the QNS name, so the address beat the member's `.q` name and global name sitting in the very same object:

```
roster = "QmXoypiz..."   global = "Alice"   qns = "alice"
qns && roster && roster !== global   →  true
→ { name: "QmXoypiz...", isQnsVerified: false }
```

The fallback did not fill a gap. It **defeated** the ladder — which is why adding tiers upstream could never have fixed it.

The fix is to never hand the resolver a fallback. An empty `displayName` reaches it as empty, which is the signal meaning "follow global"; a caller with no member record hands it an address-only object so every surface truncates identically.

## Sites

**`ThreadPanel.tsx:399` — not in the original write-up.** It rendered `<MessageList>` **without `mapSenderToUser`**, so thread messages fell back to MessageList's internal mapper. Threads are a space context, so this was the *full-severity* form of the bug, on every thread. The panel already used the enriched mapper correctly for the thread starter (`:180`) and the participant list (`:439`), so the same person could appear under two different names in one panel.

The original analysis had rated this path **least** severe of the three ("lower severity, if that path is ever taken"). It traced each poisoning line to a resolver but never asked which components actually reach that line.

**`ReactionsModal.tsx`** substituted an 8-char address prefix. Now resolves once, and derives the avatar initials from the **resolved** name so the avatar and the label beside it cannot disagree.

**`MessageList.tsx` / `useChannelMessages.ts`** now pass members through untouched.

## Two claims from the write-up that did not survive checking

**`useChannelMessages.ts:162-174` was unreachable.** `Channel.tsx:282` is its only consumer, and `Channel.tsx:307-322` wraps the mapper, falling through to it only for senders absent from `effectiveMembers` — which is built as `{...members}`, so its key set is always a superset. The poisoning branch could not execute. Fixed anyway, since correctness shouldn't depend on a wrapper two files away, but it was causing nothing.

**The DM path was never affected.** DMs route through `resolveMemberName`, whose ladder checks QNS **above** `displayName`, so a poisoned `displayName` cannot beat a `.q` name there. Impact was limited to members with no `.q` name at all, where the only difference is truncation format (`6+6` vs `6…4`).

The generalisable point: **the ladder's shape decides the blast radius**, not the poisoning itself. The same bad input is fatal above QNS and cosmetic below it.

## Verification — behavioural, not by reading

`src/dev/tests/components/ReactionsModal.test.tsx` renders the reaction list and asserts the `.q` name appears. **Confirmed red with the defect reintroduced, green with the fix** — so it is a test that could genuinely have failed. It also covers the tiers that must *not* regress (a deliberate per-space name still outranks `.q`).

`src/dev/tests/components/messageListSenderMapper.contract.test.ts` asserts every `<MessageList>` render site passes `mapSenderToUser`, with a documented exemption for `DirectMessage.tsx` (no space roster, no override slot, QNS-first ladder — nothing to enrich) and a stale-exemption check to keep the allowlist honest. **Confirmed to fail when the ThreadPanel prop is removed.** This is a source-level test because the defect is a missing prop, and mounting ThreadPanel would need a thread context, a composer and a virtualized list to assert the same thing.

953 tests pass; typecheck and lint clean, no new warnings.

## Also recorded, not fixed

`globalDisplayName` is a **comparator, not a resolver tier** — it decides whether a roster name was deliberately set, and is never itself returned. A member with an empty override, a global name and no QNS name resolves to the truncated address. **Latent, not live**: `useMembersWithPublicProfileFallback.ts:147` merges the global name into `displayName` before any render path sees it. Pinned by a test so the behaviour is documented rather than assumed. Adding a tier would change semantics shared by every name surface, which is a wider blast radius than this bug warrants.

Desktop still has **no avatar resolver** (issue §5) — unchanged here, and a cross-client call rather than a desktop one.