### PR TITLE
instrument: record when an adopted config drops Spaces this device still holds

### DIFF
--- a/src/dev/tests/services/ConfigService.unit.test.tsx
+++ b/src/dev/tests/services/ConfigService.unit.test.tsx
@@ -572,4 +572,176 @@ describe('ConfigService - Unit Tests', () => {
       expect(saved.timestamp).toBe(500);
     });
   });
+
+  /**
+   * The receive side of the vanishing-sidebar bug.
+   *
+   * saveConfig (section 5) stops THIS device publishing a truncated list. It
+   * does nothing about a truncated list arriving from another device, which is
+   * how the bug actually reaches a desktop: mobile narrows its Space list to
+   * what it can key, publishes anyway, wins on timestamp, and this device
+   * adopts it verbatim. The sidebar renders from the adopted config, so it
+   * empties while every Space row sits untouched in IndexedDB.
+   *
+   * These tests pin the instrument, not a fix — adoption is still verbatim.
+   * The first test is the characterization: it asserts the loss happens, so it
+   * will fail the day someone makes the receive side merge, which is the
+   * correct moment to revisit it.
+   */
+  describe('6. getConfig() - space-list shrink on adopt', () => {
+    const address = 'user-address-123';
+    const mockUserKey = {
+      user_key: {
+        private_key: new Uint8Array(57),
+        public_key: new Uint8Array(57),
+      },
+    } as any;
+    const DIAG_KEY = 'quorum:diag:configSpaceShrink';
+
+    /** Drive one adopt-a-newer-remote-config cycle. */
+    async function adopt({
+      storedSpaceIds,
+      remoteSpaceIds,
+      dbSpaceIds = storedSpaceIds,
+    }: {
+      storedSpaceIds: string[];
+      remoteSpaceIds: string[];
+      dbSpaceIds?: string[];
+    }) {
+      const storedConfig = { address, spaceIds: storedSpaceIds, timestamp: 500 };
+      const decryptedConfig = {
+        address,
+        spaceIds: remoteSpaceIds,
+        items: remoteSpaceIds.map(id => ({ type: 'space', id })),
+        spaceKeys: [],
+        timestamp: 1000,
+      };
+      const jsonBytes = new TextEncoder().encode(JSON.stringify(decryptedConfig));
+      const decryptedBuffer = jsonBytes.buffer.slice(
+        jsonBytes.byteOffset,
+        jsonBytes.byteOffset + jsonBytes.byteLength
+      );
+
+      mockDeps.messageDB.getUserConfig = vi.fn().mockResolvedValue(storedConfig);
+      mockDeps.messageDB.getSpaces = vi
+        .fn()
+        .mockResolvedValue(dbSpaceIds.map(id => ({ spaceId: id })));
+      mockDeps.apiClient.getUserSettings = vi.fn().mockResolvedValue({
+        data: { user_config: 'aabbccdd' + '000000000000000000000000', timestamp: 1000, signature: 'aabbcc' },
+      });
+
+      vi.spyOn(global.crypto.subtle, 'importKey').mockResolvedValue({} as CryptoKey);
+      vi.spyOn(global.crypto.subtle, 'decrypt').mockResolvedValue(decryptedBuffer as ArrayBuffer);
+
+      return configService.getConfig({ address, userKey: mockUserKey });
+    }
+
+    /** The single diagnostic entry the instrument recorded, if any. */
+    function lastEntry() {
+      const raw = localStorage.getItem(DIAG_KEY);
+      if (!raw) return undefined;
+      const ring = JSON.parse(raw);
+      return ring[ring.length - 1];
+    }
+
+    beforeEach(() => {
+      localStorage.clear();
+    });
+
+    it('adopts the narrower list verbatim, dropping Spaces this device still holds', async () => {
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const result = await adopt({
+        storedSpaceIds: ['space-a', 'space-b', 'space-c'],
+        remoteSpaceIds: ['space-c'],
+      });
+
+      // The reported symptom: only the publisher's Space survives.
+      expect(result.spaceIds).toEqual(['space-c']);
+      const saved = mockDeps.messageDB.saveUserConfig.mock.calls[0][0];
+      expect(saved.spaceIds).toEqual(['space-c']);
+    });
+
+    it('warns and records the drop, naming the Spaces about to vanish', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      await adopt({
+        storedSpaceIds: ['space-a', 'space-b', 'space-c'],
+        remoteSpaceIds: ['space-c'],
+      });
+
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('ADOPTED a config that drops 2 Space(s)'),
+        expect.objectContaining({ before: 3, after: 1, dropped: 2, stillInDb: 2 })
+      );
+      expect(lastEntry()).toMatchObject({
+        before: 3,
+        after: 1,
+        dropped: 2,
+        stillInDb: 2,
+        droppedIds: ['space-a', 'space-b'],
+        incomingTimestamp: 1000,
+      });
+    });
+
+    it('counts only dropped Spaces the local DB still holds', async () => {
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      // space-a was already gone from this device's DB, so losing it from the
+      // nav costs the user nothing. Only space-b is a real disappearance.
+      await adopt({
+        storedSpaceIds: ['space-a', 'space-b', 'space-c'],
+        remoteSpaceIds: ['space-c'],
+        dbSpaceIds: ['space-b', 'space-c'],
+      });
+
+      expect(lastEntry()).toMatchObject({ dropped: 2, stillInDb: 1 });
+    });
+
+    it('stays silent when the incoming list is not narrower', async () => {
+      // Control arm: same adopt path, same DB, nothing dropped. If this warns,
+      // the instrument is measuring adoption rather than loss and every entry
+      // above is noise.
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      await adopt({
+        storedSpaceIds: ['space-a'],
+        remoteSpaceIds: ['space-a', 'space-b'],
+      });
+
+      expect(warn).not.toHaveBeenCalled();
+      expect(localStorage.getItem(DIAG_KEY)).toBeNull();
+    });
+
+    it('keeps the diagnostic ring bounded at 20 entries', async () => {
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      localStorage.setItem(
+        DIAG_KEY,
+        JSON.stringify(Array.from({ length: 20 }, (_, i) => ({ at: `old-${i}` })))
+      );
+
+      await adopt({ storedSpaceIds: ['space-a', 'space-b'], remoteSpaceIds: ['space-b'] });
+
+      const ring = JSON.parse(localStorage.getItem(DIAG_KEY)!);
+      expect(ring).toHaveLength(20);
+      expect(ring[0].at).toBe('old-1');
+      expect(ring[19]).toMatchObject({ dropped: 1 });
+    });
+
+    it('never lets a broken diagnostic take down config sync', async () => {
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+      vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        throw new Error('quota exceeded');
+      });
+
+      const result = await adopt({
+        storedSpaceIds: ['space-a', 'space-b'],
+        remoteSpaceIds: ['space-b'],
+      });
+
+      expect(result.spaceIds).toEqual(['space-b']);
+      expect(mockDeps.messageDB.saveUserConfig).toHaveBeenCalled();
+    });
+  });
 });

--- a/src/services/ConfigService.ts
+++ b/src/services/ConfigService.ts
@@ -373,6 +373,17 @@ export class ConfigService {
       }
     }
 
+    // Diagnostic only — this does not change what gets adopted.
+    //
+    // The remote config is applied verbatim, and the sidebar renders from
+    // `config.items` (useNavItems.ts:49-53), so a publisher that narrows its
+    // Space list empties this device's nav the moment its blob wins on
+    // timestamp. Desktop refuses to publish such a list (saveConfig, below);
+    // mobile currently only warns and publishes anyway. Nothing on this side
+    // recorded the adoption, which is why every report of "all my Spaces
+    // vanished" arrived with no evidence attached.
+    await this.recordSpaceListShrinkOnAdopt(storedConfig, config);
+
     await this.messageDB.saveUserConfig({
       ...config,
       timestamp: savedConfig.timestamp,
@@ -384,6 +395,78 @@ export class ConfigService {
       () => config
     );
     return config;
+  }
+
+  /**
+   * Record — never block — an incoming config that carries fewer Spaces than
+   * this device already had.
+   *
+   * The number that matters is `stillInDb`: Spaces this device holds complete,
+   * usable rows for that are about to stop being rendered. Those are exactly
+   * the ones Settings → Restore Spaces puts back, so a non-zero count is this
+   * bug firing rather than a legitimate remove-on-another-device.
+   *
+   * Two deliberate choices:
+   * - `console.warn`, not `logger.warn`. The shared logger compiles to a no-op
+   *   in production builds, and a diagnostic that is silent in the only build
+   *   real users run is not a diagnostic.
+   * - A localStorage ring as well as the console. The console is empty unless
+   *   devtools happened to be open before the adoption, and this fires while
+   *   the user is looking at the sidebar, not at devtools.
+   *
+   * Wrapped whole in try/catch: an instrument must never be able to break the
+   * sync path it is measuring.
+   */
+  private async recordSpaceListShrinkOnAdopt(
+    storedConfig: UserConfig | undefined,
+    incoming: UserConfig
+  ): Promise<void> {
+    try {
+      const before = storedConfig?.spaceIds ?? [];
+      if (before.length === 0) return;
+
+      const after = new Set(incoming.spaceIds ?? []);
+      const dropped = before.filter(id => !after.has(id));
+      if (dropped.length === 0) return;
+
+      // Only read the DB once we know something was dropped.
+      const dbSpaceIds = new Set((await this.messageDB.getSpaces()).map(s => s.spaceId));
+      const stillInDb = dropped.filter(id => dbSpaceIds.has(id));
+
+      const entry = {
+        at: new Date().toISOString(),
+        incomingTimestamp: incoming.timestamp,
+        before: before.length,
+        after: after.size,
+        dropped: dropped.length,
+        stillInDb: stillInDb.length,
+        droppedIds: dropped.slice(0, 25),
+      };
+
+      console.warn(
+        `[ConfigService] ADOPTED a config that drops ${entry.dropped} Space(s) ` +
+          `(${entry.before} → ${entry.after}); ${entry.stillInDb} of them are still ` +
+          `present in this device's local DB and will disappear from the sidebar:`,
+        entry
+      );
+
+      if (typeof localStorage === 'undefined') return;
+      const KEY = 'quorum:diag:configSpaceShrink';
+      let ring: unknown[] = [];
+      try {
+        const raw = localStorage.getItem(KEY);
+        if (raw) {
+          const parsed: unknown = JSON.parse(raw);
+          if (Array.isArray(parsed)) ring = parsed;
+        }
+      } catch {
+        // A corrupted ring must not cost us this entry — start a fresh one.
+      }
+      ring.push(entry);
+      localStorage.setItem(KEY, JSON.stringify(ring.slice(-20)));
+    } catch (e) {
+      console.warn('[ConfigService] space-shrink diagnostic failed (ignored)', e);
+    }
   }
 
   /**


### PR DESCRIPTION
## Why

Three times on 2026-08-04 the Spaces sidebar emptied on desktop, each time
right after an action on a phone: creating a Space, deleting it, and — the
telling one — simply changing the username. Every time, Settings → Restore
Spaces brought them all back, because the Space rows never left IndexedDB.

The username case rules out any Space operation as the trigger. All three are
one event: the other device called `saveConfig`.

The sidebar renders from the synced config (`useNavItems.ts:49-53`), and
`getConfig` applies a newer remote config verbatim. So a device that publishes
a Space list narrowed to what it can currently key empties every other
device's nav the moment its blob wins on timestamp. `saveConfig` has refused to
*be* that publisher since #282, but nothing recorded being on the receiving
end — which is why every report of this arrived with no evidence attached.

## What this does

Records the adoption. It does not change it.

When an incoming config drops Spaces this device still holds, `getConfig` now
logs and appends to a bounded ring in `localStorage` under
`quorum:diag:configSpaceShrink`:

```js
JSON.parse(localStorage.getItem('quorum:diag:configSpaceShrink'))
```

Each entry carries the winning blob's timestamp, before/after counts, the
dropped ids, and `stillInDb` — how many of the dropped Spaces this device has
complete rows for. A non-zero `stillInDb` is this bug firing rather than a
legitimate removal from another device.

Two deliberate choices, both commented at the call site:

- `console.warn`, not the shared `logger`, which compiles to a no-op in
  production builds. A diagnostic that is silent in the only build real users
  run is not a diagnostic.
- A localStorage ring as well as the console, because this fires while the user
  is looking at the sidebar, not at devtools.

The whole thing is wrapped in try/catch. An instrument must never be able to
break the sync path it measures.

## Tests

Six cases in `ConfigService.unit.test.tsx` §6:

- **Characterization** — adoption drops Spaces this device holds. Asserts the
  loss, so it fails the day the receive side learns to merge, which is the right
  moment to revisit it.
- Instrument fires with the right counts, names the dropped ids.
- `stillInDb` counts only dropped Spaces the local DB still has.
- **Control arm** — nothing dropped, nothing logged. If this ever warns, the
  instrument is measuring adoption rather than loss and every entry is noise.
- Ring stays bounded at 20.
- A throwing `localStorage` does not take config sync down.

Verified falsifiable: with the instrument disabled the three assertion tests go
red, then green on restore. Full suite 959 passed / 65 files, `tsc --noEmit`
and eslint clean.

## Not fixed here

Adoption is still verbatim, and this does not stop the publisher.

The change that stops these three reproductions is in quorum-mobile — port this
repo's refuse-to-publish guard to its `saveConfig`. It was reverted there on
2026-07-31 because no mobile removal path took a Space out of `config.spaceIds`;
that is no longer true, so the precondition is now met. Filed separately.

Making the lists genuinely converge needs `deletedSpaceIds` tombstones, an
additive wire change across both apps that is waiting on a decision.

Context: `.agents/issues/.open/2026-07-31-spaces-list-cross-device-sync.md` §2b.
