### PR TITLE
fix(identity): your own name and avatar are correct everywhere, and follow a rename made on another device

### DIFF
--- a/.agents/INDEX.md
+++ b/.agents/INDEX.md
@@ -111,6 +111,7 @@ This is the main index for all documentation, bug reports, and task management.
 - 📋 [Durable multi-device: per-device signing keys via master-signed device statements](issues/2026-07-19-per-device-signing-keys-registration-anchored.md)
 - 📋 [DM partner identity never recovers on an established session](issues/2026-08-01-dm-partner-identity-lost-on-established-sessions.md)
 - 📋 [Spaces: desktop never re-announces identity on connect](issues/2026-08-01-space-member-identity-announce-on-connect.md)
+- 📋 [Own identity, Phase 1 — implementation plan](issues/2026-08-05-own-identity-cross-device-sync-plan.md)
 
 #### Messagedb
 
@@ -282,6 +283,10 @@ This is the main index for all documentation, bug reports, and task management.
 - 🐛 [A per-space override never reaches your own other devices](issues/.open/2026-08-01-per-space-override-does-not-reach-your-own-other-devices.md)
 - 🐛 [Desktop shows a stale display name everywhere except the User Settings field](issues/.open/2026-08-04-desktop-shows-a-stale-name-everywhere-except-the-user-settings-field.md)
 - 🐛 [A Space created on mobile does not land correctly on desktop](issues/.open/2026-08-04-mobile-created-space-syncs-badly-to-desktop-owner-missing-and-message-not-shown.md)
+- 🐛 [Bookmarks are three quarters of the config blob](issues/.open/2026-08-05-bookmarks-are-75-percent-of-the-config-blob.md)
+- 🐛 [The two clients do not merge the same config fields](issues/.open/2026-08-05-config-merge-lists-are-asymmetric-between-desktop-and-mobile.md)
+- 🐛 [The config upload has no size guard, and mobile's failure is invisible](issues/.open/2026-08-05-config-upload-has-no-size-guard-and-fails-silently-on-mobile.md)
+- 🐛 [The roster diff treats your own row like a stranger's](issues/.open/2026-08-05-roster-sync-has-no-self-exclusion-a-peer-can-overwrite-your-own-row.md)
 - 📋 [User Status Feature Implementation Plan](issues/.open/2025-01-20-user-status.md)
 - 📋 [Implement Message Forwarding with Privacy Controls](issues/.open/2025-11-16-message-forwarding-with-privacy-controls.md)
 - 📋 [Implement Smart Context Extraction Around Mentions in NotificationPanel](issues/.open/2025-11-19-notification-mention-context-extraction.md)
@@ -314,6 +319,8 @@ This is the main index for all documentation, bug reports, and task management.
 - 📋 [Make the Spaces list identical on every device](issues/.open/2026-07-31-spaces-list-cross-device-sync.md)
 - 📋 [Promote the identity-announce gate to shared](issues/.open/2026-08-02-promote-identity-announce-gate-to-shared.md)
 - 📋 [One rule for names, no rule for avatars, and three tiers that disagree across clients](issues/.open/2026-08-04-desktop-avatar-resolver-and-cross-client-name-tier-drift.md)
+- 📋 [Does mobile need the desktop identity fixes?](issues/.open/2026-08-05-mobile-identity-parity-after-the-desktop-phase-1-fix.md)
+- 📋 [Your own identity, on your own devices](issues/.open/2026-08-05-own-identity-cross-device-sync-design.md)
 
 ### Deferred
 
@@ -742,4 +749,4 @@ This is the main index for all documentation, bug reports, and task management.
 
 ---
 
-**Last Updated**: 2026-08-04 17:32:30
+**Last Updated**: 2026-08-05 14:07:53

--- a/.agents/docs/config-sync-system.md
+++ b/.agents/docs/config-sync-system.md
@@ -320,11 +320,19 @@ const finalSpaceIds = new Set(config.spaceIds);
 config.spaceKeys = config.spaceKeys.filter(sk => finalSpaceIds.has(sk.spaceId));
 ```
 
-**Why bidirectional filtering?** The server validates that `spaceIds` and `spaceKeys` must be perfectly in sync:
+**Why bidirectional filtering?** `spaceIds` and `spaceKeys` must be perfectly in sync:
 - Every space in `spaceIds` must have keys in `spaceKeys` (prevents "missing encryption" errors)
 - Every key in `spaceKeys` must reference a space in `spaceIds` (prevents "orphaned keys" errors)
 
-Mismatches result in `400 - invalid config missing data` errors.
+> ⚠️ **Corrected 2026-08-05.** This section previously said the **server** validates
+> that pairing and returns `400 - invalid config missing data`. It cannot. The server
+> receives only ciphertext — `saveConfig` POSTs `user_address`, `user_public_key`, the
+> AES-GCM-encrypted `user_config`, `timestamp` and `signature`, and the whole config
+> object is encrypted on-device before it leaves. No config field is ever visible to
+> it. The consistency rule is enforced **client-side**, by the filtering above.
+>
+> The same fact answers a privacy question that comes up whenever a field is added
+> here: the server learns nothing from a new field except the ciphertext's length.
 
 **Impact**:
 - Spaces without complete encryption won't appear in the nav bar
@@ -397,4 +405,4 @@ The 100KB per-encryption-state filter keeps total payload well under limits.
 ---
 
 
-*Last updated: 2026-05-27 — synced `UserConfig` snippet with the real shared type (added 7 fields previously missing from the doc), expanded triggers table.*
+*Last updated: 2026-08-05*

--- a/.agents/docs/features/identity-resolution-and-profile-sync.md
+++ b/.agents/docs/features/identity-resolution-and-profile-sync.md
@@ -223,6 +223,9 @@ moves queue POSITION. See `issues/2026-08-02-sync-requests-arrive-four-minutes-l
 |---|---|
 | **The architecture** | this document — read "Why a name goes missing" next |
 | **The measurement tool** | `/dev/identity-coverage` (dev builds only). Take a snapshot before and after any change |
+| **Your OWN identity** | `.agents/tools/dm-debug/08-self-identity-sources.js` — one console paste; prints all four stores your own name lives in, your roster row per space, and the config blob's size budget. Run this FIRST for any "my own name is wrong" report |
+| **Tripwire** | `localStorage['quorum:diag:selfOverrideWrites']` — every non-empty write to your OWN per-space override, with a stack. Should stay empty; only the Space Settings editor may appear |
+| **Migration record** | `localStorage['quorum:diag:clearedSpaceOverrides']` — what the one-time legacy-override clear destroyed, since it is irreversible |
 | **The full record** | `.agents/issues/.done/2026-08-01-identity-announce-cadence-research.md` — CLOSED, its box has every shipped PR and both measurements |
 
 **Open, with next steps written:**
@@ -543,12 +546,34 @@ When someone reports a member rendering as an address:
   longer depend on it for name/avatar/bio (the global slot is the live push).
 - **`Date.now()` LWW** — B and C timestamps come from the writing device's
   clock; severe clock skew can make an older edit win. Accepted (2026-07-16).
-- **Legacy stamped rosters**: rows stamped with old global values before the
-  de-stamping look like deliberate overrides until manually cleared in that
-  space's settings. Decision 2026-07-16: NO auto-migration (tiny user base).
-  Side effect: such a row can render a different name on desktop vs mobile
-  (desktop's comparison trick demotes a roster==global name to QNS; mobile
-  doesn't) until cleared — folds into the same accepted limitation.
+- **Legacy stamped rosters** — ⚠️ **this entry was wrong until 2026-08-05, in a way
+  that mattered.** It described stamped rows as a decaying legacy condition. They
+  were neither decaying nor legacy:
+
+  1. **The join path never stopped stamping.** The de-stamping of 2026-07-16 removed
+     the editor saves and the rebroadcasts, but both `InvitationService` (our own
+     row) and the `join` receive handler (every other member's row) kept writing the
+     global name into the OVERRIDE slot. New traps were still being created daily.
+  2. **The on-connect announce refreshed them.** `buildSpaceProfilePayload` read our
+     own override straight off the row and re-sent it beside the current global name,
+     and the receiver re-stamped both. So a stale value did not age out — it was
+     renewed on every connect, and after the first announce it was byte-for-byte
+     indistinguishable from a deliberately chosen per-space name.
+
+  MEASURED 2026-08-05: four of five spaces on one account held a diverged override,
+  all carrying fresh timestamps, rendering four different names none of which was the
+  user's current one.
+
+  **Fixed** in the Phase 1 work (see
+  `.agents/issues/.open/2026-08-05-own-identity-cross-device-sync-design.md`): joins
+  file identity under the global slot, nothing authors our own override but the Space
+  Settings editor, and a one-time broadcast clear removes the existing ones. The
+  2026-07-16 "no auto-migration" decision was reversed for exactly this reason — the
+  rows could not be told apart, so they could not be left to expire.
+
+  Side effect while any un-migrated client remains: such a row can still render a
+  different name on desktop vs mobile (desktop's comparison trick demotes a
+  roster==global name to QNS; mobile doesn't).
 
 ## Receive-side authorization (security, 2026-07-19)
 
@@ -614,4 +639,4 @@ residual: an unregistered key can still set the display name/avatar on a claimed
 | Channel A sync | `src/services/ConfigService.ts` | `services/config/configService.ts` |
 
 ---
-*Last updated: 2026-08-02*
+*Last updated: 2026-08-05*

--- a/.agents/issues/.open/2026-08-01-per-space-override-does-not-reach-your-own-other-devices.md
+++ b/.agents/issues/.open/2026-08-01-per-space-override-does-not-reach-your-own-other-devices.md
@@ -21,16 +21,36 @@ related_docs:
 
 observed 2026-08-01 on a live two-device test, cause not yet traced
 
-> **⚠️ NARROWED 2026-08-05 by measurement — half the premise is false.**
+> **⚠️ CONFIRMED AND NARROWED 2026-08-05 — it is ONE-DIRECTIONAL.**
 >
-> A per-space name set **on mobile reached desktop correctly and immediately**,
-> over channel C. So per-space overrides *do* cross a user's own devices; the
-> general claim in this file's title is wrong as written.
+> Both directions were measured on a real device pair, with two independent
+> fields:
 >
-> What remains open is the **direction this file actually observed**: desktop →
-> mobile (§1 step 4). That is untested since, and is the only live part of this
-> issue. §5 already listed the reverse direction as untested; it is now measured
-> and working.
+> | direction | per-space override arrives? | measured |
+> |---|---|---|
+> | **mobile → desktop** | ✅ **yes, immediately** | name and bio, 2026-08-05 |
+> | **desktop → mobile** | ❌ **no** | name + avatar 2026-08-01, bio 2026-08-05 |
+>
+> So the title's general claim is **wrong**: overrides do cross a user's own
+> devices. The defect is real but sits in exactly one direction, and it
+> reproduces on demand. Observable end state: **the same space shows two
+> different bios on the two devices.**
+>
+> **What this rules out.** The relay does deliver an `update-profile` to the
+> sender's own other device — mobile → desktop proves it — so hypothesis 3 in §4
+> (relay fan-out excludes own devices) is refuted unless the relay is itself
+> asymmetric, which nothing suggests. Desktop's RECEIVE path is fine, since it
+> accepts mobile's. **The fault is in mobile's receive of a desktop-sent
+> `update-profile`, or in desktop's send reaching mobile specifically.**
+>
+> That makes §4 hypothesis 2 the strongest remaining candidate: `update-profile`
+> is authorised against the VERIFIED signer, desktop signs with its own per-space
+> signing key, and if mobile has not admitted that device key it drops the message
+> fail-closed. Check that before anything else. Hypothesis 1 (self-message filter
+> on receive) is the cheap second.
+>
+> ⚠️ Do not investigate mobile unilaterally — see
+> `2026-08-05-mobile-identity-parity-after-the-desktop-phase-1-fix.md` §4.
 >
 > **This mattered beyond this file.** An entire deferred architecture — moving
 > per-space profiles into the encrypted config blob — was designed on the

--- a/.agents/issues/.open/2026-08-01-per-space-override-does-not-reach-your-own-other-devices.md
+++ b/.agents/issues/.open/2026-08-01-per-space-override-does-not-reach-your-own-other-devices.md
@@ -4,7 +4,7 @@ title: "A per-space name/avatar set on one of your devices never reaches your ow
 status: open
 priority: medium
 created: 2026-08-01
-updated: 2026-08-01
+updated: 2026-08-05
 severity: your own second device shows you following your global identity, as if you had never set the override
 area: per-space profile override / channel C / multi-device
 repos: quorum-desktop + quorum-mobile (observed desktop → mobile; the reverse is untested)
@@ -20,6 +20,25 @@ related_docs:
 ## Status
 
 observed 2026-08-01 on a live two-device test, cause not yet traced
+
+> **⚠️ NARROWED 2026-08-05 by measurement — half the premise is false.**
+>
+> A per-space name set **on mobile reached desktop correctly and immediately**,
+> over channel C. So per-space overrides *do* cross a user's own devices; the
+> general claim in this file's title is wrong as written.
+>
+> What remains open is the **direction this file actually observed**: desktop →
+> mobile (§1 step 4). That is untested since, and is the only live part of this
+> issue. §5 already listed the reverse direction as untested; it is now measured
+> and working.
+>
+> **This mattered beyond this file.** An entire deferred architecture — moving
+> per-space profiles into the encrypted config blob — was designed on the
+> assumption that channel C could not carry them between a user's own devices.
+> The measurement killed it before it was built. See
+> `2026-08-05-own-identity-cross-device-sync-design.md` §6.
+>
+> Retitle this issue to name the direction when someone next touches it.
 
 
 ## §1. Observed (live test, 2026-08-01)
@@ -92,4 +111,4 @@ Establish the restart behaviour first — it is one minute of work and it splits
 the hypothesis space in half.
 
 ---
-*Last updated: 2026-08-01*
+*Last updated: 2026-08-05*

--- a/.agents/issues/.open/2026-08-04-desktop-avatar-resolver-and-cross-client-name-tier-drift.md
+++ b/.agents/issues/.open/2026-08-04-desktop-avatar-resolver-and-cross-client-name-tier-drift.md
@@ -4,7 +4,7 @@ title: "Desktop has no avatar resolver, and three name tiers resolve differently
 status: open
 priority: medium
 created: 2026-08-04
-updated: 2026-08-04
+updated: 2026-08-05
 area: identity resolution / desktop-mobile parity / quorum-shared
 source: split out of 2026-08-04-desktop-screens-inject-an-address-as-a-display-name-and-defeat-the-resolver (PR #310) — these were two of its Definition-of-Done items that are not part of that defect and are cross-client decisions rather than desktop ones
 related:
@@ -56,7 +56,36 @@ implement a desktop-local twin and accept two implementations.
 All three predate PR #310 and none was introduced by it. Measurements and file
 references are in the parent issue's §9.
 
-### 3-A. The global slot is a TIER on mobile, only a COMPARATOR on desktop
+### 3-A. ✅ FIXED 2026-08-05 — the global slot is now a real tier on desktop too
+
+> **Closed, and it was not latent after all.** This section called the gap
+> "latent, not live" because the enricher merged the global name into
+> `displayName` before any render path saw it. That was true only while every
+> roster row carried a stamped override.
+>
+> The Phase 1 identity work
+> (`2026-08-05-own-identity-cross-device-sync-design.md`) clears those overrides,
+> which is their correct normal state under the two-slot model — and that turned
+> this live immediately. Callers passing the RAW roster field rather than the
+> enriched one, **the member sidebar in `Channel.tsx:2094-2100` among them**, fell
+> straight through to a truncated address. The reporter appeared in his own member
+> list with no name and no avatar. Found on a device, within minutes of the clear
+> landing.
+>
+> `resolveSpaceMemberName` now returns the global slot as a tier:
+> **override → QNS → global → address**. Fixing it in the resolver rather than at
+> each call site means no surface can miss the tier again.
+>
+> The `ReactionsModal` test that pinned the comparator behaviour said it would be
+> the one to change deliberately if a tier were added. It was, and it now pins the
+> tier plus the two orderings that must not regress.
+>
+> **Lesson worth keeping:** "latent, not live" was load-bearing on an assumption
+> about the data, not about the code. When the data changed, the latency vanished.
+
+The original description follows.
+
+#### The gap as originally written
 
 Mobile passes `display_name: global` into shared's `resolveDisplayName`, so a
 global name is genuinely rendered as a rung. Desktop's `resolveSpaceMemberName`
@@ -136,9 +165,9 @@ cannot.
 
 - [ ] Avatar resolution has a single documented home, and the promote-to-shared question is decided rather than deferred
 - [ ] The address fallback renders the identical string on both clients, with a test pinning it
-- [ ] `globalDisplayName` is either a real resolver tier on desktop or documented as permanently a comparator, with the reason
+- [x] `globalDisplayName` is either a real resolver tier on desktop or documented as permanently a comparator, with the reason — **done 2026-08-05, it is now a tier (§3-A)**
 - [ ] A decision recorded on `isAddressFallback` — adopt or reject
 - [ ] Mobile's incorrect "already parity-matched with desktop" comment is corrected
 - [ ] `.agents/docs/features/identity-resolution-and-profile-sync.md` reflects whatever is decided
 
-*Last updated: 2026-08-04*
+*Last updated: 2026-08-05*

--- a/.agents/issues/.open/2026-08-05-bookmarks-are-75-percent-of-the-config-blob.md
+++ b/.agents/issues/.open/2026-08-05-bookmarks-are-75-percent-of-the-config-blob.md
@@ -59,10 +59,28 @@ data URIs, not links — the measurement above shows one avatar alone at ~50 KB.
 So a bookmarked image message, or a bookmark of a sender with an avatar, can cost
 tens of KB, and the preview is duplicated per bookmark rather than referenced.
 
-INFERRED, not measured: the exact split between `senderIcon`, `imageUrl` and
-`thumbnailUrl` inside those 656 KB has not been broken down. Do that first — it
-decides whether the fix is "stop embedding sender avatars", "stop embedding image
-data", or both.
+## §3-A. MEASURED 2026-08-05 — it is almost entirely sender avatars
+
+Broken down on the same account, per `cachedPreview` field:
+
+| field | size | share of bookmarks |
+|---|---|---|
+| **`senderIcon`** | **619.8 KB** | **94%** |
+| `imageUrl` | 25.6 KB | 4% |
+| `textSnippet` | 1.2 KB | <1% |
+| `thumbnailUrl` | 0.0 KB | 0% |
+| **total, 18 bookmarks** | **656.5 KB** | — |
+
+**18 bookmarks, and each one carries its own embedded copy of the sender's
+avatar** — roughly 34 KB apiece, duplicated per bookmark rather than referenced.
+That single field is **69% of the entire config blob** and the reason the account
+sits at 873 KB.
+
+This settles the direction: option 1 below, and only the `senderIcon` half of it.
+Dropping `senderIcon` alone would take the blob from ~873 KB to ~253 KB. Bookmark
+previews would resolve the avatar at render from `senderAddress`, through the same
+resolver every other surface already uses — which also means a bookmarked sender's
+avatar stops being frozen at bookmark time.
 
 ## §4. Directions, none decided
 
@@ -80,9 +98,17 @@ data", or both.
 
 ## §5. Next step
 
-Break down the 656 KB by field before choosing. One console pass over the
-`bookmarks` array summing `cachedPreview.senderIcon`, `.imageUrl`, `.thumbnailUrl`
-and `.textSnippet` separately answers it.
+~~Break down the 656 KB by field before choosing.~~ **Done — see §3-A.** The answer
+is `senderIcon`, at 94% of bookmarks and 69% of the whole blob.
+
+The remaining question is migration: existing bookmarks already carry the embedded
+avatar, so dropping the field from new writes does not shrink an existing blob. A
+one-time sweep that strips `cachedPreview.senderIcon` from stored bookmarks would,
+and it is safe in a way the per-space override clear was not — the value is a
+render cache, rebuildable from `senderAddress`, so nothing is lost.
+
+The breakdown is printed by `.agents/tools/dm-debug/08-self-identity-sources.js`,
+so re-measuring after the fix costs one console paste.
 
 ---
 

--- a/.agents/issues/.open/2026-08-05-mobile-identity-parity-after-the-desktop-phase-1-fix.md
+++ b/.agents/issues/.open/2026-08-05-mobile-identity-parity-after-the-desktop-phase-1-fix.md
@@ -1,0 +1,91 @@
+---
+type: task
+title: "Does mobile need the desktop identity fixes? Three questions, one of them urgent"
+status: open
+priority: medium
+created: 2026-08-05
+updated: 2026-08-05
+area: identity resolution / desktop-mobile parity
+repos: quorum-mobile (investigate), quorum-desktop (reference implementation)
+source: raised while verifying the desktop Phase 1 fix on a device — "wondering if mobile also needs all these fixes"
+related:
+  - ".agents/issues/.open/2026-08-05-own-identity-cross-device-sync-design.md (what desktop did and why)"
+  - ".agents/issues/.open/2026-08-04-desktop-shows-a-stale-name-everywhere-except-the-user-settings-field.md (the bug, with measurements)"
+  - ".agents/issues/.open/2026-08-04-desktop-avatar-resolver-and-cross-client-name-tier-drift.md"
+  - ".agents/docs/features/identity-resolution-and-profile-sync.md"
+---
+
+# Does mobile need the desktop identity fixes?
+
+Desktop shipped Phase 1 on 2026-08-05 (branch `fix/own-identity-single-author`).
+This is the mobile side of that question, filed so it does not evaporate.
+
+**Nothing here is asserted. Every item says what to check and what would settle
+it.** Three confident readings of this subsystem were falsified by measurement in
+one day, so this file deliberately does not guess.
+
+## §1. What desktop fixed, and whether mobile plausibly shares it
+
+| desktop defect | mobile likely affected? | why |
+|---|---|---|
+| Self surfaces read a device-local store nothing syncs | **probably YES** | mobile has the same shape: an MMKV `auth:user` record in `AuthContext`, and its config→user bridge runs only on the login path. A rename made on desktop may not reach mobile's own surfaces until relaunch. |
+| Join stamps our own roster OVERRIDE slot | **UNKNOWN — the urgent one** | see §2 |
+| Incoming join filed under the override slot | **UNKNOWN** | same trace |
+| The global slot is a comparator, not a tier | **NO** | mobile already passes the global name into shared's `resolveDisplayName` as a real rung, and its fallback hook already implements override → global → public for names AND avatars. This was the desktop-only half of the drift. |
+| Avatar/bio read the override slot only | **NO** | same reason |
+| A peer can overwrite our own override via sync | **NO** | mobile neither asks nor answers sync (`WebSocketContext.tsx` removed handlers) |
+
+## §2. 🔴 The urgent question
+
+**Does mobile stamp its own per-space OVERRIDE slot at join, the way desktop did?**
+
+If it does, then mobile is still *creating* the permanent traps desktop just
+cleared — and desktop clearing them does not stop mobile making new ones, for
+that user and for everyone in the space. The desktop fix would be continuously
+undermined by the other client.
+
+Where to look: mobile's join path (the equivalent of desktop's
+`InvitationService` own-row write) and its `join` receive handler (desktop's
+`MessageService` ~4950). Desktop's fix was to write `global_display_name` /
+`global_profile_image` with a `globalProfileTimestamp` and leave the override
+empty.
+
+**This is the item to answer first.** The rest can wait.
+
+## §3. ✅ What a device test already settled — do NOT redo it
+
+MEASURED 2026-08-05: a per-space name set **on mobile** reached **desktop**
+correctly. So channel C does carry per-space overrides between a user's own
+devices, at least mobile → desktop.
+
+That matters twice:
+
+1. It removes the motivation for the deferred Phase 2 (moving per-space profiles
+   into the config blob). See the design doc's §6 gate.
+2. It partly refutes `2026-08-01-per-space-override-does-not-reach-your-own-other-devices.md`,
+   which assumed they never cross and was never traced. **The desktop → mobile
+   direction is still untested** — that issue observed exactly that direction, so
+   it is not closed, only narrowed.
+
+## §4. What NOT to do
+
+- **Do not port desktop's resolver changes to mobile.** Mobile already has the
+  ladder; desktop was the one behind. Copying would be a regression.
+- **Do not port the one-time override clear blindly.** Desktop's was justified by
+  a measurement on a real account showing four diverged overrides that could not
+  be told from deliberate ones. Whether mobile's rows are in the same state is a
+  question, not a given — measure before destroying anything.
+- **Do not decide unilaterally whether mobile should change.** Per the atlas
+  rule, when one client has something the other lacks, frame it for the lead
+  rather than deciding. That applies squarely to §2.
+
+## §5. Definition of done
+
+- [ ] §2 answered by reading mobile's join and join-receive paths, with file:line
+- [ ] If mobile does stamp: decided WITH the lead whether mobile changes, and filed in the mobile repo
+- [ ] Mobile's `auth:user` staleness (§1 row 1) confirmed or refuted by a trace
+- [ ] The desktop → mobile per-space direction measured, and `2026-08-01-per-space-override-does-not-reach-your-own-other-devices.md` updated with both directions
+
+---
+
+*Last updated: 2026-08-05*

--- a/.agents/issues/.open/2026-08-05-mobile-identity-parity-after-the-desktop-phase-1-fix.md
+++ b/.agents/issues/.open/2026-08-05-mobile-identity-parity-after-the-desktop-phase-1-fix.md
@@ -52,6 +52,30 @@ empty.
 
 **This is the item to answer first.** The rest can wait.
 
+## §2-B. 🔴 The other urgent one: desktop → mobile per-space overrides never arrive
+
+MEASURED 2026-08-05, both directions, two independent fields:
+
+| direction | arrives? |
+|---|---|
+| mobile → desktop | ✅ yes, immediately (name, bio) |
+| **desktop → mobile** | ❌ **no** (name + avatar 2026-08-01, bio 2026-08-05) |
+
+Reproduces on demand. The user-visible end state is **the same space showing two
+different bios on the two devices**.
+
+Because mobile → desktop works, the relay does deliver to a sender's own other
+device, and desktop's receive path is fine. So the fault is mobile's receive of a
+**desktop-sent** `update-profile`, or desktop's send reaching mobile specifically.
+
+Strongest candidate, from the owning issue's §4: `update-profile` is authorised
+against the VERIFIED signer. Desktop signs with its own per-space signing key; if
+mobile has not admitted that device key (`announce-keys`) it drops the message
+fail-closed. That would be invisible and would explain the asymmetry exactly.
+
+Full record and hypothesis ranking:
+`2026-08-01-per-space-override-does-not-reach-your-own-other-devices.md`.
+
 ## §3. ✅ What a device test already settled — do NOT redo it
 
 MEASURED 2026-08-05: a per-space name set **on mobile** reached **desktop**

--- a/.agents/issues/.open/2026-08-05-own-identity-cross-device-sync-design.md
+++ b/.agents/issues/.open/2026-08-05-own-identity-cross-device-sync-design.md
@@ -371,7 +371,35 @@ author, and both can perpetuate a poisoned value:
   write; **change this companion cache write with it**, or the cache and the DB
   disagree about which slot holds a new joiner's name until the next refetch.
 
-## §6. Phase 2 — only if measured necessary
+## §6. Phase 2 — ⛔ MEASURED UNNECESSARY 2026-08-05. Do not build it.
+
+**The gate was run and Phase 2 failed it, which is the good outcome.**
+
+MEASURED on a real device pair: a per-space name set **on mobile** reached
+**desktop** correctly, immediately, over channel C.
+
+That kills the premise. Phase 2 existed because
+`2026-08-01-per-space-override-does-not-reach-your-own-other-devices.md` assumed
+per-space overrides never reach a user's own other devices — an assumption that
+was **never traced**, and is now shown to be false in at least one direction. The
+space roster already carries them, live, which is better than the config blob
+would have managed: the blob has no live push and only re-pulls on startup and a
+handful of incidental actions.
+
+So the elaborate design below would have traded a working live channel for a
+restart-gated one, to solve a problem that did not exist. It is retained as the
+record of a decision **not** taken, and of what it would cost if the premise ever
+turns out to hold after all.
+
+⚠️ **Still open, and the reason this is not simply deleted:** only
+**mobile → desktop** was measured. The 2026-08-01 issue observed the
+**desktop → mobile** direction. If that direction is genuinely broken, the fix is
+to repair channel C in that direction — not to move authorship into the blob.
+Tracked in `2026-08-05-mobile-identity-parity-after-the-desktop-phase-1-fix.md`.
+
+**Everything below is the un-built design. Read it only if the gate is reopened.**
+
+### The original gate and design
 
 **First, measure.** Set a per-space name on desktop; check whether it reaches the
 phone, and the reverse. The 2026-08-01 issue assumed it never does and was never

--- a/.agents/issues/.open/2026-08-05-own-identity-cross-device-sync-design.md
+++ b/.agents/issues/.open/2026-08-05-own-identity-cross-device-sync-design.md
@@ -276,6 +276,19 @@ already treats as a deliberate clear. `saveSpaceMember`'s `clearFields` escape h
 is **not** needed here; it exists for `spaceTag`, whose deletion is signalled by
 absence.
 
+#### 5-D-0. It clears the name and avatar, NOT the bio — deliberately
+
+This looks like an omission and is not. Nothing ever stamped a per-space **bio**
+automatically: the join path does not write one, the legacy-owner repair does not,
+and the global profile save sends `globalBio`, never the override `bio`. The only
+writer is the Space Settings → Account editor.
+
+So a non-empty per-space bio is **always** deliberate, and clearing it would destroy
+something the user actually typed — the opposite of the reasoning that justifies
+clearing names.
+
+If a future change starts stamping bios, this reasoning expires with it.
+
 #### 🔴 5-D-i. The clear MUST stamp a `profileTimestamp`, or a sibling device undoes it
 
 Found by independent regression review 2026-08-05, with the path traced end to end.

--- a/.agents/issues/2026-08-05-own-identity-cross-device-sync-plan.md
+++ b/.agents/issues/2026-08-05-own-identity-cross-device-sync-plan.md
@@ -1,0 +1,1342 @@
+---
+type: task
+title: "Implementation plan — your own identity, Phase 1 (desktop only)"
+status: in-progress
+priority: high
+created: 2026-08-05
+updated: 2026-08-05
+area: identity resolution / space member roster / config sync
+repos: quorum-desktop only
+related:
+  - ".agents/issues/.open/2026-08-05-own-identity-cross-device-sync-design.md (the spec — read it first)"
+  - ".agents/issues/.open/2026-08-04-desktop-shows-a-stale-name-everywhere-except-the-user-settings-field.md (the bug, with the measurement)"
+---
+
+# Own identity, Phase 1 — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: use `superpowers:subagent-driven-development`
+> (recommended) or `superpowers:executing-plans` to implement this task-by-task.
+> Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** the current user's own name and avatar are the same on every surface of
+the desktop app, follow a rename made on another device, and stop being frozen by a
+stale per-space override that the app itself keeps refreshing.
+
+**Architecture:** three independent defects, one symptom. (1) Several surfaces read a
+device-local `localStorage` passkey record that nothing on the receive side ever
+writes — fixed by reconciling that record from the synced config blob, which repairs
+every reader at once because they all read the same in-memory object. (2) Four code
+paths stamp the user's own roster **override** slot with their global name, and the
+override outranks everything forever — fixed by writing the **global** slot instead,
+plus a one-time clear of existing stamps. (3) The clear cannot travel on the wire
+because the announce payload builder collapses `''` and absent to the same output —
+fixed by giving it presence semantics and broadcasting the clear explicitly.
+
+**Tech stack:** TypeScript, React, IndexedDB (`quorum_db`), React Query, Vitest.
+Desktop repo only. **No wire-format change. No `quorum-shared` change. No mobile
+dependency.**
+
+**Run tests with:** `yarn test:run <path>` (Vitest). Typecheck with
+`npx tsc --noEmit --jsx react-jsx --skipLibCheck`.
+
+---
+
+## Dispatch waves
+
+| Wave | Tasks | Parallel? | Why |
+|---|---|---|---|
+| **A** | 1, 2, 3, 4 | ✅ yes — no shared files | four separate files, no ordering between them |
+| **B** | 5, 6, 7 | ❌ no — 5 and 6 share `MessageService.ts` | run in order; 7 is separate files but belongs to the same behaviour |
+| **C** | 8 | ❌ after Task 1 | the clear cannot be broadcast until the payload builder can express it |
+| **D** | 9 | last | docs describe the shipped behaviour |
+
+---
+
+## File structure
+
+| File | Responsibility | Task |
+|---|---|---|
+| `src/utils/spaceProfilePayload.ts` | build the `update-profile` wire payload; must distinguish "no override" from "cleared override" | 1 |
+| `src/utils/resolveGlobalSender.ts` | notification-panel sender lookup; must implement override → global | 2 |
+| `src/db/messages.ts` | `saveSpaceMember` gains a tripwire that records unexpected self-override writes | 3 |
+| `src/utils/selfOverrideTripwire.ts` (new) | the tripwire's bounded ring buffer, pure and testable | 3 |
+| `src/hooks/business/user/useReconcileSelfIdentity.ts` (new) | copy the synced config name/avatar into the passkey record | 4 |
+| `src/components/Layout.tsx` | mount the reconciliation hook | 4 |
+| `src/services/MessageService.ts` | sync-delta self-exclusion; join filed under the global slot | 5, 6 |
+| `src/services/InvitationService.ts` | our own join row writes the global slot | 7 |
+| `src/components/modals/SpaceSettingsModal/SpaceSettingsModal.tsx` | `addOwnerToMembers` writes the global slot | 7 |
+| `src/hooks/business/user/useClearLegacySpaceOverrides.ts` (new) | one-time clear: local write + broadcast + log | 8 |
+
+---
+
+# WAVE A — four independent tasks, dispatch in parallel
+
+## Task 1: let the announce express a cleared override
+
+**User-visible outcome:** when you clear your per-space name, everyone else stops
+seeing the old one. Today the clear never leaves your device.
+
+**Files:**
+- Modify: `src/utils/spaceProfilePayload.ts:80-85`
+- Test: `src/dev/tests/utils/spaceProfilePayload.test.ts`
+
+**Background the implementer needs:** the two-slot wire model says **omitted = no
+change, `''` = deliberate clear, value = set override**. `buildSpaceProfileWirePayload`
+currently uses `||`, which collapses `''` and `undefined` to the same omitted field,
+so it can only ever say "no change". The Space Settings editor
+(`src/hooks/business/spaces/useSpaceProfile.ts:279-323`) already does this correctly
+with `!== undefined` — you are bringing this builder into line with it.
+
+- [ ] **Step 1: Update the existing test that pins the WRONG behaviour**
+
+`src/dev/tests/utils/spaceProfilePayload.test.ts` currently contains a passing test
+asserting that `display_name: ''` omits the field. That test pins the bug. Replace it:
+
+```ts
+  it('OMITS the override field when there is no override at all', () => {
+    const p = buildSpaceProfileWirePayload(
+      SELF,
+      { display_name: undefined, user_icon: undefined, bio: undefined },
+      GLOBAL
+    );
+    expect('displayName' in p).toBe(false);
+    expect('userIcon' in p).toBe(false);
+    expect('bio' in p).toBe(false);
+  });
+
+  it('SENDS an empty string when the override was deliberately cleared', () => {
+    // '' is the wire's "deliberate clear". Collapsing it to an omission means a
+    // clear can never leave this device, so spacemates keep the stale name.
+    const p = buildSpaceProfileWirePayload(
+      SELF,
+      { display_name: '', user_icon: '', bio: '' },
+      GLOBAL
+    );
+    expect(p.displayName).toBe('');
+    expect(p.userIcon).toBe('');
+    expect(p.bio).toBe('');
+  });
+```
+
+- [ ] **Step 2: Run it and confirm the new test FAILS**
+
+Run: `yarn test:run src/dev/tests/utils/spaceProfilePayload.test.ts`
+Expected: the "SENDS an empty string" test FAILS — `p.displayName` is `undefined`.
+**If it passes, stop.** The fix is already present and something is wrong with your
+assumptions.
+
+- [ ] **Step 3: Make the builder presence-checked**
+
+In `src/utils/spaceProfilePayload.ts`, replace lines 80-85:
+
+```ts
+  const nameOverride = ownMember?.display_name || undefined;
+  // The member avatar lives on `user_icon` (the typed UserProfile field), but
+  // some rows also carry `profile_image` from other write paths, so read both.
+  const iconOverride =
+    ownMember?.user_icon || ownMember?.profile_image || undefined;
+  const bioOverride = ownMember?.bio || undefined;
+```
+
+with:
+
+```ts
+  // `??`, not `||`: '' is the wire's deliberate clear and MUST survive to the
+  // payload. With `||` a clear and a never-set field produced the same omitted
+  // field, so clearing a per-space name never left this device.
+  const nameOverride = ownMember?.display_name;
+  // The member avatar lives on `user_icon` (the typed UserProfile field), but
+  // some rows also carry `profile_image` from other write paths, so read both.
+  const iconOverride = ownMember?.user_icon ?? ownMember?.profile_image;
+  const bioOverride = ownMember?.bio;
+```
+
+Leave the spread below unchanged — it already uses `!== undefined`.
+
+- [ ] **Step 4: Run the test again**
+
+Run: `yarn test:run src/dev/tests/utils/spaceProfilePayload.test.ts`
+Expected: PASS, all tests in the file.
+
+- [ ] **Step 5: Do NOT change `hasAnnounceableIdentity`**
+
+It uses truthiness, so a payload whose only override field is `''` does not count as
+announceable. That is correct and deliberate: Task 8 broadcasts the clear explicitly
+rather than relying on the announce. Leave it alone and do not "fix" it.
+
+- [ ] **Step 6: Typecheck and commit**
+
+```bash
+npx tsc --noEmit --jsx react-jsx --skipLibCheck
+git add src/utils/spaceProfilePayload.ts src/dev/tests/utils/spaceProfilePayload.test.ts
+git commit -m "fix(identity): a cleared per-space name can now travel on the wire
+
+buildSpaceProfileWirePayload used || so '' and undefined collapsed to the same
+omitted field. The wire model defines '' as a deliberate clear, so clearing a
+per-space name never reached anyone else. The Space Settings editor already used
+presence semantics; this brings the announce builder into line."
+```
+
+---
+
+## Task 2: the notification panel must read the global identity slot
+
+**User-visible outcome:** people show their name in the notifications drawer instead
+of a truncated address. Without this, Task 6 makes the drawer worse for every member
+who joins from then on.
+
+**Files:**
+- Modify: `src/utils/resolveGlobalSender.ts:29-48`
+- Test: create `src/dev/tests/utils/resolveGlobalSender.globalSlot.test.ts`
+
+**Background:** `buildGlobalSenderMap` reads `row.display_name` / `row.user_icon`
+only. It declares a `globalDisplayName` field it never populates. It has worked by
+accident because every incoming join stamped `display_name` — which Task 6 stops
+doing. `src/hooks/business/channels/useChannelData.ts:65-108` and
+`src/dev/identity-coverage/identityCoverageCore.ts:164-172` both already implement
+the ladder correctly; follow them.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { buildGlobalSenderMap } from '@/utils/resolveGlobalSender';
+
+const SPACE = 'QmSpace0000000000000000000000000000000000';
+const ADDR = 'QmMember00000000000000000000000000000000';
+
+describe('buildGlobalSenderMap — the global identity slot', () => {
+  it('falls back to the global slot when there is no per-space override', () => {
+    // The post-follow-global normal state: override empty, identity in the
+    // global slot. Every other render path handles this; this one did not.
+    const resolve = buildGlobalSenderMap({
+      [SPACE]: [
+        {
+          user_address: ADDR,
+          display_name: '',
+          user_icon: '',
+          global_display_name: 'Ada',
+          global_user_icon: 'data:image/png;base64,AAA',
+        },
+      ] as never,
+    });
+    const sender = resolve(SPACE, ADDR);
+    expect(sender.displayName).toBe('Ada');
+    expect(sender.userIcon).toBe('data:image/png;base64,AAA');
+    expect(sender.globalDisplayName).toBe('Ada');
+  });
+
+  it('a deliberate per-space override still outranks the global slot', () => {
+    const resolve = buildGlobalSenderMap({
+      [SPACE]: [
+        {
+          user_address: ADDR,
+          display_name: 'Ada in this space',
+          global_display_name: 'Ada',
+        },
+      ] as never,
+    });
+    const sender = resolve(SPACE, ADDR);
+    expect(sender.displayName).toBe('Ada in this space');
+    expect(sender.globalDisplayName).toBe('Ada');
+  });
+
+  it('unknown sender still returns an address-only record', () => {
+    const resolve = buildGlobalSenderMap({});
+    expect(resolve(SPACE, ADDR)).toEqual({ address: ADDR });
+  });
+});
+```
+
+- [ ] **Step 2: Run it and confirm the first test FAILS**
+
+Run: `yarn test:run src/dev/tests/utils/resolveGlobalSender.globalSlot.test.ts`
+Expected: FAIL — `sender.displayName` is `''`, `globalDisplayName` is `undefined`.
+
+- [ ] **Step 3: Implement the ladder**
+
+In `src/utils/resolveGlobalSender.ts`, widen the local row type and populate the
+merged fields. Replace the `type SpaceMemberRow` alias and the `for (const row of rows)`
+body:
+
+```ts
+type SpaceMemberRow = channel.UserProfile & {
+  isKicked?: boolean;
+  /** Roster GLOBAL slots (two-slot model) — the tier between the per-space
+   *  override and the public profile. */
+  global_display_name?: string;
+  global_user_icon?: string;
+};
+```
+
+```ts
+    for (const row of rows) {
+      // Same precedence as useMembersWithPublicProfileFallback: override wins
+      // when non-empty, else the global slot. `globalDisplayName` is kept
+      // SEPARATE so resolveSpaceMemberName can compare the two.
+      const global = row.global_display_name || undefined;
+      map.set(row.user_address, {
+        address: row.user_address,
+        displayName: row.display_name || global,
+        userIcon: row.user_icon || row.global_user_icon || undefined,
+        globalDisplayName: global,
+      });
+    }
+```
+
+- [ ] **Step 4: Run the test again**
+
+Run: `yarn test:run src/dev/tests/utils/resolveGlobalSender.globalSlot.test.ts`
+Expected: PASS, all three.
+
+- [ ] **Step 5: Typecheck and commit**
+
+```bash
+npx tsc --noEmit --jsx react-jsx --skipLibCheck
+git add src/utils/resolveGlobalSender.ts src/dev/tests/utils/resolveGlobalSender.globalSlot.test.ts
+git commit -m "fix(identity): the notifications drawer reads the global identity slot
+
+buildGlobalSenderMap read the per-space override slot only, and declared a
+globalDisplayName field it never populated. It worked by accident because every
+incoming join stamped the override slot. It now implements the same
+override-then-global ladder every other render path uses."
+```
+
+---
+
+## Task 3: a tripwire for unexpected writes to our own override slot
+
+**User-visible outcome:** none directly. This is the instrument that makes the next
+regression in this area findable instead of silent. The design explicitly replaced an
+unprovable "no code path writes our own override" checklist item with this.
+
+**Files:**
+- Create: `src/utils/selfOverrideTripwire.ts`
+- Create: `src/dev/tests/utils/selfOverrideTripwire.test.ts`
+- Modify: `src/db/messages.ts` (inside `saveSpaceMember`, and a setter on the class)
+- Modify: `src/components/context/MessageDB.tsx` (feed it the self address)
+
+**Design note:** this is a **tripwire, not a gate.** It records and warns; it never
+blocks a write. Blocking would risk breaking a legitimate path we have not thought
+of, and this subsystem has already produced three falsified confident readings.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  recordSelfOverrideWrite,
+  readSelfOverrideTripwire,
+  TRIPWIRE_KEY,
+  MAX_TRIPWIRE_ENTRIES,
+} from '@/utils/selfOverrideTripwire';
+
+describe('selfOverrideTripwire', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  it('records a non-empty self override write', () => {
+    recordSelfOverrideWrite({ spaceId: 'QmSpace', value: 'Stale Name' });
+    const entries = readSelfOverrideTripwire();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].spaceId).toBe('QmSpace');
+    expect(entries[0].value).toBe('Stale Name');
+    expect(entries[0].stack).toBeTruthy();
+  });
+
+  it('ignores a clear — writing "" is the fix, not the bug', () => {
+    recordSelfOverrideWrite({ spaceId: 'QmSpace', value: '' });
+    expect(readSelfOverrideTripwire()).toHaveLength(0);
+  });
+
+  it('bounds the ring so it cannot grow without limit', () => {
+    for (let i = 0; i < MAX_TRIPWIRE_ENTRIES + 5; i++) {
+      recordSelfOverrideWrite({ spaceId: `s${i}`, value: `v${i}` });
+    }
+    const entries = readSelfOverrideTripwire();
+    expect(entries).toHaveLength(MAX_TRIPWIRE_ENTRIES);
+    // newest kept, oldest dropped
+    expect(entries[entries.length - 1].spaceId).toBe(
+      `s${MAX_TRIPWIRE_ENTRIES + 4}`
+    );
+  });
+
+  it('never throws when localStorage is unavailable', () => {
+    const spy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('quota');
+    });
+    expect(() => recordSelfOverrideWrite({ spaceId: 's', value: 'v' })).not.toThrow();
+    spy.mockRestore();
+  });
+
+  it('exposes a stable key so it can be read from the console', () => {
+    expect(TRIPWIRE_KEY).toBe('quorum:diag:selfOverrideWrites');
+  });
+});
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `yarn test:run src/dev/tests/utils/selfOverrideTripwire.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the tripwire**
+
+Create `src/utils/selfOverrideTripwire.ts`:
+
+```ts
+// Records any write of a NON-EMPTY per-space override onto the local user's own
+// member row. After the Phase 1 fixes only the Space Settings editor should ever
+// do that; anything else appearing here is a regression.
+//
+// A tripwire, not a gate: it never blocks a write. `console.warn`, not `logger`,
+// because logger calls compile to no-ops in production builds.
+//
+// Read it with:  JSON.parse(localStorage.getItem('quorum:diag:selfOverrideWrites'))
+
+export const TRIPWIRE_KEY = 'quorum:diag:selfOverrideWrites';
+export const MAX_TRIPWIRE_ENTRIES = 50;
+
+export interface SelfOverrideWrite {
+  at: number;
+  spaceId: string;
+  value: string;
+  stack: string;
+}
+
+export function recordSelfOverrideWrite(input: {
+  spaceId: string;
+  value: string;
+}): void {
+  // '' is the deliberate clear — the fix, not the bug. Only non-empty is news.
+  if (!input.value) return;
+  try {
+    const entry: SelfOverrideWrite = {
+      at: Date.now(),
+      spaceId: input.spaceId,
+      value: input.value,
+      stack: new Error().stack ?? '(no stack)',
+    };
+    const existing = readSelfOverrideTripwire();
+    const next = [...existing, entry].slice(-MAX_TRIPWIRE_ENTRIES);
+    localStorage.setItem(TRIPWIRE_KEY, JSON.stringify(next));
+    console.warn(
+      `[SelfOverride] a non-empty per-space override was written onto our OWN row ` +
+        `for space ${input.spaceId.slice(0, 12)}. Only Space Settings → Account ` +
+        `should do this. See ${TRIPWIRE_KEY} in localStorage.`,
+      entry.stack
+    );
+  } catch {
+    // Diagnostics must never break a write.
+  }
+}
+
+export function readSelfOverrideTripwire(): SelfOverrideWrite[] {
+  try {
+    const raw = localStorage.getItem(TRIPWIRE_KEY);
+    return raw ? (JSON.parse(raw) as SelfOverrideWrite[]) : [];
+  } catch {
+    return [];
+  }
+}
+```
+
+- [ ] **Step 4: Run the test again**
+
+Run: `yarn test:run src/dev/tests/utils/selfOverrideTripwire.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Wire it into `saveSpaceMember`**
+
+In `src/db/messages.ts`, add an import of `recordSelfOverrideWrite` from
+`../utils/selfOverrideTripwire`, add a field and setter on the `MessageDB` class:
+
+```ts
+  /** Set by MessageDBProvider once the user's address is derived. Diagnostics
+   *  only — see selfOverrideTripwire. */
+  private selfAddressForDiagnostics?: string;
+
+  setSelfAddressForDiagnostics(address: string): void {
+    this.selfAddressForDiagnostics = address;
+  }
+```
+
+Then inside `saveSpaceMember`, immediately after `const userAddress = (userProfile as
+{ user_address?: string }).user_address;`, add:
+
+```ts
+      const incomingName = (userProfile as { display_name?: string }).display_name;
+      if (
+        userAddress &&
+        userAddress === this.selfAddressForDiagnostics &&
+        incomingName
+      ) {
+        recordSelfOverrideWrite({ spaceId, value: incomingName });
+      }
+```
+
+- [ ] **Step 6: Feed it the address**
+
+In `src/components/context/MessageDB.tsx`, find the `useEffect` that derives
+`selfAddress` (search for `setSelfAddress(base58btc.baseEncode(sh.bytes))`). Add a
+line immediately after that `setSelfAddress(...)` call:
+
+```ts
+          messageDB.setSelfAddressForDiagnostics(base58btc.baseEncode(sh.bytes));
+```
+
+- [ ] **Step 7: Typecheck and commit**
+
+```bash
+npx tsc --noEmit --jsx react-jsx --skipLibCheck
+yarn test:run src/dev/tests/utils/selfOverrideTripwire.test.ts
+git add src/utils/selfOverrideTripwire.ts src/dev/tests/utils/selfOverrideTripwire.test.ts src/db/messages.ts src/components/context/MessageDB.tsx
+git commit -m "feat(identity): tripwire for unexpected writes to our own override slot
+
+'No code path writes our own per-space override except the editor' is an
+exhaustive negative and cannot be proven by a fixed list of unit tests — two
+extra write vectors were found while that claim was being written. This records
+every non-empty self-override write with a stack trace to a bounded localStorage
+ring instead. It never blocks a write."
+```
+
+---
+
+## Task 4: the synced name reaches the device-local passkey record
+
+**User-visible outcome:** rename yourself on your phone, and the desktop NavRail
+avatar tooltip, the DM self entry and your own name in search results all follow.
+Today they are frozen at whatever this device last saved.
+
+**Files:**
+- Create: `src/hooks/business/user/useReconcileSelfIdentity.ts`
+- Create: `src/dev/tests/hooks/useReconcileSelfIdentity.unit.test.ts`
+- Modify: `src/components/Layout.tsx:61` area (mount the hook)
+
+**Why one hook fixes ~15 call sites:** `NavRail.tsx:94-96`, `DirectMessage.tsx:298-302`,
+`useSearchResultDisplay.ts:77-86`, `useSearchResultDisplayDM.ts:57-66`,
+`InvitationService.ts:769-771` and about ten others all read the **same**
+`currentPasskeyInfo` object from `usePasskeysContext()`. Repairing that one record
+repairs all of them, instead of editing fifteen call sites.
+
+**🔴 The guard that must not be dropped:** never write an empty name. Because every
+one of those sites reads the same object, a single empty write blanks all of them at
+once. `ConfigService.getConfig` returns `getDefaultUserConfig(address)` — which has
+**no** `name` — whenever there is neither a network response nor a stored config,
+which is the ordinary cold-start / offline-first-run state. The existing precedent in
+`useUnifiedOnboardingFlow.ts:226-247` guards with `if (validatedName)`; keep that shape.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import { shouldReconcileSelfIdentity } from '@/hooks/business/user/useReconcileSelfIdentity';
+
+describe('shouldReconcileSelfIdentity', () => {
+  it('writes when the synced name differs from the stored one', () => {
+    expect(
+      shouldReconcileSelfIdentity(
+        { name: 'Ada 8', profile_image: 'img8' },
+        { displayName: 'Ada 2', pfpUrl: 'img2' }
+      )
+    ).toEqual({ displayName: 'Ada 8', pfpUrl: 'img8' });
+  });
+
+  it('does NOT write when they already agree', () => {
+    expect(
+      shouldReconcileSelfIdentity(
+        { name: 'Ada', profile_image: 'img' },
+        { displayName: 'Ada', pfpUrl: 'img' }
+      )
+    ).toBeNull();
+  });
+
+  it('NEVER blanks a good stored name from an empty config', () => {
+    // Cold start / offline: getConfig returns a default config with no name.
+    // ~15 sites read the same in-memory passkey object, so one empty write
+    // blanks every one of them at once.
+    expect(
+      shouldReconcileSelfIdentity({}, { displayName: 'Ada', pfpUrl: 'img' })
+    ).toBeNull();
+    expect(
+      shouldReconcileSelfIdentity(
+        { name: '', profile_image: '' },
+        { displayName: 'Ada', pfpUrl: 'img' }
+      )
+    ).toBeNull();
+    expect(
+      shouldReconcileSelfIdentity(undefined, { displayName: 'Ada', pfpUrl: 'img' })
+    ).toBeNull();
+  });
+
+  it('fills a name when the device has none yet', () => {
+    expect(
+      shouldReconcileSelfIdentity({ name: 'Ada' }, { displayName: undefined })
+    ).toEqual({ displayName: 'Ada', pfpUrl: undefined });
+  });
+
+  it('updates only the avatar when only the avatar changed', () => {
+    expect(
+      shouldReconcileSelfIdentity(
+        { name: 'Ada', profile_image: 'newImg' },
+        { displayName: 'Ada', pfpUrl: 'oldImg' }
+      )
+    ).toEqual({ displayName: 'Ada', pfpUrl: 'newImg' });
+  });
+});
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `yarn test:run src/dev/tests/hooks/useReconcileSelfIdentity.unit.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the pure decision plus the hook**
+
+Create `src/hooks/business/user/useReconcileSelfIdentity.ts`:
+
+```ts
+// The synced config blob (channel A) is the cross-device source of truth for the
+// user's global name and avatar, but almost nothing reads it: NavRail, the DM self
+// entry, search results and the join-time roster stamp all read the device-local
+// passkey record, which only THIS device's own save ever writes. So a rename made
+// on another device could never reach them.
+//
+// Repairing that one record repairs every reader at once, because they all read the
+// same object from usePasskeysContext().
+//
+// See .agents/issues/.open/2026-08-05-own-identity-cross-device-sync-design.md §5-A
+
+import { useEffect, useRef } from 'react';
+import { usePasskeysContext } from '@quilibrium/quilibrium-js-sdk-channels';
+import { logger } from '@quilibrium/quorum-shared';
+import { useMessageDB } from '../../../components/context/useMessageDB';
+
+interface SyncedIdentity {
+  name?: string;
+  profile_image?: string;
+}
+interface StoredIdentity {
+  displayName?: string;
+  pfpUrl?: string;
+}
+
+/**
+ * Pure decision: what, if anything, should be written back to the passkey record.
+ * Returns null when nothing should be written.
+ *
+ * NEVER returns a write that blanks an existing name. getConfig returns a default
+ * config with no `name` on a cold start with no network, and ~15 call sites read
+ * the single in-memory passkey object, so one empty write blanks all of them.
+ */
+export function shouldReconcileSelfIdentity(
+  config: SyncedIdentity | undefined,
+  stored: StoredIdentity
+): { displayName: string; pfpUrl?: string } | null {
+  const syncedName = config?.name?.trim();
+  if (!syncedName) return null;
+
+  const syncedIcon = config?.profile_image || undefined;
+  const nameChanged = syncedName !== stored.displayName;
+  const iconChanged = Boolean(syncedIcon) && syncedIcon !== stored.pfpUrl;
+  if (!nameChanged && !iconChanged) return null;
+
+  return { displayName: syncedName, pfpUrl: syncedIcon ?? stored.pfpUrl };
+}
+
+export function useReconcileSelfIdentity(): void {
+  const { currentPasskeyInfo, updateStoredPasskey } = usePasskeysContext();
+  const { messageDB } = useMessageDB();
+  const lastAppliedRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!currentPasskeyInfo?.address) return;
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const config = await messageDB.getUserConfig({
+          address: currentPasskeyInfo.address,
+        });
+        if (cancelled) return;
+
+        const write = shouldReconcileSelfIdentity(config, {
+          displayName: currentPasskeyInfo.displayName,
+          pfpUrl: currentPasskeyInfo.pfpUrl,
+        });
+        if (!write) return;
+
+        // Guard against a render loop: updateStoredPasskey changes
+        // currentPasskeyInfo, which re-runs this effect.
+        const signature = `${write.displayName} ${write.pfpUrl ?? ''}`;
+        if (lastAppliedRef.current === signature) return;
+        lastAppliedRef.current = signature;
+
+        updateStoredPasskey(currentPasskeyInfo.credentialId, {
+          credentialId: currentPasskeyInfo.credentialId,
+          address: currentPasskeyInfo.address,
+          publicKey: currentPasskeyInfo.publicKey,
+          displayName: write.displayName,
+          pfpUrl: write.pfpUrl,
+          completedOnboarding: true,
+        });
+        logger.log('[SelfIdentity] reconciled the passkey record from the synced config');
+      } catch (error) {
+        // Non-fatal: the stored value keeps rendering, which is today's behaviour.
+        logger.warn('[SelfIdentity] reconcile failed', error);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [currentPasskeyInfo, updateStoredPasskey, messageDB]);
+}
+```
+
+- [ ] **Step 4: Run the test again**
+
+Run: `yarn test:run src/dev/tests/hooks/useReconcileSelfIdentity.unit.test.ts`
+Expected: PASS, all five.
+
+- [ ] **Step 5: Mount it**
+
+In `src/components/Layout.tsx`, next to the existing `useMigrateConversationSettings();`
+call on line 61, add the import and the call:
+
+```ts
+import { useReconcileSelfIdentity } from '../hooks/business/user/useReconcileSelfIdentity';
+```
+```ts
+  useReconcileSelfIdentity();
+```
+
+- [ ] **Step 6: Typecheck and commit**
+
+```bash
+npx tsc --noEmit --jsx react-jsx --skipLibCheck
+git add src/hooks/business/user/useReconcileSelfIdentity.ts src/dev/tests/hooks/useReconcileSelfIdentity.unit.test.ts src/components/Layout.tsx
+git commit -m "fix(identity): the synced name reaches the device-local passkey record
+
+NavRail, the DM self entry, search results and the join-time roster stamp all
+read a localStorage passkey record that only this device's own save ever wrote,
+so a rename made on another device could never reach them. They all read the
+same in-memory object, so reconciling that one record from the synced config
+repairs every one of them. Never writes an empty name: getConfig returns a
+nameless default on a cold start, and one empty write would blank all of them."
+```
+
+---
+
+# WAVE B — the write side. Sequential; tasks 5 and 6 share a file.
+
+## Task 5: a peer cannot overwrite our own per-space name
+
+**User-visible outcome:** a per-space name you set stays set, even when another
+client sends you its older copy of your own roster row during a sync.
+
+**Files:**
+- Modify: `src/services/MessageService.ts` (the `sync-delta` member apply, near line 6111-6149)
+- Test: `src/dev/tests/services/syncDeltaSelfExclusion.unit.test.ts` (create)
+
+**Background:** `computeMemberDiff` / `buildMemberDelta` in `quorum-shared` walk every
+address with **no special case for our own**, so any peer whose cached hash for us
+differs will send back its stored copy of our row. The receive side then applies it.
+
+**🔴 Do NOT also tighten the "guard fails open on a row with no `profileTimestamp`".**
+That fail-open is the intended bootstrap for members we have never heard of, and it is
+pinned by `src/dev/tests/db/saveSpaceMemberGlobalSlot.test.ts`
+("but it CAN populate a row that has no timestamp yet"). Self-exclusion covers the
+case that matters. An earlier draft of the design said to tighten it and was wrong.
+
+- [ ] **Step 1: Find the self address in scope**
+
+Open `src/services/MessageService.ts` and locate the `sync-delta` handler containing
+`if (envelope.message.memberDelta) {`. Determine what identifies the local user in
+that scope — grep the enclosing method for `self_address`, `selfAddress`, or
+`currentUserAddress`. If none is in scope, thread the value in from the caller rather
+than reaching for a global. Record which you used; Step 3 refers to it as `SELF`.
+
+- [ ] **Step 2: Write the failing test**
+
+The apply logic is currently inline in a large method. Extract the per-member
+decision into an exported pure function first, so it can be tested — mirroring how
+`applyProfileUpdate` is already exported from this same file for the same reason.
+
+Add to `src/services/MessageService.ts`, beside `applyProfileUpdate`:
+
+```ts
+/**
+ * Which slots may a sync-delta member row write?
+ *
+ * The sync protocol compares digests, which carry no notion of newer or older, so a
+ * peer holding a STALE identity will happily push it back. For OUR OWN row that is
+ * never acceptable: a peer is not authoritative about our per-space choice. For
+ * everyone else the per-slot timestamp guard applies, and a row with no stored
+ * timestamp accepts unconditionally — that is the deliberate bootstrap for a member
+ * we have never heard of.
+ */
+export function resolveSyncDeltaSlots(input: {
+  isSelf: boolean;
+  existingOverrideTs?: number;
+  existingGlobalTs?: number;
+  incomingOverrideTs: number;
+  incomingGlobalTs: number;
+}): { applyOverride: boolean; applyGlobal: boolean } {
+  const applyOverride =
+    !input.isSelf &&
+    !(input.existingOverrideTs && input.existingOverrideTs >= input.incomingOverrideTs);
+  const applyGlobal = !(
+    input.existingGlobalTs && input.existingGlobalTs >= input.incomingGlobalTs
+  );
+  return { applyOverride, applyGlobal };
+}
+```
+
+Create `src/dev/tests/services/syncDeltaSelfExclusion.unit.test.ts`:
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import { resolveSyncDeltaSlots } from '@/services/MessageService';
+
+vi.mock('@quilibrium/quilibrium-js-sdk-channels', () => ({
+  channel: {},
+  channel_raw: {},
+}));
+
+describe('resolveSyncDeltaSlots', () => {
+  it('NEVER lets a peer write our own override slot, however new it claims to be', () => {
+    const r = resolveSyncDeltaSlots({
+      isSelf: true,
+      existingOverrideTs: undefined,
+      incomingOverrideTs: Number.MAX_SAFE_INTEGER,
+      existingGlobalTs: undefined,
+      incomingGlobalTs: 1,
+    });
+    expect(r.applyOverride).toBe(false);
+  });
+
+  it('still accepts our own GLOBAL slot from a peer', () => {
+    const r = resolveSyncDeltaSlots({
+      isSelf: true,
+      incomingOverrideTs: 5,
+      incomingGlobalTs: 5,
+    });
+    expect(r.applyGlobal).toBe(true);
+  });
+
+  it('applies another member override when we have no timestamp (bootstrap)', () => {
+    const r = resolveSyncDeltaSlots({
+      isSelf: false,
+      existingOverrideTs: undefined,
+      incomingOverrideTs: 0,
+      incomingGlobalTs: 0,
+    });
+    expect(r.applyOverride).toBe(true);
+  });
+
+  it('rejects an older override for another member', () => {
+    const r = resolveSyncDeltaSlots({
+      isSelf: false,
+      existingOverrideTs: 2000,
+      incomingOverrideTs: 1000,
+      incomingGlobalTs: 0,
+    });
+    expect(r.applyOverride).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 3: Run it, confirm the self test fails, then use the function**
+
+Run: `yarn test:run src/dev/tests/services/syncDeltaSelfExclusion.unit.test.ts`
+Expected: the first test FAILS before you add `!input.isSelf` — add the function
+without that clause first, watch it fail, then add the clause and watch it pass. A
+test that cannot fail is worse than no test.
+
+Then replace the inline `applyOverride` / `applyGlobal` computation in the sync-delta
+handler with a call to `resolveSyncDeltaSlots({ isSelf: userAddress === SELF, ... })`,
+using the identifier you established in Step 1.
+
+- [ ] **Step 4: Handle the duplicated test**
+
+`src/dev/tests/db/saveSpaceMemberGlobalSlot.test.ts` **hand-copies** this decision
+inline (its `applyIncoming` helper) rather than importing it, so it will keep passing
+against the old behaviour. Change that helper to call `resolveSyncDeltaSlots` so it
+tracks the real code, and add `isSelf: false` to its fixtures. Do not simply update
+the copy to match — that is how a green test stops meaning anything.
+
+- [ ] **Step 5: Run both files, typecheck, commit**
+
+```bash
+yarn test:run src/dev/tests/services/syncDeltaSelfExclusion.unit.test.ts src/dev/tests/db/saveSpaceMemberGlobalSlot.test.ts
+npx tsc --noEmit --jsx react-jsx --skipLibCheck
+git add src/services/MessageService.ts src/dev/tests/services/syncDeltaSelfExclusion.unit.test.ts src/dev/tests/db/saveSpaceMemberGlobalSlot.test.ts
+git commit -m "fix(identity): a peer can no longer overwrite our own per-space name
+
+The roster diff in quorum-shared walks every address with no special case for
+our own, so any peer with a differing cached hash sends its stored copy of our
+row back and we applied it. A peer is never authoritative about our per-space
+choice. The global slot is still accepted, and the deliberate bootstrap for
+members we have never heard of is unchanged."
+```
+
+---
+
+## Task 6: an incoming join is a global identity, not a per-space override
+
+**User-visible outcome:** a member who joins a space today no longer gets permanently
+frozen under the name they had at that moment. Their later renames reach you.
+
+**Files:**
+- Modify: `src/services/MessageService.ts:4922-4945`
+- Test: `src/dev/tests/services/joinFilesGlobalSlot.unit.test.ts` (create)
+
+**Depends on Task 2 being merged.** Without it this change makes the notifications
+drawer render a truncated address for every future joiner.
+
+- [ ] **Step 1: Write the failing test**
+
+Extract the row-shape decision to a pure exported function beside `applyProfileUpdate`:
+
+```ts
+/**
+ * A `join` control carries the joiner's GLOBAL identity, not a per-space choice.
+ * Filing it in the override slot froze that member under whatever name they had at
+ * join time, because the override outranks every later global update and the
+ * announce keeps re-stamping it. File it in the global slot instead, stamped with
+ * joinedAt so ordinary last-write-wins applies.
+ */
+export function buildJoinedMemberRow(participant: {
+  address: string;
+  inboxAddress: string;
+  userIcon?: string;
+  displayName?: string;
+  joinedAt: number;
+}): SpaceMemberRow {
+  return {
+    user_address: participant.address,
+    inbox_address: participant.inboxAddress,
+    global_user_icon: participant.userIcon,
+    global_display_name: participant.displayName,
+    globalProfileTimestamp: participant.joinedAt,
+    isKicked: false,
+    joinedAt: participant.joinedAt,
+  } as SpaceMemberRow;
+}
+```
+
+Create `src/dev/tests/services/joinFilesGlobalSlot.unit.test.ts`:
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import { buildJoinedMemberRow } from '@/services/MessageService';
+
+vi.mock('@quilibrium/quilibrium-js-sdk-channels', () => ({
+  channel: {},
+  channel_raw: {},
+}));
+
+const P = {
+  address: 'QmJoiner0000000000000000000000000000000',
+  inboxAddress: 'inbox-1',
+  userIcon: 'data:image/png;base64,AAA',
+  displayName: 'Ada',
+  joinedAt: 1700000000000,
+};
+
+describe('buildJoinedMemberRow', () => {
+  it('files the joiner identity in the GLOBAL slot, never the override slot', () => {
+    const row = buildJoinedMemberRow(P) as Record<string, unknown>;
+    expect(row.global_display_name).toBe('Ada');
+    expect(row.global_user_icon).toBe(P.userIcon);
+    // The override slot must stay untouched — a value here outranks every later
+    // global update forever, which is the whole defect.
+    expect(row.display_name).toBeUndefined();
+    expect(row.user_icon).toBeUndefined();
+  });
+
+  it('stamps globalProfileTimestamp so later updates can win', () => {
+    const row = buildJoinedMemberRow(P) as Record<string, unknown>;
+    expect(row.globalProfileTimestamp).toBe(P.joinedAt);
+  });
+
+  it('preserves the authoritative inbox_address from the verified join', () => {
+    const row = buildJoinedMemberRow(P) as Record<string, unknown>;
+    expect(row.inbox_address).toBe('inbox-1');
+  });
+});
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `yarn test:run src/dev/tests/services/joinFilesGlobalSlot.unit.test.ts`
+Expected: FAIL — `buildJoinedMemberRow` is not exported.
+
+- [ ] **Step 3: Use it at the join receive site**
+
+At `src/services/MessageService.ts:4922-4929`, replace the inline object passed to
+`this.messageDB.saveSpaceMember(...)` with `buildJoinedMemberRow(participant)`.
+
+- [ ] **Step 4: Fix the companion optimistic cache write**
+
+Immediately below, `queryClient.setQueryData(buildSpaceMembersKey({...}), ...)` at
+lines 4930-4945 still appends `display_name: participant.displayName`. **Change it to
+match the DB write**, or the React Query cache and IndexedDB disagree about which slot
+holds a new joiner's name until the next refetch:
+
+```ts
+                      {
+                        user_address: participant.address,
+                        global_user_icon: participant.userIcon,
+                        global_display_name: participant.displayName,
+                        globalProfileTimestamp: participant.joinedAt,
+                        joinedAt: participant.joinedAt,
+                      },
+```
+
+- [ ] **Step 5: Run the test, typecheck, commit**
+
+```bash
+yarn test:run src/dev/tests/services/joinFilesGlobalSlot.unit.test.ts
+npx tsc --noEmit --jsx react-jsx --skipLibCheck
+git add src/services/MessageService.ts src/dev/tests/services/joinFilesGlobalSlot.unit.test.ts
+git commit -m "fix(identity): an incoming join is a global identity, not a per-space override
+
+A join control carries the joiner's global name. Filing it in the override slot
+froze that member under the name they had at join time: the override outranks
+every later global update, and the on-connect announce keeps re-stamping it, so
+it never decays. Filed in the global slot with a joinedAt stamp instead, so
+ordinary last-write-wins applies. The companion optimistic cache write is
+changed with it."
+```
+
+---
+
+## Task 7: our own join row writes the global slot
+
+**User-visible outcome:** joining a space no longer plants a copy of your current
+name that will still be showing months later.
+
+**Files:**
+- Modify: `src/services/InvitationService.ts:768-773`
+- Modify: `src/components/modals/SpaceSettingsModal/SpaceSettingsModal.tsx:99-104`
+
+**Note:** the `join` broadcast at `InvitationService.ts:837` (`participant.displayName`)
+is **unchanged**. It is the wire, other clients need it, and Task 6 makes receivers
+file it correctly.
+
+- [ ] **Step 1: Source the identity from the config, not the passkey record**
+
+`InvitationService.join` already calls `this.getConfig(...)` a few lines below, at line
+774. Move that call **above** the `saveSpaceMember` at 768 and reuse it. Replace
+768-773 with:
+
+```ts
+      // Two-slot model: our own row gets the GLOBAL slot, never the override.
+      // A value in the override slot outranks every later global update and the
+      // announce re-stamps it forever, so stamping it here froze us under the
+      // name we happened to have at join time.
+      const joinedAt = Date.now();
+      await this.messageDB.saveSpaceMember(space.spaceId, {
+        user_address: currentPasskeyInfo.address,
+        global_user_icon: config?.profile_image ?? currentPasskeyInfo.pfpUrl,
+        global_display_name: config?.name ?? currentPasskeyInfo.displayName,
+        globalProfileTimestamp: joinedAt,
+        inbox_address: inboxAddress,
+      } as SpaceMemberRow);
+```
+
+- [ ] **Step 2: Same treatment for the legacy-owner repair**
+
+In `SpaceSettingsModal.tsx`, `addOwnerToMembers` (lines 99-104) writes
+`display_name: user.currentPasskeyInfo.displayName`. Change it to the global slot:
+
+```ts
+      await messageDB.saveSpaceMember(spaceId, {
+        user_address: user.currentPasskeyInfo.address,
+        global_user_icon: user.currentPasskeyInfo.pfpUrl || '',
+        global_display_name: user.currentPasskeyInfo.displayName || '',
+        globalProfileTimestamp: Date.now(),
+        inbox_address: inboxAddress,
+      } as any);
+```
+
+- [ ] **Step 3: Verify with the tripwire from Task 3**
+
+Run the app, join a space, then in the console:
+`JSON.parse(localStorage.getItem('quorum:diag:selfOverrideWrites'))`
+Expected: `null` or an empty array. **Any entry naming `InvitationService` or
+`SpaceSettingsModal` means this task is not done.**
+
+- [ ] **Step 4: Typecheck and commit**
+
+```bash
+npx tsc --noEmit --jsx react-jsx --skipLibCheck
+git add src/services/InvitationService.ts src/components/modals/SpaceSettingsModal/SpaceSettingsModal.tsx
+git commit -m "fix(identity): joining a space no longer stamps our own override slot
+
+Both our own join row and the legacy-owner repair wrote the per-space override
+slot with the current global name. That slot outranks every later global update
+and the announce re-stamps it on every connect, so the value never decayed. Both
+now write the global slot, sourced from the synced config rather than the
+device-local passkey record. The join broadcast itself is unchanged."
+```
+
+---
+
+# WAVE C — the migration. After Task 1.
+
+## Task 8: clear the legacy per-space overrides, once, everywhere
+
+**User-visible outcome:** the stale names disappear — on this device, on your other
+devices, and for everyone who shares a space with you.
+
+**Files:**
+- Create: `src/hooks/business/user/useClearLegacySpaceOverrides.ts`
+- Create: `src/dev/tests/hooks/useClearLegacySpaceOverrides.unit.test.ts`
+- Modify: `src/components/Layout.tsx` (mount it)
+- Modify: `src/components/context/MessageDB.tsx` (gate the first announce on it)
+
+> ⚠️ **Do not dispatch this task to a subagent.** Steps 3 and 5 are specified as
+> required behaviour plus a pattern to follow rather than literal code, because the
+> hook has to reach into `submitChannelMessage` and the announce sequencing, both of
+> which need reading the surrounding code first. Every other task in this plan is
+> literal enough to hand off; this one is main-thread work.
+
+**🔴 Four properties, each from a review finding. Missing any one makes this fail
+silently:**
+
+1. **Broadcast, not just local.** A local write is invisible on the wire, so
+   spacemates and your other devices keep the poisoned copy — and an un-migrated
+   sibling re-announces it with a *fresh* timestamp and wins.
+2. **Stamp `profileTimestamp`.** `applyProfileUpdate` is deliberately fail-open on a
+   row with no timestamp, so an unstamped clear is overwritten by any later announce.
+3. **Log what it destroyed.** It is irreversible and runs once. Without a record,
+   nobody can later tell "never had a per-space name" from "the clear ate it".
+4. **Sequence before the first announce.** `announceProfileToAllSpacesOnConnect` fires
+   from a startup timer *and* `setResubscribe` (`MessageDB.tsx:571-591`); the timer
+   exists because that path already raced startup once.
+
+- [ ] **Step 1: Write the failing test for the pure part**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { planLegacyOverrideClear } from '@/hooks/business/user/useClearLegacySpaceOverrides';
+
+const SELF = 'QmSelf00000000000000000000000000000000';
+
+describe('planLegacyOverrideClear', () => {
+  it('clears a non-empty override on our own row', () => {
+    const plan = planLegacyOverrideClear(SELF, [
+      { spaceId: 'A', user_address: SELF, display_name: 'Old Name' },
+    ] as never);
+    expect(plan).toHaveLength(1);
+    expect(plan[0].spaceId).toBe('A');
+    expect(plan[0].previousName).toBe('Old Name');
+  });
+
+  it('ignores rows that belong to other members', () => {
+    const plan = planLegacyOverrideClear(SELF, [
+      { spaceId: 'A', user_address: 'QmOther', display_name: 'Their Name' },
+    ] as never);
+    expect(plan).toHaveLength(0);
+  });
+
+  it('ignores rows that are already clear', () => {
+    const plan = planLegacyOverrideClear(SELF, [
+      { spaceId: 'A', user_address: SELF, display_name: '' },
+      { spaceId: 'B', user_address: SELF },
+    ] as never);
+    expect(plan).toHaveLength(0);
+  });
+
+  it('also reports a stale override avatar', () => {
+    const plan = planLegacyOverrideClear(SELF, [
+      { spaceId: 'A', user_address: SELF, user_icon: 'data:image/png;base64,AAA' },
+    ] as never);
+    expect(plan).toHaveLength(1);
+    expect(plan[0].previousIcon).toBe('data:image/png;base64,AAA');
+  });
+});
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `yarn test:run src/dev/tests/hooks/useClearLegacySpaceOverrides.unit.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+Create `src/hooks/business/user/useClearLegacySpaceOverrides.ts`. Follow the shape of
+`useMigrateConversationSettings.ts` exactly: versioned `localStorage` flag keyed by
+address, `ranRef` guard, and **do not set the flag on failure** so it retries.
+
+```ts
+// One-time clear of legacy per-space overrides on the user's OWN roster rows.
+//
+// Those values are copies of an old global name, stamped at join and then re-sent
+// and re-stamped by the on-connect announce on every connect, so they never decay
+// and are byte-for-byte indistinguishable from a name the user deliberately chose.
+// Nothing can tell them apart, so they are cleared unconditionally, once.
+//
+// It BROADCASTS the clear (displayName: '') rather than writing locally, because a
+// local write is invisible on the wire and an un-migrated sibling device would
+// re-announce the old value with a fresher timestamp and win.
+//
+// See .agents/issues/.open/2026-08-05-own-identity-cross-device-sync-design.md §5-D
+
+export const CLEAR_FLAG_PREFIX = 'spaceOverridesCleared:v1:';
+export const CLEAR_LOG_KEY = 'quorum:diag:clearedSpaceOverrides';
+
+export interface OverrideClearEntry {
+  spaceId: string;
+  previousName?: string;
+  previousIcon?: string;
+}
+
+/** Pure: which of our own rows still carry a per-space override? */
+export function planLegacyOverrideClear(
+  selfAddress: string,
+  rows: { spaceId: string; user_address: string; display_name?: string; user_icon?: string }[]
+): OverrideClearEntry[] {
+  return rows
+    .filter((r) => r.user_address === selfAddress && (r.display_name || r.user_icon))
+    .map((r) => ({
+      spaceId: r.spaceId,
+      previousName: r.display_name || undefined,
+      previousIcon: r.user_icon || undefined,
+    }));
+}
+```
+
+Then the hook. For each planned space it must:
+
+1. write `display_name: ''`, `user_icon: ''`, **and `profileTimestamp: Date.now()`**
+   via `messageDB.saveSpaceMember`;
+2. send an `update-profile` through the same path the Space Settings editor uses
+   (`submitChannelMessage`, see `useSpaceProfile.ts:310-329`) carrying
+   `displayName: ''` and `userIcon: ''`;
+3. append the `OverrideClearEntry[]` to `CLEAR_LOG_KEY` in `localStorage` via
+   `console.warn` + a bounded write, mirroring `selfOverrideTripwire.ts`;
+4. set the flag only after all of the above resolve.
+
+- [ ] **Step 4: Run the test again**
+
+Run: `yarn test:run src/dev/tests/hooks/useClearLegacySpaceOverrides.unit.test.ts`
+Expected: PASS, all four.
+
+- [ ] **Step 5: Gate the first announce on the migration**
+
+In `src/components/context/MessageDB.tsx`, find
+`announceProfileToAllSpacesOnConnect` and its two triggers (the startup timer and
+`setResubscribe`, around lines 571-591). Add a module-scoped promise that resolves
+when the clear has run (or immediately when the flag is already set), and `await` it
+at the top of the announce before it builds any payload.
+
+Without this, the first post-upgrade connect re-announces the pre-clear value with a
+fresh timestamp before the migration's IndexedDB write lands, and the row is
+repoisoned by the exact mechanism the bug's §4-A-iii measured.
+
+- [ ] **Step 6: Mount it**
+
+In `src/components/Layout.tsx`, beside the other one-shot hooks:
+
+```ts
+  useClearLegacySpaceOverrides();
+```
+
+- [ ] **Step 7: Typecheck, run the full suite, commit**
+
+```bash
+npx tsc --noEmit --jsx react-jsx --skipLibCheck
+yarn test:run
+git add src/hooks/business/user/useClearLegacySpaceOverrides.ts src/dev/tests/hooks/useClearLegacySpaceOverrides.unit.test.ts src/components/Layout.tsx src/components/context/MessageDB.tsx
+git commit -m "fix(identity): clear the legacy per-space overrides once, everywhere
+
+These are copies of an old global name, stamped at join and then re-sent and
+re-stamped by the on-connect announce on every connect, so they never decay and
+cannot be told apart from a deliberately chosen name.
+
+The clear is BROADCAST rather than written locally: a local write is invisible on
+the wire, so spacemates and the user's own other devices keep the poisoned copy,
+and an un-migrated sibling re-announces it with a fresher timestamp and wins. It
+stamps profileTimestamp, because applyProfileUpdate is fail-open on an unstamped
+row. It records what it destroyed, because it is irreversible. And it is
+sequenced before the first announce, which fires from two triggers and has raced
+startup before."
+```
+
+---
+
+# WAVE D
+
+## Task 9: correct the docs this work falsified
+
+**Files:**
+- Modify: `.agents/docs/features/identity-resolution-and-profile-sync.md`
+- Modify: `.agents/docs/config-sync-system.md`
+
+- [ ] **Step 1: Fix the "decaying" claim**
+
+The identity doc's "Legacy stamped rosters" entry under *Known limitations* says such
+rows "look like deliberate overrides until manually cleared" and treats the problem as
+expiring. Two things are wrong: the join path **still stamps** (so new ones are
+created), and the on-connect announce **re-stamps** them (so they never decay).
+Rewrite it to say so, and note that Phase 1 fixed both.
+
+- [ ] **Step 2: Fix the server-validation claim**
+
+`config-sync-system.md` states the **server** validates that `spaceIds` and
+`spaceKeys` are consistent and returns `400 - invalid config missing data`. The server
+receives only ciphertext (`ConfigService.saveConfig` posts `user_address`,
+`user_public_key`, the encrypted `user_config`, `timestamp`, `signature`), so it
+cannot inspect either field. Correct it to describe the client-side guard.
+
+- [ ] **Step 3: Add the two instruments to the file map**
+
+`selfOverrideTripwire` (`quorum:diag:selfOverrideWrites`) and the clear's log
+(`quorum:diag:clearedSpaceOverrides`), beside the existing `/dev/identity-coverage`
+entry.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .agents/docs/
+git commit -m "docs(identity): correct the decaying-stamp and server-validation claims"
+```
+
+---
+
+---
+
+## Deliberately NOT in this plan
+
+**`EncryptionService.ts:174-187` (space re-key / address migration).** It deletes and
+re-saves every member row with a `...member` spread, so it carries whatever
+`display_name` currently holds into the new `spaceId`. Review flagged it as a
+carry-forward vector.
+
+Left alone on purpose: it is not an author, and after Task 8 our own rows hold `''`,
+so there is nothing to carry. If Task 3's tripwire ever names this file, that
+assumption was wrong and it needs its own fix.
+
+Recorded here so the omission is a decision rather than an oversight.
+
+## Definition of done for the branch
+
+- [ ] `yarn test:run` green
+- [ ] `npx tsc --noEmit --jsx react-jsx --skipLibCheck` clean
+- [ ] `yarn lint` clean
+- [ ] Every new test verified to go **red** when its fix is reverted — not assumed
+- [ ] `localStorage['quorum:diag:selfOverrideWrites']` empty after joining a space
+- [ ] Re-run `.agents/tools/dm-debug/08-self-identity-sources.js`: source A matches
+      source B, and no space reports `overrideOutranksGlobal: true`
+- [ ] A member who joins **after** this ships shows a name, not an address, in the
+      global notifications drawer
+
+---
+
+*Last updated: 2026-08-05*

--- a/.agents/tools/dm-debug/05-profile-sources.js
+++ b/.agents/tools/dm-debug/05-profile-sources.js
@@ -60,7 +60,11 @@
     let pubStatus = '';
     try {
       const url = `${apiBase}/users/${c.address}/public-profile`;
-      const resp = await fetch(url, { credentials: 'include' });
+      // No `credentials: 'include'`: it makes the browser demand an explicit
+      // Access-Control-Allow-Origin plus Allow-Credentials, which this endpoint
+      // does not send, so the fetch fails CORS from a dev origin. The app's own
+      // client sends no credentials either.
+      const resp = await fetch(url);
       pubStatus = resp.status;
       if (resp.ok) {
         const body = await resp.json();

--- a/.agents/tools/dm-debug/06-space-member-sources.js
+++ b/.agents/tools/dm-debug/06-space-member-sources.js
@@ -113,7 +113,11 @@ window.__spaceMemberSources = async (spaceId, focusSuffixes) => {
     let pubStatus = '';
     try {
       const url = `${apiBase}/users/${m.user_address}/public-profile`;
-      const resp = await fetch(url, { credentials: 'include' });
+      // No `credentials: 'include'`: it makes the browser demand an explicit
+      // Access-Control-Allow-Origin plus Allow-Credentials, which this endpoint
+      // does not send, so the fetch fails CORS from a dev origin. The app's own
+      // client sends no credentials either.
+      const resp = await fetch(url);
       pubStatus = resp.status;
       if (resp.ok) {
         const body = await resp.json();

--- a/.agents/tools/dm-debug/08-self-identity-sources.js
+++ b/.agents/tools/dm-debug/08-self-identity-sources.js
@@ -73,10 +73,11 @@ window.__selfIdentitySources = async () => {
   let pub = null;
   let pubStatus = '';
   try {
-    const resp = await fetch(
-      `${apiBase}/users/${selfAddress}/public-profile`,
-      { credentials: 'include' }
-    );
+    // No `credentials: 'include'` — it makes the browser demand an explicit
+    // Access-Control-Allow-Origin plus Allow-Credentials, which this endpoint
+    // does not send, so the request fails CORS from a dev origin. The app's own
+    // client does not send credentials either.
+    const resp = await fetch(`${apiBase}/users/${selfAddress}/public-profile`);
     pubStatus = resp.status;
     if (resp.ok) {
       const body = await resp.json();
@@ -96,13 +97,16 @@ window.__selfIdentitySources = async () => {
     return t.length ? t : null;
   };
   const truncate = (a) => (a.length > 10 ? `${a.slice(0, 6)}…${a.slice(-4)}` : a);
+  // The QNS name normally travels only in the public profile, but the config
+  // blob carries it too — so the ladder stays accurate even when the fetch fails.
+  const qnsName = present(pub?.primary_username) || present(config?.primaryUsername);
   const resolveSurface = (row) => {
     const rosterGlobalName = present(row?.global_display_name);
     const effectiveGlobal = rosterGlobalName || present(pub?.display_name);
     // hook line 147: the OVERRIDE slot wins the merge outright when non-empty
     const merged =
       present(row?.display_name) || rosterGlobalName || present(pub?.display_name);
-    const qns = present(pub?.primary_username);
+    const qns = qnsName;
     if (qns && merged && merged !== effectiveGlobal) return merged;
     if (qns) return `${qns}.q`;
     const demoted = merged === UNKNOWN_NAME ? null : merged;
@@ -158,12 +162,20 @@ window.__selfIdentitySources = async () => {
       readBy: 'final fallback for everyone else',
     },
     {
-      source: 'D. public profile primary_username',
-      channel: 'B — the only carrier of QNS',
-      value: pub?.primary_username ? `${pub.primary_username}.q` : '(none)',
+      source: 'QNS primary_username',
+      channel: pub?.primary_username ? 'B — public profile' : 'config blob fallback',
+      value: qnsName ? `${qnsName}.q` : '(none)',
       readBy: 'the .q rung of the ladder',
     },
   ]);
+  if (!pub) {
+    console.log(
+      `%cPublic profile not readable from this origin (HTTP ${pubStatus}) — ` +
+        'the two D rows fall back to the config blob. Everything else is local ' +
+        'and unaffected.',
+      'color:#fbbf24'
+    );
+  }
 
   const perSpace = selfRows.map((row) => ({
     _raw: row,
@@ -256,32 +268,54 @@ window.__selfIdentitySources = async () => {
       : 'No space holds a diverged override — §3 of the issue is REFUTED, look downstream at rendering.'
   );
 
-  // The repair discriminator (§4-B): a join stamp writes display_name and NO
-  // profileTimestamp; every deliberate override goes through applyProfileUpdate,
-  // which always stamps one. If that holds here, a one-shot repair is safe.
-  const stamped = stuckOverrides.filter((r) => r._raw.profileTimestamp == null);
+  // Post-fix instruments. The tripwire should stay empty: after the Phase 1
+  // work only the Space Settings editor may write our own override slot.
+  const tripwire = (() => {
+    try {
+      return JSON.parse(localStorage.getItem('quorum:diag:selfOverrideWrites')) ?? [];
+    } catch {
+      return [];
+    }
+  })();
   say(
-    stuckOverrides.length === 0 || stamped.length === stuckOverrides.length,
-    stuckOverrides.length === 0
-      ? 'No diverged override, so the repair discriminator is moot here.'
-      : `${stamped.length}/${stuckOverrides.length} diverged override(s) carry NO profileTimestamp — ` +
-          (stamped.length === stuckOverrides.length
-            ? 'the join-stamp signature, so the §4-B one-shot repair is safe.'
-            : 'some carry one, which a join stamp never writes. The §4-B discriminator is WRONG ' +
-              'as stated and the repair must NOT ship until that is explained.')
+    tripwire.length === 0,
+    tripwire.length === 0
+      ? 'Tripwire clean — nothing has written our own per-space override.'
+      : `Tripwire caught ${tripwire.length} write(s) to our OWN override slot. Only the ` +
+          'Space Settings editor may do this. Inspect quorum:diag:selfOverrideWrites — ' +
+          'each entry carries the stack that wrote it.'
   );
 
-  const globalsLanding = perSpace.filter(
-    (r) => present(r._raw.global_display_name) === present(config?.name)
-  ).length;
-  say(
-    perSpace.length > 0 && globalsLanding === perSpace.length,
-    `${globalsLanding}/${perSpace.length} space(s) have a global slot matching the config blob — ` +
-      (perSpace.length > 0 && globalsLanding === perSpace.length
-        ? 'the sender-side broadcast IS landing, so the fault is purely in precedence/rendering.'
-        : 'some global slots are behind the config blob, so the broadcast is NOT landing everywhere ' +
-          'and the receive path needs checking too.')
+  const cleared = (() => {
+    try {
+      return JSON.parse(localStorage.getItem('quorum:diag:clearedSpaceOverrides')) ?? [];
+    } catch {
+      return [];
+    }
+  })();
+  if (cleared.length) {
+    console.log(
+      `%cℹ The one-time migration cleared ${cleared.length} legacy override(s). ` +
+        'Previous values are in quorum:diag:clearedSpaceOverrides — it is irreversible, ' +
+        'so that record is the only copy.',
+      'color:#60a5fa'
+    );
+  }
+
+  // A global slot behind the config blob is only a fault for a space some device
+  // has actually broadcast into since the rename — a space no device has announced
+  // to will legitimately lag. Reported, not judged.
+  const behind = perSpace.filter(
+    (r) => present(r._raw.global_display_name) !== present(config?.name)
   );
+  if (behind.length) {
+    console.log(
+      `%cℹ ${behind.length}/${perSpace.length} space(s) have a global slot behind the ` +
+        'config blob. Expected for any space no device has announced into since the ' +
+        'rename; a fault only if every device HAS announced there.',
+      'color:#fbbf24'
+    );
+  }
 
   const out = {
     selfAddress,

--- a/.agents/tools/dm-debug/09-member-list-visibility.js
+++ b/.agents/tools/dm-debug/09-member-list-visibility.js
@@ -1,0 +1,72 @@
+// === Why is someone MISSING from the space member list? ===
+//
+// The member list hides anyone whose row has an empty `inbox_address`
+// (useChannelData.ts: `left: curr.inbox_address === ''`) or `isKicked`. So a
+// member can exist on disk, have a perfectly good name, and still not render.
+//
+// `hiddenFromList` is the answer column:
+//   hasInbox false  -> their join control never reached this client. Long-standing
+//                      sync gap, not a naming problem.
+//   hasInbox true but still missing from the UI -> something else; report it.
+//
+// Paste into the DevTools console. Read-only.
+
+(async () => {
+  const db = await new Promise((res, rej) => {
+    const q = indexedDB.open('quorum_db');
+    q.onsuccess = () => res(q.result);
+    q.onerror = () => rej(q.error);
+  });
+  const all = (s) =>
+    new Promise((res) => {
+      try {
+        const q = db.transaction(s, 'readonly').objectStore(s).getAll();
+        q.onsuccess = () => res(q.result);
+        q.onerror = () => res([]);
+      } catch {
+        res([]);
+      }
+    });
+
+  const members = await all('space_members');
+  const spaces = await all('spaces');
+
+  const rows = members.map((m) => ({
+    space: spaces.find((s) => s.spaceId === m.spaceId)?.name ?? String(m.spaceId).slice(0, 10),
+    who: String(m.user_address).slice(-6),
+    hasInbox: !!m.inbox_address,
+    isKicked: !!m.isKicked,
+    hiddenFromList: !m.inbox_address || !!m.isKicked,
+    override: m.display_name ?? '(none)',
+    global: m.global_display_name ?? '(none)',
+    joinedAt: m.joinedAt ?? '(none)',
+  }));
+
+  const hidden = rows.filter((r) => r.hiddenFromList);
+
+  console.log(
+    '%c=== member rows, and which the list hides ===',
+    'color:#60a5fa;font-weight:bold;font-size:14px'
+  );
+  console.table(rows);
+
+  if (hidden.length) {
+    console.log(
+      `%c${hidden.length} row(s) are hidden from the member list:`,
+      'color:#fbbf24;font-weight:bold'
+    );
+    console.table(hidden);
+    console.log(
+      'hasInbox=false → their join never arrived here (the known sync gap).\n' +
+        'hasInbox=true and still hidden → isKicked, or a real bug worth reporting.'
+    );
+  } else {
+    console.log(
+      '%c✔ No row is hidden. Anyone missing from the UI has NO ROW AT ALL — ' +
+        'compare against who you can see posting.',
+      'color:#4ade80;font-weight:bold'
+    );
+  }
+
+  return rows;
+})();

--- a/.agents/tools/dm-debug/README.md
+++ b/.agents/tools/dm-debug/README.md
@@ -24,6 +24,7 @@ For background on the architecture and the debug ladder, read [`../../docs/debug
 | `06-space-member-sources.js` | Space-member equivalent of 05. |
 | `07-receiver-probe.js` | **DM-loss receiver probe** (handoff §4, sender-isolation runs). Install BEFORE the sender starts; counts receive-path warnings from install and reads `messages` from IndexedDB directly. `await window.__probe.report('V')` → landed / missing numbers / warning counters. Take a second reading ~10 min later — that is what separates loss from a latency tail. |
 | `08-self-identity-sources.js` | **Why YOUR OWN name differs between two surfaces of the same app.** Prints all four identity stores side by side — the device-local `passkeys-list` (NavRail tooltip), the config blob (User Settings field), your own roster row's override + global slots per space (message authors, member lists), and the published public profile — then a verdict naming which surface reads which store and which one is stale. Written for `2026-08-04-desktop-shows-a-stale-name-everywhere-except-the-user-settings-field.md`; run it before theorising. |
+| `09-member-list-visibility.js` | **Why is someone missing from the space member list?** The list hides any row with an empty `inbox_address` or `isKicked`, so a member can exist on disk with a good name and still not render. Prints every row with a `hiddenFromList` column. Use it before assuming a missing person is a naming bug. |
 
 ## Offline analysis (node CLI, NOT console snippets)
 

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -24,6 +24,7 @@ import { OfflineBanner } from './ui/OfflineBanner';
 import { useMutedConversationsSync } from '../hooks/business/dm/useMutedConversationsSync';
 import { useMigrateConversationSettings } from '../hooks/business/dm/useMigrateConversationSettings';
 import { useReconcileSelfIdentity } from '../hooks/business/user/useReconcileSelfIdentity';
+import { useClearLegacySpaceOverrides } from '../hooks/business/user/useClearLegacySpaceOverrides';
 
 const Layout: React.FunctionComponent<{
   children: React.ReactNode;
@@ -61,6 +62,7 @@ const Layout: React.FunctionComponent<{
   useMutedConversationsSync();
   useMigrateConversationSettings();
   useReconcileSelfIdentity();
+  useClearLegacySpaceOverrides();
 
   const [toast, setToast] = React.useState<{
     id?: string;

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -23,6 +23,7 @@ import { useSidebar } from './context/SidebarProvider';
 import { OfflineBanner } from './ui/OfflineBanner';
 import { useMutedConversationsSync } from '../hooks/business/dm/useMutedConversationsSync';
 import { useMigrateConversationSettings } from '../hooks/business/dm/useMigrateConversationSettings';
+import { useReconcileSelfIdentity } from '../hooks/business/user/useReconcileSelfIdentity';
 
 const Layout: React.FunctionComponent<{
   children: React.ReactNode;
@@ -59,6 +60,7 @@ const Layout: React.FunctionComponent<{
   // Sync muted conversations to NotificationService for desktop notification filtering
   useMutedConversationsSync();
   useMigrateConversationSettings();
+  useReconcileSelfIdentity();
 
   const [toast, setToast] = React.useState<{
     id?: string;

--- a/src/components/context/MessageDB.tsx
+++ b/src/components/context/MessageDB.tsx
@@ -533,6 +533,7 @@ const MessageDBProvider: FC<MessageDBContextProps> = ({ children }) => {
             Buffer.from(new Uint8Array(keyset.userKeyset.user_key.public_key))
           );
           setSelfAddress(base58btc.baseEncode(sh.bytes));
+          messageDB.setSelfAddressForDiagnostics(base58btc.baseEncode(sh.bytes));
         }
       } catch { /* ignore */ }
     })();

--- a/src/components/modals/SpaceSettingsModal/SpaceSettingsModal.tsx
+++ b/src/components/modals/SpaceSettingsModal/SpaceSettingsModal.tsx
@@ -96,10 +96,14 @@ const SpaceSettingsModal: React.FunctionComponent<{
     try {
       const inboxKey = await messageDB.getSpaceKey(spaceId, 'inbox');
       const inboxAddress = inboxKey?.address || '';
+      // GLOBAL slot, not the override — the override outranks every later
+      // global update and the announce re-stamps it forever, so writing it here
+      // would freeze the owner under their current name.
       await messageDB.saveSpaceMember(spaceId, {
         user_address: user.currentPasskeyInfo.address,
-        user_icon: user.currentPasskeyInfo.pfpUrl || '',
-        display_name: user.currentPasskeyInfo.displayName || '',
+        global_user_icon: user.currentPasskeyInfo.pfpUrl || '',
+        global_display_name: user.currentPasskeyInfo.displayName || '',
+        globalProfileTimestamp: Date.now(),
         inbox_address: inboxAddress,
       } as any);
       setMissingOwnerMembership(false);

--- a/src/db/messages.ts
+++ b/src/db/messages.ts
@@ -12,6 +12,7 @@ import {
   isPlaceholderDisplayName,
   isPlaceholderIcon,
 } from '../utils/identityPlaceholder';
+import { recordSelfOverrideWrite } from '../utils/selfOverrideTripwire';
 import MiniSearch, { type Options } from 'minisearch';
 
 export interface EncryptedMessage {
@@ -219,6 +220,12 @@ export class MessageDB {
   // transparently from IndexedDB (Phase 1.3) on next access, so the
   // tradeoff is one ~10ms deserialize hit vs unbounded memory growth.
   private static readonly MAX_IN_MEMORY_INDICES = 10;
+  /** Set by MessageDBProvider once the user's address is derived. Diagnostics only. */
+  private selfAddressForDiagnostics?: string;
+
+  setSelfAddressForDiagnostics(address: string): void {
+    this.selfAddressForDiagnostics = address;
+  }
 
   async init() {
     if (this.db) return;
@@ -1247,6 +1254,14 @@ export class MessageDB {
       const transaction = this.db!.transaction('space_members', 'readwrite');
       const store = transaction.objectStore('space_members');
       const userAddress = (userProfile as { user_address?: string }).user_address;
+      const incomingName = (userProfile as { display_name?: string }).display_name;
+      if (
+        userAddress &&
+        userAddress === this.selfAddressForDiagnostics &&
+        incomingName
+      ) {
+        recordSelfOverrideWrite({ spaceId, value: incomingName });
+      }
       // keyPath is ['spaceId', 'user_address']. Without an address there is
       // nothing to look up (and the `put` below will fail on the keyPath
       // anyway); `store.get([spaceId, undefined])` would throw a DataError

--- a/src/dev/tests/components/ReactionsModal.test.tsx
+++ b/src/dev/tests/components/ReactionsModal.test.tsx
@@ -99,20 +99,43 @@ describe('ReactionsModal — name resolution', () => {
     expect(screen.queryByText('alice.q')).not.toBeInTheDocument();
   });
 
-  it('pins that globalDisplayName is a COMPARATOR, not a resolver tier', () => {
-    // Documenting real current behaviour, not endorsing it. `globalDisplayName`
-    // exists only so resolveSpaceMemberName can tell a deliberate per-space name
-    // from the global name echoed at join; it is never itself rendered. With an
-    // empty override, no QNS name, and a global name present, the ladder falls
-    // through to the address.
+  it('renders globalDisplayName as a real resolver TIER', () => {
+    // CHANGED DELIBERATELY 2026-08-05. This test previously pinned the opposite:
+    // that `globalDisplayName` was only a comparator and this shape rendered a
+    // truncated address. It said "if a future caller supplies the two slots
+    // separately, this test is the one that will change — deliberately". This is
+    // that change, and it was not hypothetical.
     //
-    // Latent, not live: the enricher (useMembersWithPublicProfileFallback)
-    // already merges the global name INTO `displayName`, so no production path
-    // reaches the modal in this shape. If a future caller supplies the two slots
-    // separately, this test is the one that will change — deliberately.
+    // The old behaviour was latent only while every roster row carried a stamped
+    // override, so callers passing the RAW roster field (the member sidebar,
+    // Channel.tsx) still got a name. Once the override is correctly empty — its
+    // normal state under the two-slot model — those callers rendered the address
+    // for everyone, including the user themself. Measured on a real account.
     renderWith({ displayName: undefined, globalDisplayName: 'Alice' });
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+  });
+
+  it('still prefers the QNS name over the global slot', () => {
+    // Ladder order: deliberate override → QNS → global → address. Adding the
+    // global tier must not let it jump the QNS name.
+    renderWith({
+      displayName: undefined,
+      globalDisplayName: 'Alice',
+      primaryUsername: 'alice',
+    });
+    expect(screen.getByText('alice.q')).toBeInTheDocument();
     expect(screen.queryByText('Alice')).not.toBeInTheDocument();
-    expect(screen.getByText(/QmV5xW/)).toBeInTheDocument();
+  });
+
+  it('demotes an override that merely ECHOES the global name', () => {
+    // roster === global means a legacy stamp, not a choice. It must not outrank
+    // the QNS name.
+    renderWith({
+      displayName: 'Alice',
+      globalDisplayName: 'Alice',
+      primaryUsername: 'alice',
+    });
+    expect(screen.getByText('alice.q')).toBeInTheDocument();
   });
 
   it('renders the merged global name when the enricher has filled displayName', () => {

--- a/src/dev/tests/db/saveSpaceMemberGlobalSlot.test.ts
+++ b/src/dev/tests/db/saveSpaceMemberGlobalSlot.test.ts
@@ -1,6 +1,14 @@
 import 'fake-indexeddb/auto';
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { MessageDB, type SpaceMemberRow } from '../../../db/messages';
+
+// MessageService pulls in the native SDK at module load; stub it so the pure
+// slot-resolution rule can be imported here.
+vi.mock('@quilibrium/quilibrium-js-sdk-channels', () => ({
+  channel: {},
+  channel_raw: {},
+}));
+import { resolveSyncDeltaSlots } from '../../../services/MessageService';
 
 // `db.saveSpaceMember` does a full-row `store.put`, so it writes exactly the
 // object it is handed and everything absent from that object is destroyed.
@@ -159,17 +167,24 @@ describe('member-delta staleness rule (per-slot last-write-wins)', () => {
     await db.init();
   });
 
-  /** The decision MessageService makes before writing a synced member. */
+  /**
+   * The decision MessageService makes before writing a synced member.
+   *
+   * Calls the REAL `resolveSyncDeltaSlots` rather than re-implementing it. This
+   * used to be a hand-copy, which meant changing the real rule left these tests
+   * green while they certified behaviour the shipped code no longer had.
+   * MEMBER is not our own address, hence `isSelf: false` — self-exclusion has
+   * its own tests in syncDeltaSelfExclusion.unit.test.ts.
+   */
   const applyIncoming = async (incoming: Partial<SpaceMemberRow>) => {
     const existing = await db.getSpaceMember(SPACE, MEMBER);
-    const applyOverride = !(
-      existing?.profileTimestamp &&
-      existing.profileTimestamp >= (incoming.profileTimestamp ?? 0)
-    );
-    const applyGlobal = !(
-      existing?.globalProfileTimestamp &&
-      existing.globalProfileTimestamp >= (incoming.globalProfileTimestamp ?? 0)
-    );
+    const { applyOverride, applyGlobal } = resolveSyncDeltaSlots({
+      isSelf: false,
+      existingOverrideTs: existing?.profileTimestamp,
+      existingGlobalTs: existing?.globalProfileTimestamp,
+      incomingOverrideTs: incoming.profileTimestamp ?? 0,
+      incomingGlobalTs: incoming.globalProfileTimestamp ?? 0,
+    });
     await db.saveSpaceMember(SPACE, {
       user_address: MEMBER,
       inbox_address: 'inbox-1',

--- a/src/dev/tests/hooks/channelDataAvatarLadder.unit.test.ts
+++ b/src/dev/tests/hooks/channelDataAvatarLadder.unit.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { DefaultImages } from '@/utils';
+
+/**
+ * The avatar ladder `useChannelData` applies when it flattens roster rows.
+ *
+ * Kept as a standalone spec of the RULE rather than a render test: the rule is
+ * what regressed, and it regressed because it lived at the call site instead of
+ * one place. Mirrors the implementation in useChannelData.ts.
+ */
+function pickAvatar(icon: string | undefined): string | undefined {
+  if (!icon) return undefined;
+  return icon.includes(DefaultImages.UNKNOWN_USER) ? undefined : icon;
+}
+const ladder = (override?: string, global?: string) =>
+  pickAvatar(override) ?? pickAvatar(global);
+
+const OVERRIDE = 'data:image/png;base64,OVERRIDE';
+const GLOBAL = 'data:image/png;base64,GLOBAL';
+
+describe('useChannelData avatar ladder — override → global → initials', () => {
+  it('falls back to the global avatar when there is no per-space override', () => {
+    // The regression this exists for: with the override correctly empty (its
+    // normal state under the two-slot model), an override-only read renders no
+    // avatar at all. Measured on a real account.
+    expect(ladder('', GLOBAL)).toBe(GLOBAL);
+    expect(ladder(undefined, GLOBAL)).toBe(GLOBAL);
+  });
+
+  it('prefers a deliberate per-space override over the global avatar', () => {
+    expect(ladder(OVERRIDE, GLOBAL)).toBe(OVERRIDE);
+  });
+
+  it('treats the UNKNOWN_USER placeholder as absent at EVERY rung', () => {
+    // Passing it on would render a broken-looking default instead of initials.
+    expect(ladder(DefaultImages.UNKNOWN_USER, GLOBAL)).toBe(GLOBAL);
+    expect(ladder(OVERRIDE, DefaultImages.UNKNOWN_USER)).toBe(OVERRIDE);
+    expect(ladder(DefaultImages.UNKNOWN_USER, DefaultImages.UNKNOWN_USER)).toBeUndefined();
+  });
+
+  it('returns undefined when there is no avatar anywhere, so initials engage', () => {
+    expect(ladder(undefined, undefined)).toBeUndefined();
+    expect(ladder('', '')).toBeUndefined();
+  });
+});

--- a/src/dev/tests/hooks/useClearLegacySpaceOverrides.unit.test.ts
+++ b/src/dev/tests/hooks/useClearLegacySpaceOverrides.unit.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from 'vitest';
+import { planLegacyOverrideClear } from '@/hooks/business/user/useClearLegacySpaceOverrides';
+
+vi.mock('@quilibrium/quilibrium-js-sdk-channels', () => ({
+  channel: {},
+  channel_raw: {},
+  usePasskeysContext: () => ({}),
+}));
+
+const SELF = 'QmSelf00000000000000000000000000000000';
+const OTHER = 'QmOther0000000000000000000000000000000';
+
+describe('planLegacyOverrideClear', () => {
+  it('clears a non-empty override on our own row', () => {
+    const plan = planLegacyOverrideClear(SELF, [
+      { spaceId: 'A', user_address: SELF, display_name: 'Old Name' },
+    ]);
+    expect(plan).toHaveLength(1);
+    expect(plan[0].spaceId).toBe('A');
+    expect(plan[0].previousName).toBe('Old Name');
+  });
+
+  it('never touches another member’s row', () => {
+    // Our own devices are the only thing this migration may rewrite. Clearing
+    // someone else's override would delete a name they deliberately chose.
+    const plan = planLegacyOverrideClear(SELF, [
+      { spaceId: 'A', user_address: OTHER, display_name: 'Their Name' },
+    ]);
+    expect(plan).toHaveLength(0);
+  });
+
+  it('ignores rows that are already clear', () => {
+    const plan = planLegacyOverrideClear(SELF, [
+      { spaceId: 'A', user_address: SELF, display_name: '' },
+      { spaceId: 'B', user_address: SELF },
+    ]);
+    expect(plan).toHaveLength(0);
+  });
+
+  it('also reports a stale override avatar', () => {
+    const plan = planLegacyOverrideClear(SELF, [
+      { spaceId: 'A', user_address: SELF, user_icon: 'data:image/png;base64,AAA' },
+    ]);
+    expect(plan).toHaveLength(1);
+    expect(plan[0].previousIcon).toBe('data:image/png;base64,AAA');
+  });
+
+  it('records the previous values so an irreversible clear leaves evidence', () => {
+    const plan = planLegacyOverrideClear(SELF, [
+      {
+        spaceId: 'A',
+        user_address: SELF,
+        display_name: 'Old Name',
+        user_icon: 'data:image/png;base64,AAA',
+      },
+    ]);
+    expect(plan[0]).toEqual({
+      spaceId: 'A',
+      previousName: 'Old Name',
+      previousIcon: 'data:image/png;base64,AAA',
+    });
+  });
+
+  it('plans one entry per affected space', () => {
+    const plan = planLegacyOverrideClear(SELF, [
+      { spaceId: 'A', user_address: SELF, display_name: 'One' },
+      { spaceId: 'B', user_address: SELF, display_name: 'Two' },
+      { spaceId: 'C', user_address: SELF },
+      { spaceId: 'D', user_address: OTHER, display_name: 'Not mine' },
+    ]);
+    expect(plan.map((p) => p.spaceId)).toEqual(['A', 'B']);
+  });
+});

--- a/src/dev/tests/hooks/useReconcileSelfIdentity.unit.test.ts
+++ b/src/dev/tests/hooks/useReconcileSelfIdentity.unit.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { shouldReconcileSelfIdentity } from '@/hooks/business/user/useReconcileSelfIdentity';
+
+describe('shouldReconcileSelfIdentity', () => {
+  it('writes when the synced name differs from the stored one', () => {
+    expect(
+      shouldReconcileSelfIdentity(
+        { name: 'Ada 8', profile_image: 'img8' },
+        { displayName: 'Ada 2', pfpUrl: 'img2' }
+      )
+    ).toEqual({ displayName: 'Ada 8', pfpUrl: 'img8' });
+  });
+
+  it('does NOT write when they already agree', () => {
+    expect(
+      shouldReconcileSelfIdentity(
+        { name: 'Ada', profile_image: 'img' },
+        { displayName: 'Ada', pfpUrl: 'img' }
+      )
+    ).toBeNull();
+  });
+
+  it('NEVER blanks a good stored name from an empty config', () => {
+    // Cold start / offline: getConfig returns a default config with no name.
+    // ~15 sites read the same in-memory passkey object, so one empty write
+    // blanks every one of them at once.
+    expect(
+      shouldReconcileSelfIdentity({}, { displayName: 'Ada', pfpUrl: 'img' })
+    ).toBeNull();
+    expect(
+      shouldReconcileSelfIdentity(
+        { name: '', profile_image: '' },
+        { displayName: 'Ada', pfpUrl: 'img' }
+      )
+    ).toBeNull();
+    expect(
+      shouldReconcileSelfIdentity(undefined, { displayName: 'Ada', pfpUrl: 'img' })
+    ).toBeNull();
+  });
+
+  it('fills a name when the device has none yet', () => {
+    expect(
+      shouldReconcileSelfIdentity({ name: 'Ada' }, { displayName: undefined })
+    ).toEqual({ displayName: 'Ada', pfpUrl: undefined });
+  });
+
+  it('updates only the avatar when only the avatar changed', () => {
+    expect(
+      shouldReconcileSelfIdentity(
+        { name: 'Ada', profile_image: 'newImg' },
+        { displayName: 'Ada', pfpUrl: 'oldImg' }
+      )
+    ).toEqual({ displayName: 'Ada', pfpUrl: 'newImg' });
+  });
+});

--- a/src/dev/tests/services/joinFilesGlobalSlot.unit.test.ts
+++ b/src/dev/tests/services/joinFilesGlobalSlot.unit.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest';
+import { buildJoinedMemberRow } from '@/services/MessageService';
+
+// MessageService.ts imports the native SDK at module load; stub it so this
+// pure-logic helper can be imported without the real WASM channel module.
+vi.mock('@quilibrium/quilibrium-js-sdk-channels', () => ({
+  channel: {},
+  channel_raw: {},
+}));
+
+const P = {
+  address: 'QmJoiner0000000000000000000000000000000',
+  inboxAddress: 'inbox-1',
+  userIcon: 'data:image/png;base64,AAA',
+  displayName: 'Ada',
+  joinedAt: 1700000000000,
+};
+
+describe('buildJoinedMemberRow', () => {
+  it('files the joiner identity in the GLOBAL slot, never the override slot', () => {
+    const row = buildJoinedMemberRow(P) as Record<string, unknown>;
+    expect(row.global_display_name).toBe('Ada');
+    expect(row.global_user_icon).toBe(P.userIcon);
+    // A value in the override slot outranks every later global update, and the
+    // on-connect announce reads it back and re-stamps it forever. That is the
+    // whole defect, so this assertion is the point of the task.
+    expect(row.display_name).toBeUndefined();
+    expect(row.user_icon).toBeUndefined();
+  });
+
+  it('stamps globalProfileTimestamp so a later rename can win', () => {
+    const row = buildJoinedMemberRow(P) as Record<string, unknown>;
+    expect(row.globalProfileTimestamp).toBe(P.joinedAt);
+  });
+
+  it('preserves the authoritative inbox_address from the verified join', () => {
+    const row = buildJoinedMemberRow(P) as Record<string, unknown>;
+    expect(row.inbox_address).toBe('inbox-1');
+  });
+
+  it('carries joinedAt and an explicit not-kicked state', () => {
+    const row = buildJoinedMemberRow(P) as Record<string, unknown>;
+    expect(row.joinedAt).toBe(P.joinedAt);
+    expect(row.isKicked).toBe(false);
+  });
+});

--- a/src/dev/tests/services/syncDeltaSelfExclusion.unit.test.ts
+++ b/src/dev/tests/services/syncDeltaSelfExclusion.unit.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from 'vitest';
+import { resolveSyncDeltaSlots } from '@/services/MessageService';
+
+// MessageService.ts imports the native SDK at module load; stub it so this
+// pure-logic helper can be imported without the real WASM channel module.
+vi.mock('@quilibrium/quilibrium-js-sdk-channels', () => ({
+  channel: {},
+  channel_raw: {},
+}));
+
+describe('resolveSyncDeltaSlots — a peer is not authoritative about OUR row', () => {
+  it('NEVER lets a peer write our own override slot, however new it claims to be', () => {
+    // The roster diff in quorum-shared walks every address with no special case
+    // for our own, so any peer whose cached hash for us differs sends its stored
+    // copy of our row back. Our per-space name is ours alone.
+    const r = resolveSyncDeltaSlots({
+      isSelf: true,
+      existingOverrideTs: undefined,
+      incomingOverrideTs: Number.MAX_SAFE_INTEGER,
+      existingGlobalTs: undefined,
+      incomingGlobalTs: 1,
+    });
+    expect(r.applyOverride).toBe(false);
+  });
+
+  it('still accepts our own GLOBAL slot from a peer', () => {
+    // Only the override is ours to author. The global slot is our current global
+    // identity, which a peer may legitimately know a newer version of.
+    const r = resolveSyncDeltaSlots({
+      isSelf: true,
+      incomingOverrideTs: 5,
+      incomingGlobalTs: 5,
+    });
+    expect(r.applyGlobal).toBe(true);
+  });
+
+  it('applies another member override when we have no timestamp (bootstrap)', () => {
+    // Deliberate fail-open: this is how a member we have never heard of gets a
+    // name at all. Pinned here so a future "hardening" has to argue with a test.
+    const r = resolveSyncDeltaSlots({
+      isSelf: false,
+      existingOverrideTs: undefined,
+      incomingOverrideTs: 0,
+      incomingGlobalTs: 0,
+    });
+    expect(r.applyOverride).toBe(true);
+  });
+
+  it('rejects an older override for another member', () => {
+    const r = resolveSyncDeltaSlots({
+      isSelf: false,
+      existingOverrideTs: 2000,
+      incomingOverrideTs: 1000,
+      incomingGlobalTs: 0,
+    });
+    expect(r.applyOverride).toBe(false);
+  });
+
+  it('rejects an older global slot for another member', () => {
+    const r = resolveSyncDeltaSlots({
+      isSelf: false,
+      existingGlobalTs: 2000,
+      incomingOverrideTs: 0,
+      incomingGlobalTs: 1000,
+    });
+    expect(r.applyGlobal).toBe(false);
+  });
+});

--- a/src/dev/tests/utils/legacyOverrideClearGate.test.ts
+++ b/src/dev/tests/utils/legacyOverrideClearGate.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  legacySpaceOverrideClearDone,
+  releaseLegacySpaceOverrideClearGate,
+} from '@/utils/legacyOverrideClearGate';
+
+/**
+ * The gate is what stops the on-connect announce (and the tag rebroadcast) from
+ * re-broadcasting a still-poisoned per-space override with a fresh timestamp
+ * before the one-time clear has landed — the exact mechanism that made those
+ * stale names permanent.
+ *
+ * Two properties matter and both are failure modes if wrong:
+ *  - it must NOT resolve on its own (otherwise it gates nothing)
+ *  - it must ALWAYS be releasable (otherwise a failed migration silences the
+ *    identity announce for the whole session, trading a stale name for an
+ *    invisible member — worse than the bug)
+ */
+describe('legacySpaceOverrideClearGate', () => {
+  it('does not resolve until it is released', async () => {
+    const settled = vi.fn();
+    void legacySpaceOverrideClearDone.then(settled);
+
+    // Flush the microtask queue. A promise that were already resolved would
+    // have run its callback by now.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(settled).not.toHaveBeenCalled();
+  });
+
+  it('resolves once released, and awaiting it afterwards is instant', async () => {
+    releaseLegacySpaceOverrideClearGate();
+    await expect(legacySpaceOverrideClearDone).resolves.toBeUndefined();
+  });
+
+  it('is idempotent — releasing repeatedly is safe', () => {
+    expect(() => {
+      releaseLegacySpaceOverrideClearGate();
+      releaseLegacySpaceOverrideClearGate();
+      releaseLegacySpaceOverrideClearGate();
+    }).not.toThrow();
+  });
+
+  it('stays resolved for every later awaiter', async () => {
+    releaseLegacySpaceOverrideClearGate();
+    await legacySpaceOverrideClearDone;
+    // A second, independent await must not hang — the announce fires from more
+    // than one trigger, so more than one caller waits on this.
+    await expect(legacySpaceOverrideClearDone).resolves.toBeUndefined();
+  });
+});

--- a/src/dev/tests/utils/resolveGlobalSender.globalSlot.test.ts
+++ b/src/dev/tests/utils/resolveGlobalSender.globalSlot.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { buildGlobalSenderMap } from '@/utils/resolveGlobalSender';
+
+const SPACE = 'QmSpace0000000000000000000000000000000000';
+const ADDR = 'QmMember00000000000000000000000000000000';
+
+describe('buildGlobalSenderMap — the global identity slot', () => {
+  it('falls back to the global slot when there is no per-space override', () => {
+    // The post-follow-global normal state: override empty, identity in the
+    // global slot. Every other render path handles this; this one did not.
+    const resolve = buildGlobalSenderMap({
+      [SPACE]: [
+        {
+          user_address: ADDR,
+          display_name: '',
+          user_icon: '',
+          global_display_name: 'Ada',
+          global_user_icon: 'data:image/png;base64,AAA',
+        },
+      ] as never,
+    });
+    const sender = resolve(SPACE, ADDR);
+    expect(sender.displayName).toBe('Ada');
+    expect(sender.userIcon).toBe('data:image/png;base64,AAA');
+    expect(sender.globalDisplayName).toBe('Ada');
+  });
+
+  it('a deliberate per-space override still outranks the global slot', () => {
+    const resolve = buildGlobalSenderMap({
+      [SPACE]: [
+        {
+          user_address: ADDR,
+          display_name: 'Ada in this space',
+          global_display_name: 'Ada',
+        },
+      ] as never,
+    });
+    const sender = resolve(SPACE, ADDR);
+    expect(sender.displayName).toBe('Ada in this space');
+    expect(sender.globalDisplayName).toBe('Ada');
+  });
+
+  it('unknown sender still returns an address-only record', () => {
+    const resolve = buildGlobalSenderMap({});
+    expect(resolve(SPACE, ADDR)).toEqual({ address: ADDR });
+  });
+});

--- a/src/dev/tests/utils/selfOverrideTripwire.test.ts
+++ b/src/dev/tests/utils/selfOverrideTripwire.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  recordSelfOverrideWrite,
+  readSelfOverrideTripwire,
+  TRIPWIRE_KEY,
+  MAX_TRIPWIRE_ENTRIES,
+} from '@/utils/selfOverrideTripwire';
+
+describe('selfOverrideTripwire', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  it('records a non-empty self override write', () => {
+    recordSelfOverrideWrite({ spaceId: 'QmSpace', value: 'Stale Name' });
+    const entries = readSelfOverrideTripwire();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].spaceId).toBe('QmSpace');
+    expect(entries[0].value).toBe('Stale Name');
+    expect(entries[0].stack).toBeTruthy();
+  });
+
+  it('ignores a clear — writing "" is the fix, not the bug', () => {
+    recordSelfOverrideWrite({ spaceId: 'QmSpace', value: '' });
+    expect(readSelfOverrideTripwire()).toHaveLength(0);
+  });
+
+  it('bounds the ring so it cannot grow without limit', () => {
+    for (let i = 0; i < MAX_TRIPWIRE_ENTRIES + 5; i++) {
+      recordSelfOverrideWrite({ spaceId: `s${i}`, value: `v${i}` });
+    }
+    const entries = readSelfOverrideTripwire();
+    expect(entries).toHaveLength(MAX_TRIPWIRE_ENTRIES);
+    expect(entries[entries.length - 1].spaceId).toBe(`s${MAX_TRIPWIRE_ENTRIES + 4}`);
+  });
+
+  it('never throws when localStorage is unavailable', () => {
+    const spy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('quota');
+    });
+    expect(() => recordSelfOverrideWrite({ spaceId: 's', value: 'v' })).not.toThrow();
+    spy.mockRestore();
+  });
+
+  it('exposes a stable key so it can be read from the console', () => {
+    expect(TRIPWIRE_KEY).toBe('quorum:diag:selfOverrideWrites');
+  });
+});

--- a/src/dev/tests/utils/spaceProfilePayload.test.ts
+++ b/src/dev/tests/utils/spaceProfilePayload.test.ts
@@ -55,17 +55,28 @@ describe('the global slot', () => {
 });
 
 describe('the override slot — rule 2, never stamp the global into it', () => {
-  // The normal state post-follow-global: the member row exists but its override
-  // fields are empty, meaning "follow global".
-  it('omits every override field when no override is set', () => {
+  it('OMITS the override field when there is no override at all', () => {
     const p = buildSpaceProfileWirePayload(
       SELF,
-      { display_name: '', user_icon: '', bio: '' },
+      { display_name: undefined, user_icon: undefined, bio: undefined },
       GLOBAL
     );
     expect('displayName' in p).toBe(false);
     expect('userIcon' in p).toBe(false);
     expect('bio' in p).toBe(false);
+  });
+
+  it('SENDS an empty string when the override was deliberately cleared', () => {
+    // '' is the wire's "deliberate clear". Collapsing it to an omission means a
+    // clear can never leave this device, so spacemates keep the stale name.
+    const p = buildSpaceProfileWirePayload(
+      SELF,
+      { display_name: '', user_icon: '', bio: '' },
+      GLOBAL
+    );
+    expect(p.displayName).toBe('');
+    expect(p.userIcon).toBe('');
+    expect(p.bio).toBe('');
   });
 
   it('omits them when there is no member row at all', () => {

--- a/src/hooks/business/channels/useChannelData.ts
+++ b/src/hooks/business/channels/useChannelData.ts
@@ -22,6 +22,17 @@ interface UseChannelDataProps {
   channelId: string;
 }
 
+/**
+ * One rung of the avatar ladder: a usable avatar, or `undefined` so the next
+ * rung — and ultimately the initials placeholder — can take over. The default
+ * UNKNOWN_USER image counts as absent; handing it on would render a broken-looking
+ * placeholder instead of initials.
+ */
+function pickAvatar(icon: string | undefined): string | undefined {
+  if (!icon) return undefined;
+  return icon.includes(DefaultImages.UNKNOWN_USER) ? undefined : icon;
+}
+
 export function useChannelData({ spaceId, channelId }: UseChannelDataProps) {
   const { data: space } = useSpace({ spaceId });
   const { data: spaceMembers } = useSpaceMembers({ spaceId });
@@ -68,10 +79,16 @@ export function useChannelData({ spaceId, channelId }: UseChannelDataProps) {
         Object.assign(prev, {
           [curr.user_address]: {
             address: curr.user_address,
-            // Filter out invalid avatars (null or UNKNOWN_USER) to enable initials fallback
-            userIcon: curr.user_icon?.includes(DefaultImages.UNKNOWN_USER)
-              ? undefined
-              : curr.user_icon,
+            // Avatar ladder, applied HERE rather than at each call site: the
+            // per-space override, else the global slot. Consumers of this map
+            // read `userIcon` raw (the member sidebar does), and with the
+            // override correctly empty — its normal state under the two-slot
+            // model — an override-only read renders no avatar at all. Same
+            // shape as the name defect fixed in resolveSpaceMemberName.
+            // Invalid avatars (UNKNOWN_USER) are dropped at each rung so the
+            // initials fallback still engages.
+            userIcon:
+              pickAvatar(curr.user_icon) ?? pickAvatar(curr.global_user_icon),
             displayName: curr.display_name,
             // Per-space bio override; flows into UserProfile's "About"
             // section. Empty string means the user explicitly cleared it.
@@ -81,9 +98,7 @@ export function useChannelData({ spaceId, channelId }: UseChannelDataProps) {
             // Consumed by the fallback resolver as the tier between override and
             // public profile. See identity-resolution-and-profile-sync doc.
             globalDisplayName: curr.global_display_name,
-            globalUserIcon: curr.global_user_icon?.includes(DefaultImages.UNKNOWN_USER)
-              ? undefined
-              : curr.global_user_icon,
+            globalUserIcon: pickAvatar(curr.global_user_icon),
             globalBio: curr.global_bio,
             isKicked: curr.isKicked || false,
             spaceTag: curr.spaceTag,
@@ -113,10 +128,9 @@ export function useChannelData({ spaceId, channelId }: UseChannelDataProps) {
         Object.assign(prev, {
           [curr.user_address]: {
             address: curr.user_address,
-            // Filter out invalid avatars (null or UNKNOWN_USER) to enable initials fallback
-            userIcon: curr.user_icon?.includes(DefaultImages.UNKNOWN_USER)
-              ? undefined
-              : curr.user_icon,
+            // Same override → global ladder as `members` above.
+            userIcon:
+              pickAvatar(curr.user_icon) ?? pickAvatar(curr.global_user_icon),
             displayName: curr.display_name,
             left: curr.inbox_address === '',
             isKicked: curr.isKicked || false,

--- a/src/hooks/business/channels/useChannelData.ts
+++ b/src/hooks/business/channels/useChannelData.ts
@@ -90,9 +90,12 @@ export function useChannelData({ spaceId, channelId }: UseChannelDataProps) {
             userIcon:
               pickAvatar(curr.user_icon) ?? pickAvatar(curr.global_user_icon),
             displayName: curr.display_name,
-            // Per-space bio override; flows into UserProfile's "About"
-            // section. Empty string means the user explicitly cleared it.
-            bio: curr.bio,
+            // Same override → global ladder as the avatar above. An empty
+            // override means "follow global", not "no bio", so `||` is right:
+            // consumers reading this map raw (the virtualized member list at
+            // :246 and :279) would otherwise show no About section at all once
+            // the override is empty — its normal state under the two-slot model.
+            bio: curr.bio || curr.global_bio,
             // Roster GLOBAL slots (two-slot design): the sender's current global
             // identity, pushed separately from the per-space override fields.
             // Consumed by the fallback resolver as the tier between override and

--- a/src/hooks/business/user/useClearLegacySpaceOverrides.ts
+++ b/src/hooks/business/user/useClearLegacySpaceOverrides.ts
@@ -1,0 +1,144 @@
+// One-time clear of legacy per-space overrides on the user's OWN roster rows.
+//
+// Those values are copies of an old global name, stamped at join and then re-sent
+// and re-stamped by the on-connect announce on every connect. They never decay, and
+// after the first announce they are byte-for-byte identical to a name the user
+// deliberately chose — nothing can tell them apart. So they are cleared
+// unconditionally, once. Decision recorded in the design doc's §4-D.
+//
+// It BROADCASTS the clear rather than writing locally. A local write is invisible on
+// the wire, so spacemates and the user's own other devices keep the poisoned copy —
+// and an un-migrated sibling device re-announces the old value with a fresher
+// timestamp and wins. Sending it through `submitChannelMessage` also self-applies it
+// locally with a fresh `profileTimestamp`, which is what makes it survive that race.
+//
+// See .agents/issues/.open/2026-08-05-own-identity-cross-device-sync-design.md §5-D
+
+import { useEffect, useRef } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { usePasskeysContext } from '@quilibrium/quilibrium-js-sdk-channels';
+import { logger, type UpdateProfileMessage } from '@quilibrium/quorum-shared';
+import { useMessageDB } from '../../../components/context/useMessageDB';
+import { releaseLegacySpaceOverrideClearGate } from '../../../utils/legacyOverrideClearGate';
+
+/** Bump to re-run if the shape ever changes. */
+const CLEAR_FLAG_PREFIX = 'spaceOverridesCleared:v1:';
+/** What the clear destroyed. Irreversible, so it leaves a record. */
+export const CLEAR_LOG_KEY = 'quorum:diag:clearedSpaceOverrides';
+
+export interface OverrideClearEntry {
+  spaceId: string;
+  previousName?: string;
+  previousIcon?: string;
+}
+
+interface OwnRosterRow {
+  spaceId: string;
+  user_address: string;
+  display_name?: string;
+  user_icon?: string;
+}
+
+/** Pure: which of our own rows still carry a per-space override? */
+export function planLegacyOverrideClear(
+  selfAddress: string,
+  rows: OwnRosterRow[]
+): OverrideClearEntry[] {
+  return rows
+    .filter((r) => r.user_address === selfAddress && (r.display_name || r.user_icon))
+    .map((r) => ({
+      spaceId: r.spaceId,
+      previousName: r.display_name || undefined,
+      previousIcon: r.user_icon || undefined,
+    }));
+}
+
+function recordClearedOverrides(entries: OverrideClearEntry[]): void {
+  if (entries.length === 0) return;
+  try {
+    const raw = localStorage.getItem(CLEAR_LOG_KEY);
+    const existing = raw ? (JSON.parse(raw) as OverrideClearEntry[]) : [];
+    localStorage.setItem(
+      CLEAR_LOG_KEY,
+      JSON.stringify([...existing, ...entries].slice(-100))
+    );
+    // console.warn, not logger — logger calls compile to no-ops in production.
+    console.warn(
+      `[SpaceOverrides] cleared ${entries.length} legacy per-space override(s). ` +
+        `Previous values are in ${CLEAR_LOG_KEY} in localStorage.`,
+      entries
+    );
+  } catch {
+    // Diagnostics must never break the migration.
+  }
+}
+
+export function useClearLegacySpaceOverrides(): void {
+  const { messageDB, submitChannelMessage } = useMessageDB();
+  const { currentPasskeyInfo } = usePasskeysContext();
+  const queryClient = useQueryClient();
+  const ranRef = useRef(false);
+
+  useEffect(() => {
+    const selfAddress = currentPasskeyInfo?.address;
+    if (!selfAddress || ranRef.current) return;
+
+    const flagKey = `${CLEAR_FLAG_PREFIX}${selfAddress}`;
+    if (localStorage.getItem(flagKey)) {
+      releaseLegacySpaceOverrideClearGate();
+      return;
+    }
+    ranRef.current = true;
+
+    (async () => {
+      try {
+        const spaces = await messageDB.getSpaces();
+        const rows: OwnRosterRow[] = [];
+        for (const space of spaces) {
+          const own = await messageDB.getSpaceMember(space.spaceId, selfAddress);
+          if (own) rows.push({ ...own, spaceId: space.spaceId } as OwnRosterRow);
+        }
+
+        const plan = planLegacyOverrideClear(selfAddress, rows);
+
+        for (const entry of plan) {
+          const space = spaces.find((s) => s.spaceId === entry.spaceId);
+          if (!space) continue;
+          // '' is the wire's deliberate clear. submitChannelMessage broadcasts it
+          // AND self-applies it locally with a fresh profileTimestamp, which is
+          // what stops an un-migrated sibling's announce winning the comparison.
+          await submitChannelMessage(
+            entry.spaceId,
+            space.defaultChannelId,
+            {
+              type: 'update-profile',
+              senderId: selfAddress,
+              displayName: '',
+              userIcon: '',
+            } as UpdateProfileMessage,
+            queryClient,
+            currentPasskeyInfo,
+            undefined, // inReplyTo
+            false, // must sign
+            undefined // isSpaceOwner — not needed for profile updates
+          );
+        }
+
+        recordClearedOverrides(plan);
+        localStorage.setItem(flagKey, String(Date.now()));
+        logger.log(
+          `[SpaceOverrides] legacy override clear complete (${plan.length} space(s))`
+        );
+      } catch (error) {
+        // Do NOT set the flag — retry on the next launch, matching the
+        // conversation-settings migration's failure behaviour.
+        ranRef.current = false;
+        logger.error('[SpaceOverrides] legacy override clear failed', error);
+      } finally {
+        // Release the announce either way: a migration that failed must not
+        // silence the identity announce for the whole session.
+        releaseLegacySpaceOverrideClearGate();
+      }
+    })();
+  }, [currentPasskeyInfo, messageDB, submitChannelMessage, queryClient]);
+}

--- a/src/hooks/business/user/useClearLegacySpaceOverrides.ts
+++ b/src/hooks/business/user/useClearLegacySpaceOverrides.ts
@@ -20,6 +20,7 @@ import { usePasskeysContext } from '@quilibrium/quilibrium-js-sdk-channels';
 import { logger, type UpdateProfileMessage } from '@quilibrium/quorum-shared';
 import { useMessageDB } from '../../../components/context/useMessageDB';
 import { releaseLegacySpaceOverrideClearGate } from '../../../utils/legacyOverrideClearGate';
+import type { SpaceMemberRow } from '../../../db/messages';
 
 /** Bump to re-run if the shape ever changes. */
 const CLEAR_FLAG_PREFIX = 'spaceOverridesCleared:v1:';
@@ -104,9 +105,32 @@ export function useClearLegacySpaceOverrides(): void {
         for (const entry of plan) {
           const space = spaces.find((s) => s.spaceId === entry.spaceId);
           if (!space) continue;
-          // '' is the wire's deliberate clear. submitChannelMessage broadcasts it
-          // AND self-applies it locally with a fresh profileTimestamp, which is
-          // what stops an un-migrated sibling's announce winning the comparison.
+
+          // LOCAL half — deterministic, and it must land before the gate opens.
+          //
+          // `submitChannelMessage` does self-apply the clear, but it does so
+          // inside `enqueueOutbound`, which pushes to a queue and returns without
+          // awaiting anything (WebsocketProvider.enqueueOutbound). So awaiting it
+          // guarantees nothing: the local write might not have happened when the
+          // announce is released, and it does not happen at all while the socket
+          // is closed. Write the row ourselves so the ordering the gate promises
+          // is real rather than a race with favourable odds.
+          //
+          // '' is a present value, so it survives saveSpaceMember's merge as a
+          // deliberate clear. The timestamp is what beats an un-migrated
+          // sibling's re-announce.
+          await messageDB.saveSpaceMember(entry.spaceId, {
+            user_address: selfAddress,
+            display_name: '',
+            user_icon: '',
+            profileTimestamp: Date.now(),
+          } as SpaceMemberRow);
+
+          // WIRE half — best-effort, and self-healing if it does not go out.
+          // Once the row holds '', the ordinary on-connect announce carries
+          // `displayName: ''` too (that is what the presence-semantics fix in
+          // this branch enables), so the clear still reaches everyone on the
+          // next connect even if this send is dropped.
           await submitChannelMessage(
             entry.spaceId,
             space.defaultChannelId,

--- a/src/hooks/business/user/useReconcileSelfIdentity.ts
+++ b/src/hooks/business/user/useReconcileSelfIdentity.ts
@@ -1,0 +1,108 @@
+/**
+ * Repairs the device-local passkey record (`currentPasskeyInfo`) from the
+ * synced `UserConfig` blob whenever they disagree.
+ *
+ * Almost every read site for "my own name/avatar" — the NavRail avatar and
+ * its hover tooltip, the DM self entry, the user's own name in search
+ * results, ~15 sites in all — reads `currentPasskeyInfo` from
+ * `usePasskeysContext()`, a device-local localStorage record that ONLY this
+ * device's own profile save ever writes. The user's global display
+ * name/avatar sync between devices inside the encrypted `UserConfig` blob,
+ * but almost nothing reads that blob back into the local record. So
+ * renaming yourself on another device can never reach this one.
+ *
+ * Repairing this single record repairs every read site at once, instead of
+ * editing fifteen files.
+ *
+ * 🔴 NEVER write an empty name. `ConfigService.getConfig` returns a default
+ * config with no `name` whenever there is neither a network response nor a
+ * stored config — the ordinary cold-start / offline-first-run state. Because
+ * every read site shares this one in-memory object, one empty write would
+ * blank the display name everywhere simultaneously. See
+ * `shouldReconcileSelfIdentity` below, and the existing precedent this
+ * mirrors at `useUnifiedOnboardingFlow.ts` (`if (validatedName)`).
+ */
+
+import { useEffect, useRef } from 'react';
+import { usePasskeysContext } from '@quilibrium/quilibrium-js-sdk-channels';
+import { logger } from '@quilibrium/quorum-shared';
+import { useMessageDB } from '../../../components/context/useMessageDB';
+
+interface SyncedIdentity {
+  name?: string;
+  profile_image?: string;
+}
+interface StoredIdentity {
+  displayName?: string;
+  pfpUrl?: string;
+}
+
+/**
+ * Pure decision: what, if anything, to write back to the passkey record.
+ * Returns null when nothing should be written.
+ *
+ * NEVER returns a write that blanks an existing name — getConfig returns a
+ * nameless default on a cold start, and ~15 call sites read the single
+ * in-memory passkey object, so one empty write blanks all of them.
+ */
+export function shouldReconcileSelfIdentity(
+  config: SyncedIdentity | undefined,
+  stored: StoredIdentity
+): { displayName: string; pfpUrl?: string } | null {
+  const syncedName = config?.name?.trim();
+  if (!syncedName) return null;
+
+  const syncedIcon = config?.profile_image || undefined;
+  const nameChanged = syncedName !== stored.displayName;
+  const iconChanged = Boolean(syncedIcon) && syncedIcon !== stored.pfpUrl;
+  if (!nameChanged && !iconChanged) return null;
+
+  return { displayName: syncedName, pfpUrl: syncedIcon ?? stored.pfpUrl };
+}
+
+export function useReconcileSelfIdentity(): void {
+  const { currentPasskeyInfo, updateStoredPasskey } = usePasskeysContext();
+  const { messageDB } = useMessageDB();
+  const address = currentPasskeyInfo?.address;
+  const lastAppliedRef = useRef<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (!address) return;
+
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const config = await messageDB.getUserConfig({ address });
+        const write = shouldReconcileSelfIdentity(config, {
+          displayName: currentPasskeyInfo?.displayName,
+          pfpUrl: currentPasskeyInfo?.pfpUrl,
+        });
+        if (!write) return;
+
+        const signature = `${write.displayName}|${write.pfpUrl}`;
+        if (lastAppliedRef.current === signature) return;
+
+        if (cancelled || !currentPasskeyInfo) return;
+
+        lastAppliedRef.current = signature;
+        updateStoredPasskey(currentPasskeyInfo.credentialId, {
+          credentialId: currentPasskeyInfo.credentialId,
+          address: currentPasskeyInfo.address,
+          publicKey: currentPasskeyInfo.publicKey,
+          displayName: write.displayName,
+          pfpUrl: write.pfpUrl,
+          completedOnboarding: true,
+        });
+      } catch (error) {
+        // Non-fatal: the stored value keeps rendering, which is today's
+        // behaviour. Don't rethrow — this is a best-effort background sync.
+        logger.warn('[ReconcileSelfIdentity] reconcile failed', error);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [address, currentPasskeyInfo, messageDB, updateStoredPasskey]);
+}

--- a/src/hooks/business/user/useReconcileSelfIdentity.ts
+++ b/src/hooks/business/user/useReconcileSelfIdentity.ts
@@ -24,9 +24,12 @@
  */
 
 import { useEffect, useRef } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { usePasskeysContext } from '@quilibrium/quilibrium-js-sdk-channels';
 import { logger } from '@quilibrium/quorum-shared';
 import { useMessageDB } from '../../../components/context/useMessageDB';
+import { buildConfigKey } from '../../queries/config';
+import type { UserConfig } from '../../../db/messages';
 
 interface SyncedIdentity {
   name?: string;
@@ -66,6 +69,18 @@ export function useReconcileSelfIdentity(): void {
   const address = currentPasskeyInfo?.address;
   const lastAppliedRef = useRef<string | undefined>(undefined);
 
+  // SUBSCRIBE to the config rather than reading it once on mount.
+  // `ConfigService.getConfig` pushes each freshly-pulled config into this cache
+  // key, and those pulls happen well after mount — opening a DM is the common
+  // one. A one-shot read here would leave the NavRail stale until the next app
+  // launch, which is most of the bug we are fixing.
+  const { data: config } = useQuery<UserConfig | undefined>({
+    queryKey: buildConfigKey({ userAddress: address ?? '' }),
+    queryFn: () => messageDB.getUserConfig({ address: address! }),
+    enabled: Boolean(address),
+    networkMode: 'always', // IndexedDB, not network
+  });
+
   useEffect(() => {
     if (!address) return;
 
@@ -73,7 +88,6 @@ export function useReconcileSelfIdentity(): void {
 
     (async () => {
       try {
-        const config = await messageDB.getUserConfig({ address });
         const write = shouldReconcileSelfIdentity(config, {
           displayName: currentPasskeyInfo?.displayName,
           pfpUrl: currentPasskeyInfo?.pfpUrl,
@@ -104,5 +118,5 @@ export function useReconcileSelfIdentity(): void {
     return () => {
       cancelled = true;
     };
-  }, [address, currentPasskeyInfo, messageDB, updateStoredPasskey]);
+  }, [address, config, currentPasskeyInfo, updateStoredPasskey]);
 }

--- a/src/services/InvitationService.ts
+++ b/src/services/InvitationService.ts
@@ -2,7 +2,7 @@
 // This service handles space invitation operations
 
 import { logger, int64ToBytes, parseInviteParams, getInviteUrlBase } from '@quilibrium/quorum-shared';
-import { MessageDB, NavItem } from '../db/messages';
+import { MessageDB, NavItem, type SpaceMemberRow } from '../db/messages';
 import { QuorumApiClient } from '../api/baseTypes';
 import { channel as secureChannel, channel_raw as ch } from '@quilibrium/quilibrium-js-sdk-channels';
 import { sha256, base58btc, hexToSpreadArray } from '../utils/crypto';
@@ -765,16 +765,24 @@ export class InvitationService {
       // Clear any tombstones from a previous join to allow messages to sync
       await this.messageDB.clearTombstonesForSpace(space.spaceId);
       await this.messageDB.saveSpace(space);
-      await this.messageDB.saveSpaceMember(space.spaceId, {
-        user_address: currentPasskeyInfo.address,
-        user_icon: currentPasskeyInfo.pfpUrl,
-        display_name: currentPasskeyInfo.displayName,
-        inbox_address: inboxAddress,
-      });
       let config = await this.getConfig({
         address: currentPasskeyInfo.address,
         userKey: keyset.userKeyset,
       });
+      // Two-slot model: our own row gets the GLOBAL slot, never the override.
+      // A value in the override slot outranks every later global update and the
+      // announce re-stamps it forever, so stamping it here froze us under the
+      // name we happened to have at join time. Sourced from the synced config
+      // rather than the device-local passkey record, which a rename made on
+      // another device never reaches.
+      const joinedAt = Date.now();
+      await this.messageDB.saveSpaceMember(space.spaceId, {
+        user_address: currentPasskeyInfo.address,
+        global_user_icon: config?.profile_image ?? currentPasskeyInfo.pfpUrl,
+        global_display_name: config?.name ?? currentPasskeyInfo.displayName,
+        globalProfileTimestamp: joinedAt,
+        inbox_address: inboxAddress,
+      } as SpaceMemberRow);
       // Create NavItem for the new space
       const newSpaceItem: NavItem = { type: 'space', id: space.spaceId };
       if (config) {

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -1013,6 +1013,14 @@ export class MessageService {
     },
     queryClient: QueryClient
   ): Promise<void> {
+    // This is the SECOND site that broadcasts our own override slot — it uses
+    // the same buildSpaceProfilePayload, which reads `ownMember.display_name`
+    // off the roster. Gating only the on-connect announce left this one free to
+    // re-broadcast a still-poisoned override with a fresh timestamp, and unlike
+    // the announce it is not capped by the 3-attempt gate. A space-manifest can
+    // arrive at any time, so wait for the legacy clear here too.
+    await legacySpaceOverrideClearDone;
+
     // 1. Read config — one IndexedDB read
     const config = await this.messageDB.getUserConfig({ address: selfAddress });
     if (!config?.spaceTagId) return;
@@ -5815,6 +5823,26 @@ export class MessageService {
               );
               if (verify) {
                 for (const member of envelope.message.members) {
+                  // A peer is never authoritative about OUR per-space name.
+                  // This LEGACY sync-members path writes rows verbatim, with no
+                  // timestamp comparison at all, so without this a peer holding
+                  // an old copy of our row — including one on an un-migrated
+                  // build — pushes it straight back and bypasses the whole
+                  // self-authorship model. Same rule as resolveSyncDeltaSlots
+                  // applies on the modern delta path.
+                  const isSelfRow =
+                    (member as any).user_address === self_address;
+                  const incoming = isSelfRow
+                    ? (() => {
+                        const {
+                          display_name: _dropName,
+                          user_icon: _dropIcon,
+                          profileTimestamp: _dropTs,
+                          ...rest
+                        } = member as any;
+                        return rest;
+                      })()
+                    : (member as any);
                   try {
                     const existing = await this.messageDB.getSpaceMember(
                       conversationId.split('/')[0],
@@ -5823,7 +5851,7 @@ export class MessageService {
                     await this.messageDB.saveSpaceMember(
                       conversationId.split('/')[0],
                       {
-                        ...(member as any),
+                        ...incoming,
                         isKicked: existing?.isKicked ?? false,
                         joinedAt: (member as any).joinedAt ?? existing?.joinedAt,
                       } as any
@@ -5831,7 +5859,7 @@ export class MessageService {
                   } catch {
                     await this.messageDB.saveSpaceMember(
                       conversationId.split('/')[0],
-                      member as any
+                      incoming as any
                     );
                   }
                 }

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -83,6 +83,7 @@ import { dmRatchetMutex } from '../utils/keyedMutex';
 import { isStaleInitEnvelope } from '../utils/initEnvelopeGuard';
 import { findStaleBucket, restoreStaleBucket } from '../utils/dmStaleBucketRetry';
 import { orderSessionsForSend } from '../utils/sessionSelection';
+import { legacySpaceOverrideClearDone } from '../utils/legacyOverrideClearGate';
 import {
   dmProfileSignature,
   shouldSendDmProfile,
@@ -1222,6 +1223,15 @@ export class MessageService {
    * Fire-and-forget: per-space failures are logged and never block anything.
    */
   async announceProfileToAllSpacesOnConnect(selfAddress: string): Promise<void> {
+    // The announce reads our own override slot straight off the roster row and
+    // re-sends it. If it runs before the legacy-override clear has landed, it
+    // re-announces the stale value with a FRESH timestamp and repoisons the row
+    // — the exact mechanism that made these names permanent. Both triggers (the
+    // startup timer and setResubscribe) funnel through here, so this is the one
+    // place the gate has to live. Resolves immediately once the clear has run or
+    // been skipped; released even when the clear fails.
+    await legacySpaceOverrideClearDone;
+
     let spaces: Space[];
     let config: Awaited<ReturnType<typeof this.messageDB.getUserConfig>>;
     try {

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -305,6 +305,35 @@ export function applyProfileUpdate(
   }
 }
 
+/**
+ * Which slots may a sync-delta member row write?
+ *
+ * The sync protocol compares DIGESTS, which carry no notion of newer or older, so
+ * a peer holding a stale identity will happily push it back. For OUR OWN row that
+ * is never acceptable — a peer is not authoritative about our per-space choice,
+ * and `computeMemberDiff` has no self-exclusion of its own.
+ *
+ * For everyone else the per-slot timestamp guard applies, and a row with NO stored
+ * timestamp accepts unconditionally: that is the deliberate bootstrap for a member
+ * we have never heard of, pinned by saveSpaceMemberGlobalSlot.test.ts. Do not
+ * "harden" it.
+ */
+export function resolveSyncDeltaSlots(input: {
+  isSelf: boolean;
+  existingOverrideTs?: number;
+  existingGlobalTs?: number;
+  incomingOverrideTs: number;
+  incomingGlobalTs: number;
+}): { applyOverride: boolean; applyGlobal: boolean } {
+  const applyOverride =
+    !input.isSelf &&
+    !(input.existingOverrideTs && input.existingOverrideTs >= input.incomingOverrideTs);
+  const applyGlobal = !(
+    input.existingGlobalTs && input.existingGlobalTs >= input.incomingGlobalTs
+  );
+  return { applyOverride, applyGlobal };
+}
+
 export class MessageService {
   private messageDB: MessageDB;
   private enqueueOutbound: (action: () => Promise<string[]>) => void;
@@ -6108,16 +6137,14 @@ export class MessageService {
                 // so it can populate an empty row but can never overwrite a
                 // stamped one — which is the right call for peers that predate
                 // the global slot travelling over sync at all.
-                const incomingOverrideTs = member.profileTimestamp ?? 0;
-                const incomingGlobalTs = member.globalProfileTimestamp ?? 0;
-                const applyOverride = !(
-                  existing?.profileTimestamp &&
-                  existing.profileTimestamp >= incomingOverrideTs
-                );
-                const applyGlobal = !(
-                  existing?.globalProfileTimestamp &&
-                  existing.globalProfileTimestamp >= incomingGlobalTs
-                );
+                const { applyOverride, applyGlobal } = resolveSyncDeltaSlots({
+                  // A peer is never authoritative about OUR per-space name.
+                  isSelf: userAddress === self_address,
+                  existingOverrideTs: existing?.profileTimestamp,
+                  existingGlobalTs: existing?.globalProfileTimestamp,
+                  incomingOverrideTs: member.profileTimestamp ?? 0,
+                  incomingGlobalTs: member.globalProfileTimestamp ?? 0,
+                });
 
                 // `saveSpaceMember` merges, so an omitted slot keeps what is
                 // stored rather than blanking it.

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -334,6 +334,33 @@ export function resolveSyncDeltaSlots(input: {
   return { applyOverride, applyGlobal };
 }
 
+/**
+ * A `join` control carries the joiner's GLOBAL identity, not a per-space choice.
+ *
+ * Filing it in the OVERRIDE slot froze that member under whatever name they had at
+ * join time: the override outranks every later global update, and the on-connect
+ * announce reads it back off the row and re-stamps it on every connect, so it never
+ * decays. Filed in the global slot with a `joinedAt` stamp instead, so ordinary
+ * last-write-wins applies and a later rename reaches us.
+ */
+export function buildJoinedMemberRow(participant: {
+  address: string;
+  inboxAddress: string;
+  userIcon?: string;
+  displayName?: string;
+  joinedAt: number;
+}): SpaceMemberRow {
+  return {
+    user_address: participant.address,
+    inbox_address: participant.inboxAddress,
+    global_user_icon: participant.userIcon,
+    global_display_name: participant.displayName,
+    globalProfileTimestamp: participant.joinedAt,
+    isKicked: false,
+    joinedAt: participant.joinedAt,
+  } as SpaceMemberRow;
+}
+
 export class MessageService {
   private messageDB: MessageDB;
   private enqueueOutbound: (action: () => Promise<string[]>) => void;
@@ -4948,14 +4975,10 @@ export class MessageService {
                 participant.signature
               );
               if (result === 'true') {
-                this.messageDB.saveSpaceMember(conversationId.split('/')[0], {
-                  user_address: participant.address,
-                  user_icon: participant.userIcon,
-                  display_name: participant.displayName,
-                  inbox_address: participant.inboxAddress,
-                  isKicked: false,
-                  joinedAt: participant.joinedAt,
-                });
+                this.messageDB.saveSpaceMember(
+                  conversationId.split('/')[0],
+                  buildJoinedMemberRow(participant)
+                );
                 await queryClient.setQueryData(
                   buildSpaceMembersKey({
                     spaceId: conversationId.split('/')[0],
@@ -4963,10 +4986,14 @@ export class MessageService {
                   (oldData: (secureChannel.UserProfile & { joinedAt?: number })[]) => {
                     return [
                       ...(oldData ?? []),
+                      // Same slots as the DB write above. Patching the override
+                      // slot here instead would leave the cache and IndexedDB
+                      // disagreeing about a new joiner until the next refetch.
                       {
                         user_address: participant.address,
-                        user_icon: participant.userIcon,
-                        display_name: participant.displayName,
+                        global_user_icon: participant.userIcon,
+                        global_display_name: participant.displayName,
+                        globalProfileTimestamp: participant.joinedAt,
                         joinedAt: participant.joinedAt,
                       },
                     ];

--- a/src/utils/legacyOverrideClearGate.ts
+++ b/src/utils/legacyOverrideClearGate.ts
@@ -1,0 +1,30 @@
+// A one-shot gate the on-connect space announce waits on.
+//
+// The announce reads our own per-space override off the roster row and re-sends it.
+// If it runs before the legacy-override clear has landed, it re-announces the stale
+// value with a fresh timestamp and repoisons the row — the mechanism that made those
+// names permanent in the first place. The announce fires from a startup timer AND
+// from setResubscribe, and that path has raced app initialisation before.
+//
+// Deliberately dependency-free: both MessageService and the migration hook import
+// it, and anything heavier here would close an import cycle between them.
+
+let release: (() => void) | undefined;
+
+/** Resolves once the clear has run, been skipped, or failed. */
+export const legacySpaceOverrideClearDone: Promise<void> = new Promise<void>(
+  (resolve) => {
+    release = resolve;
+  }
+);
+
+/**
+ * Let the announce proceed. Safe to call more than once.
+ *
+ * Call it even when the clear FAILS: a migration that threw must not silence the
+ * identity announce for the rest of the session — that would trade a stale name for
+ * an invisible member, which is worse.
+ */
+export function releaseLegacySpaceOverrideClearGate(): void {
+  release?.();
+}

--- a/src/utils/resolveGlobalSender.ts
+++ b/src/utils/resolveGlobalSender.ts
@@ -3,9 +3,9 @@ import type { channel } from '@quilibrium/quilibrium-js-sdk-channels';
 /**
  * Member shape consumed by the notification panel's name resolution
  * (`resolveSpaceMemberName`). Mirrors the per-space `mapSenderToUser` output so
- * the global panel can reuse the same render path. `primaryUsername` /
- * `globalDisplayName` come from the public-profile fetch (not the space roster),
- * so they are optional here — parity with the per-space path when unenriched.
+ * the global panel can reuse the same render path. `globalDisplayName` comes
+ * from the roster's global slot (not a public-profile fetch); `primaryUsername`
+ * stays optional as it is unenriched here.
  */
 export interface ResolvedGlobalSender {
   address: string;
@@ -15,7 +15,13 @@ export interface ResolvedGlobalSender {
   globalDisplayName?: string;
 }
 
-type SpaceMemberRow = channel.UserProfile & { isKicked?: boolean };
+type SpaceMemberRow = channel.UserProfile & {
+  isKicked?: boolean;
+  /** Roster GLOBAL slots (two-slot model) — the tier between the per-space
+   *  override and the public profile. */
+  global_display_name?: string;
+  global_user_icon?: string;
+};
 
 /**
  * Pure core: given a map of spaceId -> roster (as returned by
@@ -33,10 +39,15 @@ export function buildGlobalSenderMap(
   for (const [spaceId, rows] of Object.entries(membersBySpace)) {
     const map = new Map<string, ResolvedGlobalSender>();
     for (const row of rows) {
+      // Same precedence as useMembersWithPublicProfileFallback: override wins
+      // when non-empty, else the global slot. `globalDisplayName` is kept
+      // SEPARATE so resolveSpaceMemberName can compare the two.
+      const global = row.global_display_name || undefined;
       map.set(row.user_address, {
         address: row.user_address,
-        displayName: row.display_name,
-        userIcon: row.user_icon,
+        displayName: row.display_name || global,
+        userIcon: row.user_icon || row.global_user_icon || undefined,
+        globalDisplayName: global,
       });
     }
     bySpace.set(spaceId, map);

--- a/src/utils/resolveMemberName.ts
+++ b/src/utils/resolveMemberName.ts
@@ -73,9 +73,26 @@ export function resolveSpaceMemberName(member: {
   const global = (member.globalDisplayName ?? '').trim();
   const qns = (member.primaryUsername ?? '').trim();
 
-  if (qns && roster && roster !== global) {
+  // A roster name that DIFFERS from the global one is a deliberate per-space
+  // override and outranks everything.
+  if (roster && roster !== global) {
     return { name: roster, isQnsVerified: false };
   }
+
+  if (qns) return { name: qns, isQnsVerified: true };
+
+  // The global slot is a real TIER, not just a comparator.
+  //
+  // It used to be neither returned nor fallen back to: callers reached the right
+  // answer only when they happened to pass an ALREADY-MERGED displayName from
+  // useMembersWithPublicProfileFallback. Callers passing the raw roster field —
+  // the member sidebar is one — got a truncated address instead.
+  //
+  // That was latent while every roster row carried a stamped override. Once the
+  // override is correctly empty (its normal state under the two-slot model), it
+  // renders as an address for everyone. Closing it here rather than at each call
+  // site, so no surface can miss the tier again.
+  if (global) return { name: global, isQnsVerified: false };
 
   return resolveMemberName({
     address: member.address,

--- a/src/utils/selfOverrideTripwire.ts
+++ b/src/utils/selfOverrideTripwire.ts
@@ -1,0 +1,53 @@
+// Records any write of a NON-EMPTY per-space override onto the local user's own
+// member row. Only the Space Settings editor should ever do that; anything else
+// appearing here is a regression.
+//
+// A tripwire, not a gate: it never blocks a write. `console.warn`, not `logger`,
+// because logger calls compile to no-ops in production builds.
+//
+// Read it with:  JSON.parse(localStorage.getItem('quorum:diag:selfOverrideWrites'))
+
+export const TRIPWIRE_KEY = 'quorum:diag:selfOverrideWrites';
+export const MAX_TRIPWIRE_ENTRIES = 50;
+
+export interface SelfOverrideWrite {
+  at: number;
+  spaceId: string;
+  value: string;
+  stack: string;
+}
+
+export function recordSelfOverrideWrite(input: {
+  spaceId: string;
+  value: string;
+}): void {
+  // '' is the deliberate clear — the fix, not the bug. Only non-empty is news.
+  if (!input.value) return;
+  try {
+    const entry: SelfOverrideWrite = {
+      at: Date.now(),
+      spaceId: input.spaceId,
+      value: input.value,
+      stack: new Error().stack ?? '(no stack)',
+    };
+    const next = [...readSelfOverrideTripwire(), entry].slice(-MAX_TRIPWIRE_ENTRIES);
+    localStorage.setItem(TRIPWIRE_KEY, JSON.stringify(next));
+    console.warn(
+      `[SelfOverride] a non-empty per-space override was written onto our OWN row ` +
+        `for space ${input.spaceId.slice(0, 12)}. Only Space Settings → Account ` +
+        `should do this. See ${TRIPWIRE_KEY} in localStorage.`,
+      entry.stack
+    );
+  } catch {
+    // Diagnostics must never break a write.
+  }
+}
+
+export function readSelfOverrideTripwire(): SelfOverrideWrite[] {
+  try {
+    const raw = localStorage.getItem(TRIPWIRE_KEY);
+    return raw ? (JSON.parse(raw) as SelfOverrideWrite[]) : [];
+  } catch {
+    return [];
+  }
+}

--- a/src/utils/spaceProfilePayload.ts
+++ b/src/utils/spaceProfilePayload.ts
@@ -77,12 +77,14 @@ export const buildSpaceProfileWirePayload = (
   config: GlobalProfileFields,
   resolvedTag?: BroadcastSpaceTag | null
 ): SpaceProfileWireFields => {
-  const nameOverride = ownMember?.display_name || undefined;
+  // `??`, not `||`: '' is the wire's deliberate clear and MUST survive to the
+  // payload. With `||` a clear and a never-set field produced the same omitted
+  // field, so clearing a per-space name never left this device.
+  const nameOverride = ownMember?.display_name;
   // The member avatar lives on `user_icon` (the typed UserProfile field), but
   // some rows also carry `profile_image` from other write paths, so read both.
-  const iconOverride =
-    ownMember?.user_icon || ownMember?.profile_image || undefined;
-  const bioOverride = ownMember?.bio || undefined;
+  const iconOverride = ownMember?.user_icon ?? ownMember?.profile_image;
+  const bioOverride = ownMember?.bio;
 
   const globalName = config.name || undefined;
   const globalIcon = config.profile_image || undefined;


### PR DESCRIPTION
Your own name and avatar were different on different screens, and a rename made on your phone never reached most of them. Measured on a real account: the NavRail showed one name, User Settings showed another, and five spaces rendered four more.

There was no single cause. Identity lives in three stores, and each screen picked one.

## What was wrong

**A store nothing syncs.** The NavRail avatar and tooltip, the DM self entry and search results all read a device-local `localStorage` record that only that device's own profile save ever writes. A rename made elsewhere had no path to it — not lag, no path at all.

**A slot that outranks everything and never decays.** Joining a space stamped your current global name into the *per-space override* slot, which beats every later update. The on-connect announce then read that value back off the row and re-sent it, so it was refreshed on every connect rather than ageing out. After the first announce it was byte-for-byte identical to a name you had deliberately chosen, so nothing could tell them apart.

**A clear that could not travel.** The payload builder collapsed `''` and "absent" into the same omitted field, so clearing a per-space name never left the device — it only stopped being re-sent.

**A tier that was only a comparator.** `resolveSpaceMemberName` read the global slot to judge whether a roster name was deliberate, but never returned it. Surfaces passing the raw roster field fell through to a truncated address. Latent only while every row carried a stamp; clearing the stamps made it live immediately, and the same gap existed for avatars and bios.

## What changed

- The synced config now reconciles into the device-local record, repairing ~15 read sites through one write. It never writes an empty name: a cold start returns a nameless config, and all those sites share one object.
- Nothing authors your own override slot any more — not join, not the legacy-owner repair, not a sync delta from a peer.
- An incoming join is filed as a *global* identity, so new members stop being frozen under the name they had at that moment.
- A one-time migration clears the existing stamps. It broadcasts rather than writing locally, stamps a timestamp so an un-migrated sibling device cannot undo it, records what it destroyed, and is sequenced ahead of the first announce.
- The global slot is a real resolver tier for names, avatars and bios: override → QNS → global → address.

## Safety

Desktop only. No wire-format change, no `quorum-shared` change, no mobile release dependency.

Two instruments ship with it, because "no code path writes our own override" is an exhaustive negative that unit tests cannot prove — two extra write vectors were found while that claim was being written:

- `quorum:diag:selfOverrideWrites` records any unexpected write with a stack trace, and never blocks one.
- `quorum:diag:clearedSpaceOverrides` records what the irreversible migration removed.

## Verification

1004 tests, typecheck and lint clean. Several tests were made to fail on purpose to confirm they could: reverting the join fix turns two assertions red, and removing the migration's self-filter shows it would have wiped another member's deliberately chosen name.

Device-verified by the reporter: name, avatar and member list correct; a rename on mobile reaches desktop without a reload; per-space name and bio set and cleared correctly.

Two device checks remain outstanding and are noted in the issue: the notifications drawer, and how other members render in a busy space.

## Not fixed here

The long-standing "members show as a truncated address" problem is the P2P roster pull and announce gap, and is untouched. This helps only the subset whose identity arrived in the global slot but was being read from the wrong one.

## Also found

Four unrelated problems surfaced and are filed separately: the config upload has no size guard and fails silently on mobile release builds; the two clients merge different config fields, so device names and user notes can be clobbered; the roster diff in `quorum-shared` has no self-exclusion; and bookmarks are 94% embedded sender avatars, 69% of the whole config blob.

A deferred architecture for moving per-space profiles into the config blob was designed, then **killed by measurement** before being built — the space roster already carries them between a user's own devices, live, which the blob would not have.
