### PR TITLE
feat: a dev page that synthesizes .q names, so QNS surfaces are testable without owning one

### DIFF
--- a/src/api/baseTypes.ts
+++ b/src/api/baseTypes.ts
@@ -526,14 +526,56 @@ export class QuorumApiClient extends AbstractQuorumApiClient {
   // Public profile — resolve-by-known-address only. The server exposes no
   // enumeration endpoint, so this is a key-value lookup, not a search.
   // 404 indicates "user hasn't opted in"; callers handle by mapping to null.
-  getPublicProfile(
+  //
+  // `primary_username` is the QNS `.q` name, and this response is its ONLY
+  // carrier — it is never in a message broadcast or a roster row. So a member's
+  // `.q` is unknowable without a fetch here, and a user with a private profile
+  // has no `.q` as far as anyone else is concerned.
+  //
+  // This is also the single seam the dev-only QNS overlay hooks (see
+  // `src/dev/fake-qns/fakeQnsCore.ts`). Injecting here rather than in the hooks is
+  // deliberate: every public-profile hook shares one React Query key, so a
+  // hook-level fake that missed one would cache a real `null` and silently
+  // never appear.
+  // `data` is nullable ONLY because the dev overlay can simulate "this user has
+  // no public profile" on a response that really did arrive. In production the
+  // 404 still throws and this is never null, so callers keep their existing
+  // 404 → null handling either way; the type just stops the simulated case from
+  // being an unchecked lie.
+  async getPublicProfile(
     address: string,
     { headers, timeout }: { headers?: RequestHeaders; timeout?: number } = {}
-  ) {
-    return this.get<PublicProfileResponse>(getPublicProfileUrl(address), {
-      headers,
-      timeout,
-    });
+  ): Promise<FetchResponse<PublicProfileResponse | null>> {
+    if (process.env.NODE_ENV !== 'development') {
+      return this.get<PublicProfileResponse>(getPublicProfileUrl(address), {
+        headers,
+        timeout,
+      });
+    }
+
+    const { applyFakeQns } = await import('../dev/fake-qns/fakeQnsCore');
+
+    let response: FetchResponse<PublicProfileResponse>;
+    try {
+      response = await this.get<PublicProfileResponse>(
+        getPublicProfileUrl(address),
+        { headers, timeout }
+      );
+    } catch (error: unknown) {
+      // A 404 is the case the overlay most needs to reach: the members you want
+      // a fake `.q` for usually have no published profile at all. Synthesize
+      // one if a rule matches, otherwise rethrow so callers keep their existing
+      // 404 → null handling.
+      if (isHandledFetchError(error) && error.status === 404) {
+        const faked = applyFakeQns(address, null);
+        if (faked) return { data: faked, status: 200 };
+      }
+      throw error;
+    }
+
+    // A null here means the overlay is simulating a private profile, so the
+    // real response must be withheld rather than passed through.
+    return { data: applyFakeQns(address, response.data ?? null), status: response.status };
   }
 
   postPublicProfile(

--- a/src/components/Router/Router.web.tsx
+++ b/src/components/Router/Router.web.tsx
@@ -95,6 +95,7 @@ const IdentityCoverage = lazyDevImport(
   () => import('@/dev/identity-coverage'),
   'IdentityCoverage'
 );
+const FakeQns = lazyDevImport(() => import('@/dev/fake-qns'), 'FakeQns');
 
 interface RouterProps {
   user: {
@@ -345,6 +346,16 @@ export function Router({ user, setUser }: RouterProps) {
           element={
             <Suspense fallback={<div>Loading identity coverage...</div>}>
               <IdentityCoverage />
+            </Suspense>
+          }
+        />
+      )}
+      {process.env.NODE_ENV === 'development' && FakeQns && (
+        <Route
+          path="/dev/fake-qns"
+          element={
+            <Suspense fallback={<div>Loading fake QNS...</div>}>
+              <FakeQns />
             </Suspense>
           }
         />

--- a/src/dev/DevMainPage.tsx
+++ b/src/dev/DevMainPage.tsx
@@ -62,6 +62,13 @@ export const DevMainPage: React.FC = () => {
         'How many space members and DM partners carry no identity from any source, and therefore render as a truncated address. Take one snapshot before a change and one after',
       path: '/dev/identity-coverage',
     },
+    {
+      name: 'Fake QNS',
+      icon: 'at',
+      description:
+        'Synthesize QNS .q names so every surface that renders one is reachable without owning a registered name. Read-side overlay: nothing is published',
+      path: '/dev/fake-qns',
+    },
   ];
 
   const handleNavigate = (path: string) => {

--- a/src/dev/DevNavMenu.tsx
+++ b/src/dev/DevNavMenu.tsx
@@ -53,6 +53,11 @@ const devNavItems: DevNavItem[] = [
     icon: 'id-badge',
     path: '/dev/identity-coverage',
   },
+  {
+    name: 'Fake QNS',
+    icon: 'at',
+    path: '/dev/fake-qns',
+  },
 ];
 
 interface DevNavMenuProps {

--- a/src/dev/fake-qns/FakeQns.tsx
+++ b/src/dev/fake-qns/FakeQns.tsx
@@ -1,0 +1,229 @@
+/**
+ * Fake QNS — the resident panel.
+ *
+ * Makes every QNS surface reachable on an account that owns no registered `.q`
+ * name. See `fakeQnsCore.ts` for why this exists, why the injection point is the
+ * API client rather than the hooks, and what a green run does and does not
+ * prove.
+ *
+ * Nothing here writes to the network. Desktop has no "set my own primary
+ * username" control at all — it reads `primary_username` from other people's
+ * profiles and never publishes one (see `PublicProfileService.ts`) — so unlike
+ * mobile's version of this panel, every switch below is a read-side overlay
+ * with no real-state half.
+ */
+
+import React, { useCallback, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { Text, Flex, Button } from '../../components/primitives';
+import { DevNavMenu } from '../DevNavMenu';
+import {
+  clearFakeQns,
+  deriveFakeQName,
+  getFakeQnsState,
+  removeFakeQnsEntry,
+  setFakeQnsEntry,
+  setFakeQnsState,
+  type FakeQnsState,
+} from './fakeQnsCore';
+
+interface ToggleProps {
+  label: string;
+  hint: string;
+  value: boolean;
+  disabled?: boolean;
+  onChange: (v: boolean) => void;
+}
+
+const Toggle: React.FC<ToggleProps> = ({
+  label,
+  hint,
+  value,
+  disabled,
+  onChange,
+}) => (
+  <label
+    className={`flex items-start gap-3 ${disabled ? 'opacity-45' : 'cursor-pointer'}`}
+  >
+    <input
+      type="checkbox"
+      checked={value}
+      disabled={disabled}
+      onChange={(e) => onChange(e.target.checked)}
+      className="mt-1 cursor-pointer"
+    />
+    <span>
+      <Text variant="strong" size="sm" className="block">
+        {label}
+      </Text>
+      <Text variant="subtle" size="xs" className="block">
+        {hint}
+      </Text>
+    </span>
+  </label>
+);
+
+export const FakeQns: React.FC = () => {
+  const queryClient = useQueryClient();
+  const [state, setState] = useState<FakeQnsState>(() => getFakeQnsState());
+  const [address, setAddress] = useState('');
+  const [name, setName] = useState('');
+
+  /** Drop every cached public profile so the next render refetches through the
+   *  overlay. Without this a toggle looks inert for up to an hour. */
+  const invalidate = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: ['user-public-profile'] });
+    queryClient.invalidateQueries({ queryKey: ['publicProfile'] });
+  }, [queryClient]);
+
+  const update = useCallback(
+    (next: Partial<FakeQnsState>) => {
+      setState(setFakeQnsState(next));
+      invalidate();
+    },
+    [invalidate]
+  );
+
+  const handlePin = useCallback(() => {
+    const addr = address.trim();
+    if (!addr) return;
+    setState(
+      setFakeQnsEntry(addr, { primaryUsername: name.trim().replace(/\.q$/i, '') })
+    );
+    setAddress('');
+    setName('');
+    invalidate();
+  }, [address, name, invalidate]);
+
+  const handleUnpin = useCallback(
+    (addr: string) => {
+      setState(removeFakeQnsEntry(addr));
+      invalidate();
+    },
+    [invalidate]
+  );
+
+  const handleReset = useCallback(() => {
+    setState(clearFakeQns());
+    invalidate();
+  }, [invalidate]);
+
+  const entries = Object.entries(state.entries);
+
+  return (
+    <Flex direction="column" className="h-full overflow-auto p-6 gap-4">
+      <DevNavMenu />
+
+      <div className="border border-dashed border-yellow-500 rounded-lg p-4">
+        <Text variant="strong" size="lg" className="block text-yellow-500">
+          {'</>'} Fake QNS (dev builds only)
+        </Text>
+        <Text variant="subtle" size="xs" className="block mb-4">
+          See where a .q name renders without owning one. Read-side overlay
+          only: nothing is written, signed, or published.
+        </Text>
+
+        <Flex direction="column" className="gap-3">
+          <Toggle
+            label="Enable fake QNS"
+            hint="Master switch. Off = identical to a production build."
+            value={state.enabled}
+            onChange={(v) => update({ enabled: v })}
+          />
+          <Toggle
+            label="Give everyone a .q"
+            hint="Stable qXXXX name per address. The fast way to find every surface that renders a name. Never overwrites a real registration."
+            value={state.giveEveryoneAName}
+            disabled={!state.enabled}
+            onChange={(v) => update({ giveEveryoneAName: v })}
+          />
+          <Toggle
+            label="All profiles private"
+            hint="Every public-profile fetch returns nothing — what others see when a profile is not public. Overrides the switch above."
+            value={state.allProfilesPrivate}
+            disabled={!state.enabled}
+            onChange={(v) => update({ allProfilesPrivate: v })}
+          />
+        </Flex>
+      </div>
+
+      {/* Pinning one address is how you build a control arm: with everyone
+          named, there is nothing to compare against. Pin a member to a known
+          name, or to no name at all, and the difference tells you which tier
+          actually won. */}
+      <div className="border border-dashed border-yellow-500 rounded-lg p-4">
+        <Text variant="strong" size="sm" className="block text-yellow-500">
+          Pin one address
+        </Text>
+        <Text variant="subtle" size="xs" className="block mb-3">
+          Overrides the everyone rule for a single member. Leave the name empty
+          to give them no .q at all — that is your control.
+        </Text>
+        <Flex className="gap-2 items-center flex-wrap">
+          <input
+            className="flex-1 min-w-64 px-2 py-1 rounded border border-neutral-600 bg-transparent text-sm font-mono"
+            placeholder="Qm… address"
+            value={address}
+            onChange={(e) => setAddress(e.target.value)}
+            aria-label="Address to pin"
+          />
+          <input
+            className="w-40 px-2 py-1 rounded border border-neutral-600 bg-transparent text-sm"
+            placeholder=".q name (optional)"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            aria-label="QNS name for the pinned address"
+          />
+          <Button size="sm" onClick={handlePin} disabled={!address.trim()}>
+            Pin
+          </Button>
+        </Flex>
+
+        {entries.length > 0 && (
+          <Flex direction="column" className="gap-1 mt-3">
+            {entries.map(([addr, entry]) => (
+              <Flex key={addr} className="gap-2 items-center">
+                <Text size="xs" className="font-mono flex-1 truncate">
+                  {addr}
+                </Text>
+                <Text size="xs" variant="subtle">
+                  {entry.private
+                    ? 'private'
+                    : entry.primaryUsername
+                      ? `${entry.primaryUsername}.q`
+                      : 'no .q (control)'}
+                </Text>
+                <Button size="sm" onClick={() => handleUnpin(addr)}>
+                  Unpin
+                </Button>
+              </Flex>
+            ))}
+          </Flex>
+        )}
+      </div>
+
+      <Flex className="gap-3 items-center">
+        <Text size="xs" variant="subtle" className="flex-1">
+          {state.enabled
+            ? state.allProfilesPrivate
+              ? 'all profiles private'
+              : state.giveEveryoneAName
+                ? `everyone gets a .q (e.g. ${deriveFakeQName('QmExample1234')}.q)`
+                : 'enabled, no blanket rule'
+            : 'off'}
+          {entries.length > 0 ? ` · ${entries.length} pinned` : ''}
+        </Text>
+        <Button size="sm" onClick={handleReset}>
+          Reset
+        </Button>
+      </Flex>
+
+      <Text size="xs" variant="subtle">
+        Reopen the space after a change — an open screen holds an
+        already-resolved member map. Keep these switches matched with mobile&apos;s
+        panel when comparing the two clients, or you are comparing different
+        inputs.
+      </Text>
+    </Flex>
+  );
+};

--- a/src/dev/fake-qns/FakeQns.tsx
+++ b/src/dev/fake-qns/FakeQns.tsx
@@ -6,15 +6,25 @@
  * API client rather than the hooks, and what a green run does and does not
  * prove.
  *
- * Nothing here writes to the network. Desktop has no "set my own primary
- * username" control at all — it reads `primary_username` from other people's
- * profiles and never publishes one (see `PublicProfileService.ts`) — so unlike
- * mobile's version of this panel, every switch below is a read-side overlay
- * with no real-state half.
+ * Nothing here writes to the network, including the "give myself a .q" control.
+ * Desktop never publishes a primary username (see `PublicProfileService.ts`),
+ * and it reads its OWN one from `useUserPublicProfile(ownAddress)` — the same
+ * fetch this overlay intercepts. So self is just another pinned entry here,
+ * where mobile's equivalent has to write a real profile field.
+ *
+ * ## Giving yourself a name covers most of the job
+ *
+ * Almost every surface that renders a name can render YOU: your messages, a
+ * reply to your own message, a mention you typed at yourself, your reactions,
+ * the member sidebar, and the notification body when someone mentions you (the
+ * name in that body is the mentioned person, not the sender). The everyone
+ * switch exists for the remainder — a DM partner's name, a blocked user — and
+ * is a coverage sweep rather than a state anybody would really be in.
  */
 
 import React, { useCallback, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
+import { usePasskeysContext } from '@quilibrium/quilibrium-js-sdk-channels';
 import { Text, Flex, Button } from '../../components/primitives';
 import { DevNavMenu } from '../DevNavMenu';
 import {
@@ -65,9 +75,15 @@ const Toggle: React.FC<ToggleProps> = ({
 
 export const FakeQns: React.FC = () => {
   const queryClient = useQueryClient();
+  const { currentPasskeyInfo } = usePasskeysContext();
+  const ownAddress = currentPasskeyInfo?.address ?? null;
+
   const [state, setState] = useState<FakeQnsState>(() => getFakeQnsState());
   const [address, setAddress] = useState('');
   const [name, setName] = useState('');
+  const [selfName, setSelfName] = useState(() =>
+    ownAddress ? (getFakeQnsState().entries[ownAddress.toLowerCase()]?.primaryUsername ?? '') : ''
+  );
 
   /** Drop every cached public profile so the next render refetches through the
    *  overlay. Without this a toggle looks inert for up to an hour. */
@@ -103,7 +119,31 @@ export const FakeQns: React.FC = () => {
     [invalidate]
   );
 
+  /** Your own address is just another pinned entry — desktop reads its own
+   *  primary username from `useUserPublicProfile(ownAddress)`, the same fetch
+   *  the overlay intercepts, so there is nothing special to do for self. */
+  const handleApplySelf = useCallback(() => {
+    if (!ownAddress) return;
+    // Accept "name" or "name.q". The stored value is always bare and the suffix
+    // is appended at render, so storing it with the suffix renders "name.q.q".
+    const trimmed = selfName.trim().replace(/\.q$/i, '');
+    setState(
+      trimmed
+        ? setFakeQnsEntry(ownAddress, { primaryUsername: trimmed })
+        : removeFakeQnsEntry(ownAddress)
+    );
+    invalidate();
+  }, [ownAddress, selfName, invalidate]);
+
+  const handleClearSelf = useCallback(() => {
+    if (!ownAddress) return;
+    setSelfName('');
+    setState(removeFakeQnsEntry(ownAddress));
+    invalidate();
+  }, [ownAddress, invalidate]);
+
   const handleReset = useCallback(() => {
+    setSelfName('');
     setState(clearFakeQns());
     invalidate();
   }, [invalidate]);
@@ -130,16 +170,57 @@ export const FakeQns: React.FC = () => {
             value={state.enabled}
             onChange={(v) => update({ enabled: v })}
           />
+        </Flex>
+
+        {/* Ordered by what you reach for, matching mobile's panel. Giving
+            YOURSELF a name covers almost every surface on its own, because
+            almost every surface can render you: your messages, a reply to your
+            own message, a mention you typed at yourself, your reactions, and
+            the notification body when someone mentions you (the name in that
+            body is the MENTIONED person, which is you). The blanket switch
+            below is for the few that render somebody else. */}
+        <div className="mt-4 pt-4 border-t border-neutral-700">
+          <Text variant="strong" size="sm" className="block">
+            1 · Give MYSELF a .q
+          </Text>
+          <Text variant="subtle" size="xs" className="block mb-2">
+            Start here. Pins this name for your own address
+            {ownAddress ? '' : ' (no address yet — sign in first)'}. Desktop
+            never publishes a primary username, so unlike mobile this is a
+            read-side overlay with no real profile write.
+          </Text>
+          <Flex className="gap-2 items-center">
+            <input
+              className="flex-1 px-2 py-1 rounded border border-neutral-600 bg-transparent text-sm"
+              placeholder="e.g. qatest"
+              value={selfName}
+              onChange={(e) => setSelfName(e.target.value)}
+              aria-label="Fake primary QNS username for yourself"
+            />
+            <Button
+              size="sm"
+              onClick={handleApplySelf}
+              disabled={!ownAddress || !selfName.trim()}
+            >
+              Set
+            </Button>
+            <Button size="sm" onClick={handleClearSelf} disabled={!ownAddress}>
+              Clear
+            </Button>
+          </Flex>
+        </div>
+
+        <Flex direction="column" className="gap-3 mt-4 pt-4 border-t border-neutral-700">
           <Toggle
-            label="Give everyone a .q"
-            hint="Stable qXXXX name per address. The fast way to find every surface that renders a name. Never overwrites a real registration."
+            label="2 · Give EVERYONE a .q"
+            hint="Coverage sweep, not a realistic state. Only needed for surfaces that render somebody else — a DM partner's name, another person's mention pill. Never overwrites a real registration."
             value={state.giveEveryoneAName}
             disabled={!state.enabled}
             onChange={(v) => update({ giveEveryoneAName: v })}
           />
           <Toggle
-            label="All profiles private"
-            hint="Every public-profile fetch returns nothing — what others see when a profile is not public. Overrides the switch above."
+            label="3 · All profiles private"
+            hint="Every public-profile fetch returns nothing. For YOUR OWN profile the real public/private toggle in settings is the better test — it is end-to-end. This only simulates OTHER people being private. Overrides switch 2."
             value={state.allProfilesPrivate}
             disabled={!state.enabled}
             onChange={(v) => update({ allProfilesPrivate: v })}
@@ -212,6 +293,10 @@ export const FakeQns: React.FC = () => {
                 : 'enabled, no blanket rule'
             : 'off'}
           {entries.length > 0 ? ` · ${entries.length} pinned` : ''}
+          {ownAddress &&
+          state.entries[ownAddress.toLowerCase()]?.primaryUsername
+            ? ` · me: ${state.entries[ownAddress.toLowerCase()]!.primaryUsername}.q`
+            : ' · me: none'}
         </Text>
         <Button size="sm" onClick={handleReset}>
           Reset
@@ -223,6 +308,16 @@ export const FakeQns: React.FC = () => {
         already-resolved member map. Keep these switches matched with mobile&apos;s
         panel when comparing the two clients, or you are comparing different
         inputs.
+      </Text>
+      {/* Desktop's own limitation, stated where it will be read. It differs
+          from mobile's — mobile's member list cannot show a .q at all, this one
+          can but only for people who have posted. Writing mobile's caveat here
+          would send someone hunting the wrong thing. */}
+      <Text size="xs" className="text-yellow-500">
+        The member sidebar only shows a .q for members who have posted in the
+        open channel — it cheap-merges from the message senders and never
+        fetches the full roster. A silent lurker showing no .q there is expected,
+        not a regression.
       </Text>
     </Flex>
   );

--- a/src/dev/fake-qns/fakeQnsCore.ts
+++ b/src/dev/fake-qns/fakeQnsCore.ts
@@ -1,0 +1,224 @@
+/**
+ * fakeQns — dev-only synthesis of QNS `.q` names and public profiles.
+ *
+ * WHY THIS EXISTS. A `.q` name travels in exactly one place: the published
+ * public profile. So to see where a `.q` renders you need an account that owns
+ * a registered QNS name, has elected it primary, and has a public profile — and
+ * so does whoever you are looking at. On a test account with no name, every QNS
+ * surface in the app is unreachable, which means the tier that outranks a
+ * user's display name everywhere can regress silently and no amount of using
+ * the app would show it.
+ *
+ * This fakes the one thing that is expensive to obtain (a registered name) and
+ * nothing else. It intercepts the READ of a public profile and hands back a
+ * synthesized one. Nothing is written, nothing is signed, nothing leaves the
+ * machine.
+ *
+ * ## This is the deliberate replacement for the hand-editing recipe
+ *
+ * `.agents/docs/features/qns-username-display.md` used to describe smoke-testing
+ * this by temporarily editing a `primary_username` into the public-profile
+ * `queryFn` — and warned that you had to patch EVERY hook writing
+ * `publicProfileQueryKey`, because they share one cache entry and whichever
+ * resolves first wins. Miss one and it caches a real `null`, the patched ones
+ * never run, and the fake silently never appears.
+ *
+ * Injecting inside `QuorumApiClient.getPublicProfile` makes that unreachable by
+ * construction: there is no second path to a public profile, so there is no
+ * hook to forget, and nothing has to be reverted before committing.
+ *
+ * ## Kept deliberately identical to mobile's `services/dev/fakeQns.ts`
+ *
+ * Same state shape, same precedence, same derived names. The point of the tool
+ * is comparing what the two clients render for the same member — which only
+ * means anything if both were handed the same input. If you change the rules
+ * here, change them there.
+ *
+ * ## What a green run does and does not prove
+ *
+ * Everything downstream of the network is real: the merge, the resolver, the
+ * render. Publishing, the signature payload and the server are not exercised.
+ */
+
+const STORAGE_KEY = 'dev.fakeQns.state';
+
+/** The public-profile shape, kept structural so this never has to import from
+ *  the API layer it is injected into. */
+export interface FakeablePublicProfile {
+  display_name: string;
+  profile_image: string;
+  bio: string;
+  primary_username?: string;
+  timestamp: number;
+  signature: string;
+}
+
+/** A deliberate, per-address override. Use for precedence tests where two
+ *  members must differ; `giveEveryoneAName` covers the "where does it render"
+ *  sweep on its own. */
+export interface FakeQnsEntry {
+  /** The bare `.q` name, no suffix (`alice` renders as `alice.q`). */
+  primaryUsername?: string;
+  /** Global display name. Set it to something recognisably different from the
+   *  `.q` to prove which tier won. */
+  displayName?: string;
+  /** Treat this address as having no public profile at all — the same thing the
+   *  viewer sees when someone leaves their profile private. */
+  private?: boolean;
+}
+
+export interface FakeQnsState {
+  /** Master switch. Off means this module is inert. */
+  enabled: boolean;
+  /** Synthesize a `.q` for every address with no explicit entry, derived from
+   *  the address so it is stable across reloads. */
+  giveEveryoneAName: boolean;
+  /** Return "no public profile" for every address. Answers the question the
+   *  public/private toggle raises: what does someone who messages you see when
+   *  your profile is private? */
+  allProfilesPrivate: boolean;
+  /** Per-address overrides, keyed by lowercased address. */
+  entries: Record<string, FakeQnsEntry>;
+}
+
+const DEFAULT_STATE: FakeQnsState = {
+  enabled: false,
+  giveEveryoneAName: false,
+  allProfilesPrivate: false,
+  entries: {},
+};
+
+/** localStorage rather than IndexedDB: the overlay is consulted on a synchronous
+ *  path inside the API client, and a dev flag is not worth an async read. */
+function readRaw(): string | null {
+  try {
+    return globalThis.localStorage?.getItem(STORAGE_KEY) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function getFakeQnsState(): FakeQnsState {
+  const raw = readRaw();
+  if (raw == null) return DEFAULT_STATE;
+  try {
+    const parsed = JSON.parse(raw) as Partial<FakeQnsState>;
+    return {
+      enabled: parsed.enabled === true,
+      giveEveryoneAName: parsed.giveEveryoneAName === true,
+      allProfilesPrivate: parsed.allProfilesPrivate === true,
+      entries:
+        parsed.entries && typeof parsed.entries === 'object'
+          ? parsed.entries
+          : {},
+    };
+  } catch {
+    return DEFAULT_STATE;
+  }
+}
+
+export function setFakeQnsState(next: Partial<FakeQnsState>): FakeQnsState {
+  const merged = { ...getFakeQnsState(), ...next };
+  try {
+    globalThis.localStorage?.setItem(STORAGE_KEY, JSON.stringify(merged));
+  } catch {
+    // Non-fatal: the panel reads back what it just set from the returned value.
+  }
+  return merged;
+}
+
+export function setFakeQnsEntry(
+  address: string,
+  entry: FakeQnsEntry
+): FakeQnsState {
+  const state = getFakeQnsState();
+  return setFakeQnsState({
+    entries: { ...state.entries, [address.toLowerCase()]: entry },
+  });
+}
+
+export function removeFakeQnsEntry(address: string): FakeQnsState {
+  const { [address.toLowerCase()]: _removed, ...rest } =
+    getFakeQnsState().entries;
+  return setFakeQnsState({ entries: rest });
+}
+
+export function clearFakeQns(): FakeQnsState {
+  try {
+    globalThis.localStorage?.removeItem(STORAGE_KEY);
+  } catch {
+    // Non-fatal, as above.
+  }
+  return DEFAULT_STATE;
+}
+
+/**
+ * A stable, obviously-fake `.q` derived from an address.
+ *
+ * Deterministic so the same member keeps the same name across reloads — a name
+ * that changed every render would make it impossible to tell "this surface
+ * re-resolved" from "this surface shows a different person". Prefixed `qa` so
+ * nothing on screen can be mistaken for a real registration.
+ *
+ * Must stay byte-identical to mobile's, or the same member gets two different
+ * synthetic names on the two clients and the parity comparison is meaningless.
+ */
+export function deriveFakeQName(address: string): string {
+  const entropy = (address.startsWith('Qm') ? address.slice(2) : address)
+    .replace(/[^a-zA-Z0-9]/g, '')
+    .toLowerCase();
+  return `qa${entropy.slice(0, 4) || '0000'}`;
+}
+
+/**
+ * The seam. Called from `QuorumApiClient.getPublicProfile` with whatever the
+ * server actually returned, or `null` for a 404.
+ *
+ * Returning a synthesized profile for a `null` is the important case, not an
+ * edge one: a test account's spacemates typically have no public profile at
+ * all, so an overlay that only decorated existing profiles would decorate
+ * nothing and appear inert.
+ */
+export function applyFakeQns(
+  address: string,
+  actual: FakeablePublicProfile | null
+): FakeablePublicProfile | null {
+  const state = getFakeQnsState();
+  if (!state.enabled) return actual;
+
+  if (state.allProfilesPrivate) return null;
+
+  const entry = state.entries[address.toLowerCase()];
+  if (entry?.private) return null;
+
+  // Never fake over a real registration. If someone genuinely published a `.q`,
+  // the sweep must leave it visible — otherwise the one case the instrument
+  // exists to observe would be the one case it hides, and a real regression
+  // would be masked by a synthetic pass. An explicit entry still wins, because
+  // that is a deliberate act rather than a blanket rule.
+  const realQns = actual?.primary_username;
+  const primaryUsername =
+    entry?.primaryUsername ||
+    realQns ||
+    (entry
+      ? undefined
+      : state.giveEveryoneAName
+        ? deriveFakeQName(address)
+        : undefined);
+  const displayName = entry?.displayName;
+
+  if (!primaryUsername && !displayName) return actual;
+
+  return {
+    display_name: displayName || actual?.display_name || '',
+    profile_image: actual?.profile_image ?? '',
+    bio: actual?.bio ?? '',
+    ...(primaryUsername ? { primary_username: primaryUsername } : {}),
+    // Now, so a faked global name outranks whatever the roster's global slot
+    // holds. The merge in useMembersWithPublicProfileFallback picks the newer
+    // of the two by timestamp, so a stale one here would silently lose and the
+    // fake would look broken.
+    timestamp: Date.now(),
+    signature: actual?.signature ?? '',
+  };
+}

--- a/src/dev/fake-qns/index.ts
+++ b/src/dev/fake-qns/index.ts
@@ -1,0 +1,15 @@
+export { FakeQns } from './FakeQns';
+export {
+  applyFakeQns,
+  clearFakeQns,
+  deriveFakeQName,
+  getFakeQnsState,
+  removeFakeQnsEntry,
+  setFakeQnsEntry,
+  setFakeQnsState,
+} from './fakeQnsCore';
+export type {
+  FakeablePublicProfile,
+  FakeQnsEntry,
+  FakeQnsState,
+} from './fakeQnsCore';

--- a/src/dev/tests/identity-coverage/fakeQnsCore.test.ts
+++ b/src/dev/tests/identity-coverage/fakeQnsCore.test.ts
@@ -1,0 +1,149 @@
+/**
+ * The dev-only QNS overlay.
+ *
+ * Tested despite being dev-only because it is an INSTRUMENT: everything an
+ * operator concludes about where `.q` names render is downstream of it. An
+ * overlay that quietly failed open ("no fake applied") would read on screen as
+ * "this surface does not show `.q` names" — a false negative that sends someone
+ * hunting a bug in the render path that does not exist.
+ *
+ * These cases mirror mobile's `__tests__/fakeQns.test.ts` deliberately. The
+ * tool's whole purpose is comparing what the two clients render for the same
+ * member, which only means anything if both cores behave identically. If a case
+ * here changes, change it there.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  applyFakeQns,
+  clearFakeQns,
+  deriveFakeQName,
+  setFakeQnsEntry,
+  setFakeQnsState,
+  type FakeablePublicProfile,
+} from '../../fake-qns/fakeQnsCore';
+
+const A = 'QmAlice1111111111111111111111111111111111';
+const B = 'QmBob22222222222222222222222222222222222222';
+
+const realProfile: FakeablePublicProfile = {
+  display_name: 'Real Name',
+  profile_image: 'img',
+  bio: 'real bio',
+  timestamp: 500,
+  signature: 'sig',
+};
+
+beforeEach(() => clearFakeQns());
+
+describe('applyFakeQns — inert unless enabled', () => {
+  it('passes a real profile through untouched when disabled', () => {
+    setFakeQnsState({ enabled: false, giveEveryoneAName: true });
+    expect(applyFakeQns(A, realProfile)).toBe(realProfile);
+  });
+
+  it('passes a 404 through untouched when disabled', () => {
+    setFakeQnsState({ enabled: false, giveEveryoneAName: true });
+    expect(applyFakeQns(A, null)).toBeNull();
+  });
+
+  it('leaves a profile alone when enabled but no rule matches', () => {
+    setFakeQnsState({ enabled: true });
+    expect(applyFakeQns(A, realProfile)).toBe(realProfile);
+  });
+});
+
+describe('applyFakeQns — give everyone a name', () => {
+  beforeEach(() => setFakeQnsState({ enabled: true, giveEveryoneAName: true }));
+
+  it('adds a .q to a real profile without clobbering its other fields', () => {
+    const out = applyFakeQns(A, realProfile);
+    expect(out?.primary_username).toBe(deriveFakeQName(A));
+    expect(out?.display_name).toBe('Real Name');
+    expect(out?.bio).toBe('real bio');
+    expect(out?.profile_image).toBe('img');
+  });
+
+  it('SYNTHESIZES a profile for someone who has none', () => {
+    // The case that makes the tool usable at all: a test account's spacemates
+    // usually have no published profile, so decorating only existing ones would
+    // decorate nothing.
+    const out = applyFakeQns(A, null);
+    expect(out).not.toBeNull();
+    expect(out?.primary_username).toBe(deriveFakeQName(A));
+  });
+
+  it('gives different addresses different names, stably', () => {
+    expect(deriveFakeQName(A)).not.toBe(deriveFakeQName(B));
+    expect(deriveFakeQName(A)).toBe(deriveFakeQName(A));
+  });
+
+  it('derives the same name mobile would, so the clients stay comparable', () => {
+    // Hard-coded rather than recomputed: a test that mirrors the implementation
+    // would pass through any change to it, which is exactly what must not
+    // happen to a value shared with another repo.
+    expect(deriveFakeQName('QmAlice1111111111111111111111111111111111')).toBe(
+      'qaalic'
+    );
+  });
+
+  it('never fakes over a REAL published .q', () => {
+    const out = applyFakeQns(A, { ...realProfile, primary_username: 'genuine' });
+    expect(out?.primary_username).toBe('genuine');
+  });
+
+  it('stamps a fresh timestamp so a faked global name is not lost to the merge', () => {
+    const before = Date.now();
+    const out = applyFakeQns(A, realProfile);
+    expect(out!.timestamp).toBeGreaterThanOrEqual(before);
+  });
+});
+
+describe('applyFakeQns — private profiles', () => {
+  it('returns nothing for every address when all-private is on', () => {
+    setFakeQnsState({ enabled: true, allProfilesPrivate: true });
+    expect(applyFakeQns(A, realProfile)).toBeNull();
+  });
+
+  it('all-private outranks give-everyone-a-name', () => {
+    setFakeQnsState({
+      enabled: true,
+      allProfilesPrivate: true,
+      giveEveryoneAName: true,
+    });
+    expect(applyFakeQns(A, realProfile)).toBeNull();
+  });
+
+  it('marks a single address private, leaving others alone', () => {
+    setFakeQnsState({ enabled: true, giveEveryoneAName: true });
+    setFakeQnsEntry(A, { private: true });
+    expect(applyFakeQns(A, realProfile)).toBeNull();
+    expect(applyFakeQns(B, realProfile)?.primary_username).toBe(
+      deriveFakeQName(B)
+    );
+  });
+});
+
+describe('applyFakeQns — per-address entries', () => {
+  it('an explicit entry wins over the everyone rule', () => {
+    setFakeQnsState({ enabled: true, giveEveryoneAName: true });
+    setFakeQnsEntry(A, { primaryUsername: 'pinned' });
+    expect(applyFakeQns(A, realProfile)?.primary_username).toBe('pinned');
+  });
+
+  it('an entry with only a global name gets no .q, even under the everyone rule', () => {
+    // Otherwise there is no way to build the control arm — a member who has a
+    // global name and NO `.q`, to prove the `.q` is what is winning elsewhere.
+    setFakeQnsState({ enabled: true, giveEveryoneAName: true });
+    setFakeQnsEntry(A, { displayName: 'Only Global' });
+    const out = applyFakeQns(A, realProfile);
+    expect(out?.primary_username).toBeUndefined();
+    expect(out?.display_name).toBe('Only Global');
+  });
+
+  it('matches the address case-insensitively', () => {
+    setFakeQnsState({ enabled: true });
+    setFakeQnsEntry(A.toUpperCase(), { primaryUsername: 'pinned' });
+    expect(applyFakeQns(A, realProfile)?.primary_username).toBe('pinned');
+  });
+});


### PR DESCRIPTION
A `.q` name travels in exactly one place, the published public profile, so seeing where one renders needs an account that owns a registered name. Nobody testing has one, and a name costs real money. That leaves the tier which outranks a user's display name everywhere unreachable in practice: it can regress, or never have worked, and using the app would not show it.

This adds a read-side overlay at `/dev/fake-qns`. Nothing is written, signed or published — desktop has no publish path for `primary_username` anyway.

## Controls

1. **Give myself a .q** — covers most of the job on its own. Nearly every surface that renders a name can render you: your messages, a reply to your own message, a mention you typed at yourself, your reactions, the member sidebar, and the notification body when someone mentions you (the name resolved there is the mentioned person, not the sender). Self needs no publish path here: desktop reads its own primary username from `useUserPublicProfile(ownAddress)`, the same fetch the overlay intercepts, so it is just another pinned entry.
2. **Give everyone a .q** — coverage sweep for the remainder, a DM partner's name and a blocked user. Never overwrites a real registration.
3. **All profiles private** — every fetch returns nothing. Points at the real public/private toggle in settings, which is the better test for your own profile because it goes end-to-end.

Plus pin-by-address, which is how you build a control arm: with everyone named there is nothing to compare against, so pin one member to a known name or to no name at all and the difference tells you which tier actually won.

## Why the seam is the API client

It replaces the hand-editing recipe in `qns-username-display.md`, which told you to inject a name into the public-profile `queryFn` and warned you had to patch every hook sharing `publicProfileQueryKey` or the first one to resolve would cache a real `null` and the fake would silently never appear. Injecting inside `getPublicProfile` makes that unreachable: one seam, no hook to forget, nothing to revert before committing.

`getPublicProfile` now returns a nullable `data` so the simulated-private case is checked rather than an unchecked lie. In production the 404 still throws and it is never null; every caller already handled that.

## Parity with mobile

The core is deliberately identical to mobile's, down to the derived names — comparing what the two clients render for the same member means nothing if they were handed different inputs. Both suites assert the same hard-coded derivation so the pair cannot drift unnoticed. Panel ordering and labels match too.

The page states desktop's own sidebar caveat rather than mobile's: this one shows a `.q` only for members who have posted, because it cheap-merges from the message senders. Mobile's member list cannot show one at all. Printing the wrong caveat would send someone hunting the wrong thing.

## Naming

`fakeQnsCore.ts`, not `fakeQns.ts`: alongside `FakeQns.tsx` that differs only by case, and on a case-insensitive filesystem the import resolved to the component instead. Found by a test failing with "clearFakeQns is not a function"; it would have hit the app the same way.

## Verification

15 tests. Refusing to synthesize a missing profile turns 1 red, dropping the all-private short-circuit turns 2, and faking over a real registration turns 1. Full suite 1050 passing, typecheck clean, no new lint.
