### PR TITLE
fix(emoji): emojis land at the cursor, and one bad copy target no longer blanks every emoji image

### DIFF
--- a/src/components/message/MessageComposer.tsx
+++ b/src/components/message/MessageComposer.tsx
@@ -19,6 +19,11 @@ import { rectAnchor, type VirtualElement } from '../ui';
 import { ENABLE_MARKDOWN, ENABLE_MENTION_PILLS } from '../../config/features';
 import { getCaretCoordinates, type CaretCoordinates } from '../../utils/caretCoordinates';
 import { extractVisualTextWithNewlines } from '../../utils/mentionPillDom';
+import {
+  readSelectionInsideEditor,
+  insertTextAtSavedCaret,
+  type SavedCaret,
+} from '../../utils/composerSelection';
 import { useTypingNotifier } from '../../hooks/business/messages/useTypingNotifier';
 import type { TypingScope } from '@quilibrium/quorum-shared';
 
@@ -165,6 +170,29 @@ export const MessageComposer = forwardRef<
     });
     const { editorRef, extractVisualText, extractStorageText, getCursorPosition, insertPill } = pillEditor;
 
+    // Last caret position seen inside the contentEditable editor. Used to put
+    // the caret back when focus has been away (emoji panel, search box, …).
+    const savedRangeRef = useRef<SavedCaret | null>(null);
+
+    useEffect(() => {
+      if (!ENABLE_MENTION_PILLS) return;
+
+      // selectionchange is the only event that fires for every way the caret
+      // can move — typing, arrow keys, clicking, dragging a selection.
+      const handleSelectionChange = () => {
+        const editor = editorRef.current;
+        if (!editor) return;
+        const range = readSelectionInsideEditor(editor);
+        // Ignore selections belonging to other elements; that is exactly the
+        // case we need the remembered one for.
+        if (range) savedRangeRef.current = range;
+      };
+
+      document.addEventListener('selectionchange', handleSelectionChange);
+      return () =>
+        document.removeEventListener('selectionchange', handleSelectionChange);
+    }, [editorRef]);
+
     // Markdown toolbar state. The anchor is a virtual element over the current
     // selection rect; FloatingPopover handles centering/flip/clamp.
     const [showMarkdownToolbar, setShowMarkdownToolbar] = useState(false);
@@ -195,19 +223,50 @@ export const MessageComposer = forwardRef<
       },
       insertEmoji: (emoji: string) => {
         if (ENABLE_MENTION_PILLS && editorRef.current) {
-          // ContentEditable mode: use execCommand to preserve mention pills
-          editorRef.current.focus();
-          document.execCommand('insertText', false, emoji);
+          // ContentEditable mode: use execCommand to preserve mention pills.
+          //
+          // Focus alone is not enough to get the caret back. Using the emoji
+          // panel moves focus out of the editor, and if it lands on a text
+          // input (the picker's search box) the document selection moves with
+          // it — after that, focus() collapses the caret to offset 0 and the
+          // emoji lands at the start of the message. Restore the last caret we
+          // saw inside the editor before inserting.
+          const editor = editorRef.current;
+          const before = extractStorageText();
+          // focus -> restore caret -> insert. The ordering lives in
+          // insertTextAtSavedCaret so it stays under test.
+          const inserted = insertTextAtSavedCaret(
+            editor,
+            emoji,
+            savedRangeRef.current
+          );
           // Trigger input handler to sync state
           const newText = extractStorageText();
+          // execCommand reports failure by returning false rather than
+          // throwing, so without this the user just sees a click that did
+          // nothing and there is no trace of it anywhere.
+          if (!inserted || newText === before) {
+            console.error('[MessageComposer] emoji insertion did nothing', {
+              emoji,
+              returned: inserted,
+            });
+          }
           onChange(newText);
           setCursorPosition(getCursorPosition());
+          // Keep the saved caret in step so a second emoji lands after the first.
+          savedRangeRef.current = readSelectionInsideEditor(editor);
         } else {
-          // TextArea mode: append emoji to current value
-          onChange(value + emoji);
-          // Focus and move cursor to end
+          // TextArea mode: insert at the caret, not at the end. A blurred
+          // textarea still reports the selection it had when it lost focus.
+          const textarea = textareaRef.current;
+          const start = textarea?.selectionStart ?? value.length;
+          const end = textarea?.selectionEnd ?? value.length;
+          onChange(value.slice(0, start) + emoji + value.slice(end));
+          // Focus and put the cursor after the inserted emoji. Order matches
+          // handleMentionSelect below; for a textarea (unlike contentEditable)
+          // focus() does not disturb an already-set selection.
           setTimeout(() => {
-            const newPos = value.length + emoji.length;
+            const newPos = start + emoji.length;
             textareaRef.current?.setSelectionRange(newPos, newPos);
             textareaRef.current?.focus();
           }, 0);

--- a/src/dev/tests/harness/setup.harness.ts
+++ b/src/dev/tests/harness/setup.harness.ts
@@ -4,7 +4,7 @@
 // Order matters: the shim must apply before the SDK bundle evaluates, so it is a
 // separate side-effect module imported first.
 import './shim';
-import { readFileSync } from 'node:fs';
+import { readFileSync, existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { i18n } from '@lingui/core';
 import { channel_raw } from '@quilibrium/quilibrium-js-sdk-channels';
@@ -21,15 +21,32 @@ i18n.activate('en');
 // connect to a real relay, and node's undici WebSocket hangs under jsdom, so the
 // transport imports the `ws` package explicitly rather than using a global.
 
-// The published npm package ships no .wasm; the app resolves it from the sibling
-// SDK source repo via viteStaticCopy (web/vite.config.ts). Mirror that convention.
-// Override with SDK_WASM if the sibling repo lives elsewhere.
+// The published npm package ships no .wasm (it ships only dist/), so the binary
+// has to come from somewhere else. Mirrors web/vite.config.ts: prefer a local
+// SDK checkout when one exists, otherwise fall back to the copy committed in
+// public/, which is what the app itself ships and is always present.
+//
+// The sibling-checkout path is listed last because it only resolves from the
+// main checkout — from a git worktree it points at `.worktrees/quilibrium-js-
+// sdk-channels`, which does not exist. Relying on it alone broke `yarn harness`
+// in worktrees. Override with SDK_WASM to point anywhere else.
+const wasmCandidates = [
+  'node_modules/@quilibrium/quilibrium-js-sdk-channels/src/wasm/channelwasm_bg.wasm',
+  '../quilibrium-js-sdk-channels/src/wasm/channelwasm_bg.wasm',
+  'public/channelwasm_bg.wasm',
+];
 const wasmPath =
   process.env.SDK_WASM ??
-  resolve(
-    process.cwd(),
-    '../quilibrium-js-sdk-channels/src/wasm/channelwasm_bg.wasm'
+  wasmCandidates
+    .map((c) => resolve(process.cwd(), c))
+    .find((p) => existsSync(p));
+
+if (!wasmPath) {
+  throw new Error(
+    `Harness could not locate channelwasm_bg.wasm. Tried: ${wasmCandidates.join(', ')}. ` +
+      `Set SDK_WASM to an explicit path.`
   );
+}
 
 // Initialise the PACKAGE's wasm binding. channel_raw and the high-level `channel`
 // API are one bundle sharing a single `wasm` var, so this inits both.

--- a/src/dev/tests/utils/composerSelection.unit.test.ts
+++ b/src/dev/tests/utils/composerSelection.unit.test.ts
@@ -1,0 +1,300 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  isRangeInsideEditor,
+  readSelectionInsideEditor,
+  placeCaretAtEnd,
+  isSavedCaretUsable,
+  restoreSelectionInEditor,
+  insertTextAtSavedCaret,
+} from '../../../utils/composerSelection';
+
+/**
+ * Guards the emoji-at-the-start bug: using the emoji panel moved focus out of
+ * the composer, and once the document selection had moved into the picker's
+ * search box, focus() collapsed the caret to offset 0 — so the emoji was
+ * inserted at the beginning of the message instead of at the caret.
+ *
+ * WHAT THESE TESTS DO NOT COVER — read before trusting a green run.
+ *
+ * jsdom does not model the mechanism of the bug at all. Its `focus()` only
+ * checks focusability and fires events; it never touches Selection/Range state,
+ * so the real Chromium behaviour of collapsing the caret to offset 0 on refocus
+ * cannot happen here. `document.execCommand` does not exist in jsdom either.
+ *
+ * So these tests prove that composerSelection's functions are internally
+ * correct — they save, detect staleness, restore, and fall back as intended.
+ * They do NOT prove that the fix works in a browser. The browser-level evidence
+ * came from a throwaway Electron harness driving real input events, recorded in
+ * .agents/issues/2026-08-06-emoji-panel-inserts-at-start-of-message.md.
+ *
+ * The call-order test at the bottom covers the wiring in MessageComposer that
+ * these unit tests otherwise leave completely unverified.
+ */
+
+let editor: HTMLDivElement;
+let outsideInput: HTMLInputElement;
+
+/** Collapse the caret inside the editor's first text node at `offset`. */
+function putCaretAt(offset: number) {
+  const textNode = editor.firstChild!;
+  const range = document.createRange();
+  range.setStart(textNode, offset);
+  range.collapse(true);
+  const selection = window.getSelection()!;
+  selection.removeAllRanges();
+  selection.addRange(range);
+}
+
+/** Where is the caret now, as a character offset in the editor? */
+function caretOffset(): number {
+  const selection = window.getSelection()!;
+  const range = selection.getRangeAt(0);
+  const probe = document.createRange();
+  probe.selectNodeContents(editor);
+  probe.setEnd(range.startContainer, range.startOffset);
+  return probe.toString().length;
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  editor = document.createElement('div');
+  editor.contentEditable = 'true';
+  editor.textContent = 'hello world';
+  document.body.appendChild(editor);
+
+  outsideInput = document.createElement('input');
+  document.body.appendChild(outsideInput);
+
+  window.getSelection()!.removeAllRanges();
+});
+
+describe('isRangeInsideEditor', () => {
+  it('is true for a caret in the editor text', () => {
+    putCaretAt(5);
+    const range = window.getSelection()!.getRangeAt(0);
+    expect(isRangeInsideEditor(editor, range)).toBe(true);
+  });
+
+  it('is true for a caret in an empty editor (container is the editor itself)', () => {
+    editor.textContent = '';
+    const range = document.createRange();
+    range.selectNodeContents(editor);
+    range.collapse(true);
+    expect(isRangeInsideEditor(editor, range)).toBe(true);
+  });
+
+  it('is false for a range belonging to another element', () => {
+    const other = document.createElement('p');
+    other.textContent = 'somewhere else';
+    document.body.appendChild(other);
+    const range = document.createRange();
+    range.selectNodeContents(other);
+    expect(isRangeInsideEditor(editor, range)).toBe(false);
+  });
+
+  it('is false for a selection that starts in the editor but ends outside it', () => {
+    // Dragging a selection out of the composer and into the page. startContainer
+    // is inside the editor, so a check on that alone would wrongly say "inside";
+    // commonAncestorContainer is body, which is what makes this false.
+    const other = document.createElement('p');
+    other.textContent = 'somewhere else';
+    document.body.appendChild(other);
+
+    const range = document.createRange();
+    range.setStart(editor.firstChild!, 3);
+    range.setEnd(other.firstChild!, 4);
+
+    expect(range.startContainer.parentElement).toBe(editor);
+    expect(isRangeInsideEditor(editor, range)).toBe(false);
+  });
+});
+
+describe('readSelectionInsideEditor', () => {
+  it('returns the caret when it is inside the editor', () => {
+    putCaretAt(5);
+    const saved = readSelectionInsideEditor(editor);
+    expect(saved).not.toBeNull();
+    expect(saved!.range.startOffset).toBe(5);
+  });
+
+  it('returns null when the selection lives outside the editor', () => {
+    const other = document.createElement('p');
+    other.textContent = 'elsewhere';
+    document.body.appendChild(other);
+    const range = document.createRange();
+    range.setStart(other.firstChild!, 2);
+    range.collapse(true);
+    const selection = window.getSelection()!;
+    selection.removeAllRanges();
+    selection.addRange(range);
+
+    expect(readSelectionInsideEditor(editor)).toBeNull();
+  });
+
+  it('returns null when there is no selection at all', () => {
+    window.getSelection()!.removeAllRanges();
+    expect(readSelectionInsideEditor(editor)).toBeNull();
+  });
+
+  it('returns a clone, so collapsing the live selection does not move it', () => {
+    putCaretAt(5);
+    const saved = readSelectionInsideEditor(editor)!;
+
+    // Mutate the *live* selection object itself. Without cloneRange() the
+    // returned range IS the live one and would collapse to the end with it.
+    const live = window.getSelection()!.getRangeAt(0);
+    live.selectNodeContents(editor);
+    live.collapse(false);
+
+    expect(saved.range.startOffset).toBe(5);
+    expect(saved.range.startContainer).toBe(editor.firstChild);
+  });
+});
+
+describe('isSavedCaretUsable', () => {
+  it('rejects null', () => {
+    expect(isSavedCaretUsable(editor, null)).toBe(false);
+  });
+
+  it('accepts a range still attached to the editor', () => {
+    putCaretAt(3);
+    const saved = readSelectionInsideEditor(editor);
+    expect(isSavedCaretUsable(editor, saved)).toBe(true);
+  });
+
+  it('rejects a range whose nodes were wiped by sending the message', () => {
+    putCaretAt(3);
+    const saved = readSelectionInsideEditor(editor);
+    // This is what the send path does — MessageComposer.tsx clears the editor.
+    editor.innerHTML = '';
+    expect(isSavedCaretUsable(editor, saved)).toBe(false);
+  });
+});
+
+describe('restoreSelectionInEditor', () => {
+  it('puts the caret back where it was after focus moved to another input', () => {
+    putCaretAt(5); // right after "hello"
+    const saved = readSelectionInsideEditor(editor);
+
+    // Simulate the picker's search box taking the selection with it.
+    outsideInput.focus();
+    const stolen = document.createRange();
+    stolen.selectNodeContents(outsideInput);
+    const selection = window.getSelection()!;
+    selection.removeAllRanges();
+    selection.addRange(stolen);
+    expect(readSelectionInsideEditor(editor)).toBeNull();
+
+    editor.focus();
+    restoreSelectionInEditor(editor, saved);
+
+    expect(caretOffset()).toBe(5);
+  });
+
+  it('falls back to the end of the content when nothing was saved', () => {
+    restoreSelectionInEditor(editor, null);
+    expect(caretOffset()).toBe('hello world'.length);
+  });
+
+  it('falls back to the end when the saved range was invalidated', () => {
+    putCaretAt(2);
+    const saved = readSelectionInsideEditor(editor);
+    editor.innerHTML = '';
+    editor.textContent = 'a fresh draft';
+
+    restoreSelectionInEditor(editor, saved);
+
+    expect(caretOffset()).toBe('a fresh draft'.length);
+  });
+
+  it('leaves an empty editor at offset 0', () => {
+    editor.textContent = '';
+    restoreSelectionInEditor(editor, null);
+    expect(caretOffset()).toBe(0);
+  });
+});
+
+describe('placeCaretAtEnd', () => {
+  it('collapses to the end of the text', () => {
+    putCaretAt(0);
+    placeCaretAtEnd(editor);
+    expect(caretOffset()).toBe('hello world'.length);
+  });
+});
+
+/**
+ * Covers the wiring MessageComposer.insertEmoji depends on. The injected
+ * `insert` records where the caret actually is at the moment of insertion,
+ * which is the only thing that determines where the emoji lands.
+ */
+describe('insertTextAtSavedCaret', () => {
+  /** Steal the selection the way the emoji picker's search box does. */
+  function stealSelectionIntoInput() {
+    outsideInput.focus();
+    const stolen = document.createRange();
+    stolen.selectNodeContents(outsideInput);
+    const selection = window.getSelection()!;
+    selection.removeAllRanges();
+    selection.addRange(stolen);
+  }
+
+  it('has restored the caret by the time the insert runs', () => {
+    putCaretAt(5); // right after "hello"
+    const saved = readSelectionInsideEditor(editor);
+    stealSelectionIntoInput();
+
+    let offsetAtInsert = -1;
+    let insideEditorAtInsert = false;
+    insertTextAtSavedCaret(editor, '@', saved, () => {
+      offsetAtInsert = caretOffset();
+      insideEditorAtInsert = readSelectionInsideEditor(editor) !== null;
+      return true;
+    });
+
+    // Not merely "restored eventually" — restored BEFORE the insert ran.
+    expect(insideEditorAtInsert).toBe(true);
+    expect(offsetAtInsert).toBe(5);
+  });
+
+  it('has focused the editor by the time the insert runs', () => {
+    putCaretAt(5);
+    const saved = readSelectionInsideEditor(editor);
+    stealSelectionIntoInput();
+
+    // Asserting on document.activeElement would not work: jsdom does not treat
+    // a contentEditable div as focusable, so focus() never moves activeElement
+    // here. Spying on the call is what can actually be verified in jsdom, and
+    // it is the ordering that matters — in a real browser focus() must precede
+    // the restore or the restored range is not the active selection.
+    const focusSpy = vi.spyOn(editor, 'focus');
+
+    let focusCallsAtInsert = -1;
+    insertTextAtSavedCaret(editor, '@', saved, () => {
+      focusCallsAtInsert = focusSpy.mock.calls.length;
+      return true;
+    });
+
+    expect(focusCallsAtInsert).toBe(1);
+    focusSpy.mockRestore();
+  });
+
+  it('falls back to the end rather than the start when nothing is saved', () => {
+    stealSelectionIntoInput();
+
+    let offsetAtInsert = -1;
+    insertTextAtSavedCaret(editor, '@', null, () => {
+      offsetAtInsert = caretOffset();
+      return true;
+    });
+
+    // The bug was insertion at 0; the no-saved-caret fallback must not land there.
+    expect(offsetAtInsert).toBe('hello world'.length);
+  });
+
+  it('reports the insert result back to the caller', () => {
+    putCaretAt(1);
+    const saved = readSelectionInsideEditor(editor);
+    expect(insertTextAtSavedCaret(editor, '@', saved, () => false)).toBe(false);
+    expect(insertTextAtSavedCaret(editor, '@', saved, () => true)).toBe(true);
+  });
+});

--- a/src/utils/composerSelection.ts
+++ b/src/utils/composerSelection.ts
@@ -1,0 +1,147 @@
+/**
+ * Composer Selection Utilities
+ *
+ * Helpers for remembering and restoring the caret inside the composer's
+ * contentEditable editor.
+ *
+ * Why this exists: the emoji panel is a sibling of the composer, so using it
+ * moves DOM focus away from the editor. Chromium keeps the editor's selection
+ * alive when focus lands on a plain `<button>`, but NOT when it lands on a
+ * text-editing element — clicking the picker's search box moves the document
+ * selection into that input. Once that has happened, calling `editor.focus()`
+ * puts the caret at offset 0, so the emoji is inserted at the very start of the
+ * message instead of where the user was typing.
+ *
+ * The fix is to record the last caret position that was genuinely inside the
+ * editor and put it back before inserting.
+ *
+ * Platform: Web-only (uses DOM Selection/Range APIs).
+ *
+ * @module composerSelection
+ */
+
+/**
+ * A remembered caret position.
+ *
+ * `anchorNode` is deliberately kept alongside the range. A Range — including
+ * one returned by `cloneRange()` — stays *live*: the DOM spec makes the browser
+ * rewrite its boundary points when nodes are removed. So after the send path
+ * wipes the editor (`innerHTML = ''`), the range does not become invalid, it
+ * quietly collapses to `(editor, 0)` and would restore the caret to the start
+ * of whatever text appears next. Holding our own reference to the node the
+ * caret was actually in is what lets us notice it was removed.
+ */
+export interface SavedCaret {
+  range: Range;
+  anchorNode: Node;
+}
+
+/**
+ * Is this range anchored inside the given editor element?
+ *
+ * `Node.contains` reports true for the element itself, which is what we want:
+ * a caret in an empty editor has the editor as its container.
+ */
+export function isRangeInsideEditor(editor: HTMLElement, range: Range): boolean {
+  return editor.contains(range.commonAncestorContainer);
+}
+
+/**
+ * Read the current caret, but only if it sits inside the editor.
+ *
+ * Returns null when there is no selection or it belongs to some other element
+ * — which is exactly the case the remembered caret exists to cover.
+ */
+export function readSelectionInsideEditor(editor: HTMLElement): SavedCaret | null {
+  const selection = window.getSelection();
+  if (!selection || selection.rangeCount === 0) return null;
+
+  const range = selection.getRangeAt(0);
+  if (!isRangeInsideEditor(editor, range)) return null;
+
+  return { range: range.cloneRange(), anchorNode: range.startContainer };
+}
+
+/** Collapse the caret to the very end of the editor's content. */
+export function placeCaretAtEnd(editor: HTMLElement): void {
+  const selection = window.getSelection();
+  if (!selection) return;
+
+  const range = document.createRange();
+  range.selectNodeContents(editor);
+  range.collapse(false);
+  selection.removeAllRanges();
+  selection.addRange(range);
+}
+
+/**
+ * Is a previously saved caret still meaningful?
+ *
+ * False once the node it pointed into has left the document — sending a message
+ * clears the editor, and any caret remembered from the sent text is stale.
+ */
+export function isSavedCaretUsable(
+  editor: HTMLElement,
+  saved: SavedCaret | null
+): saved is SavedCaret {
+  if (!saved) return false;
+  if (!saved.anchorNode.isConnected) return false;
+  return editor.contains(saved.anchorNode);
+}
+
+/**
+ * Put the caret back where it was before focus left the editor.
+ *
+ * Falls back to the end of the content when there is nothing usable to restore
+ * — appending is the sane default, and it is what a user expects when they open
+ * the panel without ever having placed a caret.
+ *
+ * The caller is responsible for focusing the editor first; restoring a range on
+ * an unfocused element does not make it the active selection in all browsers.
+ */
+export function restoreSelectionInEditor(
+  editor: HTMLElement,
+  saved: SavedCaret | null
+): void {
+  const selection = window.getSelection();
+  if (!selection) return;
+
+  if (!isSavedCaretUsable(editor, saved)) {
+    placeCaretAtEnd(editor);
+    return;
+  }
+
+  selection.removeAllRanges();
+  selection.addRange(saved.range);
+}
+
+/** Default insertion: `execCommand` keeps the editor's native undo stack. */
+function execInsertText(text: string): boolean {
+  return document.execCommand('insertText', false, text);
+}
+
+/**
+ * Focus the editor, put the caret back where it was, then insert.
+ *
+ * The order is the whole point and is why this lives here rather than inline at
+ * the call site: `focus()` must come first (restoring a range on an unfocused
+ * element does not make it the active selection everywhere), and the restore
+ * must come before the insert (`execCommand` writes at whatever the selection
+ * is at that instant). Keeping the sequence in one place means a test can
+ * verify the real ordering instead of a copy of it.
+ *
+ * `insert` is injectable so tests can observe the selection at insertion time;
+ * jsdom implements neither `execCommand` nor the caret behaviour this works around.
+ *
+ * @returns whether the insertion reported success.
+ */
+export function insertTextAtSavedCaret(
+  editor: HTMLElement,
+  text: string,
+  saved: SavedCaret | null,
+  insert: (text: string) => boolean = execInsertText
+): boolean {
+  editor.focus();
+  restoreSelectionInEditor(editor, saved);
+  return insert(text);
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -3,8 +3,39 @@ import { viteStaticCopy } from 'vite-plugin-static-copy';
 import { nodePolyfills } from 'vite-plugin-node-polyfills';
 import react from '@vitejs/plugin-react';
 import { resolve } from 'path';
-import { readFileSync } from 'fs';
+import { readFileSync, existsSync } from 'fs';
 import { lingui } from '@lingui/vite-plugin';
+
+const PROJECT_ROOT = resolve(__dirname, '..');
+
+/**
+ * Locate the channels SDK wasm in a developer's local SDK checkout, if there is
+ * one.
+ *
+ * This is a DEVELOPER CONVENIENCE ONLY. The published npm package ships just
+ * `dist/` — no `src/`, no `.wasm` — so on any clean install none of these
+ * candidates exist. That is fine: `public/channelwasm_bg.wasm` is committed to
+ * this repo and `publicDir` serves and bundles it with no plugin involved. The
+ * copy target below merely lets someone hacking on the SDK locally override
+ * that committed copy with their working one.
+ *
+ * Returns null when there is no local checkout, so the target can be omitted
+ * entirely rather than left pointing at nothing — see the split-plugin note at
+ * the call site for why a target that matches nothing is dangerous.
+ */
+function findLocalSdkWasm(): string | null {
+  const candidates = [
+    // yarn-linked SDK: works from the main checkout and from a git worktree,
+    // because the link lives inside this tree's own node_modules.
+    'node_modules/@quilibrium/quilibrium-js-sdk-channels/src/wasm/channelwasm_bg.wasm',
+    // SDK checked out beside the repo. Only resolves from the main checkout —
+    // from `.worktrees/<name>/` this points somewhere that does not exist.
+    '../quilibrium-js-sdk-channels/src/wasm/channelwasm_bg.wasm',
+  ];
+  return candidates.find((c) => existsSync(resolve(PROJECT_ROOT, c))) ?? null;
+}
+
+const localSdkWasm = findLocalSdkWasm();
 
 /**
  * App version, read from package.json at config-load time and inlined into the
@@ -111,18 +142,27 @@ export default defineConfig(({ command }): UserConfig => ({
         plugins: ['@lingui/babel-plugin-lingui-macro'],
       },
     }),
+    // NOTE: keep each copy target in its OWN viteStaticCopy() instance.
+    // The plugin fails the entire target array when any one target matches no
+    // files, and in dev it only logs that failure rather than throwing. Sharing
+    // one instance means a single bad path silently takes every other asset
+    // down with it: that is exactly how a stale SDK path once left every emoji
+    // in the app rendering as a broken image, with nothing but one line in the
+    // terminal to show for it.
     viteStaticCopy({
       targets: [
         {
           src: 'node_modules/emoji-datasource-twitter/img/twitter/*',
           dest: 'twitter',
         },
-        {
-          src: '../quilibrium-js-sdk-channels/src/wasm/channelwasm_bg.wasm',
-          dest: './',
-        },
       ],
     }),
+    // Only registered when a local SDK checkout actually exists — see
+    // findLocalSdkWasm(). Otherwise the committed public/channelwasm_bg.wasm is
+    // what ships, and no target is registered that could match nothing.
+    ...(localSdkWasm
+      ? [viteStaticCopy({ targets: [{ src: localSdkWasm, dest: './' }] })]
+      : []),
   ],
   server: {
     allowedHosts: [


### PR DESCRIPTION
Two emoji bugs, one user-facing and one that only bites in git worktrees.

## Emojis land at the cursor

Picking an emoji from the panel inserted it at the very start of the message instead of at the caret.

`insertEmoji` focused the editor and called `execCommand('insertText')`, which writes at the current document selection. Focus alone does not restore the old caret: Chromium keeps a contentEditable's selection alive when focus moves to a plain `<button>`, but clicking the picker's search field moves the document selection into that input, after which `focus()` collapses the caret to offset 0.

The fix remembers the last caret seen inside the editor and restores it before inserting. The saved caret keeps its own anchor node rather than trusting the `Range`, which stays *live* — clearing the editor on send rewrites the range boundary to `(editor, 0)` instead of invalidating it, so a range-only staleness check would pass and silently restore to the start of whatever text came next.

Also: `execCommand` reports failure by returning `false` rather than throwing, so a no-op insertion was indistinguishable from a missed click. It now logs. The dormant textarea branch appended to the end regardless of the caret; it now splices at the selection.

## One bad copy target no longer blanks every emoji image

Running `yarn dev` from a git worktree left every emoji as a broken image and the picker empty, while the same commit was fine from the main checkout.

Both static-copy targets shared one plugin instance, and the second pointed at a sibling SDK checkout that only exists beside the main checkout. From a worktree it resolved to nothing, and `vite-plugin-static-copy` fails the *entire* target array when any one target matches no files — logging rather than throwing in dev. The emoji PNG target went down with it, so `/twitter/64/*.png` fell through to the SPA catch-all and returned `index.html`. It went unnoticed in production because the wasm that target copies is also committed under `public/`, so the failing target had no visible effect of its own.

Each target now gets its own plugin instance so a failure cannot cascade, and the SDK target is registered only when a local SDK checkout exists. The published package ships only `dist/` with no wasm, so on a clean install the committed `public/channelwasm_bg.wasm` is what ships. The test harness carried the same sibling path and could not boot in a worktree at all; it now probes the same candidates with a fallback to the committed copy.

## Verification

- 20 unit tests for the selection helpers and the insertion ordering. Every mutant tried goes red — dropping the restore, reordering restore after insert, dropping `focus()`, `startContainer` instead of `commonAncestorContainer`, and dropping `cloneRange()` are each caught by exactly one test.
- Browser-level evidence came from a throwaway Electron harness driving real input events: the search-box path failed 3/3 before and passes 3/3 after, with the paths that already worked unchanged. jsdom models neither `execCommand` nor the caret behaviour, so the unit tests deliberately do not claim to cover it.
- Clean-install simulated with neither SDK candidate present: emoji PNGs still serve, wasm still serves from `public/`.
- Full suite 79 files / 1055 tests, `tsc --noEmit` clean, `yarn build` exit 0 copying 3786 PNGs plus the wasm.
