### PR TITLE
feat(encryption): reset every DM session from settings, and align the per-conversation wording with mobile

### DIFF
--- a/src/components/context/MessageDB.tsx
+++ b/src/components/context/MessageDB.tsx
@@ -86,6 +86,7 @@ type MessageDBContextValue = {
     }>
   >;
   deleteEncryptionStates: (args: { conversationId: string }) => Promise<void>;
+  resetAllDirectMessageSessions: () => Promise<number>;
   submitMessage: (
     address: string,
     pendingMessage: string | object,
@@ -775,6 +776,11 @@ const MessageDBProvider: FC<MessageDBContextProps> = ({ children }) => {
     },
     [encryptionService]
   );
+
+  // Global "Fix DM Encryption" — resets the ratchet for every DM at once.
+  const resetAllDirectMessageSessions = useCallback(async () => {
+    return encryptionService.resetAllDirectMessageSessions();
+  }, [encryptionService]);
 
   // SyncService (must be before MessageService - provides sync dependencies)
   const syncService = useMemo(() => {
@@ -1622,6 +1628,7 @@ const MessageDBProvider: FC<MessageDBContextProps> = ({ children }) => {
         keyset,
         setKeyset,
         deleteEncryptionStates,
+        resetAllDirectMessageSessions,
         submitMessage,
         createSpace,
         updateSpace,
@@ -1663,6 +1670,7 @@ const MessageDBContext = createContext<MessageDBContextValue>({
   keyset: undefined as never,
   setKeyset: (_) => {},
   deleteEncryptionStates: () => undefined as never,
+  resetAllDirectMessageSessions: () => undefined as never,
   submitMessage: () => undefined as never,
   createSpace: () => undefined as never,
   updateSpace: () => undefined as never,

--- a/src/components/modals/ConversationSettingsModal.tsx
+++ b/src/components/modals/ConversationSettingsModal.tsx
@@ -13,6 +13,7 @@ import {
   Icon,
   Tooltip,
   Spacer,
+  Callout,
 } from '../primitives';
 import { useConfirmation } from '../../hooks/ui/useConfirmation';
 import ConfirmationModal from './ConfirmationModal';
@@ -73,18 +74,19 @@ const ConversationSettingsModal: React.FC<ConversationSettingsModalProps> = ({
   });
 
   // Confirmation hook for encryption session reset (parity with mobile's
-  // DMSettingsSheet "Reset Session"). Local-only: the next outgoing message
+  // DMSettingsSheet "Fix Encryption"). Local-only: the next outgoing message
   // establishes a fresh session via a new init envelope, and the counterparty
   // replaces its old session for this device when that envelope arrives.
   const counterpartyName =
     conversation?.conversation?.displayName ?? t`this contact`;
+  const [resetSuccess, setResetSuccess] = React.useState(false);
   const resetConfirmation = useConfirmation({
     type: 'modal',
     enableShiftBypass: false,
     modalConfig: conversation
       ? {
-          title: t`Reset Encryption Session`,
-          message: t`This will reset the encryption session with ${counterpartyName}. The next message will establish a fresh secure connection.\n\nUse this if messages are failing to send or decrypt. Message history is not affected.`,
+          title: t`Fix Encryption`,
+          message: t`This will reset the encryption session with ${counterpartyName}. The next message will establish a fresh secure connection.\n\nUse this if messages are failing to send or decrypt.`,
           preview: undefined,
           confirmText: t`Reset Session`,
           cancelText: t`Cancel`,
@@ -224,11 +226,14 @@ const ConversationSettingsModal: React.FC<ConversationSettingsModalProps> = ({
     (e: React.MouseEvent) => {
       const performReset = async () => {
         await deleteEncryptionStates({ conversationId });
-        onClose();
+        // Stay open and confirm inline rather than closing. The reset leaves no
+        // visible trace anywhere in the app, so closing the modal on success is
+        // indistinguishable from the click having done nothing.
+        setResetSuccess(true);
       };
       resetConfirmation.handleClick(e, performReset);
     },
-    [resetConfirmation, deleteEncryptionStates, conversationId, onClose]
+    [resetConfirmation, deleteEncryptionStates, conversationId]
   );
 
   // Reset confirmations when modal closes
@@ -236,6 +241,7 @@ const ConversationSettingsModal: React.FC<ConversationSettingsModalProps> = ({
     if (!visible) {
       deleteConfirmation.reset();
       resetConfirmation.reset();
+      setResetSuccess(false);
     }
   }, [visible, deleteConfirmation, resetConfirmation]);
 
@@ -407,8 +413,10 @@ const ConversationSettingsModal: React.FC<ConversationSettingsModalProps> = ({
 
         <Spacer spaceBefore="lg" spaceAfter="md" border direction="vertical" />
 
-        {/* Reset Session — quiet, understated utility link (neutral) */}
-        <Flex justify="center" align="center" className="mb-3">
+        {/* Fix Encryption — quiet, understated utility link (neutral). The
+            sublabel carries what used to be a tooltip: it is the one row here
+            a confused user is meant to find, so it should not need a hover. */}
+        <Flex direction="column" align="center" className="mb-3">
           <Button
             type="unstyled"
             className="text-subtle hover:text-main cursor-pointer"
@@ -418,18 +426,29 @@ const ConversationSettingsModal: React.FC<ConversationSettingsModalProps> = ({
           >
             <Flex align="center" gap="xs">
               <Icon name="refresh" size="sm" />
-              {t`Reset Encryption Session`}
+              {t`Fix Encryption`}
             </Flex>
           </Button>
-          <Tooltip
-            id="conv-reset-session-tooltip"
-            content={t`Reset the encryption session if messages fail to send or decrypt. The next message will establish a fresh secure connection.`}
-            maxWidth={260}
-            className="!text-left !max-w-[260px]"
-            place="top"
-          >
-            <Icon name="info-circle" size="sm" className="ml-2 text-subtle" />
-          </Tooltip>
+          <div className="text-sm text-subtle">
+            {t`Reset if messages fail to send or decrypt`}
+          </div>
+          {resetSuccess && (
+            <div className="mt-3 w-full">
+              <Callout
+                variant="success"
+                size="sm"
+                dismissible
+                onClose={() => setResetSuccess(false)}
+              >
+                <div>
+                  <div className="font-medium">{t`Encryption Reset`}</div>
+                  <div className="text-sm mt-1">
+                    {t`Your next message will establish a fresh secure connection.`}
+                  </div>
+                </div>
+              </Callout>
+            </div>
+          )}
         </Flex>
 
         {/* Delete — destructive action, kept isolated as its own centered link */}

--- a/src/components/modals/UserSettingsModal/Help.tsx
+++ b/src/components/modals/UserSettingsModal/Help.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react';
-import { Button, Icon, Spacer } from '../../primitives';
+import { Button, Callout, Icon, Spacer } from '../../primitives';
 import { t } from '@lingui/core/macro';
+import { useMessageDB } from '../../context/useMessageDB';
+import { useConfirmation } from '../../../hooks/ui/useConfirmation';
+import ConfirmationModal from '../ConfirmationModal';
 
 interface HelpProps {
   isRestoring?: boolean;
@@ -11,6 +14,41 @@ const Help: React.FunctionComponent<HelpProps> = ({
   isRestoring = false,
   onRestoreMissingSpaces,
 }) => {
+  // Global "Fix DM Encryption" — resets the ratchet for every DM at once,
+  // matching mobile's account-level action. The per-conversation equivalent
+  // lives in ConversationSettingsModal; this is the same operation fanned out,
+  // for when the user cannot tell which conversation is stuck.
+  const { resetAllDirectMessageSessions } = useMessageDB();
+  const [resetSuccess, setResetSuccess] = React.useState(false);
+  const [resetError, setResetError] = React.useState<string | null>(null);
+
+  const resetConfirmation = useConfirmation({
+    type: 'modal',
+    enableShiftBypass: false,
+    modalConfig: {
+      title: t`Fix DM Encryption`,
+      message: t`This will reset the encryption sessions for all your DM conversations. Your next message to each contact will establish a fresh secure connection.\n\nUse this if messages are failing to send or decrypt.`,
+      confirmText: t`Reset All`,
+      cancelText: t`Cancel`,
+      variant: 'warning',
+    },
+  });
+
+  const handleResetAllClick = (e: React.MouseEvent) => {
+    if (resetConfirmation.isConfirming) return;
+    setResetSuccess(false);
+    setResetError(null);
+    resetConfirmation.handleClick(e, async () => {
+      try {
+        await resetAllDirectMessageSessions();
+        setResetSuccess(true);
+      } catch (error: any) {
+        console.error('Failed to reset DM encryption sessions:', error);
+        setResetError(error?.message || t`Failed to reset encryption sessions`);
+      }
+    });
+  };
+
   return (
     <>
       <div className="modal-content-header">
@@ -65,6 +103,53 @@ const Help: React.FunctionComponent<HelpProps> = ({
           </div>
         </div>
 
+        {/* Fix DM Encryption Section */}
+        <Spacer size="md" direction="vertical" borderTop={true} />
+        <div className="text-subtitle-2 mb-2">{t`Fix DM Encryption`}</div>
+        <div className="modal-content-info">
+          <div className="flex flex-col gap-2">
+            <div className="flex items-start justify-between gap-3 p-3 rounded-md border">
+              <div className="text-sm" style={{ lineHeight: 1.3 }}>
+                {t`Reset your DM encryption sessions if messages are failing to send or decrypt.`}
+              </div>
+              <Button
+                type="secondary"
+                size="small"
+                className="whitespace-nowrap"
+                onClick={handleResetAllClick}
+                disabled={resetConfirmation.isConfirming}
+              >
+                {resetConfirmation.isConfirming ? t`Resetting...` : t`Reset`}
+              </Button>
+            </div>
+            {resetSuccess && (
+              <Callout
+                variant="success"
+                size="sm"
+                dismissible
+                onClose={() => setResetSuccess(false)}
+              >
+                <div>
+                  <div className="font-medium">{t`Encryption Reset`}</div>
+                  <div className="text-sm mt-1">
+                    {t`Your next message to each contact will establish a fresh secure connection.`}
+                  </div>
+                </div>
+              </Callout>
+            )}
+            {resetError && (
+              <Callout
+                variant="error"
+                size="sm"
+                dismissible
+                onClose={() => setResetError(null)}
+              >
+                <div className="text-sm">{resetError}</div>
+              </Callout>
+            )}
+          </div>
+        </div>
+
         {/* Data Recovery Section */}
         {onRestoreMissingSpaces && (
           <>
@@ -91,6 +176,23 @@ const Help: React.FunctionComponent<HelpProps> = ({
           </>
         )}
       </div>
+
+      {/* Confirmation for the global DM encryption reset */}
+      {resetConfirmation.modalConfig && (
+        <ConfirmationModal
+          visible={resetConfirmation.showModal}
+          title={resetConfirmation.modalConfig.title}
+          message={resetConfirmation.modalConfig.message}
+          confirmText={resetConfirmation.modalConfig.confirmText}
+          cancelText={resetConfirmation.modalConfig.cancelText}
+          variant={resetConfirmation.modalConfig.variant}
+          showProtip={false}
+          busy={resetConfirmation.isConfirming}
+          busyMessage={t`Resetting...`}
+          onConfirm={resetConfirmation.modalConfig.onConfirm}
+          onCancel={resetConfirmation.modalConfig.onCancel}
+        />
+      )}
     </>
   );
 };

--- a/src/dev/tests/services/EncryptionService.unit.test.tsx
+++ b/src/dev/tests/services/EncryptionService.unit.test.tsx
@@ -148,7 +148,101 @@ describe('EncryptionService - Unit Tests', () => {
     });
   });
 
-  describe('2. ensureKeyForSpace() - Key Generation/Retrieval', () => {
+  describe('2. resetAllDirectMessageSessions() - Global "Fix DM Encryption"', () => {
+    it('should reset every DM conversation while preserving inbox routing', async () => {
+      mockDeps.messageDB.getConversations = vi.fn().mockResolvedValue({
+        conversations: [
+          { conversationId: 'peer-a/inbox-a' },
+          { conversationId: 'peer-b/inbox-b' },
+          { conversationId: 'peer-c/inbox-c' },
+        ],
+        nextCursor: null,
+      });
+      mockDeps.messageDB.getEncryptionStates = vi
+        .fn()
+        .mockResolvedValue([{ state: 'ratchet', inboxId: 'inbox-1' }]);
+
+      const count = await encryptionService.resetAllDirectMessageSessions();
+
+      // ✅ VERIFY: only DM conversations are swept — group ratchets are not
+      // part of this action and resetting them would be silent collateral.
+      expect(mockDeps.messageDB.getConversations).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'direct' })
+      );
+
+      // ✅ VERIFY: every conversation was reset, and the caller learns how many
+      expect(count).toBe(3);
+      for (const conversationId of ['peer-a/inbox-a', 'peer-b/inbox-b', 'peer-c/inbox-c']) {
+        expect(mockDeps.messageDB.getEncryptionStates).toHaveBeenCalledWith({ conversationId });
+        expect(mockDeps.messageDB.deleteLatestState).toHaveBeenCalledWith(conversationId);
+      }
+      expect(mockDeps.messageDB.deleteEncryptionState).toHaveBeenCalledTimes(3);
+
+      // ✅ VERIFY: inbox routing survives the GLOBAL reset too.
+      // This is the one behaviour that separates this from mobile's
+      // `encryptionStateStorage.clearAll()`. Dropping the mappings here would
+      // break every conversation at once in the direction the user cannot
+      // see: peers keep writing to inboxes we no longer recognise (RX-NOSTATE)
+      // while our own sends still land, so the app looks healthy and messages
+      // silently vanish. Measured live on desktop 2026-07-25.
+      expect(mockDeps.messageDB.deleteInboxMapping).not.toHaveBeenCalled();
+    });
+
+    it('should sweep conversations across every page, not just the first', async () => {
+      // A user with more DMs than the page size must still get all of them
+      // reset; stopping at page one would leave the stuck conversation broken
+      // and the action would appear to have done nothing.
+      mockDeps.messageDB.getConversations = vi
+        .fn()
+        .mockResolvedValueOnce({
+          conversations: [{ conversationId: 'peer-a/inbox-a' }],
+          nextCursor: 1000,
+        })
+        .mockResolvedValueOnce({
+          conversations: [{ conversationId: 'peer-b/inbox-b' }],
+          nextCursor: null,
+        });
+
+      const count = await encryptionService.resetAllDirectMessageSessions();
+
+      expect(count).toBe(2);
+      expect(mockDeps.messageDB.getConversations).toHaveBeenCalledTimes(2);
+      expect(mockDeps.messageDB.getConversations).toHaveBeenLastCalledWith(
+        expect.objectContaining({ cursor: 1000 })
+      );
+      expect(mockDeps.messageDB.deleteLatestState).toHaveBeenCalledWith('peer-b/inbox-b');
+    });
+
+    it('should terminate when a page repeats instead of advancing', async () => {
+      // Guards the cursor that never advances (exactly-page-size case). Without
+      // the no-progress break this spins forever and hangs the settings modal.
+      mockDeps.messageDB.getConversations = vi.fn().mockResolvedValue({
+        conversations: [{ conversationId: 'peer-a/inbox-a' }],
+        nextCursor: 1000,
+      });
+
+      const count = await encryptionService.resetAllDirectMessageSessions();
+
+      expect(count).toBe(1);
+      expect(mockDeps.messageDB.getConversations).toHaveBeenCalledTimes(2);
+      // ✅ VERIFY: the repeated conversation is reset once, not twice
+      expect(mockDeps.messageDB.deleteLatestState).toHaveBeenCalledTimes(1);
+    });
+
+    it('should no-op cleanly when there are no DM conversations', async () => {
+      mockDeps.messageDB.getConversations = vi
+        .fn()
+        .mockResolvedValue({ conversations: [], nextCursor: null });
+
+      const count = await encryptionService.resetAllDirectMessageSessions();
+
+      expect(count).toBe(0);
+      expect(mockDeps.messageDB.getEncryptionStates).not.toHaveBeenCalled();
+      expect(mockDeps.messageDB.deleteEncryptionState).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('3. ensureKeyForSpace() - Key Generation/Retrieval', () => {
     it('should return existing spaceId if key already exists', async () => {
       const userAddress = 'user-123';
       const space = {

--- a/src/services/EncryptionService.ts
+++ b/src/services/EncryptionService.ts
@@ -82,6 +82,56 @@ export class EncryptionService {
   }
 
   /**
+   * Resets the Double Ratchet for EVERY direct conversation — the global
+   * "Fix DM Encryption" action, mirroring mobile's entry point in ProfileModal.
+   *
+   * Deliberately a fan-out over `deleteEncryptionStates` rather than a wholesale
+   * wipe of the encryption store. Mobile's global reset calls
+   * `encryptionStateStorage.clearAll()`, which also drops conversation inbox
+   * keypairs and inbox mappings. On desktop that is precisely the failure
+   * documented on `deleteEncryptionStates` above and measured live 2026-07-25:
+   * the peer keeps writing to the old inbox with a still-confirmed session,
+   * every frame lands as `RX-NOSTATE`, and the conversation goes permanently
+   * one-way with no recovery path. Routing each conversation through the
+   * hardened per-conversation reset keeps the mappings intact, so the promise
+   * this action makes to the user — the next message to each contact
+   * establishes a fresh secure connection — holds in BOTH directions.
+   *
+   * Returns the number of conversations reset, for the success message.
+   */
+  async resetAllDirectMessageSessions(): Promise<number> {
+    // Sweep every DM conversation, paginating the same way getAllDMData does
+    // for backup export. Collected into a Set first so the reset loop cannot
+    // double-visit a conversation returned on two pages.
+    const conversationIds = new Set<string>();
+    let cursor: number | undefined;
+    for (;;) {
+      const page = await this.messageDB.getConversations({
+        type: 'direct',
+        cursor,
+        limit: 1000,
+      });
+      const sizeBefore = conversationIds.size;
+      for (const conversation of page.conversations) {
+        conversationIds.add(conversation.conversationId);
+      }
+      // Stop when the store is exhausted, or when a page contributed nothing
+      // new — the latter guards a cursor that fails to advance, which would
+      // otherwise spin forever for a user sitting exactly on the page size.
+      if (!page.nextCursor || conversationIds.size === sizeBefore) break;
+      cursor = page.nextCursor;
+    }
+
+    for (const conversationId of conversationIds) {
+      // deleteEncryptionStates swallows its own failures, so one unreadable
+      // record cannot abort the sweep and leave the rest untouched.
+      await this.deleteEncryptionStates({ conversationId });
+    }
+
+    return conversationIds.size;
+  }
+
+  /**
    * Ensures space has valid keys. If missing, generates new keys and migrates all data to new address.
    */
   async ensureKeyForSpace(user_address: string, space: Space, queryClient: QueryClient) {


### PR DESCRIPTION
Adds the global **Fix DM Encryption** action to `User Settings > Help`, matching mobile's account-level entry point, and brings the existing per-conversation reset in line with mobile's copy.

### Global reset (new)

`User Settings > Help > Fix DM Encryption`, placed just before Data Recovery. Resets the Double Ratchet for every DM at once, for when the user cannot tell which conversation is stuck.

It fans out over the existing per-conversation `deleteEncryptionStates` rather than wiping the encryption store. Mobile's equivalent calls `encryptionStateStorage.clearAll()`, which also drops conversation inbox keypairs and inbox mappings. On desktop that is the failure already documented on `deleteEncryptionStates` and measured live 2026-07-25: the peer still holds a confirmed session pointing at our old conversation inbox and keeps writing to it, every frame lands as `RX-NOSTATE`, and our next send mints a brand-new inbox the peer never hears about, so the conversation goes permanently one-way with no recovery path. Preserving the mappings keeps the promise this action makes to the user true in **both** directions.

### Per-conversation reset (copy alignment)

Conversation Settings now mirrors mobile's `DMSettingsSheet`:

| | Before | After |
|---|---|---|
| Row | Reset Encryption Session | Fix Encryption |
| Sublabel | (tooltip only) | Reset if messages fail to send or decrypt |
| Dialog title | Reset Encryption Session | Fix Encryption |

The tooltip is gone: this is the one row a confused user is meant to find, so it should not need a hover.

### Both

Confirm inline on success instead of closing the modal. The reset leaves no visible trace anywhere in the app, so closing on success was indistinguishable from the click having done nothing.

### Tests

Four new cases on `resetAllDirectMessageSessions` in `EncryptionService.unit.test.tsx`, covering the full sweep, multi-page pagination, a non-advancing cursor, and the empty case. Each was verified to actually fail when the implementation is broken:

- reverting the pagination to a single page turns two of them red
- adding the mobile-style `deleteInboxMapping` call turns the routing-preservation assertion red, so a future "parity" port of `clearAll()` is blocked by a test

Full suite: 1074 passed, `tsc --noEmit` clean, lint clean on the touched files.

### Follow-up

New user-facing strings are not yet in the i18n catalogs; they fall back to English until a separate translation pass runs.
