### PR TITLE
fix(config): a refused sync no longer discards the user's change

### DIFF
--- a/src/dev/tests/services/ConfigService.unit.test.tsx
+++ b/src/dev/tests/services/ConfigService.unit.test.tsx
@@ -1054,4 +1054,130 @@ describe('ConfigService - Unit Tests', () => {
       expect(JSON.stringify(result)).not.toContain('senderIcon');
     });
   });
+
+  describe('8. saveConfig() - a rejected publish must not cost the user their edit', () => {
+    // THESE TESTS ARE EXPECTED TO FAIL until the fix lands. They exist to turn a
+    // read-the-code claim into a measurement, and they are the acceptance tests
+    // for .agents/issues/.open/2026-08-08-record-and-show-what-the-last-config-
+    // publish-actually-did.md.
+    //
+    // The claim: postUserSettings is a bare `await` with no try/catch, so a 4xx
+    // throws straight out of saveConfig and the local DB write never runs. The
+    // server refusing the blob therefore also discards whatever the user just
+    // changed, on this device, permanently — the action queue classifies the
+    // real-world rejection message as a PERMANENT error (its matcher looks for
+    // 'invalid'), so it is never retried either.
+
+    const address = 'user-reject';
+    const mockKeyset = {
+      userKeyset: {
+        user_key: {
+          private_key: new Uint8Array(57),
+          public_key: new Uint8Array(57),
+        },
+      } as any,
+      deviceKeyset: {} as any,
+    };
+
+    /** Make the DB fake actually persist, so we can read back what survived. */
+    function persistLocally() {
+      let stored: any;
+      mockDeps.messageDB.saveUserConfig = vi.fn(async (c: any) => {
+        stored = structuredClone(c);
+      });
+      mockDeps.messageDB.getUserConfig = vi.fn(async () => stored);
+      return () => stored;
+    }
+
+    /** Everything the allowSync:true path needs to reach postUserSettings. */
+    function arrangePublish() {
+      mockDeps.messageDB.getSpaces = vi.fn().mockResolvedValue([{ spaceId: 'space-1' }]);
+      mockDeps.messageDB.getSpaceKeys = vi.fn().mockResolvedValue([]);
+      mockDeps.messageDB.getEncryptionStates = vi.fn().mockResolvedValue([{ id: 'enc-1' }]);
+      mockDeps.messageDB.getBookmarks = vi.fn().mockResolvedValue([]);
+      mockDeps.messageDB.getAllUserNotes = vi.fn().mockResolvedValue([]);
+      vi.spyOn(global.crypto.subtle, 'importKey').mockResolvedValue({} as CryptoKey);
+      vi.spyOn(global.crypto.subtle, 'encrypt').mockResolvedValue(
+        new Uint8Array(16).buffer as ArrayBuffer
+      );
+    }
+
+    /**
+     * The real rejection, verbatim. The exact wording matters twice over: it is
+     * what the server returns for an oversized blob (evals-bloat #108), and
+     * ActionQueueHandlers.isPermanentError decides retry-or-not by looking for
+     * the substring 'invalid' in it.
+     */
+    const SERVER_REJECTION = new Error(
+      'Request failed with status code 400: invalid config missing data'
+    );
+
+    /** The user changed something — a new Space and a renamed profile. */
+    const editedConfig = () => ({
+      address,
+      spaceIds: ['space-1'],
+      allowSync: true,
+      timestamp: 1000,
+      name: 'edited-display-name',
+    }) as any;
+
+    it('CONTROL ARM: an accepted publish persists the edit locally', async () => {
+      // If this ever goes red, the harness is broken and the tests below prove
+      // nothing — a save that never reaches postUserSettings would "not persist"
+      // for reasons that have nothing to do with the rejection.
+      const read = persistLocally();
+      arrangePublish();
+      mockDeps.apiClient.postUserSettings = vi.fn().mockResolvedValue({});
+
+      await configService.saveConfig({ config: editedConfig(), keyset: mockKeyset });
+
+      expect(mockDeps.apiClient.postUserSettings).toHaveBeenCalled();
+      expect(read()?.name).toBe('edited-display-name');
+    });
+
+    it('persists the edit locally even when the server refuses the blob', async () => {
+      const read = persistLocally();
+      arrangePublish();
+      mockDeps.apiClient.postUserSettings = vi.fn().mockRejectedValue(SERVER_REJECTION);
+
+      await configService
+        .saveConfig({ config: editedConfig(), keyset: mockKeyset })
+        .catch(() => {
+          // Rejecting is correct and is asserted separately below. What must not
+          // happen is losing the edit on the way out.
+        });
+
+      expect(mockDeps.apiClient.postUserSettings).toHaveBeenCalled();
+      expect(read()?.name).toBe('edited-display-name');
+    });
+
+    it('still rejects, so the action queue can classify and report the failure', async () => {
+      // The guard against over-correcting the test above by swallowing the error.
+      // Swallowing would silently kill both the retry for transient failures and
+      // the 'Failed to save settings' toast for permanent ones.
+      persistLocally();
+      arrangePublish();
+      mockDeps.apiClient.postUserSettings = vi.fn().mockRejectedValue(SERVER_REJECTION);
+
+      await expect(
+        configService.saveConfig({ config: editedConfig(), keyset: mockKeyset })
+      ).rejects.toThrow(/invalid config missing data/);
+    });
+
+    it('withholds the timestamp after a rejected publish (Rule 1)', async () => {
+      // Persisting on the failure path re-opens the hole #320/#243 just closed:
+      // nothing reached the server, so nothing earned a newer timestamp. Keep the
+      // incoming one, or this device outranks every other one while being the
+      // only one that failed to publish.
+      const read = persistLocally();
+      arrangePublish();
+      mockDeps.apiClient.postUserSettings = vi.fn().mockRejectedValue(SERVER_REJECTION);
+
+      await configService
+        .saveConfig({ config: editedConfig(), keyset: mockKeyset })
+        .catch(() => {});
+
+      expect(read()?.timestamp).toBe(1000);
+    });
+  });
 });

--- a/src/services/ConfigService.ts
+++ b/src/services/ConfigService.ts
@@ -408,10 +408,14 @@ export class ConfigService {
     // The remote config is applied verbatim, and the sidebar renders from
     // `config.items` (useNavItems.ts:49-53), so a publisher that narrows its
     // Space list empties this device's nav the moment its blob wins on
-    // timestamp. Desktop refuses to publish such a list (saveConfig, below);
-    // mobile currently only warns and publishes anyway. Nothing on this side
-    // recorded the adoption, which is why every report of "all my Spaces
-    // vanished" arrived with no evidence attached.
+    // timestamp. Both clients now refuse to publish such a list — desktop in
+    // saveConfig below, mobile since its #228/#229 (an earlier revert of the
+    // mobile guard is why older notes say it "only warns and publishes
+    // anyway"; that has not been true since 2026-08-04). So the known trigger
+    // is gone, but this receiver still adopts whatever it is handed, which is
+    // why the diagnostic stays: nothing else on this side records the
+    // adoption, and every report of "all my Spaces vanished" arrived with no
+    // evidence attached.
     await this.recordSpaceListShrinkOnAdopt(storedConfig, config);
 
     await this.messageDB.saveUserConfig({
@@ -523,6 +527,10 @@ export class ConfigService {
     // advance this device's timestamp. See the note in the refuse-to-publish
     // branch for why that matters.
     const incomingTimestamp = configInput.timestamp ?? 0;
+
+    // Held rather than thrown, so the local save below still runs. Re-thrown
+    // once it has. See the catch around the POST for why both halves matter.
+    let publishError: unknown;
 
     const ts = Date.now();
     config.timestamp = ts;
@@ -691,20 +699,42 @@ export class ConfigService {
           address: config.address,
           timestamp: ts,
         });
-        await this.apiClient.postUserSettings(config.address, {
-          user_address: config.address,
-          user_public_key: Buffer.from(
-            new Uint8Array(userKey.user_key.public_key)
-          ).toString('hex'),
-          user_config: ciphertext,
-          timestamp: ts,
-          signature: signature,
-        });
-        logger.log('[ConfigService] Settings posted successfully');
+        try {
+          await this.apiClient.postUserSettings(config.address, {
+            user_address: config.address,
+            user_public_key: Buffer.from(
+              new Uint8Array(userKey.user_key.public_key)
+            ).toString('hex'),
+            user_config: ciphertext,
+            timestamp: ts,
+            signature: signature,
+          });
+          logger.log('[ConfigService] Settings posted successfully');
 
-        // Reset tombstones only after successful sync (Phase 7: Critical Fix)
-        config.deletedBookmarkIds = [];
-        config.deletedUserNoteAddresses = [];
+          // Reset tombstones only after successful sync (Phase 7: Critical Fix)
+          config.deletedBookmarkIds = [];
+          config.deletedUserNoteAddresses = [];
+        } catch (error) {
+          // A refused upload used to throw straight out of saveConfig, so the
+          // local save at the end never ran and the edit the user had just made
+          // was discarded on this device. The server rejects the WHOLE blob when
+          // it is oversized (evals bloat, #108), and the queue reads "invalid"
+          // in that message as permanent, so nothing retried it either — the
+          // change was simply gone. Hold the error, let the save happen, throw
+          // after. Covered by ConfigService.unit.test.tsx §8.
+          publishError = error;
+          logger.warn(
+            '[ConfigService] Settings POST failed — keeping the change locally, not published:',
+            error
+          );
+
+          // Nothing reached the server, so nothing earned a newer timestamp.
+          // Without this, persisting on the failure path would re-open the hole
+          // #320 closed: this device would outrank every other one while being
+          // the only one that failed to publish, and would then stop applying
+          // their configs. Publishing is what earns the right to a newer stamp.
+          config.timestamp = incomingTimestamp;
+        }
       }
     } else {
       // Sync is off, so nothing was published and the server never agreed to a
@@ -738,6 +768,13 @@ export class ConfigService {
     if (cacheUpdatedAt <= ts) {
       this.queryClient.setQueryData(cacheKey, config);
     }
+
+    // Everything local has landed; now let the failure surface. The queue needs
+    // this to classify the error (permanent vs retryable) and to show "Failed to
+    // save settings". Swallowing it here would look like a passing test and be a
+    // silent regression: no retry for transient failures, no message for real
+    // ones.
+    if (publishError) throw publishError;
   }
 
   /**


### PR DESCRIPTION
`postUserSettings` was a bare `await`, so a server rejection threw straight out of `saveConfig` and the local DB write at the end never ran. `saveUserConfig` was not called at all, meaning the setting the user had just changed was discarded on that device.

It did not self-correct. The server refuses the whole blob when it is oversized (evals bloat, #108) with `400 "invalid config missing data"`, and `ActionQueueHandlers.isPermanentError` treats any message containing `invalid` as permanent — so the task was marked failed and never retried.

## The fix

Hold the error rather than throwing it, let the local save and the cache write happen, then throw it after. The queue still sees it, so error classification, retry for transient failures, and the `Failed to save settings` toast all behave exactly as before.

The catch also restores the incoming timestamp. Persisting on a path that never reached the server would otherwise re-open what #320 closed: this device would outrank every other one while being the only one that failed to publish, and would then stop applying their configs.

Three pieces, each independently necessary:

| Piece | Removing it breaks |
|---|---|
| the `try`/`catch` | the edit is lost again |
| restoring the timestamp | Rule 1 — the device claims authority it did not earn |
| the re-throw after the write | retry and the failure toast both die silently |

## Verification

Tests were written first and confirmed red before the fix (`saveUserConfig` never called — the failures reported `undefined`, not a stale value). A control arm using the same mocks with a resolving POST passed throughout, ruling out a broken harness.

Each of the three pieces was then reverted individually and confirmed to turn a specific test red.

- `ConfigService.unit.test.tsx` — 34/34
- Full suite — 1137/1137 across 87 files
- Typecheck clean

## Scope

Desktop only, and deliberately so: mobile already persists on this path and already restores the timestamp, so it never had this bug. No change to what goes over the wire.

Does not address the fact that the user still has no way to tell that sync is failing — the toast says nothing about sync. That is tracked separately.
