### PR TITLE
feat(config): report sync failures, and make turning sync off stick

### DIFF
--- a/src/components/modals/UserSettingsModal/Privacy.tsx
+++ b/src/components/modals/UserSettingsModal/Privacy.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Switch, Icon, Tooltip } from '../../primitives';
 import { t } from '@lingui/core/macro';
 import ConfirmationModal from '../ConfirmationModal';
+import SyncStatusLine from './SyncStatusLine';
 
 interface PrivacyProps {
   allowSync: boolean;
@@ -98,6 +99,7 @@ const Privacy: React.FunctionComponent<PrivacyProps> = ({
               </Tooltip>
             </div>
           </div>
+          <SyncStatusLine allowSync={allowSync} />
           <div className="flex flex-row items-center gap-3 mb-3">
             <Switch value={nonRepudiable} onChange={setNonRepudiable} />
             <div className="flex flex-row items-center">

--- a/src/components/modals/UserSettingsModal/SyncStatusLine.tsx
+++ b/src/components/modals/UserSettingsModal/SyncStatusLine.tsx
@@ -1,87 +1,73 @@
 import * as React from 'react';
 import { t } from '@lingui/core/macro';
-import dayjs from '../../../utils/dayjs';
-import { readLastPublish, type LastPublish } from '../../../utils/lastPublish';
+import { readLastPublish } from '../../../utils/lastPublish';
 
 /**
- * One line under the sync toggle saying what the last publish attempt did.
+ * Shows a line under the sync toggle ONLY when publishing is failing.
+ * Silence means sync is fine.
  *
- * Without it, "sync is on" and "sync has been silently failing since Tuesday"
- * look identical: every outcome writes the local row and the UI looks right
- * either way. The record itself is device-local — see utils/lastPublish.
+ * A "Last synced N ago" line was built first and deliberately removed. It read
+ * as a health indicator but reported the last time this device had something to
+ * PUBLISH, not the last time it talked to the server — pulls happen on open,
+ * pushes only when something changes. So a healthy device that had not changed
+ * a setting in three days announced "Last synced 3 days ago", which is
+ * indistinguishable from three days broken. Reporting success was worse than
+ * saying nothing.
+ *
+ * The record is still written for every outcome, success included. It is the
+ * instrument later work is verified with, and its payloadBytes readings are how
+ * the unknown server size limit gets settled. Only the display is failures-only.
+ *
+ * Known limit: someone who never opens Settings never sees this. A more visible
+ * surface (a toast) was considered and deliberately deferred.
  */
 const SyncStatusLine: React.FunctionComponent<{ allowSync: boolean }> = ({
   allowSync,
 }) => {
-  const [last, setLast] = React.useState<LastPublish | null>(() =>
-    readLastPublish()
-  );
+  const [last, setLast] = React.useState(() => readLastPublish());
 
-  // localStorage fires no event for same-tab writes, so a save made while this
-  // panel is open would otherwise show a stale line until it is reopened. The
-  // panel is short-lived and the read is a single parse, so polling it is
-  // cheaper than threading the record through the config layer.
+  // localStorage fires no event for same-tab writes, so a failure occurring
+  // while this panel is open would not appear, and a recovery would not clear.
   React.useEffect(() => {
     setLast(readLastPublish());
     const id = setInterval(() => setLast(readLastPublish()), 2000);
     return () => clearInterval(id);
   }, [allowSync]);
 
-  // Trust the toggle over the record here: turning sync on or off is instant,
-  // but no record exists until the next save, so the line would contradict the
-  // switch the user just flipped.
-  if (!allowSync) {
-    return (
-      <StatusText>{t`Not syncing. Changes stay on this device.`}</StatusText>
-    );
-  }
+  // Sync off is a setting working as asked, not a fault, and any stored failure
+  // predates the switch. The toggle above already says everything there is.
+  if (!allowSync || !last) return null;
 
-  if (!last) return <StatusText>{t`Not synced yet.`}</StatusText>;
+  const message = failureMessage(last.outcome);
+  if (!message) return null;
 
-  const when = dayjs(last.at).fromNow();
-
-  switch (last.outcome) {
-    case 'published':
-      return <StatusText>{t`Last synced ${when}.`}</StatusText>;
-    case 'held':
-      return (
-        <StatusText warn>
-          {t`Waiting for Spaces to finish syncing before this device publishes again.`}
-        </StatusText>
-      );
-    case 'rejected':
-      return (
-        <StatusText warn>
-          {t`Last sync was refused by the server ${when}. Your changes are saved on this device.`}
-        </StatusText>
-      );
-    case 'timeout':
-      return (
-        <StatusText warn>{t`Last sync timed out ${when}. Will retry.`}</StatusText>
-      );
-    case 'no-keys':
-      return (
-        <StatusText warn>{t`Can't sync: no key available on this device.`}</StatusText>
-      );
-    case 'off':
-      // The record says off but the toggle says on, so a save has not run since
-      // it was switched. Say nothing has synced rather than guessing.
-      return <StatusText>{t`Not synced yet.`}</StatusText>;
-    default:
-      return null;
-  }
+  return (
+    <div className="text-xs mb-3 ml-14 -mt-2 text-warning" role="alert">
+      {message}
+    </div>
+  );
 };
 
-const StatusText: React.FunctionComponent<{
-  children: React.ReactNode;
-  warn?: boolean;
-}> = ({ children, warn }) => (
-  <div
-    className={`text-xs mb-3 ml-14 -mt-2 ${warn ? 'text-warning' : 'text-subtle'}`}
-    role={warn ? 'alert' : undefined}
-  >
-    {children}
-  </div>
-);
+/**
+ * Present tense throughout: the record always describes the most recent attempt,
+ * so a stored failure means publishing is failing now, however old it is.
+ * Returns null for every outcome that is not a fault.
+ */
+function failureMessage(outcome: string): string | null {
+  switch (outcome) {
+    case 'held':
+      return t`Waiting for Spaces to finish syncing before this device publishes again.`;
+    case 'rejected':
+      return t`Sync is failing: the server refused your settings. Your changes are saved on this device.`;
+    case 'timeout':
+      return t`Sync is failing: the request timed out. It will keep retrying.`;
+    case 'no-keys':
+      return t`Can't sync: no key is available on this device.`;
+    default:
+      // 'published' and 'off' are not faults, and neither is an unknown value
+      // written by a newer build.
+      return null;
+  }
+}
 
 export default SyncStatusLine;

--- a/src/components/modals/UserSettingsModal/SyncStatusLine.tsx
+++ b/src/components/modals/UserSettingsModal/SyncStatusLine.tsx
@@ -1,0 +1,87 @@
+import * as React from 'react';
+import { t } from '@lingui/core/macro';
+import dayjs from '../../../utils/dayjs';
+import { readLastPublish, type LastPublish } from '../../../utils/lastPublish';
+
+/**
+ * One line under the sync toggle saying what the last publish attempt did.
+ *
+ * Without it, "sync is on" and "sync has been silently failing since Tuesday"
+ * look identical: every outcome writes the local row and the UI looks right
+ * either way. The record itself is device-local — see utils/lastPublish.
+ */
+const SyncStatusLine: React.FunctionComponent<{ allowSync: boolean }> = ({
+  allowSync,
+}) => {
+  const [last, setLast] = React.useState<LastPublish | null>(() =>
+    readLastPublish()
+  );
+
+  // localStorage fires no event for same-tab writes, so a save made while this
+  // panel is open would otherwise show a stale line until it is reopened. The
+  // panel is short-lived and the read is a single parse, so polling it is
+  // cheaper than threading the record through the config layer.
+  React.useEffect(() => {
+    setLast(readLastPublish());
+    const id = setInterval(() => setLast(readLastPublish()), 2000);
+    return () => clearInterval(id);
+  }, [allowSync]);
+
+  // Trust the toggle over the record here: turning sync on or off is instant,
+  // but no record exists until the next save, so the line would contradict the
+  // switch the user just flipped.
+  if (!allowSync) {
+    return (
+      <StatusText>{t`Not syncing. Changes stay on this device.`}</StatusText>
+    );
+  }
+
+  if (!last) return <StatusText>{t`Not synced yet.`}</StatusText>;
+
+  const when = dayjs(last.at).fromNow();
+
+  switch (last.outcome) {
+    case 'published':
+      return <StatusText>{t`Last synced ${when}.`}</StatusText>;
+    case 'held':
+      return (
+        <StatusText warn>
+          {t`Waiting for Spaces to finish syncing before this device publishes again.`}
+        </StatusText>
+      );
+    case 'rejected':
+      return (
+        <StatusText warn>
+          {t`Last sync was refused by the server ${when}. Your changes are saved on this device.`}
+        </StatusText>
+      );
+    case 'timeout':
+      return (
+        <StatusText warn>{t`Last sync timed out ${when}. Will retry.`}</StatusText>
+      );
+    case 'no-keys':
+      return (
+        <StatusText warn>{t`Can't sync: no key available on this device.`}</StatusText>
+      );
+    case 'off':
+      // The record says off but the toggle says on, so a save has not run since
+      // it was switched. Say nothing has synced rather than guessing.
+      return <StatusText>{t`Not synced yet.`}</StatusText>;
+    default:
+      return null;
+  }
+};
+
+const StatusText: React.FunctionComponent<{
+  children: React.ReactNode;
+  warn?: boolean;
+}> = ({ children, warn }) => (
+  <div
+    className={`text-xs mb-3 ml-14 -mt-2 ${warn ? 'text-warning' : 'text-subtle'}`}
+    role={warn ? 'alert' : undefined}
+  >
+    {children}
+  </div>
+);
+
+export default SyncStatusLine;

--- a/src/dev/tests/components/SyncStatusLine.test.tsx
+++ b/src/dev/tests/components/SyncStatusLine.test.tsx
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach, beforeAll, afterEach, vi } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { i18n } from '@lingui/core';
+import { messages } from '@/i18n/en/messages';
+import SyncStatusLine from '@/components/modals/UserSettingsModal/SyncStatusLine';
+import type { LastPublish } from '@quilibrium/quorum-shared';
+
+const PUBLISH_KEY = 'quorum:sync:lastPublish';
+
+beforeAll(() => {
+  i18n.load('en', messages);
+  i18n.activate('en');
+});
+
+/**
+ * The line under the sync toggle is the only place a user ever learns that sync
+ * is failing. Every branch is asserted, including the two that only exist
+ * because the toggle and the record can disagree.
+ */
+describe('SyncStatusLine', () => {
+  beforeEach(() => {
+    localStorage.removeItem(PUBLISH_KEY);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const store = (record: Partial<LastPublish>) =>
+    localStorage.setItem(
+      PUBLISH_KEY,
+      JSON.stringify({ at: Date.now(), outcome: 'published', ...record })
+    );
+
+  it('says changes stay on this device when sync is off', () => {
+    render(<SyncStatusLine allowSync={false} />);
+    expect(screen.getByText(/stay on this device/i)).toBeInTheDocument();
+  });
+
+  it('trusts the toggle over a stale record when sync was just switched off', () => {
+    // The record still says the last save published. The switch is off NOW, so
+    // "Last synced 2 minutes ago" would contradict what the user just did.
+    store({ outcome: 'published' });
+    render(<SyncStatusLine allowSync={false} />);
+    expect(screen.getByText(/stay on this device/i)).toBeInTheDocument();
+    expect(screen.queryByText(/last synced/i)).not.toBeInTheDocument();
+  });
+
+  it('says not synced yet when nothing has been recorded', () => {
+    render(<SyncStatusLine allowSync={true} />);
+    expect(screen.getByText(/not synced yet/i)).toBeInTheDocument();
+  });
+
+  it('says not synced yet when sync is on but the last record predates it', () => {
+    // The mirror of the stale-record case: switched ON, but no save has run
+    // since, so the only record says 'off'. Claiming a sync would be a lie.
+    store({ outcome: 'off' });
+    render(<SyncStatusLine allowSync={true} />);
+    expect(screen.getByText(/not synced yet/i)).toBeInTheDocument();
+  });
+
+  it('reports a successful publish with a relative time', () => {
+    store({ outcome: 'published', at: Date.now() - 3 * 60 * 1000 });
+    render(<SyncStatusLine allowSync={true} />);
+    expect(screen.getByText(/last synced 3 minutes ago/i)).toBeInTheDocument();
+  });
+
+  it('explains a hold without implying anything is broken', () => {
+    store({ outcome: 'held', spacesPublished: 2, spacesHeld: 1 });
+    render(<SyncStatusLine allowSync={true} />);
+    expect(screen.getByText(/waiting for spaces to finish syncing/i)).toBeInTheDocument();
+  });
+
+  it('says a rejected sync kept the change locally', () => {
+    // The reassurance is the point: the edit IS saved on this device, and
+    // without saying so the message reads as "your change is gone".
+    store({ outcome: 'rejected', detail: 'invalid config missing data' });
+    render(<SyncStatusLine allowSync={true} />);
+    expect(screen.getByText(/refused by the server/i)).toBeInTheDocument();
+    expect(screen.getByText(/saved on this device/i)).toBeInTheDocument();
+  });
+
+  it('says a timeout will retry', () => {
+    store({ outcome: 'timeout' });
+    render(<SyncStatusLine allowSync={true} />);
+    expect(screen.getByText(/timed out/i)).toBeInTheDocument();
+    expect(screen.getByText(/will retry/i)).toBeInTheDocument();
+  });
+
+  it('reports a missing key', () => {
+    store({ outcome: 'no-keys' });
+    render(<SyncStatusLine allowSync={true} />);
+    expect(screen.getByText(/no key available/i)).toBeInTheDocument();
+  });
+
+  it('announces failures to screen readers, and successes quietly', () => {
+    store({ outcome: 'rejected' });
+    const { unmount } = render(<SyncStatusLine allowSync={true} />);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    unmount();
+
+    store({ outcome: 'published' });
+    render(<SyncStatusLine allowSync={true} />);
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('survives a corrupted record instead of taking the panel down', () => {
+    localStorage.setItem(PUBLISH_KEY, '{ not json');
+    render(<SyncStatusLine allowSync={true} />);
+    expect(screen.getByText(/not synced yet/i)).toBeInTheDocument();
+  });
+
+  it('picks up a publish that happens while the panel is open', async () => {
+    // localStorage fires no event for same-tab writes, so without the poll the
+    // line would sit on "Not synced yet" through a save the user just triggered.
+    vi.useFakeTimers();
+    render(<SyncStatusLine allowSync={true} />);
+    expect(screen.getByText(/not synced yet/i)).toBeInTheDocument();
+
+    store({ outcome: 'published', at: Date.now() });
+    // The interval's setState lands outside React's auto-act window, so without
+    // this the re-render never commits and the assertion reads the stale DOM.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2500);
+    });
+
+    expect(screen.getByText(/last synced/i)).toBeInTheDocument();
+  });
+});

--- a/src/dev/tests/components/SyncStatusLine.test.tsx
+++ b/src/dev/tests/components/SyncStatusLine.test.tsx
@@ -13,9 +13,9 @@ beforeAll(() => {
 });
 
 /**
- * The line under the sync toggle is the only place a user ever learns that sync
- * is failing. Every branch is asserted, including the two that only exist
- * because the toggle and the record can disagree.
+ * Failures-only. Silence means sync is fine, so "renders nothing" is a real
+ * assertion here rather than an absence of one: a line appearing when nothing
+ * is wrong is the regression this component was rewritten to remove.
  */
 describe('SyncStatusLine', () => {
   beforeEach(() => {
@@ -32,98 +32,112 @@ describe('SyncStatusLine', () => {
       JSON.stringify({ at: Date.now(), outcome: 'published', ...record })
     );
 
-  it('says changes stay on this device when sync is off', () => {
-    render(<SyncStatusLine allowSync={false} />);
-    expect(screen.getByText(/stay on this device/i)).toBeInTheDocument();
-  });
-
-  it('trusts the toggle over a stale record when sync was just switched off', () => {
-    // The record still says the last save published. The switch is off NOW, so
-    // "Last synced 2 minutes ago" would contradict what the user just did.
-    store({ outcome: 'published' });
-    render(<SyncStatusLine allowSync={false} />);
-    expect(screen.getByText(/stay on this device/i)).toBeInTheDocument();
-    expect(screen.queryByText(/last synced/i)).not.toBeInTheDocument();
-  });
-
-  it('says not synced yet when nothing has been recorded', () => {
-    render(<SyncStatusLine allowSync={true} />);
-    expect(screen.getByText(/not synced yet/i)).toBeInTheDocument();
-  });
-
-  it('says not synced yet when sync is on but the last record predates it', () => {
-    // The mirror of the stale-record case: switched ON, but no save has run
-    // since, so the only record says 'off'. Claiming a sync would be a lie.
-    store({ outcome: 'off' });
-    render(<SyncStatusLine allowSync={true} />);
-    expect(screen.getByText(/not synced yet/i)).toBeInTheDocument();
-  });
-
-  it('reports a successful publish with a relative time', () => {
-    store({ outcome: 'published', at: Date.now() - 3 * 60 * 1000 });
-    render(<SyncStatusLine allowSync={true} />);
-    expect(screen.getByText(/last synced 3 minutes ago/i)).toBeInTheDocument();
-  });
-
-  it('explains a hold without implying anything is broken', () => {
-    store({ outcome: 'held', spacesPublished: 2, spacesHeld: 1 });
-    render(<SyncStatusLine allowSync={true} />);
-    expect(screen.getByText(/waiting for spaces to finish syncing/i)).toBeInTheDocument();
-  });
-
-  it('says a rejected sync kept the change locally', () => {
-    // The reassurance is the point: the edit IS saved on this device, and
-    // without saying so the message reads as "your change is gone".
-    store({ outcome: 'rejected', detail: 'invalid config missing data' });
-    render(<SyncStatusLine allowSync={true} />);
-    expect(screen.getByText(/refused by the server/i)).toBeInTheDocument();
-    expect(screen.getByText(/saved on this device/i)).toBeInTheDocument();
-  });
-
-  it('says a timeout will retry', () => {
-    store({ outcome: 'timeout' });
-    render(<SyncStatusLine allowSync={true} />);
-    expect(screen.getByText(/timed out/i)).toBeInTheDocument();
-    expect(screen.getByText(/will retry/i)).toBeInTheDocument();
-  });
-
-  it('reports a missing key', () => {
-    store({ outcome: 'no-keys' });
-    render(<SyncStatusLine allowSync={true} />);
-    expect(screen.getByText(/no key available/i)).toBeInTheDocument();
-  });
-
-  it('announces failures to screen readers, and successes quietly', () => {
-    store({ outcome: 'rejected' });
-    const { unmount } = render(<SyncStatusLine allowSync={true} />);
-    expect(screen.getByRole('alert')).toBeInTheDocument();
-    unmount();
-
-    store({ outcome: 'published' });
-    render(<SyncStatusLine allowSync={true} />);
-    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
-  });
-
-  it('survives a corrupted record instead of taking the panel down', () => {
-    localStorage.setItem(PUBLISH_KEY, '{ not json');
-    render(<SyncStatusLine allowSync={true} />);
-    expect(screen.getByText(/not synced yet/i)).toBeInTheDocument();
-  });
-
-  it('picks up a publish that happens while the panel is open', async () => {
-    // localStorage fires no event for same-tab writes, so without the poll the
-    // line would sit on "Not synced yet" through a save the user just triggered.
-    vi.useFakeTimers();
-    render(<SyncStatusLine allowSync={true} />);
-    expect(screen.getByText(/not synced yet/i)).toBeInTheDocument();
-
-    store({ outcome: 'published', at: Date.now() });
-    // The interval's setState lands outside React's auto-act window, so without
-    // this the re-render never commits and the assertion reads the stale DOM.
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(2500);
+  describe('stays silent when nothing is wrong', () => {
+    it('after a successful publish', () => {
+      // The whole point of the rewrite. "Last synced 3 days ago" on a healthy
+      // device is indistinguishable from three days broken.
+      store({ outcome: 'published' });
+      const { container } = render(<SyncStatusLine allowSync={true} />);
+      expect(container).toBeEmptyDOMElement();
     });
 
-    expect(screen.getByText(/last synced/i)).toBeInTheDocument();
+    it('when nothing has ever been recorded', () => {
+      const { container } = render(<SyncStatusLine allowSync={true} />);
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('when the recorded outcome is "off"', () => {
+      store({ outcome: 'off' });
+      const { container } = render(<SyncStatusLine allowSync={true} />);
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('when sync is off, even with a failure on record', () => {
+      // The failure predates the switch, and the toggle above already says
+      // everything there is to say.
+      store({ outcome: 'rejected' });
+      const { container } = render(<SyncStatusLine allowSync={false} />);
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('when the record is corrupted', () => {
+      localStorage.setItem(PUBLISH_KEY, '{ not json');
+      const { container } = render(<SyncStatusLine allowSync={true} />);
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('when a newer build wrote an outcome this one does not know', () => {
+      store({ outcome: 'some-future-state' as never });
+      const { container } = render(<SyncStatusLine allowSync={true} />);
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+
+  describe('speaks up when publishing is failing', () => {
+    it('explains a hold without implying anything is broken', () => {
+      store({ outcome: 'held', spacesPublished: 2, spacesHeld: 1 });
+      render(<SyncStatusLine allowSync={true} />);
+      expect(screen.getByText(/waiting for spaces to finish syncing/i)).toBeInTheDocument();
+    });
+
+    it('says a refused sync kept the change on this device', () => {
+      // The reassurance is load-bearing. Without it the message reads as "your
+      // change is gone", which is exactly what is NOT true after the fix.
+      store({ outcome: 'rejected', detail: 'invalid config missing data' });
+      render(<SyncStatusLine allowSync={true} />);
+      expect(screen.getByText(/the server refused your settings/i)).toBeInTheDocument();
+      expect(screen.getByText(/saved on this device/i)).toBeInTheDocument();
+    });
+
+    it('says a timeout will keep retrying', () => {
+      store({ outcome: 'timeout' });
+      render(<SyncStatusLine allowSync={true} />);
+      expect(screen.getByText(/timed out/i)).toBeInTheDocument();
+      expect(screen.getByText(/keep retrying/i)).toBeInTheDocument();
+    });
+
+    it('reports a missing key', () => {
+      store({ outcome: 'no-keys' });
+      render(<SyncStatusLine allowSync={true} />);
+      expect(screen.getByText(/no key is available/i)).toBeInTheDocument();
+    });
+
+    it('announces the failure to screen readers', () => {
+      store({ outcome: 'rejected' });
+      render(<SyncStatusLine allowSync={true} />);
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+  });
+
+  describe('tracks changes while the panel is open', () => {
+    it('appears when a publish starts failing', () => {
+      vi.useFakeTimers();
+      store({ outcome: 'published' });
+      const { container } = render(<SyncStatusLine allowSync={true} />);
+      expect(container).toBeEmptyDOMElement();
+
+      store({ outcome: 'rejected' });
+      act(() => {
+        vi.advanceTimersByTime(2500);
+      });
+
+      expect(screen.getByText(/the server refused your settings/i)).toBeInTheDocument();
+    });
+
+    it('clears itself once a publish succeeds again', () => {
+      // The direction that is easy to forget. A warning that never goes away is
+      // worse than none, because it stops meaning anything.
+      vi.useFakeTimers();
+      store({ outcome: 'rejected' });
+      const { container } = render(<SyncStatusLine allowSync={true} />);
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+
+      store({ outcome: 'published' });
+      act(() => {
+        vi.advanceTimersByTime(2500);
+      });
+
+      expect(container).toBeEmptyDOMElement();
+    });
   });
 });

--- a/src/dev/tests/services/ConfigService.unit.test.tsx
+++ b/src/dev/tests/services/ConfigService.unit.test.tsx
@@ -42,12 +42,21 @@ beforeAll(() => {
   i18n.activate('en');
 });
 
+/** Device-local publish-outcome record — see src/utils/lastPublish.ts */
+const PUBLISH_KEY = 'quorum:sync:lastPublish';
+
 describe('ConfigService - Unit Tests', () => {
   let configService: ConfigService;
   let mockDeps: any;
   let queryClient: QueryClient;
 
   beforeEach(() => {
+    // Restore, not just clear. Several tests spy on Storage.prototype.setItem
+    // and make it throw; vi.clearAllMocks() resets call history but leaves the
+    // implementation in place, so without this the first such test silently
+    // breaks localStorage for every test after it.
+    vi.restoreAllMocks();
+
     // Create fresh QueryClient for each test
     queryClient = new QueryClient({
       defaultOptions: {
@@ -99,6 +108,10 @@ describe('ConfigService - Unit Tests', () => {
 
     // Clear all mocks before each test
     vi.clearAllMocks();
+
+    // The publish-outcome record persists across tests otherwise, so a test
+    // could read a previous test's outcome and pass without writing anything.
+    localStorage.removeItem(PUBLISH_KEY);
   });
 
   describe('1. getConfig() - Configuration Retrieval', () => {
@@ -1164,6 +1177,39 @@ describe('ConfigService - Unit Tests', () => {
       ).rejects.toThrow(/invalid config missing data/);
     });
 
+    it('records the outcome as rejected, with the size and the server message', async () => {
+      persistLocally();
+      arrangePublish();
+      mockDeps.apiClient.postUserSettings = vi.fn().mockRejectedValue(SERVER_REJECTION);
+
+      await configService
+        .saveConfig({ config: editedConfig(), keyset: mockKeyset })
+        .catch(() => {});
+
+      const record = JSON.parse(localStorage.getItem(PUBLISH_KEY)!);
+      expect(record.outcome).toBe('rejected');
+      expect(record.detail).toMatch(/invalid config missing data/);
+      // The size of a payload the server refused is the measurement that the
+      // still-unknown limit will eventually be settled with.
+      expect(record.payloadBytes).toBeGreaterThan(0);
+    });
+
+    it('distinguishes a timeout from a refusal', async () => {
+      // They mean opposite things to a user — "will retry" vs "this will never
+      // work" — so they must not collapse into one outcome.
+      persistLocally();
+      arrangePublish();
+      mockDeps.apiClient.postUserSettings = vi
+        .fn()
+        .mockRejectedValue(new Error('Request timeout'));
+
+      await configService
+        .saveConfig({ config: editedConfig(), keyset: mockKeyset })
+        .catch(() => {});
+
+      expect(JSON.parse(localStorage.getItem(PUBLISH_KEY)!).outcome).toBe('timeout');
+    });
+
     it('withholds the timestamp after a rejected publish (Rule 1)', async () => {
       // Persisting on the failure path re-opens the hole #320/#243 just closed:
       // nothing reached the server, so nothing earned a newer timestamp. Keep the
@@ -1178,6 +1224,121 @@ describe('ConfigService - Unit Tests', () => {
         .catch(() => {});
 
       expect(read()?.timestamp).toBe(1000);
+    });
+  });
+
+  describe('9. saveConfig() - every outcome leaves a record', () => {
+    // "My setting saved" has never been evidence that it synced: sync-off, a
+    // refuse-to-publish hold and a real upload all write the local row and all
+    // look identical. These assert that each one is now distinguishable after
+    // the fact, which is what the Settings line reads.
+
+    const address = 'user-outcome';
+    const mockKeyset = {
+      userKeyset: {
+        user_key: {
+          private_key: new Uint8Array(57),
+          public_key: new Uint8Array(57),
+        },
+      } as any,
+      deviceKeyset: {} as any,
+    };
+
+    function arrangePublish() {
+      mockDeps.messageDB.getSpaces = vi.fn().mockResolvedValue([{ spaceId: 'space-1' }]);
+      mockDeps.messageDB.getSpaceKeys = vi.fn().mockResolvedValue([]);
+      mockDeps.messageDB.getEncryptionStates = vi.fn().mockResolvedValue([{ id: 'enc-1' }]);
+      mockDeps.messageDB.getBookmarks = vi.fn().mockResolvedValue([]);
+      mockDeps.messageDB.getAllUserNotes = vi.fn().mockResolvedValue([]);
+      mockDeps.apiClient.postUserSettings = vi.fn().mockResolvedValue({});
+      vi.spyOn(global.crypto.subtle, 'importKey').mockResolvedValue({} as CryptoKey);
+      vi.spyOn(global.crypto.subtle, 'encrypt').mockResolvedValue(
+        new Uint8Array(16).buffer as ArrayBuffer
+      );
+    }
+
+    const record = () => JSON.parse(localStorage.getItem(PUBLISH_KEY)!);
+
+    it('records "off" when sync is disabled', async () => {
+      await configService.saveConfig({
+        config: { address, spaceIds: [], allowSync: false, timestamp: 1000 } as any,
+        keyset: mockKeyset,
+      });
+
+      expect(record().outcome).toBe('off');
+      expect(mockDeps.apiClient.postUserSettings).not.toHaveBeenCalled();
+    });
+
+    it('records "published" with the payload size and Space count', async () => {
+      arrangePublish();
+
+      await configService.saveConfig({
+        config: { address, spaceIds: ['space-1'], allowSync: true, timestamp: 1000 } as any,
+        keyset: mockKeyset,
+      });
+
+      const r = record();
+      expect(r.outcome).toBe('published');
+      expect(r.spacesPublished).toBe(1);
+      // The measurement half of the size work — free to collect here, and the
+      // only way the real server limit ever gets settled.
+      expect(r.payloadBytes).toBeGreaterThan(0);
+    });
+
+    it('records "held" with both counts when the Space list would be truncated', async () => {
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+      arrangePublish();
+      // Two Spaces listed, only one keyable locally, so the upload is held.
+      mockDeps.messageDB.getSpaces = vi.fn().mockResolvedValue([{ spaceId: 'space-1' }]);
+
+      await configService.saveConfig({
+        config: {
+          address,
+          spaceIds: ['space-1', 'space-2'],
+          allowSync: true,
+          timestamp: 1000,
+        } as any,
+        keyset: mockKeyset,
+      });
+
+      const r = record();
+      expect(r.outcome).toBe('held');
+      expect(r.spacesPublished).toBe(1);
+      expect(r.spacesHeld).toBe(1);
+      expect(mockDeps.apiClient.postUserSettings).not.toHaveBeenCalled();
+    });
+
+    it('a broken recorder never takes down config sync', async () => {
+      // An instrument that can break the path it measures is worse than none.
+      arrangePublish();
+      vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        throw new Error('quota exceeded');
+      });
+
+      await configService.saveConfig({
+        config: { address, spaceIds: ['space-1'], allowSync: true, timestamp: 1000 } as any,
+        keyset: mockKeyset,
+      });
+
+      expect(mockDeps.apiClient.postUserSettings).toHaveBeenCalled();
+      expect(mockDeps.messageDB.saveUserConfig).toHaveBeenCalled();
+    });
+
+    it('never writes the record into the synced blob', async () => {
+      // It is a per-device fact. In the blob it would broadcast to every other
+      // device, rewrite the blob on every save, and grow the payload this exists
+      // to watch.
+      arrangePublish();
+
+      await configService.saveConfig({
+        config: { address, spaceIds: ['space-1'], allowSync: true, timestamp: 1000 } as any,
+        keyset: mockKeyset,
+      });
+
+      const posted = mockDeps.apiClient.postUserSettings.mock.calls[0][1];
+      expect(JSON.stringify(posted)).not.toContain('lastPublish');
+      const saved = mockDeps.messageDB.saveUserConfig.mock.calls[0][0];
+      expect(JSON.stringify(saved)).not.toContain('lastPublish');
     });
   });
 });

--- a/src/dev/tests/services/ConfigService.unit.test.tsx
+++ b/src/dev/tests/services/ConfigService.unit.test.tsx
@@ -20,6 +20,7 @@ import { messages } from '@/i18n/en/messages';
 import { ConfigService } from '@/services/ConfigService';
 import { getDefaultUserConfig } from '@/utils';
 import { QueryClient } from '@tanstack/react-query';
+import { buildConfigKey } from '@/hooks';
 
 vi.mock('@quilibrium/quilibrium-js-sdk-channels', () => ({
   channel: {
@@ -1224,6 +1225,118 @@ describe('ConfigService - Unit Tests', () => {
         .catch(() => {});
 
       expect(read()?.timestamp).toBe(1000);
+    });
+  });
+
+  describe('10. getConfig() - allowSync is device-local and never inherited', () => {
+    // allowSync describes THIS device's relationship with the server, but it
+    // rides in the account-level blob. So a decision made on one device used to
+    // be carried to the others, and "off" could turn itself back on with nobody
+    // asking. Off must mean "do not publish" — it never meant "do not pull",
+    // and pulling is what lets a device recover without opting into publishing.
+
+    const address = 'user-devicelocal';
+    const mockUserKey = {
+      user_key: {
+        private_key: new Uint8Array(57),
+        public_key: new Uint8Array(57),
+      },
+    } as any;
+
+    /** Arrange a newer remote config that decrypts to `decrypted`. */
+    function arrangeAdopt(decrypted: any, storedConfig: any) {
+      const jsonBytes = new TextEncoder().encode(JSON.stringify(decrypted));
+      const buffer = jsonBytes.buffer.slice(
+        jsonBytes.byteOffset,
+        jsonBytes.byteOffset + jsonBytes.byteLength
+      );
+      mockDeps.messageDB.getUserConfig = vi.fn().mockResolvedValue(storedConfig);
+      mockDeps.apiClient.getUserSettings = vi.fn().mockResolvedValue({
+        data: {
+          user_config: 'aabbccdd' + '000000000000000000000000',
+          timestamp: 9000,
+          signature: 'aabbcc',
+        },
+      });
+      vi.spyOn(global.crypto.subtle, 'importKey').mockResolvedValue({} as CryptoKey);
+      vi.spyOn(global.crypto.subtle, 'decrypt').mockResolvedValue(buffer as ArrayBuffer);
+    }
+
+    it('keeps sync OFF when a remote config with sync ON wins on timestamp', async () => {
+      // The multi-device case: another device is still syncing, never learned
+      // this one went quiet, and its blob eventually outranks. Before this,
+      // that silently switched publishing back on here.
+      arrangeAdopt(
+        { address, spaceIds: ['space-new'], spaceKeys: [], allowSync: true, timestamp: 9000 },
+        { address, spaceIds: [], allowSync: false, timestamp: 500 }
+      );
+
+      const result = await configService.getConfig({ address, userKey: mockUserKey });
+
+      expect(result.allowSync).toBe(false);
+      expect(mockDeps.messageDB.saveUserConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ allowSync: false })
+      );
+    });
+
+    it('still adopts everything else from that config', async () => {
+      // The other half, and the one that would make this a bad trade if it
+      // broke: off means "do not publish", never "do not pull".
+      arrangeAdopt(
+        { address, spaceIds: ['space-new'], spaceKeys: [], allowSync: true, timestamp: 9000 },
+        { address, spaceIds: ['space-old'], allowSync: false, timestamp: 500 }
+      );
+
+      const result = await configService.getConfig({ address, userKey: mockUserKey });
+
+      expect(result.spaceIds).toEqual(['space-new']);
+    });
+
+    it('keeps sync ON when this device had it on', async () => {
+      // CONTROL ARM. Without it, hardcoding `false` would pass every other test
+      // in this block while quietly disabling sync for everyone.
+      arrangeAdopt(
+        { address, spaceIds: [], spaceKeys: [], allowSync: false, timestamp: 9000 },
+        { address, spaceIds: [], allowSync: true, timestamp: 500 }
+      );
+
+      const result = await configService.getConfig({ address, userKey: mockUserKey });
+
+      expect(result.allowSync).toBe(true);
+    });
+
+    it('a device with no stored config starts at off, not at whatever the blob says', async () => {
+      // Local storage lost, or a fresh install. The remote always wins against
+      // `?? 0`, so without this the blob decides — and the privacy-costing
+      // direction is the one that must never be inherited silently.
+      arrangeAdopt(
+        { address, spaceIds: ['space-new'], spaceKeys: [], allowSync: true, timestamp: 9000 },
+        undefined
+      );
+
+      const result = await configService.getConfig({ address, userKey: mockUserKey });
+
+      expect(result.allowSync).toBe(false);
+      // ...and it still restores, which is what makes off-by-default acceptable.
+      expect(result.spaceIds).toEqual(['space-new']);
+    });
+
+    it('the cached copy agrees with the row on disk', async () => {
+      // Three writes happen here (DB, React Query cache, return value). If they
+      // disagree the UI shows one thing until reload and another after.
+      arrangeAdopt(
+        { address, spaceIds: [], spaceKeys: [], allowSync: true, timestamp: 9000 },
+        { address, spaceIds: [], allowSync: false, timestamp: 500 }
+      );
+
+      await configService.getConfig({ address, userKey: mockUserKey });
+
+      const savedToDb = mockDeps.messageDB.saveUserConfig.mock.calls[0][0];
+      const cached = queryClient.getQueryData(
+        buildConfigKey({ userAddress: address })
+      ) as any;
+      expect(savedToDb.allowSync).toBe(false);
+      expect(cached.allowSync).toBe(false);
     });
   });
 

--- a/src/services/ConfigService.ts
+++ b/src/services/ConfigService.ts
@@ -17,6 +17,7 @@ import { t } from '@lingui/core/macro';
 import { QueryClient } from '@tanstack/react-query';
 import { buildSpacesKey, buildConfigKey } from '../hooks';
 import { validateItems } from '../utils/folderUtils';
+import { recordLastPublish, classifyPublishError } from '../utils/lastPublish';
 import { mergeDeviceNames } from './configMergeHelpers';
 import type { Ref } from '../types/ref';
 import type { SpaceInfoMap } from '../types/spaceRefs';
@@ -666,6 +667,11 @@ export class ConfigService {
         // Keep the timestamp we came in with — see `incomingTimestamp` above.
         // `ts` still gates the cache write below, so the UI updates as usual.
         config.timestamp = incomingTimestamp;
+
+        recordLastPublish('held', {
+          spacesPublished: uploadConfig.spaceIds.length,
+          spacesHeld: droppedSpaceIds.length,
+        });
       } else {
         const iv = crypto.getRandomValues(new Uint8Array(12));
         const configJson = JSON.stringify(uploadConfig);
@@ -711,6 +717,11 @@ export class ConfigService {
           });
           logger.log('[ConfigService] Settings posted successfully');
 
+          recordLastPublish('published', {
+            payloadBytes: ciphertext.length,
+            spacesPublished: uploadConfig.spaceIds.length,
+          });
+
           // Reset tombstones only after successful sync (Phase 7: Critical Fix)
           config.deletedBookmarkIds = [];
           config.deletedUserNoteAddresses = [];
@@ -727,6 +738,14 @@ export class ConfigService {
             '[ConfigService] Settings POST failed — keeping the change locally, not published:',
             error
           );
+
+          // Recorded before the timestamp restore below, so the payload size is
+          // captured even for the failures we most want to size up.
+          recordLastPublish(classifyPublishError(error), {
+            payloadBytes: ciphertext.length,
+            spacesPublished: uploadConfig.spaceIds.length,
+            detail: error instanceof Error ? error.message : String(error),
+          });
 
           // Nothing reached the server, so nothing earned a newer timestamp.
           // Without this, persisting on the failure path would re-open the hole
@@ -753,6 +772,8 @@ export class ConfigService {
       // Only the claim to authority is withheld.
       // See 2026-08-07-a-device-with-sync-off-still-claims-a-newer-timestamp.md
       config.timestamp = incomingTimestamp;
+
+      recordLastPublish('off');
     }
 
     logger.log('[ConfigService] Saving config to local DB...');

--- a/src/services/ConfigService.ts
+++ b/src/services/ConfigService.ts
@@ -419,6 +419,21 @@ export class ConfigService {
     // evidence attached.
     await this.recordSpaceListShrinkOnAdopt(storedConfig, config);
 
+    // Device-local, never inherited from the blob. `allowSync` describes THIS
+    // device's relationship with the server, but it rides in the account-level
+    // config, so a decision made on one device used to be carried to the others.
+    //
+    // Two ways that turned "off" back on without anyone asking. Local storage
+    // lost: the remote wins against `?? 0` above and is adopted verbatim, sync
+    // included. Or another device still syncing: turning sync off is never
+    // published — that is the whole point of the switch — so the other device
+    // never learns, keeps publishing, and eventually wins on timestamp.
+    //
+    // Set on `config` itself rather than only on the object below, so the DB
+    // row, the cache write and the returned value cannot disagree.
+    // See 2026-08-08-make-allowsync-a-per-device-setting.md under .agents/issues/
+    config.allowSync = storedConfig?.allowSync ?? false;
+
     await this.messageDB.saveUserConfig({
       ...config,
       timestamp: savedConfig.timestamp,

--- a/src/utils/lastPublish.ts
+++ b/src/utils/lastPublish.ts
@@ -1,0 +1,73 @@
+/**
+ * Desktop's store for the last config publish outcome.
+ *
+ * Before this existed, a device could not tell whether its config reached the
+ * server, for any reason. Sync being off, a refuse-to-publish hold and a genuine
+ * successful upload all write the local row and all look identical, so "my
+ * setting saved" was never evidence that it synced.
+ *
+ * The shape lives in quorum-shared; only the storage is per-platform
+ * (localStorage here, MMKV on mobile). The record is device-local and never
+ * enters UserConfig — in the synced blob it would broadcast a per-device fact to
+ * every other device, rewrite the blob on every save, and grow the very payload
+ * this instrument exists to watch.
+ * See .agents/issues/.open/2026-08-08-record-and-show-what-the-last-config-publish-actually-did.md
+ */
+
+import type { PublishOutcome, LastPublish } from '@quilibrium/quorum-shared';
+
+export type { PublishOutcome, LastPublish };
+
+const KEY = 'quorum:sync:lastPublish';
+
+/**
+ * A rejection whose message says the request never completed rather than that
+ * the server disliked it. Worth separating because the two mean opposite things
+ * to a user: a timeout is "will retry", a rejection is "this will not work".
+ */
+export function classifyPublishError(error: unknown): 'rejected' | 'timeout' {
+  const message = error instanceof Error ? error.message : String(error);
+  return /timeout|timed out|ETIMEDOUT|ECONNABORTED|aborted|network error/i.test(
+    message
+  )
+    ? 'timeout'
+    : 'rejected';
+}
+
+/**
+ * Never throws. An instrument that can break the path it measures is worse than
+ * no instrument — the whole point is that config sync keeps working.
+ */
+export function recordLastPublish(
+  outcome: PublishOutcome,
+  details: Omit<LastPublish, 'at' | 'outcome'> = {}
+): void {
+  try {
+    if (typeof localStorage === 'undefined') return;
+    const entry: LastPublish = { at: Date.now(), outcome, ...details };
+    localStorage.setItem(KEY, JSON.stringify(entry));
+  } catch {
+    // Quota, private mode, a serialisation edge — losing one reading is fine.
+  }
+}
+
+/** Returns null when nothing has been recorded yet, or the stored value is unusable. */
+export function readLastPublish(): LastPublish | null {
+  try {
+    if (typeof localStorage === 'undefined') return null;
+    const raw = localStorage.getItem(KEY);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      typeof (parsed as LastPublish).at !== 'number' ||
+      typeof (parsed as LastPublish).outcome !== 'string'
+    ) {
+      return null;
+    }
+    return parsed as LastPublish;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
Two related config-sync changes: a device can now tell when publishing is failing, and turning sync off actually stays off.

## Sync failures are visible

A device had no way to know whether its config reached the server. `allowSync` off, a refuse-to-publish hold, and a real upload all write the local row and all look identical, so "my setting saved" was never evidence that it synced.

Every publish now records its outcome (`published`, `off`, `no-keys`, `held`, `rejected`, `timeout`) with the payload size and Space counts, in device-local storage. A line under the sync toggle reports it.

**Failures only.** A "Last synced N ago" line was built first and deliberately removed: it read as a health indicator but reported the last time the device had something to *publish*, not the last time it reached the server. Pulls happen when the app opens, pushes only when something changes, so a healthy device that had not changed a setting in three days announced "Last synced 3 days ago" — indistinguishable from three days broken. Reporting success was worse than silence. The panel now gains zero rows in normal use.

That also settles how this behaves once sync splits into separate settings and keys toggles: still one line, still only on failure, since both tiers travel in the same upload.

The record is written for every outcome regardless of what renders. It is the instrument later work is verified against, and its `payloadBytes` readings are how the unknown server size limit gets settled — the two readings on record currently contradict each other.

## Turning sync off stays off

`allowSync` describes *this device's* relationship with the server, but it rides in the account-level blob, so a decision made on one device was carried to the others and "off" could turn itself back on with nobody asking.

Two ways it happened. Local storage lost: the remote wins the timestamp comparison against `?? 0` and is adopted verbatim, `allowSync` included. Or another device still syncing: turning sync off is never published, which is the whole point of the switch, so that device never learns, keeps publishing, and eventually wins on timestamp.

The local value is now authoritative on adopt, set on the config object itself so the DB row, the React Query cache and the returned value cannot disagree. A device with no stored config starts at off rather than at whatever the blob says.

Off means "do not publish". It has never meant "do not pull", and the pull stays ungated — publishing writes a durable decryptable archive, while pulling is one GET to a server the client is already talking to constantly. Keeping it is what lets a device recover without opting into publishing.

## Notes

- **Types come from `@quilibrium/quorum-shared` 2.1.0-41.** Only the storage is per-platform (localStorage here, MMKV on mobile).
- **Nothing crosses the wire.** The record never enters `UserConfig`, and a test asserts that — confirmed able to fail by leaking the field deliberately. `allowSync` is still published for older clients, which are unaffected either way.
- **Desktop cannot produce `no-keys`**: the action queue throws on a missing keyset before `saveConfig` runs. It stays in the type for mobile.
- **Mobile is not covered here** and is waiting on 2.1.0-41 being published.
- Also fixes a latent spy leak in the ConfigService test file — several tests make `Storage.prototype.setItem` throw, and `clearAllMocks` resets call history without restoring implementations, so the first such test silently broke localStorage for every test after it.

## Verification

1162 tests across 88 files, typecheck clean. Every new behaviour was reverted individually and confirmed to turn a specific test red:

| Reverted | Goes red |
|---|---|
| the `published` recording | records-published |
| leaking the record into the blob | never-writes-to-blob |
| the status line's poll | picks-up-a-failure-while-open |
| rendering on success | three silence tests |
| the `allowSync` fix | four device-local tests |
| hardcoding `allowSync = false` | **only** the control arm |

That last row is why the control arm exists: hardcoding `false` passes four tests while quietly disabling sync for everyone.
