### PR TITLE
fix(config): a deleted user note can be written again

### DIFF
--- a/src/components/user/UserProfile.tsx
+++ b/src/components/user/UserProfile.tsx
@@ -200,6 +200,16 @@ const UserProfile: React.FunctionComponent<{
         if (currentPasskeyInfo?.address) {
           const config = await messageDB.getUserConfig({ address: currentPasskeyInfo.address });
           if (config) {
+            // Timestamped form is the one receivers act on: it lets a note
+            // written again later survive this deletion, which the bare-address
+            // list could not express. That list is still written so clients
+            // predating `deletedUserNotes` keep receiving the deletion.
+            config.deletedUserNotes = [
+              ...(config.deletedUserNotes ?? []).filter(
+                t => t.targetAddress !== props.user.address
+              ),
+              { targetAddress: props.user.address, deletedAt: Date.now() },
+            ];
             config.deletedUserNoteAddresses = [
               ...(config.deletedUserNoteAddresses ?? []),
               props.user.address,

--- a/src/db/messages.ts
+++ b/src/db/messages.ts
@@ -88,7 +88,13 @@ export type UserConfig = {
   bookmarks?: Bookmark[];
   deletedBookmarkIds?: string[];
   userNotes?: UserNote[];
+  /** @deprecated Untimestamped, so it cannot be aged out. Published for older clients, ignored on receipt — see `deletedUserNotes`. */
   deletedUserNoteAddresses?: string[];
+  // Note tombstones carrying when the deletion happened, so a note written
+  // again afterwards survives it. A carrier that never clears its tombstones
+  // republishes them forever, which made a re-created note undeletable-proof
+  // under the bare-address form.
+  deletedUserNotes?: { targetAddress: string; deletedAt: number }[];
   mutedChannels?: {
     [spaceId: string]: string[];
   };

--- a/src/dev/tests/services/ConfigService.unit.test.tsx
+++ b/src/dev/tests/services/ConfigService.unit.test.tsx
@@ -1228,6 +1228,118 @@ describe('ConfigService - Unit Tests', () => {
     });
   });
 
+  describe('11. getConfig() - a stale tombstone must not re-delete a re-created note', () => {
+    // EXPECTED RED until the tombstone fix lands. This turns a read-the-code
+    // trace into a measurement.
+    //
+    // The trace: desktop publishes deletedUserNoteAddresses inside the blob
+    // (uploadConfig is a spread of config) and clears it locally only after a
+    // successful POST. Mobile pulls that blob and stores the tombstone, but has
+    // NO userNotes code anywhere — it is a pure carrier — so it never clears it
+    // and republishes it in every later save. Desktop then applies remote
+    // tombstones unconditionally, so the note is deleted again. Re-create it and
+    // the next adopt from mobile deletes it once more, forever.
+    //
+    // Nothing in the current data model can tell a fresh deletion from a stale
+    // carried one: the tombstone is a bare address with no time attached, and
+    // the blob timestamp is mobile's republish time, not the deletion time. So
+    // the first test below cannot pass without a per-tombstone timestamp. That
+    // is the point — it defines what the fix has to provide.
+
+    const address = 'user-notes';
+    const mockUserKey = {
+      user_key: {
+        private_key: new Uint8Array(57),
+        public_key: new Uint8Array(57),
+      },
+    } as any;
+
+    function arrangeAdopt(decrypted: any, localNotes: any[]) {
+      const jsonBytes = new TextEncoder().encode(JSON.stringify(decrypted));
+      const buffer = jsonBytes.buffer.slice(
+        jsonBytes.byteOffset,
+        jsonBytes.byteOffset + jsonBytes.byteLength
+      );
+      mockDeps.messageDB.getUserConfig = vi
+        .fn()
+        .mockResolvedValue({ address, spaceIds: [], allowSync: false, timestamp: 500 });
+      mockDeps.messageDB.getAllUserNotes = vi.fn().mockResolvedValue(localNotes);
+      mockDeps.apiClient.getUserSettings = vi.fn().mockResolvedValue({
+        data: {
+          user_config: 'aabbccdd' + '000000000000000000000000',
+          // Mobile's republish time, NOT the deletion time. This is exactly why
+          // the blob timestamp cannot stand in for a tombstone timestamp.
+          timestamp: 9000,
+          signature: 'aabbcc',
+        },
+      });
+      vi.spyOn(global.crypto.subtle, 'importKey').mockResolvedValue({} as CryptoKey);
+      vi.spyOn(global.crypto.subtle, 'decrypt').mockResolvedValue(buffer as ArrayBuffer);
+    }
+
+    it('keeps a note that was re-created after the deletion', async () => {
+      // The user deleted this note, then changed their mind and wrote it again.
+      // The tombstone still circulating describes the OLD deletion.
+      arrangeAdopt(
+        {
+          address,
+          spaceIds: [],
+          spaceKeys: [],
+          userNotes: [],
+          deletedUserNoteAddresses: ['QmTargetA'],
+          timestamp: 9000,
+        },
+        [{ targetAddress: 'QmTargetA', note: 'written again', updatedAt: 5000 }]
+      );
+
+      await configService.getConfig({ address, userKey: mockUserKey });
+
+      expect(mockDeps.messageDB.deleteUserNote).not.toHaveBeenCalledWith('QmTargetA');
+    });
+
+    it('REGRESSION GUARD: a genuine deletion still deletes', async () => {
+      // Must stay green through the fix. Tombstones exist to stop a stale device
+      // resurrecting a deleted note, and that has to keep working — a fix that
+      // simply ignores tombstones would pass the test above and be worse than
+      // the bug.
+      arrangeAdopt(
+        {
+          address,
+          spaceIds: [],
+          spaceKeys: [],
+          userNotes: [],
+          deletedUserNoteAddresses: ['QmTargetB'],
+          timestamp: 9000,
+        },
+        [{ targetAddress: 'QmTargetB', note: 'old note', updatedAt: 100 }]
+      );
+
+      await configService.getConfig({ address, userKey: mockUserKey });
+
+      expect(mockDeps.messageDB.deleteUserNote).toHaveBeenCalledWith('QmTargetB');
+    });
+
+    it('CONTROL ARM: a note nobody tombstoned is untouched', async () => {
+      // If this ever goes red the harness is wrong and neither test above means
+      // anything.
+      arrangeAdopt(
+        {
+          address,
+          spaceIds: [],
+          spaceKeys: [],
+          userNotes: [],
+          deletedUserNoteAddresses: ['QmTargetA'],
+          timestamp: 9000,
+        },
+        [{ targetAddress: 'QmUnrelated', note: 'fine', updatedAt: 5000 }]
+      );
+
+      await configService.getConfig({ address, userKey: mockUserKey });
+
+      expect(mockDeps.messageDB.deleteUserNote).not.toHaveBeenCalledWith('QmUnrelated');
+    });
+  });
+
   describe('10. getConfig() - allowSync is device-local and never inherited', () => {
     // allowSync describes THIS device's relationship with the server, but it
     // rides in the account-level blob. So a decision made on one device used to

--- a/src/dev/tests/services/ConfigService.unit.test.tsx
+++ b/src/dev/tests/services/ConfigService.unit.test.tsx
@@ -1229,22 +1229,20 @@ describe('ConfigService - Unit Tests', () => {
   });
 
   describe('11. getConfig() - a stale tombstone must not re-delete a re-created note', () => {
-    // EXPECTED RED until the tombstone fix lands. This turns a read-the-code
-    // trace into a measurement.
+    // The bug these were written against, MEASURED before the fix: desktop
+    // publishes its note tombstones inside the blob (uploadConfig is a spread of
+    // config) and clears them locally only after a successful POST. Mobile pulls
+    // that blob and stores them, but has NO userNotes code anywhere — it is a
+    // pure carrier — so it never clears them and republishes the same tombstone
+    // in every later save. Desktop applied remote tombstones unconditionally, so
+    // a note the user re-created was deleted again on every adopt, forever, with
+    // no error and no way out.
     //
-    // The trace: desktop publishes deletedUserNoteAddresses inside the blob
-    // (uploadConfig is a spread of config) and clears it locally only after a
-    // successful POST. Mobile pulls that blob and stores the tombstone, but has
-    // NO userNotes code anywhere — it is a pure carrier — so it never clears it
-    // and republishes it in every later save. Desktop then applies remote
-    // tombstones unconditionally, so the note is deleted again. Re-create it and
-    // the next adopt from mobile deletes it once more, forever.
-    //
-    // Nothing in the current data model can tell a fresh deletion from a stale
-    // carried one: the tombstone is a bare address with no time attached, and
-    // the blob timestamp is mobile's republish time, not the deletion time. So
-    // the first test below cannot pass without a per-tombstone timestamp. That
-    // is the point — it defines what the fix has to provide.
+    // The bare-address form could not be repaired in place: it carries no
+    // deletion time, and the blob timestamp is the carrier's republish time, so
+    // a months-old deletion always looks current. Hence `deletedUserNotes`,
+    // which carries `deletedAt` and can be compared against a note's own
+    // `updatedAt`.
 
     const address = 'user-notes';
     const mockUserKey = {
@@ -1278,8 +1276,31 @@ describe('ConfigService - Unit Tests', () => {
     }
 
     it('keeps a note that was re-created after the deletion', async () => {
-      // The user deleted this note, then changed their mind and wrote it again.
-      // The tombstone still circulating describes the OLD deletion.
+      // The user deleted this note at 1000, changed their mind, and wrote it
+      // again at 5000. The tombstone still circulating describes the OLD
+      // deletion, so it must not win.
+      arrangeAdopt(
+        {
+          address,
+          spaceIds: [],
+          spaceKeys: [],
+          userNotes: [],
+          deletedUserNotes: [{ targetAddress: 'QmTargetA', deletedAt: 1000 }],
+          timestamp: 9000,
+        },
+        [{ targetAddress: 'QmTargetA', note: 'written again', updatedAt: 5000 }]
+      );
+
+      await configService.getConfig({ address, userKey: mockUserKey });
+
+      expect(mockDeps.messageDB.deleteUserNote).not.toHaveBeenCalledWith('QmTargetA');
+    });
+
+    it('ignores the legacy untimestamped tombstone entirely', async () => {
+      // This is the poisoning fix itself. Old clients still receive this array,
+      // and a carrier still republishes it forever, so honouring it on receipt
+      // is what made the deletion permanent. Nothing else in the blob mentions
+      // QmTargetA, so acting on it here would be acting on the legacy form.
       arrangeAdopt(
         {
           address,
@@ -1298,17 +1319,16 @@ describe('ConfigService - Unit Tests', () => {
     });
 
     it('REGRESSION GUARD: a genuine deletion still deletes', async () => {
-      // Must stay green through the fix. Tombstones exist to stop a stale device
-      // resurrecting a deleted note, and that has to keep working — a fix that
-      // simply ignores tombstones would pass the test above and be worse than
-      // the bug.
+      // Tombstones exist to stop a stale device resurrecting a deleted note, and
+      // that has to keep working. A "fix" that simply ignored tombstones would
+      // satisfy both tests above and be worse than the bug.
       arrangeAdopt(
         {
           address,
           spaceIds: [],
           spaceKeys: [],
           userNotes: [],
-          deletedUserNoteAddresses: ['QmTargetB'],
+          deletedUserNotes: [{ targetAddress: 'QmTargetB', deletedAt: 5000 }],
           timestamp: 9000,
         },
         [{ targetAddress: 'QmTargetB', note: 'old note', updatedAt: 100 }]
@@ -1319,8 +1339,28 @@ describe('ConfigService - Unit Tests', () => {
       expect(mockDeps.messageDB.deleteUserNote).toHaveBeenCalledWith('QmTargetB');
     });
 
+    it('a tombstone still applies when no local note exists', async () => {
+      // The ordinary case: the deletion arrives on a device that has the note or
+      // has nothing. Absent counts as updatedAt 0, so the tombstone wins.
+      arrangeAdopt(
+        {
+          address,
+          spaceIds: [],
+          spaceKeys: [],
+          userNotes: [],
+          deletedUserNotes: [{ targetAddress: 'QmTargetC', deletedAt: 5000 }],
+          timestamp: 9000,
+        },
+        []
+      );
+
+      await configService.getConfig({ address, userKey: mockUserKey });
+
+      expect(mockDeps.messageDB.deleteUserNote).toHaveBeenCalledWith('QmTargetC');
+    });
+
     it('CONTROL ARM: a note nobody tombstoned is untouched', async () => {
-      // If this ever goes red the harness is wrong and neither test above means
+      // If this ever goes red the harness is wrong and none of the above means
       // anything.
       arrangeAdopt(
         {
@@ -1328,7 +1368,7 @@ describe('ConfigService - Unit Tests', () => {
           spaceIds: [],
           spaceKeys: [],
           userNotes: [],
-          deletedUserNoteAddresses: ['QmTargetA'],
+          deletedUserNotes: [{ targetAddress: 'QmTargetA', deletedAt: 9000 }],
           timestamp: 9000,
         },
         [{ targetAddress: 'QmUnrelated', note: 'fine', updatedAt: 5000 }]

--- a/src/services/ConfigService.ts
+++ b/src/services/ConfigService.ts
@@ -299,13 +299,32 @@ export class ConfigService {
       config.conversationSettings
     );
 
-    // Merge user notes from remote
-    const deletedNoteAddresses = config.deletedUserNoteAddresses ?? [];
+    // Merge user notes from remote.
+    //
+    // Only the TIMESTAMPED tombstones are honoured. `deletedUserNoteAddresses`
+    // is still published for clients that predate `deletedUserNotes`, but is
+    // deliberately ignored here: a bare address carries no deletion time, and a
+    // client that carries userNotes without implementing them never clears the
+    // array, so it republishes the same tombstone in every later save. Applying
+    // those unconditionally deleted a note the user had re-created — again on
+    // every adopt, with no way out. The blob timestamp is no substitute; it is
+    // the carrier's republish time, so a months-old deletion looks current.
+    // See §11 of ConfigService.unit.test.tsx.
+    const noteTombstones = config.deletedUserNotes ?? [];
+    const localNoteUpdatedAt = new Map(
+      (await this.messageDB.getAllUserNotes()).map(n => [n.targetAddress, n.updatedAt])
+    );
 
-    // Always apply remote tombstones — even when there are no notes to merge
-    for (const addr of deletedNoteAddresses) {
-      await this.messageDB.deleteUserNote(addr);
+    // A deletion only beats a note older than itself. That keeps tombstones
+    // doing their real job — a stale device cannot resurrect a note deleted
+    // after it last synced — while letting a deliberate rewrite survive.
+    const appliedTombstones = noteTombstones.filter(
+      t => (localNoteUpdatedAt.get(t.targetAddress) ?? 0) < t.deletedAt
+    );
+    for (const tombstone of appliedTombstones) {
+      await this.messageDB.deleteUserNote(tombstone.targetAddress);
     }
+    const deletedNoteAddresses = appliedTombstones.map(t => t.targetAddress);
 
     if (config.userNotes && config.userNotes.length > 0) {
       const localNotes = await this.messageDB.getAllUserNotes();
@@ -740,6 +759,7 @@ export class ConfigService {
           // Reset tombstones only after successful sync (Phase 7: Critical Fix)
           config.deletedBookmarkIds = [];
           config.deletedUserNoteAddresses = [];
+          config.deletedUserNotes = [];
         } catch (error) {
           // A refused upload used to throw straight out of saveConfig, so the
           // local save at the end never ran and the edit the user had just made


### PR DESCRIPTION
Delete a user note, later write a new one about the same person, and the new one gets deleted too. Every time. Silently, with no way out.

## Why

Deleting a note writes a tombstone into the config blob, so the deletion reaches your other devices instead of being undone by one of them re-uploading the note. Desktop clears its own tombstone after a successful upload, so the marker is meant to be short-lived.

**Mobile has no user-notes code at all** (zero references anywhere) but still downloads and re-uploads the whole blob, tombstones included. With nothing to clear them, it republishes the same tombstone in every later save, indefinitely. Desktop applied incoming tombstones unconditionally, so:

1. You delete your note about someone. Correct.
2. Mobile picks up the tombstone and keeps it, permanently.
3. You write a new note about the same person.
4. Mobile syncs, still carrying "this note is deleted".
5. Desktop deletes your new note.
6. Repeat forever.

The bare-address form could not be repaired in place. It carries no deletion time, and the blob timestamp is the carrier's *republish* time, so a months-old deletion always looks current. There was nothing to compare against.

## The fix

Honour only the timestamped tombstones (`deletedUserNotes`, new in shared 2.1.0-42), and only when the deletion is newer than the note. `deletedUserNoteAddresses` is still published so older clients keep receiving deletions, but is ignored on receipt.

## Compatibility

- **Older desktop** keeps reading the legacy array, so deletions still reach it.
- **Newer desktop** ignores it, so a carrier republishing it forever is harmless.
- **Mobile needs no change** and is unaffected either way. It carries the new field exactly as blindly as the old one. The usual wait-for-a-publish constraint does not apply here, because mobile does not implement the feature.

## Verification

Written test-first: the failing test is in the first commit, measured red before any fix existed. 1167 tests across the suite, typecheck clean.

Five tests, and the two ways of getting this wrong each turn a specific one red:

| Broken deliberately | Goes red |
|---|---|
| apply tombstones without comparing to `updatedAt` | keeps a note re-created after the deletion |
| honour the legacy bare-address array again | ignores the legacy untimestamped tombstone |

Three stay green throughout: a genuine deletion still deletes, a tombstone still applies when no local note exists, and a control arm. The first of those matters most — a fix that simply ignored tombstones would satisfy both reds and reintroduce note resurrection, which is what tombstones exist to prevent.

## Not included

`deviceNames` has a related defect found alongside this one: no per-entry timestamp, so `mergeDeviceNames` resolves conflicts as "remote wins" and a stale carried value can revert a rename made elsewhere. Left alone deliberately. Same fix cost, but the symptom is a device label reverting rather than something unrecoverable.
