### PR TITLE
feat(backup): back up Space keys, and never let a restore undo a deletion

### DIFF
--- a/.agents/INDEX.md
+++ b/.agents/INDEX.md
@@ -405,6 +405,7 @@ This is the main index for all documentation, bug reports, and task management.
 - 🐛 [Emoji panel inserts the emoji at the start of the message](issues/.done/2026-08-06-emoji-panel-inserts-at-start-of-message.md)
 - 🐛 [Messages arriving over sync never reach an open channel, so it stays completely empty until you reload](issues/.done/2026-08-06-synced-messages-never-reach-an-open-channel-so-it-stays-empty.md)
 - 🐛 [A device with sync off still claims a newer timestamp](issues/.done/2026-08-07-a-device-with-sync-off-still-claims-a-newer-timestamp.md)
+- 🐛 [An armed sync crashes after a kick](issues/.done/2026-08-09-armed-sync-crashes-after-a-kick.md)
 - 🐛 [Bug: Emoji Picker Grid Has Empty Space on Right Side in Mobile Drawer](issues/.done/emoji-picker-mobile-drawer-empty-space.md)
 - 🐛 [Channel/Group Save Race Condition](issues/.done/channel-group-save-race-condition.md)
 - 🐛 [Config Save Missing React Query Cache Update Causes Stale allowSync](issues/.done/config-save-stale-cache-allowsync.md)
@@ -768,4 +769,4 @@ This is the main index for all documentation, bug reports, and task management.
 
 ---
 
-**Last Updated**: 2026-08-09 14:04:55
+**Last Updated**: 2026-08-09 14:46:59

--- a/.agents/INDEX.md
+++ b/.agents/INDEX.md
@@ -768,4 +768,4 @@ This is the main index for all documentation, bug reports, and task management.
 
 ---
 
-**Last Updated**: 2026-08-09 13:08:29
+**Last Updated**: 2026-08-09 13:08:46

--- a/.agents/INDEX.md
+++ b/.agents/INDEX.md
@@ -768,4 +768,4 @@ This is the main index for all documentation, bug reports, and task management.
 
 ---
 
-**Last Updated**: 2026-08-09 13:41:55
+**Last Updated**: 2026-08-09 14:04:55

--- a/.agents/INDEX.md
+++ b/.agents/INDEX.md
@@ -768,4 +768,4 @@ This is the main index for all documentation, bug reports, and task management.
 
 ---
 
-**Last Updated**: 2026-08-09 13:08:46
+**Last Updated**: 2026-08-09 13:09:05

--- a/.agents/INDEX.md
+++ b/.agents/INDEX.md
@@ -768,4 +768,4 @@ This is the main index for all documentation, bug reports, and task management.
 
 ---
 
-**Last Updated**: 2026-08-09 13:09:05
+**Last Updated**: 2026-08-09 13:41:55

--- a/.agents/INDEX.md
+++ b/.agents/INDEX.md
@@ -768,4 +768,4 @@ This is the main index for all documentation, bug reports, and task management.
 
 ---
 
-**Last Updated**: 2026-08-09 12:21:26
+**Last Updated**: 2026-08-09 13:08:29

--- a/.agents/docs/quorum-db-schema.md
+++ b/.agents/docs/quorum-db-schema.md
@@ -67,6 +67,7 @@ Quick reference for debugging and creating console snippets.
 | **user_notes** | `targetAddress` | — |
 | **search_indices** | `indexKey` | `by_lastUpdated` |
 | **space_member_devices** | `[spaceId, deviceInboxAddress]` | `by_member` |
+| **departed_spaces** | `spaceId` | — |
 
 ---
 
@@ -499,6 +500,38 @@ Serialized MiniSearch indices, persisted so full-text search survives restarts.
 
 ---
 
+### departed_spaces
+
+**Key:** `spaceId`
+
+**Indexes:** none
+
+Spaces this user left or was removed from. A departure tombstone, and the Space
+analogue of `deleted_messages`.
+
+**Why it exists:** restoring a `.qmbak` taken before a departure would otherwise
+re-add the Space *and* call `postHubAdd`, so a user who was kicked would silently
+re-announce themselves to the Space that removed them. Being additive is not
+enough on its own — that protects state the user *changed*, not state the user
+*removed*.
+
+**Written by the departure call sites, never by `MessageDB.deleteSpace()`.**
+`deleteSpace` looks like the single choke point, but `EncryptionService` also
+calls it to retire the old id during a space-address **migration**, which is not
+a departure. The two genuine sites are `SpaceService.deleteSpace` (`left`) and
+`MessageService`'s removed-from-space handler (`removed`).
+
+Cleared by `InvitationService` on rejoin, alongside `clearTombstonesForSpace`.
+
+**Consumed by the backup restore only, not by config sync.** A synced config is
+the account's *current* state, published after the departure; a backup file is
+stale by construction. Gating the sync adopt path on this would break leaving a
+Space on one device and rejoining it on another.
+
+Fields: `spaceId`, `reason` (`'left' | 'removed'`), `departedAt`.
+
+---
+
 ### space_member_devices
 
 **Key:** `[spaceId, deviceInboxAddress]` (compound)
@@ -667,6 +700,7 @@ for (const s of stores) console.log(s, await countStore(s));
 | 12 | Added: user_notes store (private per-user annotations, local-only) |
 | 13 | Added: search_indices store (persisted MiniSearch full-text indices) |
 | 14 | Added: space_member_devices store (per-device space signing keys — durable multi-device) |
+| 15 | Added: departed_spaces store (Spaces the user left or was removed from — stops a backup restore re-joining them) |
 
 **When you bump this:** update `QUORUM_DB_VERSION` in `src/db/dbVersion.ts` (the
 only place the number lives), add the row above, and classify any new store in
@@ -675,4 +709,4 @@ only place the number lives), add the row above, and classify any new store in
 
 ---
 
-*Last updated: 2026-08-01*
+*Last updated: 2026-08-09*

--- a/.agents/docs/quorum-db-schema.md
+++ b/.agents/docs/quorum-db-schema.md
@@ -68,6 +68,7 @@ Quick reference for debugging and creating console snippets.
 | **search_indices** | `indexKey` | `by_lastUpdated` |
 | **space_member_devices** | `[spaceId, deviceInboxAddress]` | `by_member` |
 | **departed_spaces** | `spaceId` | — |
+| **deleted_conversations** | `conversationId` | — |
 
 ---
 
@@ -500,6 +501,37 @@ Serialized MiniSearch indices, persisted so full-text search survives restarts.
 
 ---
 
+### deleted_conversations
+
+**Key:** `conversationId`
+
+**Indexes:** none
+
+Conversations the user deleted. The conversation-level counterpart of
+`deleted_messages`.
+
+**Why it exists:** deleting a chat removes the `conversations` row and bulk-deletes
+its messages, and the backup import used to re-`put()` both unconditionally — so
+restoring an older backup silently brought a deleted chat back. Per-message
+tombstones alone were not enough: the bulk-delete path wrote none (only the
+single-message `deleteMessage` path did), and even with them the empty
+`conversations` row would still have reappeared in the sidebar.
+
+Written by `deleteConversation`, in the same transaction as the row removal, so an
+interruption cannot leave the chat deleted with no record of why. Cleared by
+`saveConversation` — saving a conversation means it exists again, so the old
+removal is no longer the user's current intent. The backup import writes to the
+object store directly rather than through `saveConversation`, so a restore cannot
+clear its own gate.
+
+**Both gates are needed.** After a deleted chat resumes, the conversation tombstone
+is gone and only the per-message tombstones stop a later restore from resurrecting
+the messages that were deleted with it.
+
+Fields: `conversationId`, `deletedAt`.
+
+---
+
 ### departed_spaces
 
 **Key:** `spaceId`
@@ -701,6 +733,7 @@ for (const s of stores) console.log(s, await countStore(s));
 | 13 | Added: search_indices store (persisted MiniSearch full-text indices) |
 | 14 | Added: space_member_devices store (per-device space signing keys — durable multi-device) |
 | 15 | Added: departed_spaces store (Spaces the user left or was removed from — stops a backup restore re-joining them) |
+| 16 | Added: deleted_conversations store (chats the user deleted — stops a backup restore resurrecting them) |
 
 **When you bump this:** update `QUORUM_DB_VERSION` in `src/db/dbVersion.ts` (the
 only place the number lives), add the row above, and classify any new store in

--- a/.agents/issues/.done/2026-08-09-armed-sync-crashes-after-a-kick.md
+++ b/.agents/issues/.done/2026-08-09-armed-sync-crashes-after-a-kick.md
@@ -1,0 +1,91 @@
+---
+type: bug
+title: "An already-armed sync crashes with an unhandled rejection after the user is kicked from a Space"
+status: done
+priority: medium
+ai_generated: true
+created: 2026-08-09
+updated: 2026-08-09
+area: sync / spaces
+related:
+  - ".agents/issues/.open/2026-08-09-backup-restore-overhaul-design.md"
+---
+
+# An armed sync crashes after a kick
+
+> **Found by measurement, not by reading.** The `space-kick` harness scenario
+> (added alongside the backup/restore work) kicks a real bot from a real Space
+> against the live relay. The kick behaved correctly; vitest then reported an
+> unhandled rejection the scenario had not been looking for.
+
+## Status
+
+**Fixed 2026-08-09** in the same branch as the backup/restore overhaul. The
+scenario now runs clean with no unhandled errors.
+
+## Symptom
+
+```
+TypeError: Cannot read properties of undefined (reading 'address')
+ ❯ SyncService.initiateSync src/services/SyncService.ts:247
+    247|       inboxKey.address!,
+```
+
+An **unhandled promise rejection**, not a caught failure — so it escapes to the
+process rather than being logged and skipped.
+
+## Root cause
+
+`initiateSync` reads the Space's `inbox` key and immediately dereferences it with
+a non-null assertion:
+
+```ts
+const inboxKey = await this.messageDB.getSpaceKey(spaceId, 'inbox');
+// ...
+inboxKey.address!,
+```
+
+Being kicked deletes the Space **and all of its keys** (`MessageService`'s
+removed-from-space handler loops `deleteSpaceKey` over every key). A sync armed
+*before* the kick then fires *after* it, finds no inbox key, and throws.
+
+The `!` makes this a lie the type system accepts: the value is genuinely optional
+at this point in the lifecycle.
+
+This is the same class of problem the code immediately below the kick handler
+already guards against, and says so:
+
+> *"The space is gone from under us. Any armed convergence timer would fire ~20s
+> from now against a deleted space and broadcast a sync-request into a space we
+> were just removed from."* — hence `forgetRosterConvergence(spaceId)`.
+
+The convergence timer was disarmed. `initiateSync` was not.
+
+## Fix
+
+Return early when the key is absent, matching what the method already does a few
+lines later when there are no sync candidates: there is nothing to sync into a
+Space we are no longer in.
+
+Deliberately a **guard, not a repair** — the correct behaviour when the Space is
+gone is to do nothing, quietly. Anything more ambitious would be inventing work
+for a Space the user is not in.
+
+## Verification
+
+- [x] `space-kick` scenario runs with **zero unhandled errors** (it reported one
+      on every run before the guard).
+- [x] Full suite green (1203).
+- [ ] Not separately unit-tested. The guard is a null check on a path whose
+      trigger is a race between an armed timer and a kick; the harness scenario is
+      what exercises it, and it does so incidentally rather than by design.
+
+## Prevention
+
+- **A non-null assertion on anything fetched from the database is a claim about
+  lifecycle, not about types.** Space keys are deleted on kick, leave, and
+  migration; any `!` on a key lookup is asserting the Space still exists, which is
+  exactly what those three events falsify.
+- **Unhandled rejections in a test run are findings, not noise.** vitest flagged
+  this as "might cause false positive tests" and it would have been easy to read
+  past, since the scenario it appeared in was passing.

--- a/.agents/issues/.open/2026-08-09-backup-restore-overhaul-design.md
+++ b/.agents/issues/.open/2026-08-09-backup-restore-overhaul-design.md
@@ -256,29 +256,49 @@ Covered by `backupSpaceRestore.test.ts`, control-armed (a never-deleted message
 must still restore, or the gate could pass by writing nothing) and
 mutation-verified.
 
-**Space departures — OPEN, and the harder half.** No leave/kick tombstone exists
-anywhere (READ: no `deletedSpaceIds`, `leftSpaces` or equivalent in `src/`). So
-restoring a backup taken before leaving **will** re-add the Space, and worse than
-locally: `adoptSpaces` calls `postHubAdd` and sends a `sync` control message, so a
-kicked user silently re-announces to a Space that removed them. That is an
-outward-facing action taken on stale state.
+**Space departures — MEASURED 2026-08-09, and the news is good.**
 
-The obvious fix — write the tombstone inside `MessageDB.deleteSpace()`, the single
-choke point all three removal paths funnel through — **does not work as stated**,
-and this is the trap to avoid:
+The departure record is device-local, so it is gone in the very case the feature
+exists for: total data loss, then restore. That looked like a hole. **It is not,
+for the case that matters**, and the reason is cryptographic rather than
+bookkeeping.
 
-| Caller | Meaning |
+`kickUser` does not merely edit a member list. It **rotates the Space's config
+key**, re-establishes the group ratchet without the removed member, and
+**re-encrypts the manifest to the new key** ([`SpaceService.ts`](../../../src/services/SpaceService.ts),
+kickUser). A restore rebuilds a Space by decrypting that manifest with the config
+key **from the backup** — now the old one — and it does so *before* it would
+announce the user to the hub ([`ConfigService.ts`](../../../src/services/ConfigService.ts),
+adoptSpaces). So the decrypt fails, the adopt aborts, and `postHubAdd` is never
+reached.
+
+**Measured, not read:** [`space-kick.scenario.test.ts`](../../../src/dev/tests/harness/space-kick.scenario.test.ts)
+runs two real bots against the live relay:
+
+| Step | Result |
 |---|---|
-| [`SpaceService.ts:685`](../../../src/services/SpaceService.ts#L685) | leave / delete — a real departure |
-| [`MessageService.ts:5638`](../../../src/services/MessageService.ts#L5638) | kicked — a real departure |
-| [`EncryptionService.ts:305`](../../../src/services/EncryptionService.ts#L305) | **not a departure** — a space-address *migration*, which deletes the old `spaceId` and immediately re-saves under a new one |
+| CONTROL — B reads A's post while still a member | ✅ received (so the assertions below are not vacuous) |
+| B is kicked, A posts again | ✅ B **cannot read it** |
+| B restores their **pre-kick** backup onto a wiped device | ✅ `restored=0, failed=1` — the Space does **not** come back |
+| The failure is reported, readably | ✅ *"you no longer have access to this Space — its keys were changed…"* |
 
-Tombstoning in `deleteSpace` would mark a migrated Space as "left". It happens to
-be harmless for the restore gate (the retired id should not be resurrected either),
-but it conflates two different facts under one name, which is how the next bug gets
-written. **The tombstone must be recorded by the departure call sites, not by the
-store method.** A rejoin must clear it — `clearTombstonesForSpace` is the existing
-precedent for exactly that.
+Two things came out of that run that reading would not have produced. The failure
+first surfaced to the user as `Unexpected token 'D', "Decryption"... is not valid
+JSON` — the raw SDK error through `JSON.parse`, accurate and useless — now
+translated. And vitest reported an unhandled rejection that turned out to be a
+genuine pre-existing crash, filed and fixed as
+[`2026-08-09-armed-sync-crashes-after-a-kick.md`](../.done/2026-08-09-armed-sync-crashes-after-a-kick.md).
+
+**What the tombstone is still for.** Leaving voluntarily triggers **no rekey** —
+only the owner kicking someone does — so a leaver's keys stay valid and their
+restore would re-add the Space. That is the case the record covers, and it is the
+benign one: they chose to leave and can leave again.
+
+**Residual, honestly stated.** The **hub key is not rotated** on a kick. Nothing
+reachable through the app uses it (the restore aborts first), but someone crafting
+requests by hand could still subscribe to the hub and receive traffic they cannot
+decrypt. Whether the node rejects that is a **server-side question this repo
+cannot answer** and worth putting to whoever owns it.
 
 This needs a DB version bump and touches kick/leave, so it is **its own slice**
 (now slice 2b) rather than an addendum. Until it lands, the restore reports which
@@ -540,8 +560,25 @@ the standing "Space message history is not included" note.
 *Observable:* import a v1 file → a successful restore that states plainly why no
 Spaces came back, instead of a bare message count.
 
-**Slice 4 — DM sessions.** Restore ratchet states only where no state exists for
-that conversation. **The only slice gated on the SDK answer (§10.3).**
+**Slice 4 — DM sessions. 🟢 DECIDED 2026-08-09: do not restore DM ratchet state, ever.**
+
+The right answer turned out to be the simplest one, and the app already does it.
+Import never writes DM ratchet state; when a conversation has no session, the
+first send force-starts a fresh one
+([`MessageService.ts:1537`](../../../src/services/MessageService.ts#L1537)). So
+after a restore a DM opens and is **immediately usable** — history back, typing
+works, new session established on send.
+
+That removes the hazard rather than managing it: nothing is rewound, so no message
+key can be re-derived, and there is nothing to ask the SDK about in order to ship.
+
+The only genuinely unrecoverable thing is messages a peer sent **during the gap**,
+addressed to the old session. Recovering those is precisely what would require
+restoring the old ratchet, which is precisely what is dangerous. So we accept the
+loss and say so in the UI.
+
+*Was: "restore ratchet states only where no state exists, gated on the SDK answer."
+Superseded — that design managed a risk this one does not take.*
 *Observable:* the two-party harness in §9.
 > **This slice must not block slices 1-3, 5 or 6.** If the SDK answer is slow or
 > unfavourable, ship D4 — the honest-copy fallback — and close the rest of the issue
@@ -616,9 +653,16 @@ live sessions untouched.
    below but blocks nothing else.
 2. **Re-verify §6.1 against the code.** If `inbox_mapping` or `latest_states` gain a
    reader between now and implementation, the DM slice grows.
-3. **The SDK question (§6) — and an asymmetry that needs a deliberate decision.**
-   Can a rewound sending chain re-derive an already-used message key, and can the SDK
-   expose a receive-only restore (D1)?
+3. ~~**The SDK question (§6)**~~ — **NO LONGER A BLOCKER, 2026-08-09.** Resolved by
+   not taking the risk: DM ratchet state is never restored (slice 4), so nothing is
+   rewound. The Space side inherits the sync path's behaviour rather than adding to
+   it — a synced new device already adopts a Space ratchet state from the config
+   blob, and that blob is itself a snapshot refreshed only on save, measured stale
+   for a long time on a real account (see `config-sync-system.md`). So a backup
+   restore does what multi-device login already does. Still worth asking, but as a
+   question about the existing sync path, not a gate on this work.
+
+   Retained below for whoever raises it:
 
    > ⚠️ **Raised by security review 2026-08-09, and it is a fair hit.** Slice 4 (DM
    > ratchet restore) is *blocked* pending this answer, while **slice 2 shipped and

--- a/.agents/issues/.open/2026-08-09-backup-restore-overhaul-design.md
+++ b/.agents/issues/.open/2026-08-09-backup-restore-overhaul-design.md
@@ -609,9 +609,27 @@ live sessions untouched.
    below but blocks nothing else.
 2. **Re-verify §6.1 against the code.** If `inbox_mapping` or `latest_states` gain a
    reader between now and implementation, the DM slice grows.
-3. **The SDK question (§6):** can a rewound sending chain re-derive an already-used
-   message key, and can the SDK expose a receive-only restore (D1)? Gates slice 4 only.
-   Ask about the Space-side Triple Ratchet staleness (§3 step 6) in the same conversation.
+3. **The SDK question (§6) — and an asymmetry that needs a deliberate decision.**
+   Can a rewound sending chain re-derive an already-used message key, and can the SDK
+   expose a receive-only restore (D1)?
+
+   > ⚠️ **Raised by security review 2026-08-09, and it is a fair hit.** Slice 4 (DM
+   > ratchet restore) is *blocked* pending this answer, while **slice 2 shipped and
+   > restores a Space's Triple Ratchet state** captured at export time. Two ratchets,
+   > opposite treatment, and the difference was not a reasoned call — it fell out of
+   > which slice happened to get written first.
+   >
+   > Two things make the Space side *less* alarming, neither of which settles it:
+   > `adoptSpaces` is the pre-existing path a fresh device already runs on every
+   > synced login, and it regenerates and re-registers a fresh inbox keypair rather
+   > than resuming an old session outright. What is genuinely new is the **staleness
+   > envelope**: a synced config refreshes continuously, whereas a `.qmbak` is
+   > designed to sit in a drawer for months. This work is what makes "resume from an
+   > arbitrarily old group ratchet state" a normal user action.
+   >
+   > **Put the Space case to the SDK owner in the same conversation as the DM case**,
+   > and record the answer here. If it turns out unsafe, slice 2's Space-state restore
+   > needs the same gating slice 4 already has.
 4. **Space messages in the default export?** Still open, but **no longer blocked on
    a measurement** — see §5.1. The size picture came back different from the
    assumption: the dominant term is the ~2 MB-per-created-Space eval pool, not
@@ -632,9 +650,22 @@ live sessions untouched.
    - *File stolen, account key safe* → AES-GCM under the account-derived key already
      protects it completely. A passphrase adds nothing.
    - *File stolen **and** account key compromised* → the attacker can already log in,
-     read future DMs and impersonate the user. Space ownership is marginal against a
-     loss that is already total. A passphrase only helps if stored separately from the
-     key, which for most users it would not be.
+     read future DMs and impersonate the user. A passphrase only helps if stored
+     separately from the key, which for most users it would not be.
+   - ⚠️ **Corrected 2026-08-09 after security review.** The bullet above used to end
+     "Space ownership is marginal against a loss that is already total." **That is
+     not true for the sync-off user this whole document exists to protect**, and the
+     overstatement mattered. Before this work, a stolen `.key` file gave an attacker
+     impersonation but **not** Space ownership: with `allowSync=false` those keys
+     never left the device and the server held no copy. This branch changes that —
+     the `.qmbak` now contains them, under a key derived deterministically from the
+     `.key` file's own contents, so one theft now yields both. The domain prefix adds
+     no secrecy here; it prevents cross-purpose key confusion, not a second attacker
+     requirement. And both files land in the same Downloads folder by construction —
+     the folder commodity infostealers and cloud-backup sync target wholesale.
+     **The decision stands** (a forgotten passphrase bricking a disaster-recovery
+     file is the worse failure), but it now rests on the durability argument alone,
+     not on a claim that the marginal loss is nil.
    - *Cost:* a forgotten passphrase makes the backup undecryptable — exactly the data
      loss the feature exists to prevent. Adding a second losable secret to a
      disaster-recovery artifact is net-negative for durability.
@@ -643,7 +674,10 @@ live sessions untouched.
      ([`2026-06-11-port-key-paste-import-and-copy-export.md`](../port-from-mobile/.done/2026-06-11-port-key-paste-import-and-copy-export.md)).
    **What survives is a labelling requirement, not a crypto one** (slice 3): the export
    UI must say the file contains Space ownership keys. People choose where to store
-   "my chat history" differently from "the keys to my Spaces".
+   "my chat history" differently from "the keys to my Spaces". **Add to that** (from
+   the correction above): the copy should advise keeping the `.qmbak` and the `.key`
+   export in *different* places, since co-locating them is the single decision that
+   turns "safe" into "total loss" under this design.
 
 ---
 

--- a/.agents/issues/.open/2026-08-09-backup-restore-overhaul-design.md
+++ b/.agents/issues/.open/2026-08-09-backup-restore-overhaul-design.md
@@ -264,13 +264,40 @@ This also decouples the fix from the config-sync overhaul: reading `space_keys`
 directly means a correct backup **does not depend on the parked tiering decision**,
 and works identically whether sync is on, off, or has never been on.
 
-> ⚠️ **Size.** ~10k polynomial evals (~2 MB) are pre-allocated per **created** Space
-> and deleted Spaces have been observed to leak state rather than remove it (see
-> [`2025-12-09-encryption-state-evals-bloat.md`](2025-12-09-encryption-state-evals-bloat.md);
-> a real account measured 4112 KB of encryption states). A `.qmbak` is a local file,
-> not an API payload, so the ~1 MB config ceiling does not apply — but a
-> multi-hundred-MB download is its own failure. **Measure a real account's export
-> before choosing whether Space messages are included by default (§7).**
+### 5.1 Size — MEASURED 2026-08-09
+
+~10k polynomial evals (~2 MB) are pre-allocated per **created** Space, a joined one
+costs ~12-63 KB, and deleted Spaces leak their state rather than remove it (see
+[`2025-12-09-encryption-state-evals-bloat.md`](2025-12-09-encryption-state-evals-bloat.md);
+a real account measured 4112 KB of encryption states, and another 19.4 MB local
+across 10 states of which 8 were orphaned debris).
+
+Measured against the real export path (`backupSpaceKeyCoverage.test.ts`, "MEASUREMENT"):
+
+| Export | `.qmbak` bytes |
+|---|---|
+| 1 Space + 1 DM, no eval pool | **6,469 B** (~6 KB) |
+| Same, with one 2 MB eval pool | **4,200,753 B** (~4.0 MB) |
+| Growth | **4,194,284 B = exactly 2.00× the pool** |
+
+**Two findings.**
+
+1. **The eval pool passes into the backup intact.** Nothing filters it, exactly as
+   nothing filters it out of the config upload. Backup size is therefore governed by
+   the evals bug, not by message volume — the account above would produce an ~8 MB
+   file with *no messages at all*.
+2. **🆕 The file is 2× its payload, because the ciphertext is hex-encoded**
+   ([`BackupService.ts`](../../../src/services/BackupService.ts), `Buffer.from(encrypted).toString('hex')`).
+   Two hex chars per byte. **Switching the encoding to base64 would cut every
+   backup by ~33%** (2.00× → 1.33×) for a few lines of change, with the same
+   v1-reader discipline as the rest of §7. Worth doing in slice 5 when the size
+   budget is being decided anyway. Not urgent — a local file has no server ceiling
+   — but it is the cheapest size win available and nothing else in the design
+   competes with it.
+
+**A `.qmbak` is a local file, not an API payload, so the ~1 MB config ceiling does
+not apply.** The practical ceiling is what a user will tolerate downloading, and on
+these numbers the dominant term is a bug being fixed elsewhere.
 
 ---
 
@@ -402,11 +429,15 @@ disks and must keep importing, restoring what they contain.
 
 One issue, shipped in order. Each slice ends in something observable.
 
-**Slice 1 — Export the Space keys.** Read `space_keys` + Space rows directly from
-IndexedDB (not from `user_config`), bump to v2 with per-domain presence flags, keep
-the v1 reader. No import change.
-*Observable:* export a backup with sync off; a dev-tools dump of the decrypted
-payload shows every Space and its `owner` key. **Today it shows none.**
+**Slice 1 — Export the Space keys. ✅ SHIPPED 2026-08-09.**
+`MessageDB.getAllSpaceData()` reads the `spaces` and `space_keys` stores directly;
+format bumped to v2 with per-domain presence flags; v1 reader kept; a file from a
+*newer* format is refused rather than half-restored. Import unchanged.
+*Observable, now true:* a sync-off export carries all seven Space keys including
+`owner`. Covered by `backupSpaceKeyCoverage.test.ts`, whose sync-off assertions
+were inverted in the same commit — and which pins that
+`user_config.spaceKeys` is **still** empty in that export, so the fix demonstrably
+works by reading the owning store rather than by the snapshot quietly filling in.
 
 **Slice 2 — Restore Spaces, additive only.** Import adopts absent Spaces by reusing
 the §3 mechanism; present Spaces untouched. Report counts per domain.
@@ -449,10 +480,14 @@ by using the app. Reasoning about the diff is not verification here.
       Not both-empty, not both-populated — the instrument discriminates.
 - [x] **Mutation check on the instrument itself.** ✅ Assembling `spaceKeys` outside
       the `allowSync` branch turns Arm A red and leaves the controls green.
+- [x] **Size measured** ✅ **2026-08-09** — §5.1. Done against the real export path
+      with a realistic eval pool rather than a real account, so it is repeatable.
+      §10.4 no longer waits on it.
 - [ ] **Still owed: one real-account export.** The instrument measures the real
-      save/export chain against a seeded database, which is the mechanism — but not
-      a real account's actual on-disk state, and not the file size. Both remain open;
-      the size number gates §10.4.
+      save/export chain against a *seeded* database. That establishes the mechanism,
+      not one real account's actual on-disk state — in particular how many orphaned
+      encryption states a long-lived account is really carrying. Worth one export
+      when convenient; it blocks nothing.
 - [ ] Wipe → login → import. Record per domain what returned and what did not.
 - [ ] **Additive invariant, adversarially.** Import an *old* backup into a *live*
       account with more Spaces and newer DMs. Assert byte-equality of every
@@ -494,11 +529,15 @@ live sessions untouched.
 3. **The SDK question (§6):** can a rewound sending chain re-derive an already-used
    message key, and can the SDK expose a receive-only restore (D1)? Gates slice 4 only.
    Ask about the Space-side Triple Ratchet staleness (§3 step 6) in the same conversation.
-4. **Space messages in the default export?** Largest contributor to file size, and the
-   only domain that partly self-heals via peer resync. A checkbox at export is the
-   obvious answer, but a default that quietly excludes history from a file called
-   "backup" repeats the framing problem this issue exists to fix. Needs the size
-   measurement from §9.
+4. **Space messages in the default export?** Still open, but **no longer blocked on
+   a measurement** — see §5.1. The size picture came back different from the
+   assumption: the dominant term is the ~2 MB-per-created-Space eval pool, not
+   message volume, and hex encoding doubles whatever that comes to. An account with
+   no messages at all can already produce an ~8 MB file. So "Space messages are the
+   size risk" was wrong; they should be judged on whether a backup that silently
+   omits history deserves the name, which is a product call. Two cheap wins to fold
+   in when it is made: base64 instead of hex (~33% off every file), and excluding
+   orphaned encryption states for Spaces no longer in `spaces`.
 5. **Config scalars: fill-absent, or ask the user?** (§4) — product decision.
 6. **Does restore belong in onboarding?** Today import is only reachable post-login
    from Settings. For the Safari install flow

--- a/.agents/issues/.open/2026-08-09-backup-restore-overhaul-design.md
+++ b/.agents/issues/.open/2026-08-09-backup-restore-overhaul-design.md
@@ -507,6 +507,13 @@ import again → "0 restored, 1 already present". Both property tests
 mutation-verified.
 
 **Slice 2b — Space-departure tombstones. ✅ SHIPPED 2026-08-09.**
+Both write sites are now asserted at the call site, not only through the DB
+helper: `SpaceService.unit.test.tsx` for `left`, and
+`MessageService.kickDeparture.unit.test.ts` for `removed` — the latter driving a
+real kick frame through `handleNewMessage`, with controls for "kick names someone
+else" and "signature does not verify". `InvitationService.unit.test.tsx` covers
+the clear-on-rejoin. All three mutation-verified.
+
 New `departed_spaces` store at DB v15, written at the two genuine departure sites
 — `SpaceService.deleteSpace` (`left`) and `MessageService`'s removed-from-space
 handler (`removed`) — and **not** in `MessageDB.deleteSpace`, which

--- a/.agents/issues/.open/2026-08-09-backup-restore-overhaul-design.md
+++ b/.agents/issues/.open/2026-08-09-backup-restore-overhaul-design.md
@@ -523,11 +523,15 @@ this backup was taken", nothing re-registered. Mutation-verified, and the
 departure write is asserted at the `SpaceService` call site rather than only
 through the DB helper.
 
-**Slice 3 — Honest reporting and pre-flight.** Before writing a file, show what it
-will contain (including that it holds Space ownership keys — §10.7). Before
-restoring, show what the file holds and what will be skipped.
-*Observable:* the export dialog names the domains; a v1 file imported into v2 code
-says plainly that it has no Space keys.
+**Slice 3 — Honest reporting and pre-flight. ✅ SHIPPED 2026-08-09.**
+The export copy now says the file contains Space keys including ownership of
+Spaces you created (§10.7's surviving requirement). The restore reports per
+domain: Spaces restored, Spaces left untouched because they were already present,
+messages withheld because they were deleted after the backup, Spaces skipped with
+the reason, plus the v1 "this file has no Space keys, export a fresh one" case and
+the standing "Space message history is not included" note.
+*Observable:* import a v1 file → a successful restore that states plainly why no
+Spaces came back, instead of a bare message count.
 
 **Slice 4 — DM sessions.** Restore ratchet states only where no state exists for
 that conversation. **The only slice gated on the SDK answer (§10.3).**

--- a/.agents/issues/.open/2026-08-09-backup-restore-overhaul-design.md
+++ b/.agents/issues/.open/2026-08-09-backup-restore-overhaul-design.md
@@ -227,7 +227,64 @@ choose its own rule.** Every case above then falls out without a mode:
 | `allowSync` | **Never restore it.** Device-local | Adopting it from a file re-opens exactly what [`2026-08-08-make-allowsync-a-per-device-setting.md`](2026-08-08-make-allowsync-a-per-device-setting.md) closed |
 | Space messages | Upsert by id, if included at all (§7) | |
 
-Two consequences worth stating out loud, because they are what make this safe:
+### 4.1 Additive is only half of it — deletions need tombstones
+
+**Raised 2026-08-09, and the case list above misses it entirely.** Take a backup,
+then delete some DMs, or leave a Space, or get kicked from one — then restore the
+older backup. Every rule in the table says "the file has it, the device doesn't,
+so add it", and the user's deliberate removal is silently undone.
+
+Additive and tombstones are **orthogonal**, and both are required:
+
+| Axis | What it protects | Mechanism |
+|---|---|---|
+| The user **changed** something | live keys beat stale keys | additive — never overwrite what is present |
+| The user **removed** something | a deletion is not undone | tombstone — never re-add what was removed |
+
+The unifying rule: **an import must never contradict a decision the user made
+after the backup was taken.** "Absent locally" is not sufficient grounds to
+restore, because absence has two causes — never known, and deliberately removed —
+and only a tombstone distinguishes them.
+
+**DM messages — FIXED 2026-08-09.** Tombstones existed (`deleted_messages`, DB v7)
+but were written for **channel messages only**, on an explicit rationale: *"DMs
+don't have a sync mechanism, so tombstones aren't needed"*. That was true when
+written. **Backup restore is precisely the mechanism that makes it false.** DM
+deletions now write tombstones too — purely additive, since nothing else consumes
+them for DMs — and `importDMData` refuses to write any message carrying one.
+Covered by `backupSpaceRestore.test.ts`, control-armed (a never-deleted message
+must still restore, or the gate could pass by writing nothing) and
+mutation-verified.
+
+**Space departures — OPEN, and the harder half.** No leave/kick tombstone exists
+anywhere (READ: no `deletedSpaceIds`, `leftSpaces` or equivalent in `src/`). So
+restoring a backup taken before leaving **will** re-add the Space, and worse than
+locally: `adoptSpaces` calls `postHubAdd` and sends a `sync` control message, so a
+kicked user silently re-announces to a Space that removed them. That is an
+outward-facing action taken on stale state.
+
+The obvious fix — write the tombstone inside `MessageDB.deleteSpace()`, the single
+choke point all three removal paths funnel through — **does not work as stated**,
+and this is the trap to avoid:
+
+| Caller | Meaning |
+|---|---|
+| [`SpaceService.ts:685`](../../../src/services/SpaceService.ts#L685) | leave / delete — a real departure |
+| [`MessageService.ts:5638`](../../../src/services/MessageService.ts#L5638) | kicked — a real departure |
+| [`EncryptionService.ts:305`](../../../src/services/EncryptionService.ts#L305) | **not a departure** — a space-address *migration*, which deletes the old `spaceId` and immediately re-saves under a new one |
+
+Tombstoning in `deleteSpace` would mark a migrated Space as "left". It happens to
+be harmless for the restore gate (the retired id should not be resurrected either),
+but it conflates two different facts under one name, which is how the next bug gets
+written. **The tombstone must be recorded by the departure call sites, not by the
+store method.** A rejoin must clear it — `clearTombstonesForSpace` is the existing
+precedent for exactly that.
+
+This needs a DB version bump and touches kick/leave, so it is **its own slice**
+(now slice 2b) rather than an addendum. Until it lands, the restore reports which
+Spaces it re-registered so the behaviour is at least not silent.
+
+Two further consequences worth stating out loud, because they are what make this safe:
 
 - **Additive-only means an import can never make a device worse.** That single
   invariant covers cases 5, 6 and 7 and removes the need to reason about backup age
@@ -439,10 +496,22 @@ were inverted in the same commit — and which pins that
 `user_config.spaceKeys` is **still** empty in that export, so the fix demonstrably
 works by reading the owning store rather than by the snapshot quietly filling in.
 
-**Slice 2 — Restore Spaces, additive only.** Import adopts absent Spaces by reusing
-the §3 mechanism; present Spaces untouched. Report counts per domain.
-*Observable:* wipe a sync-off device, log in, import → the Space list comes back and
-channels load. Import again → "0 restored, N already present".
+**Slice 2 — Restore Spaces, additive only. ✅ SHIPPED 2026-08-09.**
+`ConfigService.adoptSpaces` extracted from `getConfig` (pure move, 46 existing
+tests green) and reused by the import via injection, so `BackupService` does not
+depend on `ConfigService`. Exposed on the MessageDB context as `adoptSpaces`,
+following the `saveConfig` pattern. Import reports per-domain counts.
+Deletion tombstones for DMs landed with it (§4.1).
+*Observable:* wipe a sync-off device, import → Spaces return and channels load;
+import again → "0 restored, 1 already present". Both property tests
+mutation-verified.
+
+**Slice 2b — Space-departure tombstones. 🔴 NEXT, and it is a correctness gap, not
+a polish item.** See §4.1: leaving or being kicked leaves no record, so a restore
+re-adds the Space *and* re-announces to its hub. Needs a DB version bump, writes
+at the two genuine departure call sites (**not** in `deleteSpace`, which
+`EncryptionService` also uses for a migration), a clear-on-rejoin, and a gate in
+`adoptSpaces`.
 
 **Slice 3 — Honest reporting and pre-flight.** Before writing a file, show what it
 will contain (including that it holds Space ownership keys — §10.7). Before

--- a/.agents/issues/.open/2026-08-09-backup-restore-overhaul-design.md
+++ b/.agents/issues/.open/2026-08-09-backup-restore-overhaul-design.md
@@ -506,12 +506,22 @@ Deletion tombstones for DMs landed with it (§4.1).
 import again → "0 restored, 1 already present". Both property tests
 mutation-verified.
 
-**Slice 2b — Space-departure tombstones. 🔴 NEXT, and it is a correctness gap, not
-a polish item.** See §4.1: leaving or being kicked leaves no record, so a restore
-re-adds the Space *and* re-announces to its hub. Needs a DB version bump, writes
-at the two genuine departure call sites (**not** in `deleteSpace`, which
-`EncryptionService` also uses for a migration), a clear-on-rejoin, and a gate in
-`adoptSpaces`.
+**Slice 2b — Space-departure tombstones. ✅ SHIPPED 2026-08-09.**
+New `departed_spaces` store at DB v15, written at the two genuine departure sites
+— `SpaceService.deleteSpace` (`left`) and `MessageService`'s removed-from-space
+handler (`removed`) — and **not** in `MessageDB.deleteSpace`, which
+`EncryptionService` also uses for a space-address migration. Cleared by
+`InvitationService` on rejoin, next to the existing `clearTombstonesForSpace`.
+
+**The gate lives in `BackupService`, not `adoptSpaces`.** That method also serves
+config sync, where the payload is the account's *current* state published after
+the departure, rather than a snapshot from the past; blocking there would break
+leaving a Space on one device and rejoining on another. A backup file is stale by
+construction, a synced config is not — and that distinction is asserted by a test.
+*Observable:* leave a Space, import an older backup → "you left this Space after
+this backup was taken", nothing re-registered. Mutation-verified, and the
+departure write is asserted at the `SpaceService` call site rather than only
+through the DB helper.
 
 **Slice 3 — Honest reporting and pre-flight.** Before writing a file, show what it
 will contain (including that it holds Space ownership keys — §10.7). Before

--- a/.agents/tools/dm-debug/10-backup-payload-size.js
+++ b/.agents/tools/dm-debug/10-backup-payload-size.js
@@ -1,0 +1,106 @@
+// === Quorum Backup Payload Size — where does a .qmbak's weight come from? ===
+//
+// READ-ONLY. Opens the DB, measures nothing else, writes nothing.
+//
+// Answers one question: of the encryption states this account is carrying, how
+// many belong to a Space or conversation that still EXISTS, and how many are
+// orphans left behind by Spaces that were deleted?
+//
+// Why it matters: `getAllEncryptionStates()` is an unfiltered getAll, so the
+// backup export used to include orphans too. A created Space pre-allocates a
+// ~2 MB polynomial eval pool, and deleting the Space has been observed to leak
+// that state rather than remove it (2025-12-09-encryption-state-evals-bloat.md).
+// Orphans are dead weight in a backup BY CONSTRUCTION: the restore rebuilds
+// Spaces by iterating the Spaces in the file, so a state whose Space is absent
+// can never be matched to anything.
+//
+// The `.qmbak` on disk is ~2x the payload, because the ciphertext is hex-encoded
+// (2 characters per byte), so the file column below is the number that matters.
+//
+// Paste into the dev console with the app open and logged in.
+
+indexedDB.open('quorum_db').onsuccess = (e) => {
+  const db = e.target.result;
+  const tx = db.transaction(['spaces', 'conversations', 'encryption_states']);
+  const out = {};
+  let pending = 3;
+
+  const done = () => {
+    if (--pending) return;
+
+    const liveSpaces = new Set(out.spaces.map((s) => s.spaceId));
+    const liveConvos = new Set(out.conversations.map((c) => c.conversationId));
+
+    const kb = (n) => Math.round(n / 1024);
+    const rows = [];
+    let liveBytes = 0;
+    let orphanBytes = 0;
+    let orphanCount = 0;
+
+    for (const s of out.encryption_states) {
+      const bytes = JSON.stringify(s).length;
+      const [left, right] = String(s.conversationId ?? '').split('/');
+      const isPairShaped = left && left === right;
+
+      let kind;
+      if (!isPairShaped) kind = 'other (kept)';
+      else if (liveSpaces.has(left)) kind = 'live Space';
+      else if (liveConvos.has(s.conversationId)) kind = 'live DM';
+      else kind = '❌ ORPHAN';
+
+      if (kind === '❌ ORPHAN') {
+        orphanBytes += bytes;
+        orphanCount++;
+      } else {
+        liveBytes += bytes;
+      }
+
+      rows.push({
+        conversationId: String(s.conversationId ?? '').slice(0, 22) + '…',
+        kind,
+        KB: kb(bytes),
+      });
+    }
+
+    rows.sort((a, b) => b.KB - a.KB);
+    console.table(rows);
+
+    const total = liveBytes + orphanBytes;
+    console.table([
+      {
+        part: 'states worth keeping',
+        payloadMB: (liveBytes / 1048576).toFixed(2),
+        approxFileMB: ((liveBytes * 2) / 1048576).toFixed(2),
+      },
+      {
+        part: `ORPHANS (${orphanCount}) — unusable by any restore`,
+        payloadMB: (orphanBytes / 1048576).toFixed(2),
+        approxFileMB: ((orphanBytes * 2) / 1048576).toFixed(2),
+      },
+      {
+        part: 'total encryption states',
+        payloadMB: (total / 1048576).toFixed(2),
+        approxFileMB: ((total * 2) / 1048576).toFixed(2),
+      },
+    ]);
+
+    console.log(
+      `[backup-size] ${out.spaces.length} Space(s), ` +
+        `${out.conversations.length} conversation(s), ` +
+        `${out.encryption_states.length} encryption state(s)`
+    );
+    if (orphanCount > 0) {
+      console.log(
+        `[backup-size] filtering orphans should shrink the .qmbak by about ` +
+          `${((orphanBytes * 2) / 1048576).toFixed(1)} MB`
+      );
+    }
+  };
+
+  for (const store of ['spaces', 'conversations', 'encryption_states']) {
+    tx.objectStore(store).getAll().onsuccess = (r) => {
+      out[store] = r.target.result;
+      done();
+    };
+  }
+};

--- a/src/components/context/MessageDB.tsx
+++ b/src/components/context/MessageDB.tsx
@@ -185,6 +185,20 @@ type MessageDBContextValue = {
       deviceKeyset: secureChannel.DeviceKeyset;
     };
   }) => Promise<void>;
+  /**
+   * Adopt Spaces from key material, skipping any already present locally.
+   * Exposed so the backup restore path can reuse the same additive adoption a
+   * synced login runs, rather than reimplementing it. See ConfigService.adoptSpaces.
+   */
+  adoptSpaces: ({
+    spaceKeys,
+  }: {
+    spaceKeys: NonNullable<UserConfig['spaceKeys']>;
+  }) => Promise<{
+    restored: string[];
+    alreadyPresent: string[];
+    failed: { spaceId: string; reason: string }[];
+  }>;
   setSelfAddress: React.Dispatch<React.SetStateAction<string>>;
   ensureKeyForSpace: (user_address: string, space: Space) => Promise<string>;
   sendInviteToUser: (
@@ -753,6 +767,13 @@ const MessageDBProvider: FC<MessageDBContextProps> = ({ children }) => {
       };
     }) => {
       return configService.saveConfig({ config, keyset });
+    },
+    [configService]
+  );
+
+  const adoptSpaces = React.useCallback(
+    async ({ spaceKeys }: { spaceKeys: NonNullable<UserConfig['spaceKeys']> }) => {
+      return configService.adoptSpaces({ spaceKeys });
     },
     [configService]
   );
@@ -1638,6 +1659,7 @@ const MessageDBProvider: FC<MessageDBContextProps> = ({ children }) => {
         retryDirectMessage,
         getConfig,
         saveConfig,
+        adoptSpaces,
         setSelfAddress,
         ensureKeyForSpace,
         sendInviteToUser,
@@ -1680,6 +1702,7 @@ const MessageDBContext = createContext<MessageDBContextValue>({
   retryDirectMessage: () => undefined as never,
   getConfig: () => undefined as never,
   saveConfig: () => undefined as never,
+  adoptSpaces: () => undefined as never,
   setSelfAddress: (_) => {},
   ensureKeyForSpace: () => undefined as never,
   sendInviteToUser: () => undefined as never,

--- a/src/components/modals/UserSettingsModal/Security.tsx
+++ b/src/components/modals/UserSettingsModal/Security.tsx
@@ -594,7 +594,7 @@ const Security: React.FunctionComponent<SecurityProps> = ({
                     "the keys to my Spaces" in different places, and they can
                     only make that call if we tell them which one this is.
                   */}
-                  {t`Export an encrypted backup of your direct messages and your Spaces, so you can restore them if you lose access to this device. The file contains your Space keys, including ownership of Spaces you created, and can only be opened by this account.`}
+                  {t`Export an encrypted backup of your direct messages and your Spaces, so you can restore them if you lose access to this device. The file contains your Space keys, including ownership of Spaces you created, and can only be opened by this account. Keep it somewhere separate from your exported account key.`}
                 </div>
                 <Button
                   type="secondary"

--- a/src/components/modals/UserSettingsModal/Security.tsx
+++ b/src/components/modals/UserSettingsModal/Security.tsx
@@ -190,23 +190,26 @@ const Security: React.FunctionComponent<SecurityProps> = ({
   /**
    * Confirmation before writing the file.
    *
-   * Not a "are you sure" speed bump — the export is harmless in itself. It is
-   * the one moment the user is deciding WHERE this file will live, and the only
-   * moment telling them what is in it can change that decision. A .qmbak now
-   * carries Space ownership keys, and the account key that opens it is itself
-   * downloadable from this same screen: put both in one folder and a single
-   * theft takes the Spaces with it.
+   * Not an "are you sure" speed bump — the export is harmless in itself. It is
+   * the moment the user learns what the file actually holds, which is no longer
+   * just messages: it carries Space ownership keys too.
+   *
+   * Deliberately states no storage advice. An earlier draft warned that anyone
+   * holding both this file AND the exported account key could take over those
+   * Spaces. That is noise for a sync-ON user, whose account key alone already
+   * fetches the Space keys from the server — and worse, framing the COMBINATION
+   * as the danger implies the account key by itself is less than total, which is
+   * the opposite of true. It is only incremental for a sync-OFF user, for whom
+   * the server holds nothing and this file is the only other copy. Rather than
+   * state something true for one group and misleading for the other, the copy
+   * sticks to what is true for both. The sync-off nuance belongs in the docs.
    */
   const exportConfirmation = useConfirmation({
     type: 'modal',
     enableShiftBypass: false,
     modalConfig: {
       title: t`Export a backup?`,
-      message: t`This file contains the keys to your Spaces, including ownership of any Space you created, plus your direct message history.
-
-Only this account can open it. Anyone who has both this file and your exported account key could take over those Spaces, so keep them in different places.
-
-Space message history is not included. It syncs back from other members.`,
+      message: t`This file contains your direct message history and the keys to your Spaces, including ownership of any you created. Only this account can open it.\n\nSpace message history is not included. It syncs back from other members.`,
       confirmText: t`Export backup`,
       cancelText: t`Cancel`,
       variant: 'warning',

--- a/src/components/modals/UserSettingsModal/Security.tsx
+++ b/src/components/modals/UserSettingsModal/Security.tsx
@@ -221,6 +221,11 @@ const Security: React.FunctionComponent<SecurityProps> = ({
         t`${result.spacesAlreadyPresent.length} Spaces were already on this device and were left unchanged.`
       );
     }
+    if (result.conversationsSkippedAsDeleted > 0) {
+      parts.push(
+        t`${result.conversationsSkippedAsDeleted} conversations were not restored because you deleted them after this backup was made.`
+      );
+    }
     if (result.messagesSkippedAsDeleted > 0) {
       parts.push(
         t`${result.messagesSkippedAsDeleted} messages were not restored because you deleted them after this backup was made.`
@@ -231,6 +236,11 @@ const Security: React.FunctionComponent<SecurityProps> = ({
         t`${result.spacesFailed.length} Spaces were skipped: ${result.spacesFailed
           .map((s) => s.reason)
           .join('; ')}`
+      );
+    }
+    if (result.domains.space_keys && !result.domains.spaces) {
+      parts.push(
+        t`This backup is inconsistent: it reports Space keys but contains no Space list, so Spaces could not be restored.`
       );
     }
     if (!result.domains.space_keys) {

--- a/src/components/modals/UserSettingsModal/Security.tsx
+++ b/src/components/modals/UserSettingsModal/Security.tsx
@@ -13,6 +13,8 @@ import {
   type SensitiveCopyMode,
 } from '../../../utils/clipboardSecurity';
 import type { RestoreReport } from '../../../services/BackupService';
+import { useConfirmation } from '../../../hooks/ui/useConfirmation';
+import ConfirmationModal from '../ConfirmationModal';
 
 interface SecurityProps {
   stagedRegistration: any;
@@ -184,6 +186,38 @@ const Security: React.FunctionComponent<SecurityProps> = ({
   };
 
   const isBackupBusy = isExportingBackup || isImportingBackup;
+
+  /**
+   * Confirmation before writing the file.
+   *
+   * Not a "are you sure" speed bump — the export is harmless in itself. It is
+   * the one moment the user is deciding WHERE this file will live, and the only
+   * moment telling them what is in it can change that decision. A .qmbak now
+   * carries Space ownership keys, and the account key that opens it is itself
+   * downloadable from this same screen: put both in one folder and a single
+   * theft takes the Spaces with it.
+   */
+  const exportConfirmation = useConfirmation({
+    type: 'modal',
+    enableShiftBypass: false,
+    modalConfig: {
+      title: t`Export a backup?`,
+      message: t`This file contains the keys to your Spaces, including ownership of any Space you created, plus your direct message history.
+
+Only this account can open it. Anyone who has both this file and your exported account key could take over those Spaces, so keep them in different places.
+
+Space message history is not included. It syncs back from other members.`,
+      confirmText: t`Export backup`,
+      cancelText: t`Cancel`,
+      variant: 'warning',
+    },
+  });
+
+  /** Asks first; `handleExportBackup` runs only once the user confirms. */
+  const handleExportBackupClick = (e: React.MouseEvent) => {
+    if (exportConfirmation.isConfirming) return;
+    exportConfirmation.handleClick(e, handleExportBackup);
+  };
 
   const handleExportBackup = async () => {
     setIsExportingBackup(true);
@@ -588,19 +622,19 @@ const Security: React.FunctionComponent<SecurityProps> = ({
               <div className="flex items-start justify-between gap-3">
                 <div className="text-sm" style={{ lineHeight: 1.3 }}>
                   {/*
-                    Says what the file contains, because it is no longer just
-                    messages: it now holds your Space keys, including ownership
-                    of Spaces you created. People store "my chat history" and
-                    "the keys to my Spaces" in different places, and they can
-                    only make that call if we tell them which one this is.
+                    Deliberately short. What the file actually CONTAINS — Space
+                    keys, including ownership of Spaces you created — is the
+                    kind of thing people need at the moment they decide where to
+                    put the file, not while scanning a settings page. It lives in
+                    the confirmation modal instead.
                   */}
-                  {t`Export an encrypted backup of your direct messages and your Spaces, so you can restore them if you lose access to this device. The file contains your Space keys, including ownership of Spaces you created, and can only be opened by this account. Keep it somewhere separate from your exported account key.`}
+                  {t`Export an encrypted backup of your direct messages and your Spaces, so you can restore them if you lose access to this device.`}
                 </div>
                 <Button
                   type="secondary"
                   size="small"
                   className="whitespace-nowrap"
-                  onClick={handleExportBackup}
+                  onClick={handleExportBackupClick}
                   disabled={isBackupBusy}
                 >
                   {isExportingBackup ? t`Exporting...` : t`Export`}
@@ -636,6 +670,22 @@ const Security: React.FunctionComponent<SecurityProps> = ({
         </div>
 
       </div>
+      {/* Says what the file holds, at the moment the user chooses where to keep it. */}
+      {exportConfirmation.modalConfig && (
+        <ConfirmationModal
+          visible={exportConfirmation.showModal}
+          title={exportConfirmation.modalConfig.title}
+          message={exportConfirmation.modalConfig.message}
+          confirmText={exportConfirmation.modalConfig.confirmText}
+          cancelText={exportConfirmation.modalConfig.cancelText}
+          variant={exportConfirmation.modalConfig.variant}
+          showProtip={false}
+          busy={exportConfirmation.isConfirming}
+          busyMessage={t`Exporting...`}
+          onConfirm={exportConfirmation.modalConfig.onConfirm}
+          onCancel={exportConfirmation.modalConfig.onCancel}
+        />
+      )}
     </>
   );
 };

--- a/src/components/modals/UserSettingsModal/Security.tsx
+++ b/src/components/modals/UserSettingsModal/Security.tsx
@@ -12,6 +12,7 @@ import {
   SENSITIVE_CLIPBOARD_CLEAR_MS,
   type SensitiveCopyMode,
 } from '../../../utils/clipboardSecurity';
+import type { RestoreReport } from '../../../services/BackupService';
 
 interface SecurityProps {
   stagedRegistration: any;
@@ -19,7 +20,7 @@ interface SecurityProps {
   removeDevice: (key: string) => void;
   downloadKey: () => void;
   exportBackup: () => Promise<void>;
-  importBackup: (file: File) => Promise<{ messagesWritten: number; conversationsWritten: number }>;
+  importBackup: (file: File) => Promise<RestoreReport>;
   getPrivateKeyHex?: () => Promise<string>;
   removedDevices?: string[];
   deviceNames?: { [inboxAddress: string]: string };
@@ -198,6 +199,54 @@ const Security: React.FunctionComponent<SecurityProps> = ({
     }
   };
 
+  /**
+   * Describes what the restore did AND what it deliberately did not do.
+   *
+   * A bare "restored N messages" is what let the feature imply for months that it
+   * protected Spaces when it could not restore a single one. Every line below is
+   * a case where something the user might expect back did not come back, and each
+   * has a different reason the user can act on.
+   */
+  const summariseRestore = (result: RestoreReport): string => {
+    const parts: string[] = [
+      t`Restored ${result.messagesWritten} messages and ${result.conversationsWritten} conversations.`,
+    ];
+
+    if (result.spacesRestored.length > 0) {
+      parts.push(t`Restored ${result.spacesRestored.length} Spaces.`);
+    }
+    if (result.spacesAlreadyPresent.length > 0) {
+      // Not a failure: the additive rule leaving live Spaces untouched.
+      parts.push(
+        t`${result.spacesAlreadyPresent.length} Spaces were already on this device and were left unchanged.`
+      );
+    }
+    if (result.messagesSkippedAsDeleted > 0) {
+      parts.push(
+        t`${result.messagesSkippedAsDeleted} messages were not restored because you deleted them after this backup was made.`
+      );
+    }
+    if (result.spacesFailed.length > 0) {
+      parts.push(
+        t`${result.spacesFailed.length} Spaces were skipped: ${result.spacesFailed
+          .map((s) => s.reason)
+          .join('; ')}`
+      );
+    }
+    if (!result.domains.space_keys) {
+      // The v1 case. Without this the user sees a successful restore and no
+      // Spaces, with nothing to explain why.
+      parts.push(
+        t`This backup was made by an older version and contains no Space keys, so Spaces could not be restored. Export a fresh backup to protect them.`
+      );
+    }
+    if (!result.domains.space_messages) {
+      parts.push(t`Space message history is not included in backups; it syncs from other members.`);
+    }
+
+    return parts.join(' ');
+  };
+
   const handleImportBackup = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
@@ -210,9 +259,7 @@ const Security: React.FunctionComponent<SecurityProps> = ({
     setBackupSuccess(null);
     try {
       const result = await importBackup(file);
-      setBackupSuccess(
-        t`Restored ${result.messagesWritten} messages and ${result.conversationsWritten} conversations.`
-      );
+      setBackupSuccess(summariseRestore(result));
     } catch (error: any) {
       console.error('Backup import failed:', error);
       setBackupError(error.message || t`Failed to import backup`);
@@ -530,7 +577,14 @@ const Security: React.FunctionComponent<SecurityProps> = ({
             <div className="flex flex-col gap-2 p-3 rounded-md border">
               <div className="flex items-start justify-between gap-3">
                 <div className="text-sm" style={{ lineHeight: 1.3 }}>
-                  {t`Export an encrypted backup of your direct messages to restore them if you lose access to this device.`}
+                  {/*
+                    Says what the file contains, because it is no longer just
+                    messages: it now holds your Space keys, including ownership
+                    of Spaces you created. People store "my chat history" and
+                    "the keys to my Spaces" in different places, and they can
+                    only make that call if we tell them which one this is.
+                  */}
+                  {t`Export an encrypted backup of your direct messages and your Spaces, so you can restore them if you lose access to this device. The file contains your Space keys, including ownership of Spaces you created, and can only be opened by this account.`}
                 </div>
                 <Button
                   type="secondary"

--- a/src/db/dbVersion.ts
+++ b/src/db/dbVersion.ts
@@ -13,4 +13,4 @@
 export const QUORUM_DB_NAME = 'quorum_db';
 
 /** Schema version the app opens the database at. */
-export const QUORUM_DB_VERSION = 14;
+export const QUORUM_DB_VERSION = 15;

--- a/src/db/dbVersion.ts
+++ b/src/db/dbVersion.ts
@@ -13,4 +13,4 @@
 export const QUORUM_DB_NAME = 'quorum_db';
 
 /** Schema version the app opens the database at. */
-export const QUORUM_DB_VERSION = 15;
+export const QUORUM_DB_VERSION = 16;

--- a/src/db/messages.ts
+++ b/src/db/messages.ts
@@ -2280,6 +2280,47 @@ export class MessageDB {
   }
 
   /**
+   * Collects Space rows and their key material for backup export.
+   *
+   * Reads the `spaces` and `space_keys` stores DIRECTLY, and deliberately not
+   * `user_config.spaceKeys`. That field looks like the Space key store and is
+   * actually a snapshot assembled in one branch of one function: `saveConfig`
+   * only builds it inside `if (config.allowSync)` (ConfigService.ts:554,591), and
+   * `getDefaultUserConfig` initialises it to `[]` (utils.ts:15). A user who has
+   * never enabled sync therefore has an empty `spaceKeys` on disk permanently, so
+   * exporting via that field captures no key material at all — measured, see
+   * src/dev/tests/services/backupSpaceKeyCoverage.test.ts.
+   *
+   * Reading the owning stores instead makes the export independent of whether
+   * sync is on, off, or has never been on.
+   *
+   * The Space *definition* is not what matters here — a restore re-fetches the
+   * manifest from the API (ConfigService.ts:148). What cannot be re-derived is
+   * the key material, above all the `owner` private key, which is the sole proof
+   * of Space ownership and exists in no other copy.
+   */
+  async getAllSpaceData(): Promise<{
+    spaces: Space[];
+    space_keys: {
+      address?: string;
+      spaceId: string;
+      keyId: string;
+      publicKey: string;
+      privateKey: string;
+    }[];
+  }> {
+    await this.init();
+
+    const spaces = await this.getSpaces();
+
+    const space_keys = (
+      await Promise.all(spaces.map((s) => this.getSpaceKeys(s.spaceId)))
+    ).flat();
+
+    return { spaces, space_keys };
+  }
+
+  /**
    * Imports DM data from a backup into IndexedDB using a single atomic transaction.
    * Deduplicates messages/conversations by key using put() (existing records kept).
    * Skips encryption_states and user_config (Phase 2: user has active sessions).

--- a/src/db/messages.ts
+++ b/src/db/messages.ts
@@ -435,6 +435,18 @@ export class MessageDB {
           // departure. See `markSpaceDeparted`.
           db.createObjectStore('departed_spaces', { keyPath: 'spaceId' });
         }
+
+        if (event.oldVersion < 16) {
+          // Conversation-deletion tombstones.
+          //
+          // Message tombstones alone are not enough: deleting a chat removes the
+          // `conversations` row too, and `importDMData` used to re-`put()` it
+          // unconditionally. The chat would reappear in the sidebar — empty, but
+          // back — after the user had deliberately removed it.
+          db.createObjectStore('deleted_conversations', {
+            keyPath: 'conversationId',
+          });
+        }
       };
     });
   }
@@ -1155,14 +1167,24 @@ export class MessageDB {
     }
 
     return new Promise((resolve, reject) => {
-      const transaction = this.db!.transaction('conversations', 'readwrite');
-      const store = transaction.objectStore('conversations');
-      const request = store.put(conversation);
+      // Clears any deletion tombstone: saving a conversation means it exists
+      // again (the peer wrote, or the user started the chat afresh), so the old
+      // removal is no longer the user's current intent and must stop blocking a
+      // restore. Mirrors clearSpaceDeparture on rejoin.
+      //
+      // The backup import deliberately does NOT come through here — it writes to
+      // the store directly — so a restore cannot clear its own gate.
+      const transaction = this.db!.transaction(
+        ['conversations', 'deleted_conversations'],
+        'readwrite'
+      );
+      transaction.objectStore('conversations').put(conversation);
+      transaction
+        .objectStore('deleted_conversations')
+        .delete(conversation.conversationId);
 
-      request.onsuccess = () => {
-        resolve();
-      };
-      request.onerror = () => reject(request.error);
+      transaction.oncomplete = () => resolve();
+      transaction.onerror = () => reject(transaction.error);
     });
   }
 
@@ -1883,6 +1905,49 @@ export class MessageDB {
     });
   }
 
+  /**
+   * Remove a Space AND record the departure, atomically.
+   *
+   * Use this for a genuine departure (leave / kicked) instead of calling
+   * `deleteSpace` and `markSpaceDeparted` in sequence. Those are two independent
+   * IndexedDB transactions, and an interruption between them — a crash, a
+   * force-quit, a quota error on the second write — leaves the Space deleted with
+   * no departure record. That state is indistinguishable from "never had it", so
+   * a later backup restore re-adds the Space and calls `postHubAdd`, re-announcing
+   * a removed user to the Space that removed them. One transaction over both
+   * stores removes the window rather than just reordering it: writing the
+   * tombstone first would instead risk a Space the user still belongs to being
+   * marked departed and silently skipped by a future restore.
+   *
+   * `deleteSpace` deliberately keeps its narrower behaviour — `EncryptionService`
+   * uses it to retire the old id during a space-address migration, which is not a
+   * departure and must not be tombstoned.
+   */
+  async deleteSpaceAsDeparture({
+    spaceId,
+    reason,
+  }: {
+    spaceId: string;
+    reason: 'left' | 'removed';
+  }): Promise<void> {
+    await this.init();
+    return new Promise((resolve, reject) => {
+      const transaction = this.db!.transaction(
+        ['spaces', 'departed_spaces'],
+        'readwrite'
+      );
+      transaction.objectStore('spaces').delete(spaceId);
+      transaction
+        .objectStore('departed_spaces')
+        .put({ spaceId, reason, departedAt: Date.now() });
+
+      transaction.oncomplete = () => resolve();
+      transaction.onerror = () => reject(transaction.error);
+      transaction.onabort = () =>
+        reject(transaction.error ?? new Error('departure transaction aborted'));
+    });
+  }
+
   async getSpace(spaceId: string): Promise<Space | null> {
     await this.init();
     return new Promise((resolve, reject) => {
@@ -2439,6 +2504,7 @@ export class MessageDB {
     messagesWritten: number;
     conversationsWritten: number;
     messagesSkippedAsDeleted: number;
+    conversationsSkippedAsDeleted: number;
   }> {
     await this.init();
 
@@ -2452,9 +2518,23 @@ export class MessageDB {
     // getAll instead of a get per message, and an import racing a deletion is not
     // a real scenario.
     const deletedIds = new Set(await this.getDeletedMessageIds());
+    const deletedConversationIds = new Set(await this.getDeletedConversationIds());
 
-    const admissible = messages.filter((m) => !deletedIds.has(m.messageId));
+    const admissible = messages.filter(
+      (m) =>
+        !deletedIds.has(m.messageId) &&
+        // A chat deleted wholesale leaves per-message tombstones too, but gate on
+        // the conversation as well so a backup predating the tombstone work
+        // cannot slip its messages back in underneath a deleted chat.
+        !deletedConversationIds.has(`${m.spaceId}/${m.channelId}`)
+    );
     const messagesSkippedAsDeleted = messages.length - admissible.length;
+
+    const admissibleConversations = conversations.filter(
+      (c) => !deletedConversationIds.has(c.conversationId)
+    );
+    const conversationsSkippedAsDeleted =
+      conversations.length - admissibleConversations.length;
 
     return new Promise((resolve, reject) => {
       const transaction = this.db!.transaction(['messages', 'conversations'], 'readwrite');
@@ -2465,7 +2545,7 @@ export class MessageDB {
       let conversationsWritten = 0;
 
       // Write conversations first (metadata)
-      for (const conv of conversations) {
+      for (const conv of admissibleConversations) {
         const request = conversationStore.put(conv);
         request.onsuccess = () => { conversationsWritten++; };
       }
@@ -2477,7 +2557,12 @@ export class MessageDB {
       }
 
       transaction.oncomplete = () => {
-        resolve({ messagesWritten, conversationsWritten, messagesSkippedAsDeleted });
+        resolve({
+          messagesWritten,
+          conversationsWritten,
+          messagesSkippedAsDeleted,
+          conversationsSkippedAsDeleted,
+        });
       };
       transaction.onerror = () => reject(transaction.error);
       transaction.onabort = () => reject(new Error('Import transaction aborted'));
@@ -2491,10 +2576,21 @@ export class MessageDB {
     const [spaceId, channelId] = conversationId.split('/');
     if (!spaceId || !channelId) return;
     return new Promise((resolve, reject) => {
-      // Include 'bookmarks' store to cascade delete bookmarks for deleted messages
-      const transaction = this.db!.transaction(['messages', 'bookmarks'], 'readwrite');
+      // Include 'bookmarks' to cascade-delete bookmarks, and 'deleted_messages'
+      // to tombstone every message removed here.
+      //
+      // Deleting a whole conversation is the COMMON deletion action, and it used
+      // to write no tombstones at all — only the single-message `deleteMessage`
+      // path did. So restoring an older backup silently resurrected an entire
+      // deleted chat, which is exactly the invariant the tombstone gate exists to
+      // uphold. Same rule, applied to the path users actually take.
+      const transaction = this.db!.transaction(
+        ['messages', 'bookmarks', 'deleted_messages'],
+        'readwrite'
+      );
       const store = transaction.objectStore('messages');
       const bookmarkStore = transaction.objectStore('bookmarks');
+      const deletedMessagesStore = transaction.objectStore('deleted_messages');
       const bookmarkIndex = bookmarkStore.index('by_message');
       const index = store.index('by_conversation_time');
 
@@ -2530,13 +2626,33 @@ export class MessageDB {
             }
           };
 
+          deletedMessagesStore.put({
+            messageId: msg.messageId,
+            spaceId: msg.spaceId,
+            channelId: msg.channelId,
+            deletedAt: Date.now(),
+          } as DeletedMessageRecord);
+
           store.delete(msg.messageId);
           cursor.continue();
-        } else {
-          resolve();
         }
       };
 
+      request.onerror = () => reject(request.error);
+      // Resolve when the TRANSACTION commits, not when the cursor is exhausted:
+      // the tombstone puts above are still in flight at that point.
+      transaction.oncomplete = () => resolve();
+      transaction.onerror = () => reject(transaction.error);
+    });
+  }
+
+  /** Every conversationId the user has deleted. Consumed by the backup import. */
+  async getDeletedConversationIds(): Promise<string[]> {
+    await this.init();
+    return new Promise((resolve, reject) => {
+      const transaction = this.db!.transaction(['deleted_conversations'], 'readonly');
+      const request = transaction.objectStore('deleted_conversations').getAllKeys();
+      request.onsuccess = () => resolve(request.result as string[]);
       request.onerror = () => reject(request.error);
     });
   }
@@ -2544,14 +2660,22 @@ export class MessageDB {
   async deleteConversation(conversationId: string): Promise<void> {
     await this.init();
     return new Promise((resolve, reject) => {
-      const transaction = this.db!.transaction('conversations', 'readwrite');
-      const store = transaction.objectStore('conversations');
-      const request = store.delete([conversationId]);
+      // Row removal and tombstone in ONE transaction — same reasoning as
+      // deleteSpaceAsDeparture: two writes leave a window where the chat is gone
+      // with no record of why, and a later restore silently brings it back.
+      const transaction = this.db!.transaction(
+        ['conversations', 'deleted_conversations'],
+        'readwrite'
+      );
+      transaction.objectStore('conversations').delete([conversationId]);
+      transaction
+        .objectStore('deleted_conversations')
+        .put({ conversationId, deletedAt: Date.now() });
 
-      request.onsuccess = () => {
-        resolve();
-      };
-      request.onerror = () => reject(request.error);
+      transaction.oncomplete = () => resolve();
+      transaction.onerror = () => reject(transaction.error);
+      transaction.onabort = () =>
+        reject(transaction.error ?? new Error('conversation delete aborted'));
     });
   }
 

--- a/src/db/messages.ts
+++ b/src/db/messages.ts
@@ -421,6 +421,20 @@ export class MessageDB {
           });
           memberDevices.createIndex('by_member', ['spaceId', 'userAddress']);
         }
+
+        if (event.oldVersion < 15) {
+          // Departure tombstones: Spaces this user left or was removed from.
+          //
+          // Mirrors `deleted_messages` for Spaces. Restoring a backup taken
+          // before a departure would otherwise re-add the Space AND re-register
+          // with its hub, so a removed user silently re-announces to a Space
+          // that kicked them.
+          //
+          // Written by the departure call sites, NOT by `deleteSpace` — that
+          // method is also used for a space-address migration, which is not a
+          // departure. See `markSpaceDeparted`.
+          db.createObjectStore('departed_spaces', { keyPath: 'spaceId' });
+        }
       };
     });
   }
@@ -1583,6 +1597,71 @@ export class MessageDB {
         resolve();
       };
       transaction.onerror = () => reject(transaction.error);
+    });
+  }
+
+  /**
+   * Record that this user is no longer in a Space.
+   *
+   * **Call this from the departure sites, never from `deleteSpace()`.** It is
+   * tempting to put it there — all removal paths funnel through it, so it looks
+   * like the single choke point — but `EncryptionService` also calls
+   * `deleteSpace` to retire the old id during a space-address MIGRATION, which is
+   * not a departure. Tombstoning there would file two different facts under one
+   * name.
+   *
+   * Consumed by the backup restore, which must not resurrect a Space the user
+   * left after the backup was taken. Deliberately NOT consulted by the config
+   * sync adopt path: a synced config is the account's CURRENT state, published
+   * after the departure, whereas a backup file is stale by construction. Gating
+   * sync on this would break the legitimate case of rejoining on another device.
+   */
+  async markSpaceDeparted({
+    spaceId,
+    reason,
+  }: {
+    spaceId: string;
+    reason: 'left' | 'removed';
+  }): Promise<void> {
+    await this.init();
+    return new Promise((resolve, reject) => {
+      const transaction = this.db!.transaction(['departed_spaces'], 'readwrite');
+      const store = transaction.objectStore('departed_spaces');
+      const request = store.put({ spaceId, reason, departedAt: Date.now() });
+      request.onsuccess = () => resolve();
+      request.onerror = () => reject(request.error);
+    });
+  }
+
+  /**
+   * Clear a departure record, because the user is in the Space again.
+   *
+   * Mirrors `clearTombstonesForSpace`, which does the same for that Space's
+   * message tombstones on rejoin. Without it, a rejoined Space could never be
+   * restored from a later backup.
+   */
+  async clearSpaceDeparture(spaceId: string): Promise<void> {
+    await this.init();
+    return new Promise((resolve, reject) => {
+      const transaction = this.db!.transaction(['departed_spaces'], 'readwrite');
+      const store = transaction.objectStore('departed_spaces');
+      const request = store.delete(spaceId);
+      request.onsuccess = () => resolve();
+      request.onerror = () => reject(request.error);
+    });
+  }
+
+  /** Every Space this user left or was removed from, with the reason. */
+  async getDepartedSpaces(): Promise<
+    { spaceId: string; reason: 'left' | 'removed'; departedAt: number }[]
+  > {
+    await this.init();
+    return new Promise((resolve, reject) => {
+      const transaction = this.db!.transaction(['departed_spaces'], 'readonly');
+      const store = transaction.objectStore('departed_spaces');
+      const request = store.getAll();
+      request.onsuccess = () => resolve(request.result ?? []);
+      request.onerror = () => reject(request.error);
     });
   }
 

--- a/src/db/messages.ts
+++ b/src/db/messages.ts
@@ -1534,10 +1534,22 @@ export class MessageDB {
       const messageRequest = messageStore.delete(messageId);
       messageRequest.onerror = () => reject(messageRequest.error);
 
-      // Save tombstone to prevent re-sync (only for channel messages, not DMs)
-      // DMs don't have a sync mechanism, so tombstones aren't needed
-      // DM detection: spaceId === channelId (both are partner's address)
-      if (message && message.spaceId !== message.channelId) {
+      // Save a tombstone so the message cannot come back.
+      //
+      // This used to be channel-messages-only, on the reasoning that "DMs don't
+      // have a sync mechanism, so tombstones aren't needed". That was true when
+      // written and **backup restore is exactly the mechanism that makes it
+      // false**: importing a backup taken before the deletion re-`put()`s every
+      // message it contains, so a deleted DM would silently reappear. A user who
+      // deleted a message deliberately — the case where it matters most — would
+      // have no way to know, and no second chance to delete it before the peer
+      // side of the conversation had already moved on.
+      //
+      // Writing the record is purely additive: nothing else consumes tombstones
+      // for DMs (`isMessageDeleted` guards the peer-sync re-add path, which DMs
+      // never take), so this changes no existing behaviour. The import gate in
+      // `importDMData` is the consumer.
+      if (message) {
         const tombstone: DeletedMessageRecord = {
           messageId,
           spaceId: message.spaceId,
@@ -1571,6 +1583,21 @@ export class MessageDB {
         resolve();
       };
       transaction.onerror = () => reject(transaction.error);
+    });
+  }
+
+  /**
+   * Every tombstoned messageId. Used by the backup import to refuse to
+   * resurrect a message the user deleted after the backup was taken.
+   */
+  async getDeletedMessageIds(): Promise<string[]> {
+    await this.init();
+    return new Promise((resolve, reject) => {
+      const transaction = this.db!.transaction(['deleted_messages'], 'readonly');
+      const store = transaction.objectStore('deleted_messages');
+      const request = store.getAllKeys();
+      request.onsuccess = () => resolve(request.result as string[]);
+      request.onerror = () => reject(request.error);
     });
   }
 
@@ -2329,8 +2356,27 @@ export class MessageDB {
   async importDMData({ messages, conversations }: {
     messages: Message[];
     conversations: Conversation[];
-  }): Promise<{ messagesWritten: number; conversationsWritten: number }> {
+  }): Promise<{
+    messagesWritten: number;
+    conversationsWritten: number;
+    messagesSkippedAsDeleted: number;
+  }> {
     await this.init();
+
+    // Tombstone gate.
+    //
+    // "Additive" protects state the user CHANGED after the backup; it does
+    // nothing for state the user REMOVED. Without this, restoring a backup taken
+    // before a deletion resurrects the deleted message — the import would undo a
+    // deliberate act, silently, and the user would have no signal that it
+    // happened. Read before the write transaction rather than inside it: one
+    // getAll instead of a get per message, and an import racing a deletion is not
+    // a real scenario.
+    const deletedIds = new Set(await this.getDeletedMessageIds());
+
+    const admissible = messages.filter((m) => !deletedIds.has(m.messageId));
+    const messagesSkippedAsDeleted = messages.length - admissible.length;
+
     return new Promise((resolve, reject) => {
       const transaction = this.db!.transaction(['messages', 'conversations'], 'readwrite');
       const messageStore = transaction.objectStore('messages');
@@ -2346,13 +2392,13 @@ export class MessageDB {
       }
 
       // Write messages (dedup by messageId via put)
-      for (const msg of messages) {
+      for (const msg of admissible) {
         const request = messageStore.put(msg);
         request.onsuccess = () => { messagesWritten++; };
       }
 
       transaction.oncomplete = () => {
-        resolve({ messagesWritten, conversationsWritten });
+        resolve({ messagesWritten, conversationsWritten, messagesSkippedAsDeleted });
       };
       transaction.onerror = () => reject(transaction.error);
       transaction.onabort = () => reject(new Error('Import transaction aborted'));

--- a/src/dev/db-inspector/dbDumpUtil.ts
+++ b/src/dev/db-inspector/dbDumpUtil.ts
@@ -46,6 +46,9 @@ const SAFE_STORES = [
   'channel_threads',
   'thread_read_times',
   'space_member_devices',
+  // Which Spaces the user left or was removed from. Safe: ids and a timestamp,
+  // no key material.
+  'departed_spaces',
 ] as const;
 
 // Stores with sensitive data that need redaction

--- a/src/dev/db-inspector/dbDumpUtil.ts
+++ b/src/dev/db-inspector/dbDumpUtil.ts
@@ -49,6 +49,10 @@ const SAFE_STORES = [
   // Which Spaces the user left or was removed from. Safe: ids and a timestamp,
   // no key material.
   'departed_spaces',
+  // Which conversations the user deleted. Safe: ids and a timestamp; the
+  // conversationId is a peer address, which this store already exposes
+  // elsewhere (conversations, messages) at the same sensitivity.
+  'deleted_conversations',
 ] as const;
 
 // Stores with sensitive data that need redaction

--- a/src/dev/tests/harness/space-kick.scenario.test.ts
+++ b/src/dev/tests/harness/space-kick.scenario.test.ts
@@ -1,0 +1,213 @@
+// A kicked member is actually shut out — and a backup cannot let them back in.
+//
+//   yarn harness space-kick
+//
+// ── Why this scenario exists ────────────────────────────────────────────────
+//
+// The backup/restore work added a departure record so that restoring an old
+// `.qmbak` cannot re-add a Space you were kicked from. But that record lives in
+// local IndexedDB, so it is gone in the very case the feature exists for: total
+// data loss, then restore. The claim that the kicked user is still shut out then
+// rests on CRYPTOGRAPHY rather than on bookkeeping:
+//
+//   `kickUser` rotates the Space's config key, re-establishes the group ratchet
+//   without the kicked member, and re-encrypts the manifest to the NEW config
+//   key. A restore rebuilds a Space by decrypting that manifest with the config
+//   key FROM THE BACKUP — which is now the old one — and it does that BEFORE it
+//   would announce the user to the hub.
+//
+// That was read from the code, not observed. Reading is how this codebase has
+// been wrong before, and the consequence here is a person re-announcing
+// themselves to a group that removed them. So this measures it against a real
+// relay with real crypto.
+//
+// ── What it asserts ─────────────────────────────────────────────────────────
+//
+//   1. After the kick, B cannot read anything A posts.        (exclusion works)
+//   2. B restoring their pre-kick backup does NOT rebuild the Space, and never
+//      reaches the hub announcement.                          (the real question)
+//   3. CONTROL: before the kick, B could read A's posts, and a restore of the
+//      same Space DOES rebuild when B was never kicked.
+//
+// Without (3) this scenario would pass just as well against a bot that never
+// received anything at all, which is the failure mode these harness files are
+// most prone to.
+//
+// See `.agents/issues/.open/2026-08-09-backup-restore-overhaul-design.md` §4.1.
+import { test, expect } from 'vitest';
+import { createSpaceBot, type HarnessSpaceBot } from './spaceBot';
+import { BackupService } from '../../../services/BackupService';
+import { makeApiClient } from './transport';
+import type { UserRegistration } from '@quilibrium/quilibrium-js-sdk-channels';
+
+const WINDOW_MS = Number(process.env.HARNESS_SPACE_WINDOW_MS ?? 120_000);
+const SAMPLE_MS = Number(process.env.HARNESS_SPACE_SAMPLE_MS ?? 2000);
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+function postTexts(bot: HarnessSpaceBot): string[] {
+  return bot.captured
+    .filter((m) => m.content?.type === 'post')
+    .map((m) => (m.content as { text?: string }).text ?? '');
+}
+
+/** Poll until `check` passes or the window closes. Returns whether it passed. */
+async function waitFor(
+  label: string,
+  check: () => boolean,
+  windowMs = WINDOW_MS
+): Promise<boolean> {
+  const deadline = Date.now() + windowMs;
+  while (Date.now() < deadline) {
+    if (check()) return true;
+    await sleep(SAMPLE_MS);
+  }
+  console.log(`[space-kick] gave up waiting for: ${label}`);
+  return false;
+}
+
+test(
+  'space-kick: a kicked member is excluded, and their backup cannot let them back in',
+  async () => {
+    const stamp = String(Date.now()).slice(-6);
+    // process.stdout.write, not console.log: vitest's reporter swallows console
+    // output here, and the evidence this scenario produces is the point of it.
+    const say = (msg: string) => process.stdout.write(`
+[space-kick] ${msg}
+`);
+
+    const a = await createSpaceBot('kick-a');
+    const b = await createSpaceBot('kick-b');
+    await a.start();
+    await b.start();
+
+    try {
+      // ── Setup: A owns a Space, B joins it ─────────────────────────────────
+      const { spaceId, channelId } = await a.createSpace(`Kick ${stamp}`);
+      say(`A created ${spaceId.slice(0, 12)}…`);
+
+      const link = await a.inviteLink(spaceId);
+      await b.join(link);
+      say('B joined');
+
+      // ── CONTROL: B can read A's posts BEFORE the kick ─────────────────────
+      // If this fails the scenario is measuring a broken join, not a working
+      // kick, and everything below is meaningless.
+      const beforeText = `before-kick-${stamp}`;
+      await a.post(spaceId, channelId, beforeText);
+
+      const readBefore = await waitFor('B to receive the pre-kick post', () =>
+        postTexts(b).includes(beforeText)
+      );
+      expect(
+        readBefore,
+        'CONTROL FAILED: B never received a post while still a member — ' +
+          'the kick assertions below would be vacuous'
+      ).toBe(true);
+      say('control ok: B received the pre-kick post');
+
+      // B takes a backup while still a member. This is the file that must not
+      // be able to let them back in.
+      const backupBlob = await new BackupService({
+        messageDB: b.messageDB,
+      }).exportBackup({
+        keyset: b.identity.keyset.userKeyset,
+        address: b.identity.address,
+      });
+      const backupFile = await backupBlob.text();
+      say('B exported a pre-kick backup');
+
+      // ── The kick ──────────────────────────────────────────────────────────
+      const aRegistration = (await makeApiClient().getUser(a.identity.address))
+        ?.data as UserRegistration;
+
+      await a.graph.spaceService.kickUser(
+        spaceId,
+        b.identity.address,
+        a.identity.keyset.userKeyset,
+        a.identity.keyset.deviceKeyset,
+        aRegistration,
+        a.queryClient
+      );
+      await a.graph.outbound.flush();
+      say('A kicked B (config key rotated, group ratchet re-established)');
+
+      // Let the rekey settle on the relay before A posts again.
+      await sleep(SAMPLE_MS * 2);
+
+      // ── 1. B cannot read anything posted after the kick ───────────────────
+      const afterText = `after-kick-${stamp}`;
+      await a.post(spaceId, channelId, afterText);
+
+      // Deliberately give it the FULL window to arrive. A short wait would make
+      // "B did not receive it" indistinguishable from "it had not arrived yet".
+      const leaked = await waitFor(
+        "B to (wrongly) receive A's post-kick message",
+        () => postTexts(b).includes(afterText)
+      );
+      expect(
+        leaked,
+        'A kicked member read a message posted after the kick'
+      ).toBe(false);
+      say('ok: B could not read the post-kick message');
+
+      // ── 2. B's pre-kick backup cannot rebuild the Space ───────────────────
+      // Simulate total data loss: a fresh database with none of B's state, and
+      // crucially none of the departure record — the case the local tombstone
+      // cannot cover.
+      const wiped = await createSpaceBot('kick-b-restored');
+      await wiped.start();
+
+      try {
+        const report = await new BackupService({
+          messageDB: wiped.messageDB,
+          adoptSpaces: (args) => wiped.graph.configService.adoptSpaces(args),
+        }).importBackup({
+          keyset: b.identity.keyset.userKeyset,
+          fileContent: backupFile,
+        });
+
+        say(
+          `restore report: restored=${report.spacesRestored.length} ` +
+            `failed=${report.spacesFailed.length} ` +
+            `reasons=${JSON.stringify(report.spacesFailed.map((f) => f.reason))}`
+        );
+
+        // The Space must NOT come back. The config key was rotated by the kick,
+        // so the manifest decrypt fails and the adopt path aborts before the
+        // hub announcement.
+        expect(
+          report.spacesRestored,
+          'a kicked member restored their way back into the Space'
+        ).not.toContain(spaceId);
+
+        // And it must be REPORTED, not silently dropped — the restore has to be
+        // able to tell the user why the Space did not come back.
+        expect(
+          report.spacesFailed.map((f) => f.spaceId),
+          'the Space was neither restored nor reported as failed'
+        ).toContain(spaceId);
+
+        // ...and the reason has to be readable. The first run of this scenario
+        // surfaced the raw SDK failure through JSON.parse — `Unexpected token
+        // 'D', "Decryption"... is not valid JSON` — which is accurate and
+        // useless to the person reading it.
+        const reason =
+          report.spacesFailed.find((f) => f.spaceId === spaceId)?.reason ?? '';
+        expect(reason, `unreadable failure reason: ${reason}`).toMatch(
+          /no longer have access/i
+        );
+
+        // Nothing rendered: no Space row on the restored device.
+        expect(await wiped.messageDB.getSpaces()).toEqual([]);
+        say('ok: the pre-kick backup did not rebuild the Space');
+      } finally {
+        wiped.stop();
+      }
+    } finally {
+      a.stop();
+      b.stop();
+    }
+  },
+  WINDOW_MS * 4
+);

--- a/src/dev/tests/services/InvitationService.unit.test.tsx
+++ b/src/dev/tests/services/InvitationService.unit.test.tsx
@@ -11,6 +11,15 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { InvitationService } from '@/services/InvitationService';
 import { QueryClient } from '@tanstack/react-query';
 
+// Mock multiformats sha256 so Buffer-based digest works in jsdom — under this
+// environment `Buffer instanceof Uint8Array` is false and multiformats' coerce()
+// throws. Same mock, and same reason, as SpaceService.unit.test.tsx.
+vi.mock('multiformats/hashes/sha2', () => ({
+  sha256: {
+    digest: vi.fn().mockResolvedValue({ bytes: new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]) }),
+  },
+}));
+
 vi.mock('@quilibrium/quilibrium-js-sdk-channels', () => ({
   channel: {
     SealHubEnvelope: vi.fn().mockResolvedValue(JSON.stringify({ envelope: 'mock' })),
@@ -304,6 +313,74 @@ describe('InvitationService - Unit Tests', () => {
       );
 
       expect(result).toBeUndefined();
+    });
+
+    /**
+     * Rejoining must clear the departure tombstone.
+     *
+     * `departed_spaces` (DB v15) blocks a backup restore from re-adding a Space
+     * the user left or was kicked from. If a rejoin does not clear it, a user who
+     * is invited back can never restore that Space from a backup again — the
+     * restore silently refuses with "you were removed from this Space" forever,
+     * long after it stopped being true.
+     *
+     * The clear sits next to the pre-existing `clearTombstonesForSpace` call,
+     * which does the same job for that Space's message tombstones. This asserts
+     * both, so the pair cannot drift apart.
+     *
+     * See `.agents/issues/.open/2026-08-09-backup-restore-overhaul-design.md` §4.1.
+     */
+    it('clears the departure tombstone when rejoining, alongside message tombstones', async () => {
+      mockDeps.messageDB.clearTombstonesForSpace = vi.fn().mockResolvedValue(0);
+      mockDeps.messageDB.clearSpaceDeparture = vi.fn().mockResolvedValue(undefined);
+      mockDeps.messageDB.getUserConfig = vi
+        .fn()
+        .mockResolvedValue({ address: 'address-self', spaceIds: [] });
+      invitationService = new InvitationService(mockDeps);
+
+      // A direct (non-secret-fetch) invite: the link carries the ratchet template
+      // and secret inline, which is the branch that does not need getSpaceInviteEval.
+      const template = Buffer.from(
+        JSON.stringify({ dkg_ratchet: JSON.stringify({ id: 1, total: 1 }) }),
+        'utf-8'
+      ).toString('hex');
+      const secret = 'aa'.repeat(56);
+
+      // spaceId matches what the mocked manifest decrypt returns.
+      const inviteLink =
+        `https://qm.one/invite/#spaceId=space-123&configKey=aabbcc&hubKey=ddeeff` +
+        `&template=${template}&secret=${secret}`;
+
+      await invitationService.joinInviteLink(
+        inviteLink,
+        {
+          userKeyset: {
+            user_key: { public_key: [1, 2, 3], private_key: [4, 5, 6] },
+          } as any,
+          deviceKeyset: {
+            inbox_keyset: {
+              inbox_address: 'QmDeviceInboxAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+              inbox_key: { public_key: [1, 2, 3], private_key: [4, 5, 6] },
+              inbox_encryption_key: {
+                public_key: [7, 8, 9],
+                private_key: [10, 11, 12],
+              },
+            },
+            identity_key: { public_key: [13, 14, 15], private_key: [16, 17, 18] },
+            signed_pre_key: { public_key: [19, 20], private_key: [21, 22] },
+            pre_key: { public_key: [23, 24], private_key: [25, 26] },
+          } as any,
+        },
+        {
+          credentialId: 'cred',
+          address: 'address-self',
+          publicKey: 'pubkey',
+          completedOnboarding: true,
+        }
+      );
+
+      expect(mockDeps.messageDB.clearSpaceDeparture).toHaveBeenCalledWith('space-123');
+      expect(mockDeps.messageDB.clearTombstonesForSpace).toHaveBeenCalledWith('space-123');
     });
   });
 

--- a/src/dev/tests/services/MessageService.kickDeparture.unit.test.ts
+++ b/src/dev/tests/services/MessageService.kickDeparture.unit.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Being kicked from a Space must RECORD the departure, not just delete the Space.
+ *
+ * ── Why this test exists ────────────────────────────────────────────────────
+ *
+ * `departed_spaces` (DB v15) is what stops a backup restore re-adding a Space the
+ * user is no longer in. The restore gate is well covered in
+ * `backupSpaceRestore.test.ts`, but those tests drive `MessageDB` directly — they
+ * write the tombstone themselves. Nothing exercised the two places that write it
+ * for real.
+ *
+ * The `left` site is asserted in `SpaceService.unit.test.tsx`. This is the other
+ * one, and the more dangerous of the two: leaving is voluntary, being kicked is
+ * adversarial. If this line were dropped in a refactor, the whole suite would stay
+ * green and a kicked user's next backup restore would silently re-add the Space
+ * and `postHubAdd` them back into it — re-announcing them to the Space that just
+ * removed them, months later, with no signal at either end.
+ *
+ * The kick handler is ~150 lines of sequential cleanup buried inside
+ * `handleNewMessage`, which is exactly the shape a refactor disturbs.
+ *
+ * See `.agents/issues/.open/2026-08-09-backup-restore-overhaul-design.md` §4.1.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MessageService } from '../../../services/MessageService';
+
+const SPACE_ID = 'QmSpaceAddressAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+const SPACE_INBOX = 'QmSpaceInboxBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
+const DEVICE_INBOX = 'QmDeviceInboxCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC';
+const SELF = 'QmSelfAddressDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD';
+const SOMEONE_ELSE = 'QmOtherMemberEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE';
+
+const OWNER_PUBLIC_KEY = 'ab'.repeat(57);
+
+/** Who the kick names. Varied per test to cover "not me". */
+let kickTarget = SELF;
+/** Whether the owner signature over the envelope verifies. */
+let signatureVerifies = true;
+
+vi.mock('@quilibrium/quilibrium-js-sdk-channels', () => ({
+  channel: {
+    // The space frame opens to a kick control message.
+    UnsealHubEnvelope: vi.fn(async () =>
+      Array.from(
+        new TextEncoder().encode(
+          JSON.stringify({
+            type: 'control',
+            message: { type: 'kick', kick: kickTarget },
+          })
+        )
+      )
+    ),
+    UnsealSyncEnvelope: vi.fn(async () =>
+      Array.from(
+        new TextEncoder().encode(
+          JSON.stringify({
+            type: 'control',
+            message: { type: 'kick', kick: kickTarget },
+          })
+        )
+      )
+    ),
+  },
+  channel_raw: {
+    js_sign_ed448: vi.fn().mockReturnValue(JSON.stringify('mock-signature')),
+    // Returned through JSON.parse by the handler, so this must be JSON.
+    js_verify_ed448: vi.fn(() => JSON.stringify(signatureVerifies)),
+  },
+}));
+
+const keyset = {
+  deviceKeyset: {
+    inbox_keyset: {
+      inbox_address: DEVICE_INBOX,
+      inbox_key: { public_key: [1, 2, 3], private_key: [4, 5, 6] },
+    },
+    identity_key: { public_key: [7, 8, 9] },
+  },
+  userKeyset: {},
+} as any;
+
+const spaceKey = {
+  publicKey: '00'.repeat(57),
+  privateKey: '00'.repeat(57),
+  address: SPACE_INBOX,
+};
+
+/**
+ * A hub-broadcast space frame. `encryptedContent` IS the exterior envelope
+ * (`MessageService` does `JSON.parse(message.encryptedContent)`), so the owner
+ * fields the kick branch authenticates against live here.
+ */
+function kickFrame(ts = 1000) {
+  return {
+    inboxAddress: SPACE_INBOX,
+    encryptedContent: JSON.stringify({
+      type: 'group',
+      owner_public_key: OWNER_PUBLIC_KEY,
+      envelope: 'sealed-envelope-bytes',
+      owner_signature: 'cd'.repeat(57),
+    }),
+    timestamp: ts,
+  } as any;
+}
+
+describe('being kicked from a Space records the departure', () => {
+  let messageService: MessageService;
+  let mockDeps: any;
+
+  beforeEach(() => {
+    kickTarget = SELF;
+    signatureVerifies = true;
+
+    mockDeps = {
+      messageDB: {
+        getAllEncryptionStates: vi.fn().mockResolvedValue([
+          {
+            inboxId: SPACE_INBOX,
+            conversationId: `${SPACE_ID}/${SPACE_ID}`,
+            // No `sending_inbox` — this is what selects the SPACE path.
+            state: JSON.stringify({}),
+          },
+        ]),
+        getEncryptionStates: vi.fn().mockResolvedValue([]),
+        deleteEncryptionState: vi.fn().mockResolvedValue(undefined),
+        getConversation: vi.fn().mockResolvedValue({ conversation: null }),
+        getSpace: vi.fn().mockResolvedValue({ spaceId: SPACE_ID, spaceName: 'Alpha' }),
+        getSpaceKey: vi.fn().mockResolvedValue(spaceKey),
+        getSpaceKeys: vi.fn().mockResolvedValue([]),
+        deleteSpaceKey: vi.fn().mockResolvedValue(undefined),
+        getSpaceMembers: vi.fn().mockResolvedValue([]),
+        deleteSpaceMember: vi.fn().mockResolvedValue(undefined),
+        getSpaceMember: vi.fn().mockResolvedValue(null),
+        saveSpaceMember: vi.fn().mockResolvedValue(undefined),
+        getAllSpaceMessages: vi.fn().mockResolvedValue([]),
+        deleteMessage: vi.fn().mockResolvedValue(undefined),
+        getUserConfig: vi.fn().mockResolvedValue({ address: SELF, spaceIds: [SPACE_ID] }),
+        saveEncryptionState: vi.fn().mockResolvedValue(undefined),
+        saveMessage: vi.fn().mockResolvedValue(undefined),
+        getMessage: vi.fn().mockResolvedValue(null),
+        getMessages: vi.fn().mockResolvedValue({ messages: [], hasMore: false }),
+        isMessageDeleted: vi.fn().mockResolvedValue(false),
+        updateMessage: vi.fn().mockResolvedValue(undefined),
+        // The two under test.
+        deleteSpace: vi.fn().mockResolvedValue(undefined),
+        deleteSpaceAsDeparture: vi.fn().mockResolvedValue(undefined),
+      },
+      enqueueOutbound: vi.fn(),
+      addOrUpdateConversation: vi.fn(),
+      apiClient: {
+        // The owner key the kick is signed with must be one the Space registration
+        // vouches for, or the handler rejects the kick before doing anything.
+        getSpace: vi.fn().mockResolvedValue({
+          data: { owner_public_keys: [OWNER_PUBLIC_KEY] },
+        }),
+        postHubDelete: vi.fn().mockResolvedValue({ data: {} }),
+      },
+      deleteEncryptionStates: vi.fn().mockResolvedValue(undefined),
+      deleteInboxMessages: vi.fn().mockResolvedValue(undefined),
+      navigate: vi.fn(),
+      spaceInfo: { current: {} },
+      syncInfo: { current: {} },
+      synchronizeAll: vi.fn().mockResolvedValue(undefined),
+      informSyncData: vi.fn().mockResolvedValue(undefined),
+      initiateSync: vi.fn().mockResolvedValue(undefined),
+      requestSync: vi.fn().mockResolvedValue(true),
+      directSync: vi.fn().mockResolvedValue(undefined),
+      saveConfig: vi.fn().mockResolvedValue(undefined),
+      sendHubMessage: vi.fn().mockResolvedValue('message-id'),
+      handleSyncInitiateV2: vi.fn().mockResolvedValue(undefined),
+      handleSyncManifest: vi.fn().mockResolvedValue(undefined),
+    };
+
+    messageService = new MessageService(mockDeps);
+  });
+
+  const deliver = (frame: any) =>
+    messageService.handleNewMessage(SELF, keyset, frame, {
+      refetchQueries: vi.fn(),
+      setQueryData: vi.fn(),
+      invalidateQueries: vi.fn(),
+      getQueryData: vi.fn(),
+    } as any);
+
+  const settle = () => new Promise((r) => setTimeout(r, 0));
+
+  it('records the departure as `removed`, atomically with the delete', async () => {
+    await deliver(kickFrame());
+    await settle();
+
+    expect(mockDeps.messageDB.deleteSpaceAsDeparture).toHaveBeenCalledWith({
+      spaceId: SPACE_ID,
+      reason: 'removed',
+    });
+    // The non-atomic pair must not be used here: a bare deleteSpace would leave
+    // the Space gone with no record of why, which a later restore reads as
+    // "never had it".
+    expect(mockDeps.messageDB.deleteSpace).not.toHaveBeenCalled();
+  });
+
+  it('CONTROL: a kick naming someone else records nothing', async () => {
+    // Without this the test above could pass on a handler that tombstoned every
+    // kick it saw, including other people's.
+    kickTarget = SOMEONE_ELSE;
+
+    await deliver(kickFrame());
+    await settle();
+
+    expect(mockDeps.messageDB.deleteSpaceAsDeparture).not.toHaveBeenCalled();
+  });
+
+  it('CONTROL: an unverified kick records nothing', async () => {
+    // The owner signature is what makes a kick authentic. If a forged frame could
+    // drive this path, an attacker could evict a user from their own Space —
+    // and, with the tombstone written, block them restoring it from a backup.
+    signatureVerifies = false;
+
+    await deliver(kickFrame());
+    await settle();
+
+    expect(mockDeps.messageDB.deleteSpaceAsDeparture).not.toHaveBeenCalled();
+  });
+});

--- a/src/dev/tests/services/SpaceService.unit.test.tsx
+++ b/src/dev/tests/services/SpaceService.unit.test.tsx
@@ -102,7 +102,7 @@ describe('SpaceService - Unit Tests', () => {
         getSpaceMembers: vi.fn().mockResolvedValue([]),
         deleteSpaceMember: vi.fn().mockResolvedValue(undefined),
         deleteSpace: vi.fn().mockResolvedValue(undefined),
-        markSpaceDeparted: vi.fn().mockResolvedValue(undefined),
+        deleteSpaceAsDeparture: vi.fn().mockResolvedValue(undefined),
         getAllSpaceMessages: vi.fn().mockResolvedValue([]),
         deleteMessage: vi.fn().mockResolvedValue(undefined),
         getEncryptionStates: vi.fn().mockResolvedValue([]),
@@ -294,16 +294,18 @@ describe('SpaceService - Unit Tests', () => {
         expect.objectContaining({ hub_address: 'hub-address' })
       );
       expect(mockDeps.messageDB.deleteEncryptionState).toHaveBeenCalledTimes(1);
-      expect(mockDeps.messageDB.deleteSpace).toHaveBeenCalledWith(spaceId);
       expect(mockDeps.enqueueOutbound).toHaveBeenCalledTimes(1);
-      // Records the departure, so a later backup restore cannot re-add this
-      // Space and re-register with its hub. Asserted at the call site because
-      // this is the wiring the backup tests cannot see — they call
-      // markSpaceDeparted directly.
-      expect(mockDeps.messageDB.markSpaceDeparted).toHaveBeenCalledWith({
+      // Removal and departure record in ONE call, so an interruption cannot
+      // leave the Space deleted with no record of why — which a later backup
+      // restore would read as "never had it" and re-add. Asserted at the call
+      // site because this is the wiring the backup tests cannot see; they drive
+      // MessageDB directly.
+      expect(mockDeps.messageDB.deleteSpaceAsDeparture).toHaveBeenCalledWith({
         spaceId,
         reason: 'left',
       });
+      // ...and the non-atomic pair is NOT used here any more.
+      expect(mockDeps.messageDB.deleteSpace).not.toHaveBeenCalled();
     });
 
     // The sidebar and the Spaces list read ['Spaces'], not the config query.

--- a/src/dev/tests/services/SpaceService.unit.test.tsx
+++ b/src/dev/tests/services/SpaceService.unit.test.tsx
@@ -102,6 +102,7 @@ describe('SpaceService - Unit Tests', () => {
         getSpaceMembers: vi.fn().mockResolvedValue([]),
         deleteSpaceMember: vi.fn().mockResolvedValue(undefined),
         deleteSpace: vi.fn().mockResolvedValue(undefined),
+        markSpaceDeparted: vi.fn().mockResolvedValue(undefined),
         getAllSpaceMessages: vi.fn().mockResolvedValue([]),
         deleteMessage: vi.fn().mockResolvedValue(undefined),
         getEncryptionStates: vi.fn().mockResolvedValue([]),
@@ -295,6 +296,14 @@ describe('SpaceService - Unit Tests', () => {
       expect(mockDeps.messageDB.deleteEncryptionState).toHaveBeenCalledTimes(1);
       expect(mockDeps.messageDB.deleteSpace).toHaveBeenCalledWith(spaceId);
       expect(mockDeps.enqueueOutbound).toHaveBeenCalledTimes(1);
+      // Records the departure, so a later backup restore cannot re-add this
+      // Space and re-register with its hub. Asserted at the call site because
+      // this is the wiring the backup tests cannot see — they call
+      // markSpaceDeparted directly.
+      expect(mockDeps.messageDB.markSpaceDeparted).toHaveBeenCalledWith({
+        spaceId,
+        reason: 'left',
+      });
     });
 
     // The sidebar and the Spaces list read ['Spaces'], not the config query.

--- a/src/dev/tests/services/backupSpaceKeyCoverage.test.ts
+++ b/src/dev/tests/services/backupSpaceKeyCoverage.test.ts
@@ -478,6 +478,39 @@ describe('Backup export — Space key coverage', () => {
       ).toContain(`${SPACE_ID}/${SPACE_ID}`);
     });
 
+    it('keeps a DM state whose conversation row does not exist yet', async () => {
+      // The gap a reviewer found in the first version of this filter. A DM's
+      // encryption state can legitimately exist before its conversation row: if
+      // the first frame of a new session is a control message (typing,
+      // delivery-ack, profile update) the handler returns before saveMessage
+      // creates the row. Matching on the X/X id shape alone called that an
+      // orphan and dropped it.
+      //
+      // Kept now because the state carries `sending_inbox`, which is the same
+      // discriminator the receive path uses to tell a DM from a Space.
+      // MUST differ from PEER_ADDRESS: that one has a conversation row seeded in
+      // beforeEach, so it would be kept by the live-conversation check and this
+      // test would pass without the discriminator ever running. Caught by
+      // mutation — the first version of this test used PEER_ADDRESS and stayed
+      // green with the discriminator removed.
+      const ROWLESS_PEER = 'Qmdp5Pt6drCHVWYNhPvcQtHdTgQr2gtCnU2ke83CfWHyvt';
+      await db.saveEncryptionState(
+        {
+          conversationId: `${ROWLESS_PEER}/${ROWLESS_PEER}`,
+          inboxId: 'QmRowlessInbox',
+          state: JSON.stringify({ sending_inbox: { inbox_public_key: 'x' } }),
+          timestamp: 700,
+        } as any,
+        true
+      );
+
+      const { payload } = await saveThenExport(false);
+
+      expect(
+        payload.encryption_states.map((s: any) => s.conversationId)
+      ).toContain(`${ROWLESS_PEER}/${ROWLESS_PEER}`);
+    });
+
     it('keeps a DM state, which has the same id shape as a Space state', async () => {
       // The filter cannot key on shape alone: a DM conversationId is `X/X` too.
       // Dropping DM states would be a silent data loss dressed up as a size win.

--- a/src/dev/tests/services/backupSpaceKeyCoverage.test.ts
+++ b/src/dev/tests/services/backupSpaceKeyCoverage.test.ts
@@ -362,9 +362,14 @@ describe('Backup export — Space key coverage', () => {
     expect(payload.space_keys.map((k: any) => k.keyId).sort()).toEqual(
       [...CREATED_SPACE_KEY_IDS].sort()
     );
-    // ...and the sync path still does its own separate thing.
+    // ...and the sync path still does its own separate thing: the config was
+    // published with its spaceKeys assembled as before.
     expect(postedConfigs).toHaveLength(1);
-    expect(payload.user_config.spaceKeys).toHaveLength(1);
+    // But the BACKUP no longer carries that snapshot — it would duplicate the
+    // multi-megabyte eval pool already present in `encryption_states`. Key
+    // material travels once, from the store that owns it. See the
+    // "no weight it cannot use" block.
+    expect(payload.user_config.spaceKeys).toBeUndefined();
   });
 
   // ── Format and back-compat ─────────────────────────────────────────────────
@@ -435,6 +440,69 @@ describe('Backup export — Space key coverage', () => {
   });
 
   // ── Size: the number that gates the Space-messages decision ────────────────
+
+  describe('the file carries no weight it cannot use', () => {
+    // Both of these were found by exporting on a REAL account: 3 Spaces and 2
+    // DMs produced a 17.6 MB file, several times what the per-Space cost
+    // predicts. Neither is visible on a seeded database, because a seeded one has
+    // no debris and no sync history.
+
+    it('excludes encryption states orphaned by deleted Spaces', async () => {
+      // A created Space pre-allocates a ~2 MB eval pool, and deleting the Space
+      // has been observed to leak that state rather than remove it. The export
+      // read every state unfiltered, so the debris rode along — and it is dead
+      // weight by construction, since the restore only rebuilds Spaces present in
+      // the file.
+      const GHOST = 'QmcfTNSyig9DSfAqSmWXsGLkLiG9TGS87XXpJy3juKbKSs';
+      await db.saveEncryptionState(
+        {
+          conversationId: `${GHOST}/${GHOST}`,
+          inboxId: 'QmGhostInbox',
+          state: JSON.stringify({ evals: 'e'.repeat(64 * 1024) }),
+          timestamp: 900,
+        } as any,
+        true
+      );
+
+      const { payload, raw } = await saveThenExport(false);
+
+      expect(
+        payload.encryption_states.map((s: any) => s.conversationId)
+      ).not.toContain(`${GHOST}/${GHOST}`);
+      expect(raw).not.toContain('e'.repeat(1024));
+
+      // CONTROL: the live Space's own state is still there. Without this the
+      // filter could pass by dropping everything.
+      expect(
+        payload.encryption_states.map((s: any) => s.conversationId)
+      ).toContain(`${SPACE_ID}/${SPACE_ID}`);
+    });
+
+    it('keeps a DM state, which has the same id shape as a Space state', async () => {
+      // The filter cannot key on shape alone: a DM conversationId is `X/X` too.
+      // Dropping DM states would be a silent data loss dressed up as a size win.
+      const { payload } = await saveThenExport(false);
+
+      expect(
+        payload.encryption_states.map((s: any) => s.conversationId)
+      ).toContain(DM_CONVERSATION_ID);
+    });
+
+    it('does not ship the Space eval pool twice via user_config', async () => {
+      // With sync ON the stored config carries a per-Space bundle that EMBEDS
+      // that Space's encryption state — the same pool already exported under
+      // `encryption_states`. It travelled twice in every backup.
+      const { payload } = await saveThenExport(true);
+
+      expect(payload.user_config).toBeDefined();
+      expect(payload.user_config.spaceKeys).toBeUndefined();
+
+      // CONTROL: the rest of the config still travels, and the key material is
+      // still present via the store that owns it.
+      expect(payload.user_config.address).toBe(USER_ADDRESS);
+      expect(payload.space_keys.map((k: any) => k.keyId)).toContain('owner');
+    });
+  });
 
   it('MEASUREMENT: a created Space\'s eval pool dominates the file, and hex doubles it', async () => {
     // Answers §10.4 of the overhaul design without needing a real account export.

--- a/src/dev/tests/services/backupSpaceKeyCoverage.test.ts
+++ b/src/dev/tests/services/backupSpaceKeyCoverage.test.ts
@@ -1,0 +1,365 @@
+/**
+ * Backup export — does a `.qmbak` actually contain the Space keys?
+ *
+ * PURPOSE
+ * Settles §1 and §10.1 of `.agents/issues/.open/2026-08-09-backup-restore-overhaul-design.md`,
+ * which claims that a user with sync OFF exports a backup containing **no Space
+ * key material at all** — including the `owner` private key, which is the only
+ * proof of Space ownership and has no other copy anywhere.
+ *
+ * That claim was INFERRED from reading three places in the code, never observed.
+ * The whole design rests on it, so it gets an instrument rather than an argument.
+ *
+ * APPROACH — integration, deliberately NOT unit
+ * Real `MessageDB` on fake-indexeddb, real `ConfigService.saveConfig`, real
+ * `BackupService.exportBackup`, real WebCrypto. Only the network (`apiClient`)
+ * and the wasm signing core are stubbed. Mocking `messageDB` here would measure
+ * the mock, which is exactly the failure mode this instrument exists to avoid:
+ * the claim IS about what the real save/export chain leaves on disk.
+ *
+ * READING THE RESULT
+ *   Arm A red, Arm B green  → the design's §1 holds. Expected.
+ *   Both arms green         → §1 is REFUTED. Backups already carry Space keys;
+ *                             slices 1-2 of the design are unnecessary. Stop and
+ *                             rewrite the issue before writing any code.
+ *   Both arms red           → the harness is broken, not the app. Neither arm
+ *                             means anything. Fix the harness first.
+ *
+ * The last case is why Arm B exists. Without a control that SHOULD find the key,
+ * "we found no key" is indistinguishable from "we looked in the wrong place".
+ */
+
+import 'fake-indexeddb/auto';
+import { describe, it, expect, beforeEach, beforeAll, vi } from 'vitest';
+import { webcrypto } from 'node:crypto';
+import { i18n } from '@lingui/core';
+import { messages } from '@/i18n/en/messages';
+import { MessageDB } from '@/db/messages';
+import { ConfigService } from '@/services/ConfigService';
+import { BackupService } from '@/services/BackupService';
+import { getDefaultUserConfig } from '@/utils';
+import { QueryClient } from '@tanstack/react-query';
+
+// The wasm core is never initialised in this suite (see vitest.config.ts), so the
+// two signing calls saveConfig makes are stubbed. Nothing under test depends on
+// the signature being real — the payload we inspect is produced before signing.
+vi.mock('@quilibrium/quilibrium-js-sdk-channels', () => ({
+  channel: {
+    SealHubEnvelope: vi.fn().mockResolvedValue({ sealed: 'hub-envelope' }),
+  },
+  channel_raw: {
+    js_sign_ed448: vi.fn().mockReturnValue(JSON.stringify('mock-signature')),
+    js_verify_ed448: vi.fn().mockReturnValue(JSON.stringify(true)),
+    js_generate_ed448: vi.fn().mockReturnValue(
+      JSON.stringify({ public_key: [1, 2, 3], private_key: [4, 5, 6] })
+    ),
+  },
+}));
+
+/**
+ * The value the whole instrument hunts for.
+ *
+ * A distinctive hex sentinel rather than a realistic key: the strongest assertion
+ * available is "does this string appear ANYWHERE in the decrypted payload", which
+ * is independent of any belief about which field is supposed to carry it. A
+ * realistic-looking random key would work identically but makes a failure much
+ * harder to read.
+ */
+const OWNER_PRIVATE_KEY = 'c0ffee'.repeat(19); // 114 hex chars, Ed448-private-key length
+
+/**
+ * Synthetic CIDv0 addresses. `MessageDB.saveConversation` rejects any direct
+ * conversation not keyed `<Qm…>/<Qm…>` where both halves are the same
+ * base58-decodable 46-char CID (messages.ts:1119-1135), so these cannot be
+ * hand-written placeholders. Generated as CIDv0 (0x12 0x20 + digest) over a
+ * constant byte fill — valid to the validator, and transparently not anyone's
+ * real address.
+ */
+const SPACE_ID = 'QmZDbJ9cy9z1J74DgtGJEQW6yop3j15t6i31KW5McmVKzp'; // digest 0xA1…
+const USER_ADDRESS = 'QmaNDKajtL35LxRkwWgNn2Sz6mxkJRXxmeXwef4pNxBzUq'; // digest 0xB2…
+const PEER_ADDRESS = 'QmbWqM1roW69PooJC96TKePsDk7Ssqz3Sb2syp4H98texr'; // digest 0xC3…
+const DM_INBOX = 'QmcfTNSyig9DSfAqSmWXsGLkLiG9TGS87XXpJy3juKbKSs'; // digest 0xD4…
+/** Direct conversations are keyed `<addr>/<addr>`, not `<addr>/<inbox>`. */
+const DM_CONVERSATION_ID = `${PEER_ADDRESS}/${PEER_ADDRESS}`;
+
+/** Ed448 keyset shape BackupService/ConfigService read `user_key` off. */
+const KEYSET = {
+  user_key: {
+    private_key: new Uint8Array(57).fill(7),
+    public_key: new Uint8Array(57).fill(9),
+  },
+} as any;
+
+beforeAll(() => {
+  i18n.load('en', messages);
+  i18n.activate('en');
+
+  // setup.ts replaces global crypto with vi.fn() stubs whose subtle.digest
+  // resolves a zero-filled buffer. Real AES-GCM and SHA-512 are required here:
+  // the instrument encrypts a backup and decrypts it again, and a stubbed digest
+  // would make every derived key identical — the round trip would "pass" while
+  // measuring nothing. Registered in this file's beforeAll, which runs after
+  // setup.ts's.
+  for (const target of [globalThis, global]) {
+    Object.defineProperty(target, 'crypto', {
+      value: webcrypto,
+      configurable: true,
+      writable: true,
+    });
+  }
+});
+
+describe('Backup export — Space key coverage (design §1 / §10.1)', () => {
+  let db: MessageDB;
+  let configService: ConfigService;
+  let backupService: BackupService;
+  let postedConfigs: any[];
+
+  beforeEach(async () => {
+    const FDBFactory = (await import('fake-indexeddb/lib/FDBFactory')).default;
+    globalThis.indexedDB = new FDBFactory();
+    localStorage.clear();
+
+    db = new MessageDB();
+    await db.init();
+
+    postedConfigs = [];
+    configService = new ConfigService({
+      messageDB: db,
+      apiClient: {
+        postUserSettings: vi.fn(async (_addr: string, body: any) => {
+          postedConfigs.push(body);
+          return { data: {} };
+        }),
+        getUserSettings: vi.fn().mockRejectedValue(new Error('offline')),
+      },
+      spaceInfo: { current: {} },
+      enqueueOutbound: vi.fn(),
+      sendHubMessage: vi.fn().mockResolvedValue('hub-msg'),
+      queryClient: new QueryClient({
+        defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+      }),
+    } as any);
+
+    backupService = new BackupService({ messageDB: db });
+
+    await seedSpaceWithFullKeyset();
+    await seedDirectMessageConversation();
+  });
+
+  /**
+   * Mirrors what SpaceService writes when a user CREATES a Space
+   * (SpaceService.ts:356-431): seven keys, of which `owner` is the irreplaceable
+   * one, plus the Space's Triple Ratchet state under `<spaceId>/<spaceId>`.
+   */
+  async function seedSpaceWithFullKeyset() {
+    await db.saveSpace({ spaceId: SPACE_ID, name: 'Alpha' } as any);
+
+    const keys = [
+      { keyId: 'config', privateKey: 'aa'.repeat(57) },
+      { keyId: 'hub', privateKey: 'bb'.repeat(57), address: 'QmHubAlpha' },
+      { keyId: 'owner', privateKey: OWNER_PRIVATE_KEY },
+      { keyId: 'inbox', privateKey: 'dd'.repeat(57), address: 'QmInboxAlpha' },
+      { keyId: 'signing', privateKey: 'ee'.repeat(57), address: 'QmInboxAlpha' },
+      { keyId: 'QmGroupAlpha', privateKey: 'ff'.repeat(57) },
+      { keyId: SPACE_ID, privateKey: '11'.repeat(57) },
+    ];
+    for (const k of keys) {
+      await db.saveSpaceKey({
+        spaceId: SPACE_ID,
+        keyId: k.keyId,
+        publicKey: 'pub-' + k.keyId,
+        privateKey: k.privateKey,
+        ...(k.address ? { address: k.address } : {}),
+      } as any);
+    }
+
+    await db.saveEncryptionState(
+      {
+        conversationId: `${SPACE_ID}/${SPACE_ID}`,
+        inboxId: 'QmInboxAlpha',
+        state: JSON.stringify({ triple_ratchet: 'space-state' }),
+        timestamp: 1000,
+      } as any,
+      true
+    );
+  }
+
+  /**
+   * A DM, so the export has known-good content. Its presence in the payload is
+   * the positive control for "the export ran and produced something real" — it
+   * separates "no Space keys" from "no output at all".
+   */
+  async function seedDirectMessageConversation() {
+    await db.saveConversation({
+      conversationId: DM_CONVERSATION_ID,
+      type: 'direct',
+      timestamp: 2000,
+      address: PEER_ADDRESS,
+      icon: '',
+      displayName: 'Peer',
+    } as any);
+
+    await db.saveEncryptionState(
+      {
+        conversationId: DM_CONVERSATION_ID,
+        inboxId: DM_INBOX,
+        state: JSON.stringify({ sending_inbox: { inbox_public_key: 'dm' } }),
+        timestamp: 2000,
+      } as any,
+      true
+    );
+  }
+
+  /**
+   * Decrypts a produced .qmbak the way BackupService.importBackup does.
+   *
+   * The derivation is re-implemented rather than imported because the service
+   * exposes no decrypt-to-payload method. That is safe here specifically because
+   * AES-GCM is authenticated: a wrong key throws instead of returning plausible
+   * garbage, so a mistake in this helper cannot turn into a false pass.
+   */
+  async function decryptBackup(blob: Blob) {
+    const file = JSON.parse(await blob.text());
+
+    const prefix = new TextEncoder().encode('quorum-backup-v1');
+    const priv = new Uint8Array(KEYSET.user_key.private_key);
+    const combined = new Uint8Array(prefix.length + priv.length);
+    combined.set(prefix);
+    combined.set(priv, prefix.length);
+
+    const derived = await crypto.subtle.digest('SHA-512', combined);
+    const key = await crypto.subtle.importKey(
+      'raw',
+      derived.slice(0, 32),
+      { name: 'AES-GCM', length: 256 },
+      false,
+      ['decrypt']
+    );
+
+    const plaintext = await crypto.subtle.decrypt(
+      { name: 'AES-GCM', iv: Buffer.from(file.iv, 'hex') },
+      key,
+      Buffer.from(file.ciphertext, 'hex')
+    );
+
+    const json = new TextDecoder().decode(plaintext);
+    return { file, payload: JSON.parse(json), raw: json };
+  }
+
+  /** Saves a config through the real ConfigService, then exports a real backup. */
+  async function saveThenExport(allowSync: boolean) {
+    await configService.saveConfig({
+      config: {
+        ...getDefaultUserConfig(USER_ADDRESS),
+        allowSync,
+        spaceIds: [SPACE_ID],
+        items: [{ type: 'space', id: SPACE_ID }],
+      } as any,
+      keyset: { userKeyset: KEYSET, deviceKeyset: {} as any },
+    });
+
+    const blob = await backupService.exportBackup({
+      keyset: KEYSET,
+      address: USER_ADDRESS,
+    });
+    return decryptBackup(blob);
+  }
+
+  // ── Positive control ────────────────────────────────────────────────────────
+  // If this fails, nothing below is interpretable: it means the export produced
+  // nothing, so "no owner key found" would be trivially true and meaningless.
+
+  it('CONTROL: the export produces a decryptable file with real content', async () => {
+    const { file, payload } = await saveThenExport(false);
+
+    expect(file.version).toBe(1);
+    expect(payload.conversations).toHaveLength(1);
+    expect(payload.conversations[0].address).toBe(PEER_ADDRESS);
+    expect(payload.encryption_states.length).toBeGreaterThan(0);
+  });
+
+  it('CONTROL: Space ratchet states ARE already exported (design §5)', async () => {
+    // Independent of the key question, and load-bearing for the design: the
+    // Space-side Triple Ratchet state already ships in every .qmbak today. Only
+    // the keys that make it meaningful are missing.
+    const { payload } = await saveThenExport(false);
+
+    const spaceState = payload.encryption_states.find(
+      (s: any) => s.conversationId === `${SPACE_ID}/${SPACE_ID}`
+    );
+    expect(spaceState).toBeDefined();
+  });
+
+  // ── Arm A — the claim under test ────────────────────────────────────────────
+
+  it('ARM A (sync OFF): the backup contains NO Space key material', async () => {
+    const { payload, raw } = await saveThenExport(false);
+
+    // The strongest form of the assertion: the owner private key appears nowhere
+    // in the decrypted payload, whatever field might have carried it.
+    expect(raw).not.toContain(OWNER_PRIVATE_KEY);
+
+    // And the specific mechanism the design names: spaceKeys never gets assembled.
+    expect(payload.user_config?.spaceKeys ?? []).toHaveLength(0);
+
+    // There is no second source — the payload has no space_keys domain at all.
+    expect(payload).not.toHaveProperty('space_keys');
+    expect(payload).not.toHaveProperty('spaces');
+  });
+
+  it('ARM A: the Space is listed but unusable — ids without keys', async () => {
+    // The shape that makes this dangerous rather than merely incomplete: the file
+    // LOOKS like it knows about the Space. A restore reading spaceIds would report
+    // a Space it cannot actually rebuild.
+    const { payload } = await saveThenExport(false);
+
+    expect(payload.user_config?.spaceIds).toContain(SPACE_ID);
+    expect(payload.user_config?.spaceKeys ?? []).toHaveLength(0);
+  });
+
+  // ── Arm B — the control that proves Arm A looked in the right place ─────────
+
+  it('ARM B (sync ON, control): the SAME export DOES carry the owner key', async () => {
+    const { payload, raw } = await saveThenExport(true);
+
+    // Same seed, same export call, one flag different. If this is also empty the
+    // harness never had a chance of finding the key and Arm A proves nothing.
+    expect(raw).toContain(OWNER_PRIVATE_KEY);
+
+    const spaceKeys = payload.user_config?.spaceKeys ?? [];
+    expect(spaceKeys).toHaveLength(1);
+    expect(spaceKeys[0].spaceId).toBe(SPACE_ID);
+    expect(spaceKeys[0].keys.map((k: any) => k.keyId).sort()).toEqual(
+      ['QmGroupAlpha', SPACE_ID, 'config', 'hub', 'inbox', 'owner', 'signing'].sort()
+    );
+  });
+
+  it('ARM B: confirms the sync branch is what populates spaceKeys', async () => {
+    // Pins the mechanism rather than the symptom: the assembled spaceKeys also
+    // reached the upload, so the difference between the arms is the allowSync
+    // branch in saveConfig and nothing else.
+    await saveThenExport(true);
+    expect(postedConfigs).toHaveLength(1);
+  });
+
+  // ── The consequence, stated as a test ──────────────────────────────────────
+
+  it('a sync-OFF backup cannot rebuild the Space; a sync-ON one can', async () => {
+    const off = await saveThenExport(false);
+    expect(off.raw).not.toContain(OWNER_PRIVATE_KEY);
+
+    // Fresh DB + fresh service, same account: this is the restore-onto-a-wiped-
+    // device situation. What the file holds is all there is.
+    const FDBFactory = (await import('fake-indexeddb/lib/FDBFactory')).default;
+    globalThis.indexedDB = new FDBFactory();
+    const wiped = new MessageDB();
+    await wiped.init();
+    expect(await wiped.getSpaces()).toHaveLength(0);
+    expect(await wiped.getSpaceKeys(SPACE_ID)).toHaveLength(0);
+
+    // Nothing in the sync-off payload could repopulate those two.
+    const restorable = off.payload.user_config?.spaceKeys ?? [];
+    expect(restorable).toHaveLength(0);
+  });
+});

--- a/src/dev/tests/services/backupSpaceKeyCoverage.test.ts
+++ b/src/dev/tests/services/backupSpaceKeyCoverage.test.ts
@@ -1,32 +1,29 @@
 /**
- * Backup export — does a `.qmbak` actually contain the Space keys?
+ * Backup export — does a `.qmbak` carry the Space keys?
  *
- * PURPOSE
- * Settles §1 and §10.1 of `.agents/issues/.open/2026-08-09-backup-restore-overhaul-design.md`,
- * which claims that a user with sync OFF exports a backup containing **no Space
- * key material at all** — including the `owner` private key, which is the only
- * proof of Space ownership and has no other copy anywhere.
+ * WHY THIS FILE EXISTS
+ * `.agents/issues/.open/2026-08-09-backup-restore-overhaul-design.md` §1 claimed
+ * that a user with sync OFF exported a backup containing **no Space key material
+ * at all** — including the `owner` private key, the sole proof of Space ownership,
+ * which has no other copy anywhere. That was INFERRED from reading three places in
+ * the code. This file measured it, and it held.
  *
- * That claim was INFERRED from reading three places in the code, never observed.
- * The whole design rests on it, so it gets an instrument rather than an argument.
+ * Slice 1 then fixed it: `getAllSpaceData` reads the `spaces` and `space_keys`
+ * stores directly instead of the `user_config.spaceKeys` snapshot. The assertions
+ * below are now the other way round — a sync-off export MUST carry the keys.
+ *
+ * The pre-fix behaviour is still pinned, from the other side: §"the snapshot is
+ * still empty" proves the export works because it reads the owning stores, and
+ * NOT because something incidentally started populating the config. Without that
+ * test, a later change could reintroduce the dependency on `allowSync` and every
+ * other assertion here would stay green.
  *
  * APPROACH — integration, deliberately NOT unit
  * Real `MessageDB` on fake-indexeddb, real `ConfigService.saveConfig`, real
- * `BackupService.exportBackup`, real WebCrypto. Only the network (`apiClient`)
- * and the wasm signing core are stubbed. Mocking `messageDB` here would measure
- * the mock, which is exactly the failure mode this instrument exists to avoid:
- * the claim IS about what the real save/export chain leaves on disk.
- *
- * READING THE RESULT
- *   Arm A red, Arm B green  → the design's §1 holds. Expected.
- *   Both arms green         → §1 is REFUTED. Backups already carry Space keys;
- *                             slices 1-2 of the design are unnecessary. Stop and
- *                             rewrite the issue before writing any code.
- *   Both arms red           → the harness is broken, not the app. Neither arm
- *                             means anything. Fix the harness first.
- *
- * The last case is why Arm B exists. Without a control that SHOULD find the key,
- * "we found no key" is indistinguishable from "we looked in the wrong place".
+ * `BackupService.exportBackup`, real WebCrypto. Only the network and the wasm
+ * signing core are stubbed. Mocking `messageDB` would measure the mock, which is
+ * the exact failure mode this file exists to rule out: the claim IS about what
+ * the real save/export chain leaves in the file.
  */
 
 import 'fake-indexeddb/auto';
@@ -36,13 +33,19 @@ import { i18n } from '@lingui/core';
 import { messages } from '@/i18n/en/messages';
 import { MessageDB } from '@/db/messages';
 import { ConfigService } from '@/services/ConfigService';
-import { BackupService } from '@/services/BackupService';
+import {
+  BackupService,
+  BackupError,
+  BACKUP_FORMAT_VERSION,
+  domainsOf,
+  V1_DOMAINS,
+} from '@/services/BackupService';
 import { getDefaultUserConfig } from '@/utils';
 import { QueryClient } from '@tanstack/react-query';
 
 // The wasm core is never initialised in this suite (see vitest.config.ts), so the
-// two signing calls saveConfig makes are stubbed. Nothing under test depends on
-// the signature being real — the payload we inspect is produced before signing.
+// signing calls saveConfig makes are stubbed. Nothing under test depends on the
+// signature being real — the payload inspected here is built before signing.
 vi.mock('@quilibrium/quilibrium-js-sdk-channels', () => ({
   channel: {
     SealHubEnvelope: vi.fn().mockResolvedValue({ sealed: 'hub-envelope' }),
@@ -57,13 +60,12 @@ vi.mock('@quilibrium/quilibrium-js-sdk-channels', () => ({
 }));
 
 /**
- * The value the whole instrument hunts for.
+ * The value the instrument hunts for.
  *
  * A distinctive hex sentinel rather than a realistic key: the strongest assertion
  * available is "does this string appear ANYWHERE in the decrypted payload", which
- * is independent of any belief about which field is supposed to carry it. A
- * realistic-looking random key would work identically but makes a failure much
- * harder to read.
+ * holds regardless of which field is supposed to carry it. A random-looking key
+ * would work identically but makes a failure far harder to read.
  */
 const OWNER_PRIVATE_KEY = 'c0ffee'.repeat(19); // 114 hex chars, Ed448-private-key length
 
@@ -82,7 +84,17 @@ const DM_INBOX = 'QmcfTNSyig9DSfAqSmWXsGLkLiG9TGS87XXpJy3juKbKSs'; // digest 0xD
 /** Direct conversations are keyed `<addr>/<addr>`, not `<addr>/<inbox>`. */
 const DM_CONVERSATION_ID = `${PEER_ADDRESS}/${PEER_ADDRESS}`;
 
-/** Ed448 keyset shape BackupService/ConfigService read `user_key` off. */
+/** The seven keys SpaceService writes when a user CREATES a Space (SpaceService.ts:356-431). */
+const CREATED_SPACE_KEY_IDS = [
+  'config',
+  'hub',
+  'owner',
+  'inbox',
+  'signing',
+  'QmGroupAlpha',
+  SPACE_ID,
+];
+
 const KEYSET = {
   user_key: {
     private_key: new Uint8Array(57).fill(7),
@@ -96,8 +108,8 @@ beforeAll(() => {
 
   // setup.ts replaces global crypto with vi.fn() stubs whose subtle.digest
   // resolves a zero-filled buffer. Real AES-GCM and SHA-512 are required here:
-  // the instrument encrypts a backup and decrypts it again, and a stubbed digest
-  // would make every derived key identical — the round trip would "pass" while
+  // this file encrypts a backup and decrypts it again, and a stubbed digest would
+  // make every derived key identical — the round trip would "pass" while
   // measuring nothing. Registered in this file's beforeAll, which runs after
   // setup.ts's.
   for (const target of [globalThis, global]) {
@@ -109,7 +121,7 @@ beforeAll(() => {
   }
 });
 
-describe('Backup export — Space key coverage (design §1 / §10.1)', () => {
+describe('Backup export — Space key coverage', () => {
   let db: MessageDB;
   let configService: ConfigService;
   let backupService: BackupService;
@@ -143,42 +155,46 @@ describe('Backup export — Space key coverage (design §1 / §10.1)', () => {
 
     backupService = new BackupService({ messageDB: db });
 
-    await seedSpaceWithFullKeyset();
+    await seedCreatedSpace();
     await seedDirectMessageConversation();
   });
 
-  /**
-   * Mirrors what SpaceService writes when a user CREATES a Space
-   * (SpaceService.ts:356-431): seven keys, of which `owner` is the irreplaceable
-   * one, plus the Space's Triple Ratchet state under `<spaceId>/<spaceId>`.
-   */
-  async function seedSpaceWithFullKeyset() {
+  /** Mirrors what SpaceService writes when a user CREATES a Space. */
+  async function seedCreatedSpace(evalPoolBytes = 0) {
     await db.saveSpace({ spaceId: SPACE_ID, name: 'Alpha' } as any);
 
-    const keys = [
-      { keyId: 'config', privateKey: 'aa'.repeat(57) },
-      { keyId: 'hub', privateKey: 'bb'.repeat(57), address: 'QmHubAlpha' },
-      { keyId: 'owner', privateKey: OWNER_PRIVATE_KEY },
-      { keyId: 'inbox', privateKey: 'dd'.repeat(57), address: 'QmInboxAlpha' },
-      { keyId: 'signing', privateKey: 'ee'.repeat(57), address: 'QmInboxAlpha' },
-      { keyId: 'QmGroupAlpha', privateKey: 'ff'.repeat(57) },
-      { keyId: SPACE_ID, privateKey: '11'.repeat(57) },
-    ];
-    for (const k of keys) {
+    const privateKeys: Record<string, string> = {
+      config: 'aa'.repeat(57),
+      hub: 'bb'.repeat(57),
+      owner: OWNER_PRIVATE_KEY,
+      inbox: 'dd'.repeat(57),
+      signing: 'ee'.repeat(57),
+      QmGroupAlpha: 'ff'.repeat(57),
+      [SPACE_ID]: '11'.repeat(57),
+    };
+    for (const keyId of CREATED_SPACE_KEY_IDS) {
       await db.saveSpaceKey({
         spaceId: SPACE_ID,
-        keyId: k.keyId,
-        publicKey: 'pub-' + k.keyId,
-        privateKey: k.privateKey,
-        ...(k.address ? { address: k.address } : {}),
+        keyId,
+        publicKey: 'pub-' + keyId,
+        privateKey: privateKeys[keyId],
+        ...(keyId === 'hub' || keyId === 'inbox' || keyId === 'signing'
+          ? { address: 'QmAddr' + keyId }
+          : {}),
       } as any);
     }
 
     await db.saveEncryptionState(
       {
         conversationId: `${SPACE_ID}/${SPACE_ID}`,
-        inboxId: 'QmInboxAlpha',
-        state: JSON.stringify({ triple_ratchet: 'space-state' }),
+        inboxId: 'QmAddrinbox',
+        state: JSON.stringify({
+          triple_ratchet: 'space-state',
+          // Stand-in for the ~10k polynomial evals pre-allocated per created
+          // Space (2025-12-09-encryption-state-evals-bloat.md). Zero by default
+          // to keep the suite fast; the size test supplies a realistic pool.
+          evals: 'e'.repeat(evalPoolBytes),
+        }),
         timestamp: 1000,
       } as any,
       true
@@ -186,9 +202,9 @@ describe('Backup export — Space key coverage (design §1 / §10.1)', () => {
   }
 
   /**
-   * A DM, so the export has known-good content. Its presence in the payload is
-   * the positive control for "the export ran and produced something real" — it
-   * separates "no Space keys" from "no output at all".
+   * A DM, so the export has known-good content. Its presence is the positive
+   * control for "the export ran and produced something real" — it separates
+   * "no Space keys" from "no output at all".
    */
   async function seedDirectMessageConversation() {
     await db.saveConversation({
@@ -211,17 +227,8 @@ describe('Backup export — Space key coverage (design §1 / §10.1)', () => {
     );
   }
 
-  /**
-   * Decrypts a produced .qmbak the way BackupService.importBackup does.
-   *
-   * The derivation is re-implemented rather than imported because the service
-   * exposes no decrypt-to-payload method. That is safe here specifically because
-   * AES-GCM is authenticated: a wrong key throws instead of returning plausible
-   * garbage, so a mistake in this helper cannot turn into a false pass.
-   */
-  async function decryptBackup(blob: Blob) {
-    const file = JSON.parse(await blob.text());
-
+  /** Derives the backup key exactly as BackupService.deriveKey does. */
+  async function deriveKey(usage: KeyUsage) {
     const prefix = new TextEncoder().encode('quorum-backup-v1');
     const priv = new Uint8Array(KEYSET.user_key.private_key);
     const combined = new Uint8Array(prefix.length + priv.length);
@@ -229,22 +236,48 @@ describe('Backup export — Space key coverage (design §1 / §10.1)', () => {
     combined.set(priv, prefix.length);
 
     const derived = await crypto.subtle.digest('SHA-512', combined);
-    const key = await crypto.subtle.importKey(
+    return crypto.subtle.importKey(
       'raw',
       derived.slice(0, 32),
       { name: 'AES-GCM', length: 256 },
       false,
-      ['decrypt']
+      [usage]
     );
+  }
 
+  /**
+   * Decrypts a produced .qmbak the way importBackup does.
+   *
+   * The derivation is re-implemented rather than imported because the service
+   * exposes no decrypt-to-payload method. Safe here specifically because AES-GCM
+   * is authenticated: a wrong key throws instead of returning plausible garbage,
+   * so a mistake in this helper cannot become a false pass.
+   */
+  async function decryptBackup(blob: Blob) {
+    const file = JSON.parse(await blob.text());
     const plaintext = await crypto.subtle.decrypt(
       { name: 'AES-GCM', iv: Buffer.from(file.iv, 'hex') },
-      key,
+      await deriveKey('decrypt'),
       Buffer.from(file.ciphertext, 'hex')
     );
+    const raw = new TextDecoder().decode(plaintext);
+    return { file, payload: JSON.parse(raw), raw, bytes: blob.size };
+  }
 
-    const json = new TextDecoder().decode(plaintext);
-    return { file, payload: JSON.parse(json), raw: json };
+  /** Writes a backup file at an arbitrary version — for back-compat tests. */
+  async function makeBackupFile(version: number, payload: unknown) {
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+    const encrypted = await crypto.subtle.encrypt(
+      { name: 'AES-GCM', iv },
+      await deriveKey('encrypt'),
+      new TextEncoder().encode(JSON.stringify(payload))
+    );
+    return JSON.stringify({
+      version,
+      iv: Buffer.from(iv).toString('hex'),
+      ciphertext: Buffer.from(encrypted).toString('hex'),
+      createdAt: Date.now(),
+    });
   }
 
   /** Saves a config through the real ConfigService, then exports a real backup. */
@@ -259,107 +292,190 @@ describe('Backup export — Space key coverage (design §1 / §10.1)', () => {
       keyset: { userKeyset: KEYSET, deviceKeyset: {} as any },
     });
 
-    const blob = await backupService.exportBackup({
-      keyset: KEYSET,
-      address: USER_ADDRESS,
-    });
-    return decryptBackup(blob);
+    return decryptBackup(
+      await backupService.exportBackup({ keyset: KEYSET, address: USER_ADDRESS })
+    );
   }
 
-  // ── Positive control ────────────────────────────────────────────────────────
-  // If this fails, nothing below is interpretable: it means the export produced
-  // nothing, so "no owner key found" would be trivially true and meaningless.
+  // ── Positive controls ───────────────────────────────────────────────────────
+  // If these fail nothing else is interpretable: an empty export would make
+  // "no owner key found" trivially true and meaningless.
 
   it('CONTROL: the export produces a decryptable file with real content', async () => {
     const { file, payload } = await saveThenExport(false);
 
-    expect(file.version).toBe(1);
+    expect(file.version).toBe(BACKUP_FORMAT_VERSION);
     expect(payload.conversations).toHaveLength(1);
     expect(payload.conversations[0].address).toBe(PEER_ADDRESS);
     expect(payload.encryption_states.length).toBeGreaterThan(0);
   });
 
-  it('CONTROL: Space ratchet states ARE already exported (design §5)', async () => {
-    // Independent of the key question, and load-bearing for the design: the
-    // Space-side Triple Ratchet state already ships in every .qmbak today. Only
-    // the keys that make it meaningful are missing.
+  it('CONTROL: Space ratchet states were already exported before slice 1', async () => {
+    // Independent of the key question and load-bearing for the design: the
+    // Space-side Triple Ratchet state has always shipped in a .qmbak. Only the
+    // keys that make it meaningful were missing.
     const { payload } = await saveThenExport(false);
 
-    const spaceState = payload.encryption_states.find(
-      (s: any) => s.conversationId === `${SPACE_ID}/${SPACE_ID}`
-    );
-    expect(spaceState).toBeDefined();
+    expect(
+      payload.encryption_states.find(
+        (s: any) => s.conversationId === `${SPACE_ID}/${SPACE_ID}`
+      )
+    ).toBeDefined();
   });
 
-  // ── Arm A — the claim under test ────────────────────────────────────────────
+  // ── Slice 1: the behaviour that changed ─────────────────────────────────────
 
-  it('ARM A (sync OFF): the backup contains NO Space key material', async () => {
+  it('sync OFF: the backup carries every Space key, including `owner`', async () => {
     const { payload, raw } = await saveThenExport(false);
 
-    // The strongest form of the assertion: the owner private key appears nowhere
-    // in the decrypted payload, whatever field might have carried it.
-    expect(raw).not.toContain(OWNER_PRIVATE_KEY);
-
-    // And the specific mechanism the design names: spaceKeys never gets assembled.
-    expect(payload.user_config?.spaceKeys ?? []).toHaveLength(0);
-
-    // There is no second source — the payload has no space_keys domain at all.
-    expect(payload).not.toHaveProperty('space_keys');
-    expect(payload).not.toHaveProperty('spaces');
-  });
-
-  it('ARM A: the Space is listed but unusable — ids without keys', async () => {
-    // The shape that makes this dangerous rather than merely incomplete: the file
-    // LOOKS like it knows about the Space. A restore reading spaceIds would report
-    // a Space it cannot actually rebuild.
-    const { payload } = await saveThenExport(false);
-
-    expect(payload.user_config?.spaceIds).toContain(SPACE_ID);
-    expect(payload.user_config?.spaceKeys ?? []).toHaveLength(0);
-  });
-
-  // ── Arm B — the control that proves Arm A looked in the right place ─────────
-
-  it('ARM B (sync ON, control): the SAME export DOES carry the owner key', async () => {
-    const { payload, raw } = await saveThenExport(true);
-
-    // Same seed, same export call, one flag different. If this is also empty the
-    // harness never had a chance of finding the key and Arm A proves nothing.
+    // The strongest form: the owner key is in the file, wherever it lives.
     expect(raw).toContain(OWNER_PRIVATE_KEY);
 
-    const spaceKeys = payload.user_config?.spaceKeys ?? [];
-    expect(spaceKeys).toHaveLength(1);
-    expect(spaceKeys[0].spaceId).toBe(SPACE_ID);
-    expect(spaceKeys[0].keys.map((k: any) => k.keyId).sort()).toEqual(
-      ['QmGroupAlpha', SPACE_ID, 'config', 'hub', 'inbox', 'owner', 'signing'].sort()
+    expect(payload.spaces.map((s: any) => s.spaceId)).toEqual([SPACE_ID]);
+    expect(payload.space_keys.map((k: any) => k.keyId).sort()).toEqual(
+      [...CREATED_SPACE_KEY_IDS].sort()
+    );
+    expect(
+      payload.space_keys.find((k: any) => k.keyId === 'owner').privateKey
+    ).toBe(OWNER_PRIVATE_KEY);
+  });
+
+  it('sync OFF: the config snapshot is STILL empty — the keys come from the store', async () => {
+    // This is the test that keeps the fix honest. The export must work because it
+    // reads `space_keys` directly, NOT because something started populating
+    // user_config.spaceKeys when sync is off. If that snapshot ever fills in
+    // here, the export has quietly re-acquired a dependency on `allowSync` and
+    // every other assertion in this file would still pass.
+    const { payload } = await saveThenExport(false);
+
+    expect(payload.user_config?.spaceKeys ?? []).toHaveLength(0);
+    expect(payload.space_keys.length).toBe(CREATED_SPACE_KEY_IDS.length);
+  });
+
+  it('sync ON: same export, same keys — the flag no longer changes the outcome', async () => {
+    // Before slice 1 this arm was the control that proved the sync-off arm was
+    // looking in the right place. It now pins the real goal: the backup is
+    // identical in substance whether sync is on or off.
+    const { payload, raw } = await saveThenExport(true);
+
+    expect(raw).toContain(OWNER_PRIVATE_KEY);
+    expect(payload.space_keys.map((k: any) => k.keyId).sort()).toEqual(
+      [...CREATED_SPACE_KEY_IDS].sort()
+    );
+    // ...and the sync path still does its own separate thing.
+    expect(postedConfigs).toHaveLength(1);
+    expect(payload.user_config.spaceKeys).toHaveLength(1);
+  });
+
+  // ── Format and back-compat ─────────────────────────────────────────────────
+
+  it('declares per-domain presence, including what it does NOT carry', async () => {
+    const { payload } = await saveThenExport(false);
+
+    expect(payload.domains).toMatchObject({
+      dm_messages: true,
+      dm_conversations: true,
+      encryption_states: true,
+      user_config: true,
+      spaces: true,
+      space_keys: true,
+      // Still out of scope. Declared false rather than omitted so a restore can
+      // say so instead of silently restoring nothing.
+      space_messages: false,
+    });
+  });
+
+  it('a v1 file still imports, and reports that it has no Space keys', async () => {
+    // v1 files are on users' disks right now. Refusing them would be the same
+    // outcome as having no backup at all.
+    const v1 = await makeBackupFile(1, {
+      messages: [],
+      conversations: [
+        {
+          conversationId: DM_CONVERSATION_ID,
+          type: 'direct',
+          timestamp: 1,
+          address: PEER_ADDRESS,
+          icon: '',
+          displayName: 'Peer',
+        },
+      ],
+      encryption_states: [],
+    });
+
+    const result = await backupService.importBackup({
+      keyset: KEYSET,
+      fileContent: v1,
+    });
+
+    expect(result.version).toBe(1);
+    expect(result.conversationsWritten).toBe(1);
+    expect(result.domains).toEqual(V1_DOMAINS);
+    expect(result.domains.space_keys).toBe(false);
+  });
+
+  it('a file from a NEWER format is refused, not half-restored', async () => {
+    // Opposite call from v1: a future file may hold domains this build would
+    // silently drop, and a partial restore that looks complete is worse than a
+    // clear refusal.
+    const future = await makeBackupFile(99, { messages: [], conversations: [] });
+
+    await expect(
+      backupService.importBackup({ keyset: KEYSET, fileContent: future })
+    ).rejects.toThrow(BackupError);
+    await expect(
+      backupService.importBackup({ keyset: KEYSET, fileContent: future })
+    ).rejects.toThrow(/newer version/i);
+  });
+
+  it('domainsOf falls back correctly for a v1 file with no domains block', () => {
+    expect(domainsOf({ version: 1 }, { messages: [], conversations: [] } as any)).toEqual(
+      V1_DOMAINS
     );
   });
 
-  it('ARM B: confirms the sync branch is what populates spaceKeys', async () => {
-    // Pins the mechanism rather than the symptom: the assembled spaceKeys also
-    // reached the upload, so the difference between the arms is the allowSync
-    // branch in saveConfig and nothing else.
-    await saveThenExport(true);
-    expect(postedConfigs).toHaveLength(1);
-  });
+  // ── Size: the number that gates the Space-messages decision ────────────────
 
-  // ── The consequence, stated as a test ──────────────────────────────────────
+  it('MEASUREMENT: a created Space\'s eval pool dominates the file, and hex doubles it', async () => {
+    // Answers §10.4 of the overhaul design without needing a real account export.
+    // A created Space pre-allocates ~10k polynomial evals (~2 MB) into its
+    // encryption state; a joined one costs ~12-63 KB
+    // (2025-12-09-encryption-state-evals-bloat.md, measured on a real account).
+    const EVAL_POOL = 2 * 1024 * 1024; // 2 MB, the measured per-created-Space cost
 
-  it('a sync-OFF backup cannot rebuild the Space; a sync-ON one can', async () => {
-    const off = await saveThenExport(false);
-    expect(off.raw).not.toContain(OWNER_PRIVATE_KEY);
+    const lean = await saveThenExport(false);
 
-    // Fresh DB + fresh service, same account: this is the restore-onto-a-wiped-
-    // device situation. What the file holds is all there is.
-    const FDBFactory = (await import('fake-indexeddb/lib/FDBFactory')).default;
-    globalThis.indexedDB = new FDBFactory();
-    const wiped = new MessageDB();
-    await wiped.init();
-    expect(await wiped.getSpaces()).toHaveLength(0);
-    expect(await wiped.getSpaceKeys(SPACE_ID)).toHaveLength(0);
+    // Re-seed the same Space with a realistic eval pool.
+    await db.saveEncryptionState(
+      {
+        conversationId: `${SPACE_ID}/${SPACE_ID}`,
+        inboxId: 'QmAddrinbox',
+        state: JSON.stringify({ triple_ratchet: 's', evals: 'e'.repeat(EVAL_POOL) }),
+        timestamp: 1001,
+      } as any,
+      true
+    );
+    const fat = await saveThenExport(false);
 
-    // Nothing in the sync-off payload could repopulate those two.
-    const restorable = off.payload.user_config?.spaceKeys ?? [];
-    expect(restorable).toHaveLength(0);
+    const growth = fat.bytes - lean.bytes;
+
+    // The eval pool passes through to the file essentially intact...
+    expect(growth).toBeGreaterThan(EVAL_POOL);
+
+    // ...and then hex encoding of the ciphertext doubles it. This is the finding
+    // that matters for the size budget: the .qmbak on disk is ~2x its payload,
+    // so a 4 MB account (two created Spaces) yields an ~8 MB download. Asserted
+    // as a range rather than a constant so AES-GCM padding/IV noise cannot make
+    // it flaky.
+    expect(growth).toBeGreaterThan(EVAL_POOL * 1.9);
+    expect(growth).toBeLessThan(EVAL_POOL * 2.2);
+
+    // Written straight to stdout: vitest's default reporter swallows console.log,
+    // and the point of this test is as much the number as the assertion. Run the
+    // file directly to read it off.
+    process.stdout.write(
+      `\n[backup size] lean=${lean.bytes}B  with-2MB-evals=${fat.bytes}B  ` +
+        `growth=${growth}B (${(growth / EVAL_POOL).toFixed(2)}x the pool)\n`
+    );
   });
 });

--- a/src/dev/tests/services/backupSpaceRestore.test.ts
+++ b/src/dev/tests/services/backupSpaceRestore.test.ts
@@ -69,6 +69,10 @@ const SPACE_A = 'QmZDbJ9cy9z1J74DgtGJEQW6yop3j15t6i31KW5McmVKzp';
 const SPACE_B = 'QmbWqM1roW69PooJC96TKePsDk7Ssqz3Sb2syp4H98texr';
 const USER_ADDRESS = 'QmaNDKajtL35LxRkwWgNn2Sz6mxkJRXxmeXwef4pNxBzUq';
 
+/** A distinct peer for the isolation tests, so they cannot collide with the
+ *  deletion-axis describe block's conversation. */
+const PEER_FOR_ISOLATION = 'QmcfTNSyig9DSfAqSmWXsGLkLiG9TGS87XXpJy3juKbKSs';
+
 const OWNER_KEY_IN_BACKUP = 'aaaa'.repeat(28);
 const OWNER_KEY_ON_DEVICE = 'bbbb'.repeat(28);
 
@@ -415,6 +419,128 @@ describe('Backup restore — Spaces, additive only', () => {
       ).toBeDefined();
     });
 
+    it('a whole conversation deleted after the backup stays deleted', async () => {
+      // The case the single-message tests missed entirely. "Delete Chat" is the
+      // common deletion action and it goes through a DIFFERENT path
+      // (deleteMessagesForConversation + deleteConversation) that wrote no
+      // tombstones at all, so restoring an older backup silently brought the
+      // entire chat back.
+      await seedDm(db, 'msg-in-deleted-chat');
+      const file = await exportFrom(db);
+
+      await db.deleteMessagesForConversation(CONV);
+      await db.deleteConversation(CONV);
+
+      const report = await backupService.importBackup({
+        keyset: KEYSET,
+        fileContent: file,
+      });
+
+      // Neither the messages nor the conversation row come back.
+      expect(
+        await db.getMessage({ spaceId: PEER, channelId: PEER, messageId: 'msg-in-deleted-chat' })
+      ).toBeUndefined();
+      // getConversation returns a wrapper object, so assert on the payload:
+      // the wrapper is truthy even when nothing was found.
+      expect(
+        (await db.getConversation({ conversationId: CONV }))?.conversation
+      ).toBeUndefined();
+      expect(report.conversationsSkippedAsDeleted).toBe(1);
+      expect(report.conversationsWritten).toBe(0);
+      expect(report.messagesWritten).toBe(0);
+    });
+
+    it('CONTROL: a conversation that was never deleted DOES restore', async () => {
+      await seedDm(db, 'msg-kept');
+      const file = await exportFrom(db);
+
+      db = await freshDb();
+      wire(db);
+
+      const report = await backupService.importBackup({
+        keyset: KEYSET,
+        fileContent: file,
+      });
+
+      expect(report.conversationsWritten).toBe(1);
+      expect(report.conversationsSkippedAsDeleted).toBe(0);
+      expect(
+        (await db.getConversation({ conversationId: CONV }))?.conversation
+      ).toBeDefined();
+    });
+
+    it('starting the chat again clears the tombstone, so it can restore once more', async () => {
+      // The peer writes again, or the user re-opens the chat. saveConversation is
+      // the choke point that clears the record. The import writes to the store
+      // directly and so cannot clear its own gate.
+      await seedDm(db, 'msg-x');
+      const file = await exportFrom(db);
+
+      await db.deleteMessagesForConversation(CONV);
+      await db.deleteConversation(CONV);
+      expect(await db.getDeletedConversationIds()).toContain(CONV);
+
+      await db.saveConversation({
+        conversationId: CONV,
+        type: 'direct',
+        timestamp: 5,
+        address: PEER,
+        icon: '',
+        displayName: 'Peer',
+      } as any);
+      expect(await db.getDeletedConversationIds()).not.toContain(CONV);
+
+      const report = await backupService.importBackup({
+        keyset: KEYSET,
+        fileContent: file,
+      });
+      expect(report.conversationsSkippedAsDeleted).toBe(0);
+    });
+
+    it('messages from a deleted chat stay gone even after the chat resumes', async () => {
+      // The case that makes the PER-MESSAGE tombstones in the bulk-delete path
+      // load-bearing rather than redundant with the conversation gate.
+      //
+      // Delete the chat → both tombstones written. The peer then writes again,
+      // which clears the CONVERSATION tombstone (the chat legitimately exists
+      // once more). Now restore an old backup: the conversation gate no longer
+      // blocks anything, so only the per-message tombstones stand between the
+      // user and the resurrection of messages they deleted.
+      //
+      // Found by mutation: removing the bulk tombstone write left every other
+      // test in this file green.
+      await seedDm(db, 'msg-deleted-then-chat-resumed');
+      const file = await exportFrom(db);
+
+      await db.deleteMessagesForConversation(CONV);
+      await db.deleteConversation(CONV);
+
+      // The peer writes again — chat is back, conversation tombstone cleared.
+      await db.saveConversation({
+        conversationId: CONV,
+        type: 'direct',
+        timestamp: 9,
+        address: PEER,
+        icon: '',
+        displayName: 'Peer',
+      } as any);
+      expect(await db.getDeletedConversationIds()).not.toContain(CONV);
+
+      const report = await backupService.importBackup({
+        keyset: KEYSET,
+        fileContent: file,
+      });
+
+      expect(
+        await db.getMessage({
+          spaceId: PEER,
+          channelId: PEER,
+          messageId: 'msg-deleted-then-chat-resumed',
+        })
+      ).toBeUndefined();
+      expect(report.messagesSkippedAsDeleted).toBe(1);
+    });
+
     it('deleting a DM now writes a tombstone at all', async () => {
       // Pins the behaviour change this relies on. Tombstones used to be written
       // for channel messages only, on the reasoning that DMs have no sync
@@ -522,6 +648,122 @@ describe('Backup restore — Spaces, additive only', () => {
       const adopted = await configService.adoptSpaces({ spaceKeys: [bundle] as any });
 
       expect(adopted.restored).toEqual([SPACE_A]);
+    });
+  });
+
+  describe('failure isolation and reporting', () => {
+    // Everything here was found by code review, not by a failing test — the
+    // properties that were mutation-tested held, and the reporting around them
+    // was where the gaps were.
+
+    it('a Space whose manifest cannot be fetched is REPORTED, not silently dropped', async () => {
+      // It previously fell out of restored/alreadyPresent/failed alike, while its
+      // keys — saved a few lines earlier — were already on disk with no `spaces`
+      // row to render them. A user saw a clean restore with a Space missing.
+      await seedSpace(db, SPACE_A, OWNER_KEY_IN_BACKUP);
+      const file = await exportFrom(db);
+
+      db = await freshDb();
+      wire(db);
+      (configService as any).apiClient.getSpaceManifest = vi
+        .fn()
+        .mockResolvedValue(undefined);
+
+      const report = await backupService.importBackup({
+        keyset: KEYSET,
+        fileContent: file,
+      });
+
+      expect(report.spacesRestored).toEqual([]);
+      expect(report.spacesFailed).toEqual([
+        { spaceId: SPACE_A, reason: 'could not fetch Space manifest' },
+      ]);
+    });
+
+    it('one failing Space does not abandon the rest of the batch', async () => {
+      // The per-Space try/catch promises this, but the getSpace() read sat
+      // outside it, so a single transient IndexedDB failure threw straight out
+      // and discarded results for every Space already restored.
+      await seedSpace(db, SPACE_A, OWNER_KEY_IN_BACKUP);
+      await seedSpace(db, SPACE_B, OWNER_KEY_IN_BACKUP);
+      const file = await exportFrom(db);
+
+      db = await freshDb();
+      wire(db);
+
+      const realGetSpace = db.getSpace.bind(db);
+      let calls = 0;
+      db.getSpace = vi.fn(async (id: string) => {
+        calls += 1;
+        if (calls === 1) throw new Error('transient IDB failure');
+        return realGetSpace(id);
+      }) as any;
+
+      const report = await backupService.importBackup({
+        keyset: KEYSET,
+        fileContent: file,
+      });
+
+      // One reported as failed, the other still restored — not an aborted batch.
+      expect(report.spacesFailed).toHaveLength(1);
+      expect(report.spacesRestored).toHaveLength(1);
+      expect(report.spacesFailed[0].reason).toMatch(/transient IDB failure/);
+    });
+
+    it('a Space-restore failure does not erase an already-written DM restore', async () => {
+      // importDMData commits at step 4; step 5 used to be unguarded, so any throw
+      // rejected the whole call and the user was told "Failed to import backup"
+      // about an import whose messages had landed and were staying.
+      await seedSpace(db, SPACE_A, OWNER_KEY_IN_BACKUP);
+      await db.saveConversation({
+        conversationId: `${PEER_FOR_ISOLATION}/${PEER_FOR_ISOLATION}`,
+        type: 'direct',
+        timestamp: 1,
+        address: PEER_FOR_ISOLATION,
+        icon: '',
+        displayName: 'Peer',
+      } as any);
+      const file = await exportFrom(db);
+
+      db = await freshDb();
+      wire(db);
+      db.getDepartedSpaces = vi
+        .fn()
+        .mockRejectedValue(new Error('departure read exploded')) as any;
+
+      const report = await backupService.importBackup({
+        keyset: KEYSET,
+        fileContent: file,
+      });
+
+      // The DM half survived and is reported, rather than the whole call rejecting.
+      expect(report.conversationsWritten).toBe(1);
+      expect(report.spacesFailed).toEqual([
+        { spaceId: '*', reason: 'departure read exploded' },
+      ]);
+    });
+
+    it('a backup with Space keys but no adoptSpaces reports them, rather than ignoring them', async () => {
+      await seedSpace(db, SPACE_A, OWNER_KEY_IN_BACKUP);
+      const file = await exportFrom(db);
+
+      db = await freshDb();
+      wire(db);
+      // Export-only construction — the configuration the constructor documents.
+      const noAdopt = new BackupService({ messageDB: db });
+
+      const report = await noAdopt.importBackup({
+        keyset: KEYSET,
+        fileContent: file,
+      });
+
+      expect(report.spacesRestored).toEqual([]);
+      expect(report.spacesFailed).toEqual([
+        {
+          spaceId: SPACE_A,
+          reason: 'Space restore is not available in this context',
+        },
+      ]);
     });
   });
 

--- a/src/dev/tests/services/backupSpaceRestore.test.ts
+++ b/src/dev/tests/services/backupSpaceRestore.test.ts
@@ -427,6 +427,104 @@ describe('Backup restore — Spaces, additive only', () => {
     });
   });
 
+  describe('a restore must not re-join a Space the user left', () => {
+    // The Space half of the deletion axis, and the one with an outward-facing
+    // consequence: adoptSpaces calls postHubAdd and sends a sync control
+    // message, so re-adding a Space the user was kicked from would re-announce
+    // them to the Space that removed them.
+
+    it('a Space left after the backup is not restored', async () => {
+      await seedSpace(db, SPACE_A, OWNER_KEY_IN_BACKUP);
+      const file = await exportFrom(db);
+
+      // The user leaves. (Recorded by SpaceService/MessageService in the app;
+      // called directly here so the test does not depend on those flows.)
+      await db.deleteSpace(SPACE_A);
+      await db.markSpaceDeparted({ spaceId: SPACE_A, reason: 'left' });
+
+      const report = await backupService.importBackup({
+        keyset: KEYSET,
+        fileContent: file,
+      });
+
+      expect(report.spacesRestored).toEqual([]);
+      expect(report.spacesFailed).toEqual([
+        { spaceId: SPACE_A, reason: 'you left this Space after this backup was taken' },
+      ]);
+      expect(await db.getSpaces()).toHaveLength(0);
+    });
+
+    it('being removed is reported differently from leaving', async () => {
+      await seedSpace(db, SPACE_A, OWNER_KEY_IN_BACKUP);
+      const file = await exportFrom(db);
+
+      await db.deleteSpace(SPACE_A);
+      await db.markSpaceDeparted({ spaceId: SPACE_A, reason: 'removed' });
+
+      const report = await backupService.importBackup({
+        keyset: KEYSET,
+        fileContent: file,
+      });
+
+      expect(report.spacesFailed[0].reason).toMatch(/removed from this Space/);
+    });
+
+    it('CONTROL: a Space that was never departed DOES restore', async () => {
+      // Without this the gate could pass by restoring nothing at all.
+      await seedSpace(db, SPACE_A, OWNER_KEY_IN_BACKUP);
+      const file = await exportFrom(db);
+
+      db = await freshDb();
+      wire(db);
+
+      const report = await backupService.importBackup({
+        keyset: KEYSET,
+        fileContent: file,
+      });
+
+      expect(report.spacesRestored).toEqual([SPACE_A]);
+    });
+
+    it('rejoining clears the departure, so the Space can be restored again', async () => {
+      await seedSpace(db, SPACE_A, OWNER_KEY_IN_BACKUP);
+      const file = await exportFrom(db);
+
+      await db.deleteSpace(SPACE_A);
+      await db.markSpaceDeparted({ spaceId: SPACE_A, reason: 'left' });
+      // The user is invited back (InvitationService clears the record here).
+      await db.clearSpaceDeparture(SPACE_A);
+
+      const report = await backupService.importBackup({
+        keyset: KEYSET,
+        fileContent: file,
+      });
+
+      expect(report.spacesRestored).toEqual([SPACE_A]);
+    });
+
+    it('the gate does NOT apply to config sync — only to stale backup files', async () => {
+      // adoptSpaces serves both paths. A synced config is the account's CURRENT
+      // state, published after the departure; a backup is stale by construction.
+      // Gating sync on departures would break leaving on one device and
+      // rejoining on another, so the gate lives in BackupService, not here.
+      await seedSpace(db, SPACE_A, OWNER_KEY_IN_BACKUP);
+      const bundle = {
+        spaceId: SPACE_A,
+        encryptionState: (
+          await db.getEncryptionStates({ conversationId: `${SPACE_A}/${SPACE_A}` })
+        )[0],
+        keys: await db.getSpaceKeys(SPACE_A),
+      };
+
+      await db.deleteSpace(SPACE_A);
+      await db.markSpaceDeparted({ spaceId: SPACE_A, reason: 'left' });
+
+      const adopted = await configService.adoptSpaces({ spaceKeys: [bundle] as any });
+
+      expect(adopted.restored).toEqual([SPACE_A]);
+    });
+  });
+
   it('a v1 file restores DMs and reports that Spaces were not in it', async () => {
     // Regression guard for the back-compat promise: v1 files predate Space key
     // capture, and must still import rather than be refused.

--- a/src/dev/tests/services/backupSpaceRestore.test.ts
+++ b/src/dev/tests/services/backupSpaceRestore.test.ts
@@ -1,0 +1,503 @@
+/**
+ * Backup restore — Spaces come back, and an import can never make a device worse.
+ *
+ * Slice 2 of `.agents/issues/.open/2026-08-09-backup-restore-overhaul-design.md`.
+ *
+ * THE PROPERTY UNDER TEST
+ * §4 of the design argues the restore must reconcile **per record**, not per
+ * file: a single import is routinely "restore the DMs, touch none of the Spaces"
+ * for one device and "add three Spaces" for another. The safety property that
+ * falls out is stronger and much easier to test than the case list:
+ *
+ *     an import is ADDITIVE — it can add what is missing, and can never
+ *     overwrite, downgrade or remove what is already there.
+ *
+ * If that holds, a stale backup, a backup restored onto the wrong device, and a
+ * backup imported twice are all automatically safe, with no need to reason about
+ * the file's age. So it is asserted as a property (byte-equality of every
+ * pre-existing key row) rather than case by case.
+ *
+ * The blast radius is why: these are Space private keys, including `owner`, which
+ * has no other copy anywhere. A restore that quietly rolled one back would be
+ * undetectable by using the app.
+ */
+
+import 'fake-indexeddb/auto';
+import { describe, it, expect, beforeEach, beforeAll, vi } from 'vitest';
+import { webcrypto } from 'node:crypto';
+import { i18n } from '@lingui/core';
+import { messages } from '@/i18n/en/messages';
+import { MessageDB } from '@/db/messages';
+import { ConfigService } from '@/services/ConfigService';
+import { BackupService } from '@/services/BackupService';
+import { getDefaultUserConfig } from '@/utils';
+import { QueryClient } from '@tanstack/react-query';
+
+vi.mock('@quilibrium/quilibrium-js-sdk-channels', () => ({
+  channel: {
+    SealHubEnvelope: vi.fn().mockResolvedValue({ sealed: 'hub-envelope' }),
+  },
+  channel_raw: {
+    js_sign_ed448: vi.fn().mockReturnValue(JSON.stringify('mock-signature')),
+    js_verify_ed448: vi.fn().mockReturnValue(JSON.stringify(true)),
+    // Echoes back a manifest for the Space that was actually asked for.
+    //
+    // A fixed spaceId here is NOT good enough, and getting this wrong is subtle:
+    // adoptSpaces persists the decrypted MANIFEST (`saveSpace(manifest)`), so a
+    // stub returning a constant id writes every Space under that one id. The
+    // restore then looks like it worked — the keys land correctly, keyed by the
+    // real id — while `getSpace(realId)` stays empty, so the additive guard never
+    // fires and a re-import restores the same Space forever. Caught by the
+    // import-twice test below, which is precisely why that test exists.
+    //
+    // The stub reads the id back out of the ciphertext the caller passed, which
+    // `getSpaceManifest` below plants for exactly this purpose.
+    js_decrypt_inbox_message: vi.fn((argJson: string) => {
+      const { ciphertext } = JSON.parse(argJson);
+      const spaceId = ciphertext.ciphertext;
+      return JSON.stringify([
+        ...Buffer.from(JSON.stringify({ spaceId, name: 'S' }), 'utf-8'),
+      ]);
+    }),
+    js_generate_ed448: vi.fn().mockReturnValue(
+      JSON.stringify({ public_key: [1, 2, 3], private_key: [4, 5, 6] })
+    ),
+  },
+}));
+
+const SPACE_A = 'QmZDbJ9cy9z1J74DgtGJEQW6yop3j15t6i31KW5McmVKzp';
+const SPACE_B = 'QmbWqM1roW69PooJC96TKePsDk7Ssqz3Sb2syp4H98texr';
+const USER_ADDRESS = 'QmaNDKajtL35LxRkwWgNn2Sz6mxkJRXxmeXwef4pNxBzUq';
+
+const OWNER_KEY_IN_BACKUP = 'aaaa'.repeat(28);
+const OWNER_KEY_ON_DEVICE = 'bbbb'.repeat(28);
+
+const KEYSET = {
+  user_key: {
+    private_key: new Uint8Array(57).fill(7),
+    public_key: new Uint8Array(57).fill(9),
+  },
+} as any;
+
+beforeAll(() => {
+  i18n.load('en', messages);
+  i18n.activate('en');
+
+  for (const target of [globalThis, global]) {
+    Object.defineProperty(target, 'crypto', {
+      value: webcrypto,
+      configurable: true,
+      writable: true,
+    });
+  }
+
+  // ⚠️ HARNESS FIX, NOT A PRODUCT BUG. Do not "fix" the app for this.
+  //
+  // Under vitest's jsdom environment `Buffer instanceof Uint8Array` is FALSE:
+  // jsdom installs its own `Uint8Array` global, while Node's Buffer extends
+  // Node's. multiformats' `coerce()` does an instanceof check and throws
+  // "Unknown type, must be binary type", so `sha256.digest(Buffer.from(...))`
+  // — which the real adopt path calls (ConfigService, inbox address derivation)
+  // — fails here and nowhere else.
+  //
+  // In the browser there is one realm and `Buffer` is a polyfill extending that
+  // same `Uint8Array`, so the instanceof holds. This path also runs in
+  // production on every synced multi-device login, which is independent evidence
+  // it is fine there.
+  //
+  // Point the global at the constructor Buffer actually extends so the two
+  // agree. Scoped to this file; vitest isolates environments per file.
+  Object.defineProperty(globalThis, 'Uint8Array', {
+    value: Object.getPrototypeOf(Buffer.prototype).constructor,
+    configurable: true,
+    writable: true,
+  });
+});
+
+describe('Backup restore — Spaces, additive only', () => {
+  let db: MessageDB;
+  let configService: ConfigService;
+  let backupService: BackupService;
+
+  async function freshDb() {
+    const FDBFactory = (await import('fake-indexeddb/lib/FDBFactory')).default;
+    globalThis.indexedDB = new FDBFactory();
+    const next = new MessageDB();
+    await next.init();
+    return next;
+  }
+
+  function wire(target: MessageDB) {
+    configService = new ConfigService({
+      messageDB: target,
+      apiClient: {
+        postUserSettings: vi.fn().mockResolvedValue({ data: {} }),
+        getUserSettings: vi.fn().mockRejectedValue(new Error('offline')),
+        // The restore re-fetches the Space definition rather than trusting the
+        // file (design §3, step 4) — these are that fetch.
+        getSpace: vi.fn().mockResolvedValue({ data: { registration: 'reg' } }),
+        // Plants the requested spaceId in the ciphertext so the decrypt stub can
+        // return a manifest describing the right Space — see js_decrypt_inbox_message.
+        getSpaceManifest: vi.fn(async (spaceId: string) => ({
+          data: {
+            space_manifest: JSON.stringify({
+              ciphertext: spaceId,
+              initialization_vector: 'iv',
+              associated_data: 'ad',
+            }),
+            ephemeral_public_key: 'aabb',
+          },
+        })),
+        postHubAdd: vi.fn().mockResolvedValue({ data: {} }),
+      },
+      spaceInfo: { current: {} },
+      enqueueOutbound: vi.fn(),
+      sendHubMessage: vi.fn().mockResolvedValue('hub-msg'),
+      queryClient: new QueryClient({
+        defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+      }),
+    } as any);
+
+    backupService = new BackupService({
+      messageDB: target,
+      adoptSpaces: (args) => configService.adoptSpaces(args),
+    });
+  }
+
+  beforeEach(async () => {
+    db = await freshDb();
+    localStorage.clear();
+    wire(db);
+  });
+
+  async function seedSpace(
+    target: MessageDB,
+    spaceId: string,
+    ownerPrivateKey: string
+  ) {
+    await target.saveSpace({ spaceId, name: 'S' } as any);
+    for (const [keyId, privateKey] of [
+      ['config', '11'.repeat(57)],
+      ['hub', '22'.repeat(57)],
+      ['owner', ownerPrivateKey],
+    ] as const) {
+      await target.saveSpaceKey({
+        spaceId,
+        keyId,
+        publicKey: 'pub-' + keyId,
+        privateKey,
+        ...(keyId === 'hub' ? { address: 'QmHub' + spaceId.slice(2, 8) } : {}),
+      } as any);
+    }
+    await target.saveEncryptionState(
+      {
+        conversationId: `${spaceId}/${spaceId}`,
+        inboxId: 'QmInbox' + spaceId.slice(2, 8),
+        state: JSON.stringify({ triple_ratchet: spaceId }),
+        timestamp: 1000,
+      } as any,
+      true
+    );
+  }
+
+  /** Produces a real .qmbak from whatever is currently in `source`. */
+  async function exportFrom(source: MessageDB) {
+    const svc = new BackupService({ messageDB: source });
+    const blob = await svc.exportBackup({ keyset: KEYSET, address: USER_ADDRESS });
+    return blob.text();
+  }
+
+  // ── The headline behaviour ─────────────────────────────────────────────────
+
+  it('restores a Space onto a wiped device', async () => {
+    await seedSpace(db, SPACE_A, OWNER_KEY_IN_BACKUP);
+    const file = await exportFrom(db);
+
+    // Wipe: new device, same account, nothing but the file.
+    db = await freshDb();
+    wire(db);
+    expect(await db.getSpaces()).toHaveLength(0);
+
+    const report = await backupService.importBackup({
+      keyset: KEYSET,
+      fileContent: file,
+    });
+
+    expect(report.spacesRestored).toEqual([SPACE_A]);
+    expect(report.spacesAlreadyPresent).toEqual([]);
+
+    // The irreplaceable part actually landed.
+    const owner = (await db.getSpaceKeys(SPACE_A)).find((k) => k.keyId === 'owner');
+    expect(owner?.privateKey).toBe(OWNER_KEY_IN_BACKUP);
+  });
+
+  // ── The additive property ──────────────────────────────────────────────────
+
+  it('PROPERTY: an older backup cannot overwrite a live Space\'s keys', async () => {
+    // The dangerous case. The file holds one owner key, the device holds a
+    // DIFFERENT one for the same Space — as it would if the key were rotated, or
+    // if the backup were simply stale. The device's copy must win untouched.
+    await seedSpace(db, SPACE_A, OWNER_KEY_IN_BACKUP);
+    const staleFile = await exportFrom(db);
+
+    db = await freshDb();
+    wire(db);
+    await seedSpace(db, SPACE_A, OWNER_KEY_ON_DEVICE);
+
+    const before = await db.getSpaceKeys(SPACE_A);
+
+    const report = await backupService.importBackup({
+      keyset: KEYSET,
+      fileContent: staleFile,
+    });
+
+    expect(report.spacesRestored).toEqual([]);
+    expect(report.spacesAlreadyPresent).toEqual([SPACE_A]);
+
+    // Byte-equality of every pre-existing row, not just the owner key: asserted
+    // as a property so a future change cannot quietly alter a different key.
+    const after = await db.getSpaceKeys(SPACE_A);
+    expect(after).toEqual(before);
+    expect(
+      after.find((k) => k.keyId === 'owner')?.privateKey
+    ).toBe(OWNER_KEY_ON_DEVICE);
+  });
+
+  it('PROPERTY: a partial device gets only what it is missing', async () => {
+    // The case a whole-file "merge vs restore" mode cannot express: within one
+    // import, one Space must be left alone and another must be restored.
+    await seedSpace(db, SPACE_A, OWNER_KEY_IN_BACKUP);
+    await seedSpace(db, SPACE_B, OWNER_KEY_IN_BACKUP);
+    const file = await exportFrom(db);
+
+    db = await freshDb();
+    wire(db);
+    await seedSpace(db, SPACE_A, OWNER_KEY_ON_DEVICE); // has A, missing B
+
+    const report = await backupService.importBackup({
+      keyset: KEYSET,
+      fileContent: file,
+    });
+
+    expect(report.spacesRestored).toEqual([SPACE_B]);
+    expect(report.spacesAlreadyPresent).toEqual([SPACE_A]);
+    expect(
+      (await db.getSpaceKeys(SPACE_A)).find((k) => k.keyId === 'owner')?.privateKey
+    ).toBe(OWNER_KEY_ON_DEVICE);
+  });
+
+  it('PROPERTY: importing the same file twice is a no-op the second time', async () => {
+    await seedSpace(db, SPACE_A, OWNER_KEY_IN_BACKUP);
+    const file = await exportFrom(db);
+
+    db = await freshDb();
+    wire(db);
+
+    const first = await backupService.importBackup({ keyset: KEYSET, fileContent: file });
+    const keysAfterFirst = await db.getSpaceKeys(SPACE_A);
+
+    const second = await backupService.importBackup({ keyset: KEYSET, fileContent: file });
+
+    expect(first.spacesRestored).toEqual([SPACE_A]);
+    expect(second.spacesRestored).toEqual([]);
+    expect(second.spacesAlreadyPresent).toEqual([SPACE_A]);
+    expect(await db.getSpaceKeys(SPACE_A)).toEqual(keysAfterFirst);
+  });
+
+  // ── Refusing to write something broken ─────────────────────────────────────
+
+  it('skips a Space whose encryption state is missing, rather than writing a corrupt one', async () => {
+    // adoptSpaces persists `{ ...encryptionState, inboxId }`. With no state that
+    // writes a row that looks present and can decrypt nothing — worse than not
+    // restoring, because it would also block a later correct restore via the
+    // `if (!existingSpace)` guard.
+    await seedSpace(db, SPACE_A, OWNER_KEY_IN_BACKUP);
+    const file = await exportFrom(db);
+
+    // Strip the Space's encryption state out of the payload, keeping the keys.
+    const svc = new BackupService({ messageDB: db });
+    const parsed = JSON.parse(file);
+    const decrypted = await decryptPayload(parsed);
+    decrypted.encryption_states = decrypted.encryption_states.filter(
+      (s: any) => s.conversationId !== `${SPACE_A}/${SPACE_A}`
+    );
+    const tampered = await reencrypt(parsed, decrypted);
+    void svc;
+
+    db = await freshDb();
+    wire(db);
+
+    const report = await backupService.importBackup({
+      keyset: KEYSET,
+      fileContent: tampered,
+    });
+
+    expect(report.spacesRestored).toEqual([]);
+    expect(report.spacesFailed).toEqual([
+      { spaceId: SPACE_A, reason: 'no encryption state in backup' },
+    ]);
+    expect(await db.getSpaces()).toHaveLength(0);
+  });
+
+  // ── Deletions must survive a restore ───────────────────────────────────────
+
+  describe('a restore must not undo a deletion made after the backup', () => {
+    // The second axis of safety, and the one "additive" does NOT cover.
+    // Additive protects state the user CHANGED; nothing about it protects state
+    // the user REMOVED. Restoring a backup taken before a deletion would
+    // re-`put()` the deleted message and silently undo a deliberate act.
+    const PEER = 'QmcfTNSyig9DSfAqSmWXsGLkLiG9TGS87XXpJy3juKbKSs';
+    const CONV = `${PEER}/${PEER}`;
+
+    async function seedDm(target: MessageDB, messageId: string) {
+      await target.saveConversation({
+        conversationId: CONV,
+        type: 'direct',
+        timestamp: 1,
+        address: PEER,
+        icon: '',
+        displayName: 'Peer',
+      } as any);
+      await target.saveMessage(
+        {
+          messageId,
+          spaceId: PEER,
+          channelId: PEER,
+          createdDate: 1000,
+          content: { type: 'post', body: 'secret' },
+        } as any,
+        PEER,
+        PEER,
+        'direct'
+      );
+    }
+
+    it('a DM deleted after the backup stays deleted', async () => {
+      await seedDm(db, 'msg-regrettable');
+      const file = await exportFrom(db);
+
+      // The user changes their mind and deletes it.
+      await db.deleteMessage('msg-regrettable');
+      expect(await db.getMessage({ spaceId: PEER, channelId: PEER, messageId: 'msg-regrettable' }))
+        .toBeUndefined();
+
+      // Later, they restore the older backup for unrelated reasons.
+      const report = await backupService.importBackup({
+        keyset: KEYSET,
+        fileContent: file,
+      });
+
+      expect(
+        await db.getMessage({ spaceId: PEER, channelId: PEER, messageId: 'msg-regrettable' })
+      ).toBeUndefined();
+      expect(report.messagesSkippedAsDeleted).toBe(1);
+      expect(report.messagesWritten).toBe(0);
+    });
+
+    it('CONTROL: a message that was never deleted DOES restore', async () => {
+      // Without this, the test above would pass just as well if the import
+      // silently wrote nothing at all.
+      await seedDm(db, 'msg-wanted');
+      const file = await exportFrom(db);
+
+      db = await freshDb();
+      wire(db);
+
+      const report = await backupService.importBackup({
+        keyset: KEYSET,
+        fileContent: file,
+      });
+
+      expect(report.messagesWritten).toBe(1);
+      expect(report.messagesSkippedAsDeleted).toBe(0);
+      expect(
+        await db.getMessage({ spaceId: PEER, channelId: PEER, messageId: 'msg-wanted' })
+      ).toBeDefined();
+    });
+
+    it('deleting a DM now writes a tombstone at all', async () => {
+      // Pins the behaviour change this relies on. Tombstones used to be written
+      // for channel messages only, on the reasoning that DMs have no sync
+      // mechanism to re-add them — which backup restore made false.
+      await seedDm(db, 'msg-tombstoned');
+      await db.deleteMessage('msg-tombstoned');
+
+      expect(await db.isMessageDeleted('msg-tombstoned')).toBe(true);
+      expect(await db.getDeletedMessageIds()).toContain('msg-tombstoned');
+    });
+  });
+
+  it('a v1 file restores DMs and reports that Spaces were not in it', async () => {
+    // Regression guard for the back-compat promise: v1 files predate Space key
+    // capture, and must still import rather than be refused.
+    const v1 = await makeV1File();
+
+    const report = await backupService.importBackup({
+      keyset: KEYSET,
+      fileContent: v1,
+    });
+
+    expect(report.version).toBe(1);
+    expect(report.domains.space_keys).toBe(false);
+    expect(report.spacesRestored).toEqual([]);
+    expect(await db.getSpaces()).toHaveLength(0);
+  });
+
+  // ── helpers ────────────────────────────────────────────────────────────────
+
+  async function deriveKey(usage: KeyUsage) {
+    const prefix = new TextEncoder().encode('quorum-backup-v1');
+    const priv = new Uint8Array(KEYSET.user_key.private_key);
+    const combined = new Uint8Array(prefix.length + priv.length);
+    combined.set(prefix);
+    combined.set(priv, prefix.length);
+    const derived = await crypto.subtle.digest('SHA-512', combined);
+    return crypto.subtle.importKey(
+      'raw',
+      derived.slice(0, 32),
+      { name: 'AES-GCM', length: 256 },
+      false,
+      [usage]
+    );
+  }
+
+  async function decryptPayload(file: any) {
+    const plaintext = await crypto.subtle.decrypt(
+      { name: 'AES-GCM', iv: Buffer.from(file.iv, 'hex') },
+      await deriveKey('decrypt'),
+      Buffer.from(file.ciphertext, 'hex')
+    );
+    return JSON.parse(new TextDecoder().decode(plaintext));
+  }
+
+  async function reencrypt(file: any, payload: unknown) {
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+    const encrypted = await crypto.subtle.encrypt(
+      { name: 'AES-GCM', iv },
+      await deriveKey('encrypt'),
+      new TextEncoder().encode(JSON.stringify(payload))
+    );
+    return JSON.stringify({
+      ...file,
+      iv: Buffer.from(iv).toString('hex'),
+      ciphertext: Buffer.from(encrypted).toString('hex'),
+    });
+  }
+
+  async function makeV1File() {
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+    const encrypted = await crypto.subtle.encrypt(
+      { name: 'AES-GCM', iv },
+      await deriveKey('encrypt'),
+      new TextEncoder().encode(
+        JSON.stringify({ messages: [], conversations: [], encryption_states: [] })
+      )
+    );
+    return JSON.stringify({
+      version: 1,
+      iv: Buffer.from(iv).toString('hex'),
+      ciphertext: Buffer.from(encrypted).toString('hex'),
+      createdAt: Date.now(),
+    });
+  }
+});

--- a/src/hooks/business/user/useUserSettings.ts
+++ b/src/hooks/business/user/useUserSettings.ts
@@ -9,7 +9,7 @@ import { type BroadcastSpaceTag, logger } from '@quilibrium/quorum-shared';
 import type { UserConfig } from '../../../db/messages';
 import { DefaultImages } from '../../../utils';
 import { useUploadRegistration } from '../../mutations/useUploadRegistration';
-import { BackupService } from '../../../services/BackupService';
+import { BackupService, type RestoreReport } from '../../../services/BackupService';
 import { PublicProfileService } from '../../../services/PublicProfileService';
 import { QuorumApiClient } from '../../../api/baseTypes';
 import type { PublicProfileResponse } from '../../../api/baseTypes';
@@ -54,7 +54,7 @@ export interface UseUserSettingsReturn {
   removeDevice: (identityKey: string) => void;
   downloadKey: () => Promise<void>;
   exportBackup: () => Promise<void>;
-  importBackup: (file: File) => Promise<{ messagesWritten: number; conversationsWritten: number }>;
+  importBackup: (file: File) => Promise<RestoreReport>;
   getPrivateKeyHex: () => Promise<string>;
   saveDeviceName: (name: string) => Promise<void>;
   deviceNames: { [inboxAddress: string]: string };
@@ -89,7 +89,7 @@ export const useUserSettings = (
     address: currentPasskeyInfo?.address!,
   });
   const { keyset } = useRegistrationContext();
-  const { messageDB, actionQueueService, getConfig, updateUserProfile, setTypingConfig, broadcastDeviceRevocations } = useMessageDB();
+  const { messageDB, actionQueueService, getConfig, adoptSpaces, updateUserProfile, setTypingConfig, broadcastDeviceRevocations } = useMessageDB();
   const queryClient = useQueryClient();
   const uploadRegistration = useUploadRegistration();
 
@@ -289,11 +289,13 @@ export const useUserSettings = (
     window.URL.revokeObjectURL(url);
   };
 
-  const importBackup = async (file: File): Promise<{ messagesWritten: number; conversationsWritten: number }> => {
+  const importBackup = async (file: File): Promise<RestoreReport> => {
     if (!keyset?.userKeyset) throw new Error('No keyset available');
 
     const fileContent = await file.text();
-    const backupService = new BackupService({ messageDB });
+    // adoptSpaces is what turns this from a DM-history restore into a real one.
+    // It is additive: Spaces this device already has are counted and left alone.
+    const backupService = new BackupService({ messageDB, adoptSpaces });
     return backupService.importBackup({
       keyset: keyset.userKeyset,
       fileContent,

--- a/src/services/BackupService.ts
+++ b/src/services/BackupService.ts
@@ -118,12 +118,92 @@ export function domainsOf(
   };
 }
 
+/**
+ * Adopts Spaces from key material, skipping any already present locally.
+ *
+ * Injected rather than imported so BackupService does not depend on
+ * ConfigService. In the app this is `ConfigService.adoptSpaces`, which is the
+ * same path a fresh device runs on every synced login — see its doc comment for
+ * the additive guarantee this relies on.
+ */
+export type AdoptSpacesFn = (args: {
+  spaceKeys: NonNullable<UserConfig['spaceKeys']>;
+}) => Promise<{
+  restored: string[];
+  alreadyPresent: string[];
+  failed: { spaceId: string; reason: string }[];
+}>;
+
+/** Per-domain outcome of a restore, so the caller can say what did NOT happen. */
+export interface RestoreReport {
+  messagesWritten: number;
+  conversationsWritten: number;
+  /** Messages in the file that were NOT written because the user deleted them. */
+  messagesSkippedAsDeleted: number;
+  spacesRestored: string[];
+  spacesAlreadyPresent: string[];
+  spacesFailed: { spaceId: string; reason: string }[];
+  /** Format of the file that was read. */
+  version: BackupVersion;
+  /** What that file captured. */
+  domains: BackupDomains;
+}
+
 export class BackupService {
   private messageDB: MessageDB;
+  private adoptSpaces?: AdoptSpacesFn;
   private isProcessing = false;
 
-  constructor({ messageDB }: { messageDB: MessageDB }) {
+  constructor({
+    messageDB,
+    adoptSpaces,
+  }: {
+    messageDB: MessageDB;
+    /** Omit to disable Space restore entirely (export-only usage, tests). */
+    adoptSpaces?: AdoptSpacesFn;
+  }) {
     this.messageDB = messageDB;
+    this.adoptSpaces = adoptSpaces;
+  }
+
+  /**
+   * Rebuilds the per-Space key bundles that `adoptSpaces` expects from the flat
+   * arrays stored in a v2 payload.
+   *
+   * A Space with no encryption state is dropped rather than passed on: adoptSpaces
+   * would persist `{ ...undefined, inboxId }`, writing a corrupt state row that
+   * looks present and cannot decrypt anything. `saveConfig` filters the same case
+   * on the way out (ConfigService.ts:591), and this is the same rule on the way
+   * back in.
+   */
+  private buildSpaceBundles(payload: BackupPayload): {
+    bundles: NonNullable<UserConfig['spaceKeys']>;
+    skipped: { spaceId: string; reason: string }[];
+  } {
+    const bundles: NonNullable<UserConfig['spaceKeys']> = [];
+    const skipped: { spaceId: string; reason: string }[] = [];
+
+    for (const space of payload.spaces ?? []) {
+      const keys = (payload.space_keys ?? []).filter(
+        (k) => k.spaceId === space.spaceId
+      );
+      const encryptionState = (payload.encryption_states ?? []).find(
+        (s) => s.conversationId === `${space.spaceId}/${space.spaceId}`
+      );
+
+      if (keys.length === 0) {
+        skipped.push({ spaceId: space.spaceId, reason: 'no key material in backup' });
+        continue;
+      }
+      if (!encryptionState) {
+        skipped.push({ spaceId: space.spaceId, reason: 'no encryption state in backup' });
+        continue;
+      }
+
+      bundles.push({ spaceId: space.spaceId, encryptionState, keys });
+    }
+
+    return { bundles, skipped };
   }
 
   /**
@@ -293,14 +373,7 @@ export class BackupService {
   }: {
     keyset: secureChannel.UserKeyset;
     fileContent: string;
-  }): Promise<{
-    messagesWritten: number;
-    conversationsWritten: number;
-    /** Format of the file that was read (1 or 2). */
-    version: BackupVersion;
-    /** What that file captured — lets the caller say what could NOT be restored. */
-    domains: BackupDomains;
-  }> {
+  }): Promise<RestoreReport> {
     if (this.isProcessing) {
       throw new Error('A backup operation is already in progress');
     }
@@ -362,21 +435,61 @@ export class BackupService {
         );
       }
 
-      // 4. Import messages and conversations only.
-      //
-      // Space restore is deliberately NOT wired up here yet — it needs the
-      // additive per-record reconcile from slice 2 of the overhaul design, and
-      // adopting Spaces without it risks overwriting a live device's keys. The
-      // keys are captured now so that files taken from today onward can be
-      // restored once that lands; a file never taken cannot be fixed later.
+      // 4. DM messages and conversations — upsert by id, unchanged and already
+      // idempotent, which is what makes a second import of the same file a no-op.
       const result = await this.messageDB.importDMData({
         messages: payload.messages,
         conversations: payload.conversations,
       });
 
-      logger.log('[BackupService] Import complete:', result);
+      // 5. Spaces — additive only.
+      //
+      // Reconciled per record rather than per file: `adoptSpaces` restores a
+      // Space only when this device does not already have it, so importing into
+      // a live account cannot overwrite working key material, and importing an
+      // OLDER backup cannot roll a Space back. That single property is what makes
+      // every merge case safe (design §4) without asking the file how old it is.
+      //
+      // Encryption states are deliberately still not written for DMs — that is
+      // the SDK-gated slice, see design §6.
+      let spacesRestored: string[] = [];
+      let spacesAlreadyPresent: string[] = [];
+      let spacesFailed: { spaceId: string; reason: string }[] = [];
 
-      return { ...result, version: backupFile.version, domains };
+      if (domains.space_keys && this.adoptSpaces) {
+        const { bundles, skipped } = this.buildSpaceBundles(payload);
+        spacesFailed = skipped;
+
+        if (bundles.length > 0) {
+          const adopted = await this.adoptSpaces({ spaceKeys: bundles });
+          spacesRestored = adopted.restored;
+          spacesAlreadyPresent = adopted.alreadyPresent;
+          spacesFailed = [...skipped, ...adopted.failed];
+        }
+      } else if (!domains.space_keys) {
+        logger.warn(
+          '[BackupService] No Space key material in this backup ' +
+            `(format v${backupFile.version}) — DM history restored, Spaces cannot be.`
+        );
+      }
+
+      const report: RestoreReport = {
+        ...result,
+        spacesRestored,
+        spacesAlreadyPresent,
+        spacesFailed,
+        version: backupFile.version,
+        domains,
+      };
+
+      logger.log('[BackupService] Import complete:', {
+        ...report,
+        spacesRestored: spacesRestored.length,
+        spacesAlreadyPresent: spacesAlreadyPresent.length,
+        spacesFailed: spacesFailed.length,
+      });
+
+      return report;
     } finally {
       this.isProcessing = false;
     }

--- a/src/services/BackupService.ts
+++ b/src/services/BackupService.ts
@@ -316,7 +316,33 @@ export class BackupService {
         const [left, right] = String(s.conversationId).split('/');
         // Anything not of the X/X form is left alone rather than guessed at.
         if (!left || left !== right) return true;
-        return liveSpaceIds.has(left) || liveConversationIds.has(s.conversationId);
+
+        // Belongs to something live: keep, no further questions.
+        if (liveSpaceIds.has(left) || liveConversationIds.has(s.conversationId)) {
+          return true;
+        }
+
+        // Neither a live Space nor a live conversation. Before dropping it, ask
+        // whether it is even a Space state — using the SAME discriminator the
+        // receive path uses to route a frame: a DM state carries `sending_inbox`
+        // and a Space state does not (MessageService `if (keys.sending_inbox)`).
+        //
+        // This closes a gap an earlier version had. A DM's encryption state can
+        // legitimately exist with NO conversation row yet: if the first frame of
+        // a new session is a control message (typing, delivery-ack, profile
+        // update) the handler returns before saveMessage ever creates the row.
+        // Matching on id shape alone would have called that an orphan and
+        // dropped it. Inert today, since DM ratchet state is never restored, but
+        // the comment used to claim a guarantee the code did not provide.
+        try {
+          if (JSON.parse(String(s.state)).sending_inbox) return true;
+        } catch {
+          // Unparseable state: keep it. Dropping something we cannot read is a
+          // guess, and this filter is only ever allowed to remove things it is
+          // certain about.
+          return true;
+        }
+        return false;
       });
 
       const droppedStates = dmData.encryption_states.length - usableStates.length;

--- a/src/services/BackupService.ts
+++ b/src/services/BackupService.ts
@@ -1,15 +1,68 @@
 import { logger } from '@quilibrium/quorum-shared';
 import { channel as secureChannel } from '@quilibrium/quilibrium-js-sdk-channels';
 import { MessageDB, UserConfig, EncryptionState } from '../db/messages';
-import type { Message, Conversation } from '@quilibrium/quorum-shared';
+import type { Message, Conversation, Space } from '@quilibrium/quorum-shared';
+
+/**
+ * Backup format versions.
+ *
+ * v1 — DM messages, DM conversations, encryption states, user_config.
+ * v2 — adds `spaces` + `space_keys`, read from the stores that own them rather
+ *      than from the `user_config.spaceKeys` snapshot, and adds `domains`.
+ *
+ * v1 files exist on users' disks and MUST keep importing. Every reader is
+ * expected to handle both; only the writer is pinned to the newest.
+ */
+export const BACKUP_FORMAT_VERSION = 2;
+export type BackupVersion = 1 | 2;
 
 /** Encrypted backup file structure (written to .qmbak) */
 export interface BackupFile {
-  version: 1;
+  version: BackupVersion;
   iv: string;         // hex-encoded AES-GCM IV
   ciphertext: string; // hex-encoded encrypted payload
   createdAt: number;  // export timestamp
 }
+
+/** Space key material as stored in the `space_keys` object store. */
+export interface BackupSpaceKey {
+  address?: string;
+  spaceId: string;
+  keyId: string;
+  publicKey: string;
+  privateKey: string;
+}
+
+/**
+ * Which domains this file actually captured.
+ *
+ * Distinguishes "this format never captured it" from "captured it, and there was
+ * nothing there" — an empty `space_keys` means something completely different in
+ * a v1 file (never collected) than in a v2 one (the user genuinely has no
+ * Spaces). Without this, a restore cannot honestly tell a user why nothing came
+ * back, which is the failure this whole rework exists to stop repeating.
+ */
+export interface BackupDomains {
+  dm_messages: boolean;
+  dm_conversations: boolean;
+  encryption_states: boolean;
+  user_config: boolean;
+  spaces: boolean;
+  space_keys: boolean;
+  /** Reserved: Space message history is not exported yet (overhaul design slice 5). */
+  space_messages: boolean;
+}
+
+/** What a v1 file captured, for reporting on files written before v2. */
+export const V1_DOMAINS: BackupDomains = {
+  dm_messages: true,
+  dm_conversations: true,
+  encryption_states: true,
+  user_config: true,
+  spaces: false,
+  space_keys: false,
+  space_messages: false,
+};
 
 /** Decrypted backup payload */
 export interface BackupPayload {
@@ -17,6 +70,12 @@ export interface BackupPayload {
   conversations: Conversation[];
   encryption_states: EncryptionState[];
   user_config?: UserConfig;
+  /** v2+ */
+  spaces?: Space[];
+  /** v2+ — the irreplaceable part; see MessageDB.getAllSpaceData. */
+  space_keys?: BackupSpaceKey[];
+  /** v2+ — absent on v1 files, for which V1_DOMAINS applies. */
+  domains?: BackupDomains;
 }
 
 /** Error categories for user-facing messages */
@@ -26,6 +85,38 @@ export type BackupErrorType =
   | 'IMPORT_FAILED';
 
 const BACKUP_DOMAIN_PREFIX = 'quorum-backup-v1';
+
+/**
+ * What a given file actually captured.
+ *
+ * Deliberately NOT "does the array have entries" — an empty `space_keys` in a v2
+ * file means the user has no Spaces, which is a true and useful answer, whereas
+ * in a v1 file it means the format never looked. Falls back to the file's version
+ * when `domains` is absent, so v1 files describe themselves correctly.
+ *
+ * The domain prefix stays `quorum-backup-v1` at every version: it is a key
+ * derivation salt, not a format version, and changing it would make every
+ * existing backup undecryptable.
+ */
+export function domainsOf(
+  file: Pick<BackupFile, 'version'>,
+  payload: BackupPayload
+): BackupDomains {
+  if (payload.domains) return payload.domains;
+  if (file.version === 1) return V1_DOMAINS;
+
+  // A v2 file with no `domains` block shouldn't exist, but infer rather than
+  // throw — a restore that works is worth more than a strict parse.
+  return {
+    dm_messages: Array.isArray(payload.messages),
+    dm_conversations: Array.isArray(payload.conversations),
+    encryption_states: Array.isArray(payload.encryption_states),
+    user_config: !!payload.user_config,
+    spaces: Array.isArray(payload.spaces),
+    space_keys: Array.isArray(payload.space_keys),
+    space_messages: false,
+  };
+}
 
 export class BackupService {
   private messageDB: MessageDB;
@@ -79,14 +170,40 @@ export class BackupService {
     try {
       logger.log('[BackupService] Starting backup export...');
 
-      // 1. Collect all DM data
-      const payload: BackupPayload = await this.messageDB.getAllDMData({ address });
+      // 1. Collect DM data and Space key material.
+      //
+      // Space keys are read from the `space_keys` store, NOT from
+      // `user_config.spaceKeys` — that snapshot is only ever assembled when sync
+      // is on, so exporting via it captures nothing for precisely the users with
+      // no server-side copy to fall back on. See MessageDB.getAllSpaceData.
+      const dmData = await this.messageDB.getAllDMData({ address });
+      const spaceData = await this.messageDB.getAllSpaceData();
+
+      const payload: BackupPayload = {
+        ...dmData,
+        spaces: spaceData.spaces,
+        space_keys: spaceData.space_keys,
+        domains: {
+          dm_messages: true,
+          dm_conversations: true,
+          encryption_states: true,
+          user_config: true,
+          spaces: true,
+          space_keys: true,
+          // Space message history is still out of scope (overhaul design slice 5).
+          // Declared false rather than omitted so a restore can say so plainly
+          // instead of silently restoring nothing.
+          space_messages: false,
+        },
+      };
 
       logger.log('[BackupService] Collected data:', {
         messages: payload.messages.length,
         conversations: payload.conversations.length,
         encryption_states: payload.encryption_states.length,
         hasUserConfig: !!payload.user_config,
+        spaces: payload.spaces?.length ?? 0,
+        space_keys: payload.space_keys?.length ?? 0,
       });
 
       // 2. Encrypt the payload
@@ -103,15 +220,28 @@ export class BackupService {
 
       // 3. Build backup file
       const backupFile: BackupFile = {
-        version: 1,
+        version: BACKUP_FORMAT_VERSION,
         iv: Buffer.from(iv).toString('hex'),
         ciphertext: Buffer.from(encrypted).toString('hex'),
         createdAt: Date.now(),
       };
 
-      logger.log('[BackupService] Backup export complete');
+      const blob = new Blob([JSON.stringify(backupFile)], {
+        type: 'application/json',
+      });
 
-      return new Blob([JSON.stringify(backupFile)], { type: 'application/json' });
+      // Size is logged because nothing else measures it and the budget is real:
+      // ~2 MB of polynomial evals is pre-allocated per CREATED Space and rides in
+      // its encryption state (see 2025-12-09-encryption-state-evals-bloat.md).
+      // A local file has no ~1 MB server ceiling, but a user still has to
+      // download it.
+      logger.log('[BackupService] Backup export complete', {
+        version: backupFile.version,
+        bytes: blob.size,
+        approxMB: Math.round((blob.size / 1024 / 1024) * 100) / 100,
+      });
+
+      return blob;
     } finally {
       this.isProcessing = false;
     }
@@ -132,8 +262,18 @@ export class BackupService {
     if (!parsed || typeof parsed !== 'object') {
       throw new BackupError('INVALID_FORMAT', 'File is not a valid backup');
     }
-    if (parsed.version !== 1) {
-      throw new BackupError('INVALID_FORMAT', `Unknown backup version: ${parsed.version}`);
+    // Both versions are readable. v1 files are on users' disks right now and a
+    // rejected restore is the same outcome as no backup at all; they simply
+    // carry less (see V1_DOMAINS). A version ABOVE the one this build knows is a
+    // different case — that file was written by a newer client and may hold
+    // domains this code would silently drop, so refuse rather than half-restore.
+    if (parsed.version !== 1 && parsed.version !== 2) {
+      throw new BackupError(
+        'INVALID_FORMAT',
+        parsed.version > BACKUP_FORMAT_VERSION
+          ? `This backup was made by a newer version of Quorum (format ${parsed.version}). Update the app, then import it.`
+          : `Unknown backup version: ${parsed.version}`
+      );
     }
     if (typeof parsed.iv !== 'string' || typeof parsed.ciphertext !== 'string' || typeof parsed.createdAt !== 'number') {
       throw new BackupError('INVALID_FORMAT', 'Backup file is missing required fields');
@@ -153,7 +293,14 @@ export class BackupService {
   }: {
     keyset: secureChannel.UserKeyset;
     fileContent: string;
-  }): Promise<{ messagesWritten: number; conversationsWritten: number }> {
+  }): Promise<{
+    messagesWritten: number;
+    conversationsWritten: number;
+    /** Format of the file that was read (1 or 2). */
+    version: BackupVersion;
+    /** What that file captured — lets the caller say what could NOT be restored. */
+    domains: BackupDomains;
+  }> {
     if (this.isProcessing) {
       throw new Error('A backup operation is already in progress');
     }
@@ -192,14 +339,36 @@ export class BackupService {
         throw new BackupError('INVALID_FORMAT', 'Backup payload is missing messages or conversations');
       }
 
+      const domains = domainsOf(backupFile, payload);
+
       logger.log('[BackupService] Decrypted payload:', {
+        version: backupFile.version,
         messages: payload.messages.length,
         conversations: payload.conversations.length,
         encryption_states: payload.encryption_states?.length ?? 0,
         hasUserConfig: !!payload.user_config,
+        spaces: payload.spaces?.length ?? 0,
+        space_keys: payload.space_keys?.length ?? 0,
+        domains,
       });
 
-      // 4. Import messages and conversations only (skip encryption_states and user_config)
+      // A v1 file predates Space key capture entirely, so a user importing one
+      // will get no Spaces back and no error to explain why. Say it here rather
+      // than let it read as a restore that worked.
+      if (!domains.space_keys) {
+        logger.warn(
+          '[BackupService] This backup contains no Space key material ' +
+            `(format v${backupFile.version}). DM history will restore; Spaces cannot.`
+        );
+      }
+
+      // 4. Import messages and conversations only.
+      //
+      // Space restore is deliberately NOT wired up here yet — it needs the
+      // additive per-record reconcile from slice 2 of the overhaul design, and
+      // adopting Spaces without it risks overwriting a live device's keys. The
+      // keys are captured now so that files taken from today onward can be
+      // restored once that lands; a file never taken cannot be fixed later.
       const result = await this.messageDB.importDMData({
         messages: payload.messages,
         conversations: payload.conversations,
@@ -207,7 +376,7 @@ export class BackupService {
 
       logger.log('[BackupService] Import complete:', result);
 
-      return result;
+      return { ...result, version: backupFile.version, domains };
     } finally {
       this.isProcessing = false;
     }

--- a/src/services/BackupService.ts
+++ b/src/services/BackupService.ts
@@ -289,8 +289,71 @@ export class BackupService {
       const dmData = await this.messageDB.getAllDMData({ address });
       const spaceData = await this.messageDB.getAllSpaceData();
 
+      // Drop encryption states that belong to nothing this backup can restore.
+      //
+      // `getAllEncryptionStates()` is an unfiltered getAll, so it also returns
+      // states for Spaces the user no longer has. Those are ~2 MB each for a
+      // created Space (the polynomial eval pool) and they LEAK: a deleted Space
+      // has been observed leaving its state behind rather than removing it (see
+      // 2025-12-09-encryption-state-evals-bloat.md, which measured 19.4 MB local
+      // across 10 states while the UI showed 2 Spaces).
+      //
+      // They are dead weight by construction, not merely wasteful: the restore
+      // rebuilds Spaces by iterating `payload.spaces`, so a state whose Space is
+      // absent can never be matched to anything. MEASURED on a real account —
+      // 3 Spaces and 2 DMs produced a 17.6 MB file, of which roughly 13 MB was
+      // orphan states that no restore could ever use.
+      //
+      // A DM conversationId has the same `X/X` shape as a Space's, so shape
+      // alone cannot tell them apart. Keep a state if X is a live Space OR X/X is
+      // a live conversation; drop only what matches neither.
+      const liveSpaceIds = new Set(spaceData.spaces.map((s) => s.spaceId));
+      const liveConversationIds = new Set(
+        dmData.conversations.map((c) => c.conversationId)
+      );
+
+      const usableStates = dmData.encryption_states.filter((s) => {
+        const [left, right] = String(s.conversationId).split('/');
+        // Anything not of the X/X form is left alone rather than guessed at.
+        if (!left || left !== right) return true;
+        return liveSpaceIds.has(left) || liveConversationIds.has(s.conversationId);
+      });
+
+      const droppedStates = dmData.encryption_states.length - usableStates.length;
+      if (droppedStates > 0) {
+        const bytes =
+          JSON.stringify(dmData.encryption_states).length -
+          JSON.stringify(usableStates).length;
+        logger.log(
+          `[BackupService] skipped ${droppedStates} orphaned encryption state(s) ` +
+            `(~${Math.round(bytes / 1024)} KB) belonging to no current Space or conversation`
+        );
+      }
+
+      // Strip `spaceKeys` from the exported config.
+      //
+      // It is a duplicate, and an expensive one. For a sync-ON user the stored
+      // config carries a per-Space bundle that EMBEDS that Space's encryption
+      // state — the same ~2 MB eval pool already present in `encryption_states`
+      // above. So the pool shipped twice in every backup.
+      //
+      // It is also the unreliable copy: `saveConfig` only assembles it inside the
+      // allowSync branch, which is why a sync-off user's was empty and why this
+      // rework reads `space_keys` from the store that owns it instead (§1 of the
+      // overhaul design). Now that the owning stores are exported directly, the
+      // snapshot has no reader and no reason to travel.
+      //
+      // Everything else in the config — settings, bookmarks, notes, profile — is
+      // kept.
+      const { spaceKeys: _redundantSpaceKeys, ...configWithoutSpaceKeys } =
+        dmData.user_config ?? ({} as NonNullable<typeof dmData.user_config>);
+
       const payload: BackupPayload = {
         ...dmData,
+        user_config: dmData.user_config
+          ? (configWithoutSpaceKeys as typeof dmData.user_config)
+          : undefined,
+        encryption_states: usableStates,
         spaces: spaceData.spaces,
         space_keys: spaceData.space_keys,
         domains: {

--- a/src/services/BackupService.ts
+++ b/src/services/BackupService.ts
@@ -176,14 +176,42 @@ export class BackupService {
    * on the way out (ConfigService.ts:591), and this is the same rule on the way
    * back in.
    */
-  private buildSpaceBundles(payload: BackupPayload): {
+  private async buildSpaceBundles(payload: BackupPayload): Promise<{
     bundles: NonNullable<UserConfig['spaceKeys']>;
     skipped: { spaceId: string; reason: string }[];
-  } {
+  }> {
     const bundles: NonNullable<UserConfig['spaceKeys']> = [];
     const skipped: { spaceId: string; reason: string }[] = [];
 
+    // Departure gate — the deletion axis for Spaces (design §4.1).
+    //
+    // Additive alone would happily re-add a Space the user left or was removed
+    // from after the backup was taken, and `adoptSpaces` re-registers with the
+    // hub, so a kicked user would silently re-announce to the Space that removed
+    // them.
+    //
+    // Gated HERE and not inside `adoptSpaces` on purpose. That method also serves
+    // config sync, where the payload is the account's CURRENT state — published
+    // after the departure — rather than a snapshot from the past. Blocking there
+    // would break the legitimate case of leaving on one device and rejoining on
+    // another. A backup file is stale by construction; a synced config is not.
+    const departed = new Map(
+      (await this.messageDB.getDepartedSpaces()).map((d) => [d.spaceId, d])
+    );
+
     for (const space of payload.spaces ?? []) {
+      const departure = departed.get(space.spaceId);
+      if (departure) {
+        skipped.push({
+          spaceId: space.spaceId,
+          reason:
+            departure.reason === 'removed'
+              ? 'you were removed from this Space after this backup was taken'
+              : 'you left this Space after this backup was taken',
+        });
+        continue;
+      }
+
       const keys = (payload.space_keys ?? []).filter(
         (k) => k.spaceId === space.spaceId
       );
@@ -457,7 +485,7 @@ export class BackupService {
       let spacesFailed: { spaceId: string; reason: string }[] = [];
 
       if (domains.space_keys && this.adoptSpaces) {
-        const { bundles, skipped } = this.buildSpaceBundles(payload);
+        const { bundles, skipped } = await this.buildSpaceBundles(payload);
         spacesFailed = skipped;
 
         if (bundles.length > 0) {

--- a/src/services/BackupService.ts
+++ b/src/services/BackupService.ts
@@ -140,6 +140,8 @@ export interface RestoreReport {
   conversationsWritten: number;
   /** Messages in the file that were NOT written because the user deleted them. */
   messagesSkippedAsDeleted: number;
+  /** Conversations in the file NOT written because the user deleted the chat. */
+  conversationsSkippedAsDeleted: number;
   spacesRestored: string[];
   spacesAlreadyPresent: string[];
   spacesFailed: { spaceId: string; reason: string }[];
@@ -465,10 +467,23 @@ export class BackupService {
 
       // 4. DM messages and conversations — upsert by id, unchanged and already
       // idempotent, which is what makes a second import of the same file a no-op.
-      const result = await this.messageDB.importDMData({
-        messages: payload.messages,
-        conversations: payload.conversations,
-      });
+      let result;
+      try {
+        result = await this.messageDB.importDMData({
+          messages: payload.messages,
+          conversations: payload.conversations,
+        });
+      } catch (e) {
+        // Typed, so the UI can distinguish "this file is wrong" from "this device
+        // could not write it" — previously both surfaced as whatever raw string
+        // IndexedDB happened to produce.
+        throw new BackupError(
+          'IMPORT_FAILED',
+          e instanceof Error
+            ? `Could not write the restored data: ${e.message}`
+            : 'Could not write the restored data'
+        );
+      }
 
       // 5. Spaces — additive only.
       //
@@ -484,21 +499,51 @@ export class BackupService {
       let spacesAlreadyPresent: string[] = [];
       let spacesFailed: { spaceId: string; reason: string }[] = [];
 
-      if (domains.space_keys && this.adoptSpaces) {
-        const { bundles, skipped } = await this.buildSpaceBundles(payload);
-        spacesFailed = skipped;
-
-        if (bundles.length > 0) {
-          const adopted = await this.adoptSpaces({ spaceKeys: bundles });
-          spacesRestored = adopted.restored;
-          spacesAlreadyPresent = adopted.alreadyPresent;
-          spacesFailed = [...skipped, ...adopted.failed];
-        }
-      } else if (!domains.space_keys) {
+      if (!domains.space_keys) {
         logger.warn(
           '[BackupService] No Space key material in this backup ' +
             `(format v${backupFile.version}) — DM history restored, Spaces cannot be.`
         );
+      } else if (!this.adoptSpaces) {
+        // The file HAS Space keys but this instance cannot adopt them. Previously
+        // neither branch fired here, so the restore silently ignored them and the
+        // report said nothing at all — the same silent gap this rework exists to
+        // close, just one layer up.
+        logger.warn(
+          '[BackupService] Backup contains Space keys but no adoptSpaces was ' +
+            'provided — Spaces were not restored.'
+        );
+        spacesFailed = (payload.spaces ?? []).map((s) => ({
+          spaceId: s.spaceId,
+          reason: 'Space restore is not available in this context',
+        }));
+      } else {
+        // Wrapped so a Space-restore failure cannot erase a DM restore that has
+        // ALREADY been written to disk at step 4. Without this the whole promise
+        // rejected and the user was told "Failed to import backup" about an
+        // import whose messages had landed and were staying — which reads as
+        // total failure and invites a needless retry. Per-domain outcomes, in
+        // keeping with the rest of the design.
+        try {
+          const { bundles, skipped } = await this.buildSpaceBundles(payload);
+          spacesFailed = skipped;
+
+          if (bundles.length > 0) {
+            const adopted = await this.adoptSpaces({ spaceKeys: bundles });
+            spacesRestored = adopted.restored;
+            spacesAlreadyPresent = adopted.alreadyPresent;
+            spacesFailed = [...skipped, ...adopted.failed];
+          }
+        } catch (e) {
+          logger.error('[BackupService] Space restore failed', e);
+          spacesFailed = [
+            ...spacesFailed,
+            {
+              spaceId: '*',
+              reason: e instanceof Error ? e.message : String(e),
+            },
+          ];
+        }
       }
 
       const report: RestoreReport = {

--- a/src/services/ConfigService.ts
+++ b/src/services/ConfigService.ts
@@ -369,19 +369,6 @@ export class ConfigService {
             continue;
           }
 
-          for (const key of space.keys) {
-            // Per-device-signing flip (Option A): a fresh device no longer
-            // adopts the shared `signing` slot. It signs with its own
-            // per-device `inbox` key (getSigningKey falls through to it) and
-            // announces that key via announce-keys. Skipping the synced
-            // `signing` key here — and NOT deriving one from `inbox` below —
-            // is what puts a fresh second device on its own key. Devices set
-            // up before this flip keep any previously-saved `signing` slot
-            // untouched (getSigningKey still reads it), so nothing regresses.
-            if (key.keyId === 'signing') continue;
-            await this.messageDB.saveSpaceKey(key);
-          }
-
           const reg = (await this.apiClient.getSpace(space.spaceId)).data;
           this.spaceInfo.current[space.spaceId] = reg;
 
@@ -432,6 +419,26 @@ export class ConfigService {
               )
             ).toString('utf-8')
           ) as Space;
+
+          // Written only once the manifest has decrypted — i.e. once we know
+          // this Space can actually be rebuilt. Saving them earlier left
+          // orphaned key rows for a Space that never got a `spaces` row: rows
+          // nothing renders, nothing exports (getAllSpaceData iterates Spaces,
+          // not keys), and nothing cleans up. The kicked-user case reaches
+          // exactly that path, because a kick rotates the config key and the
+          // old one can no longer open the manifest.
+          for (const key of space.keys) {
+            // Per-device-signing flip (Option A): a fresh device no longer
+            // adopts the shared `signing` slot. It signs with its own
+            // per-device `inbox` key (getSigningKey falls through to it) and
+            // announces that key via announce-keys. Skipping the synced
+            // `signing` key here — and NOT deriving one from `inbox` below —
+            // is what puts a fresh second device on its own key. Devices set
+            // up before this flip keep any previously-saved `signing` slot
+            // untouched (getSigningKey still reads it), so nothing regresses.
+            if (key.keyId === 'signing') continue;
+            await this.messageDB.saveSpaceKey(key);
+          }
 
           const ip = ch.js_generate_ed448();
           const inboxPair = JSON.parse(ip);
@@ -530,9 +537,23 @@ export class ConfigService {
           // Counted, not rethrown: one unreachable Space must not abandon the
           // rest of the batch. Unchanged behaviour — only now it is reportable
           // instead of visible solely in the console.
+          //
+          // The manifest-decrypt failure is named specially because it is the
+          // EXPECTED outcome for someone who was kicked: a kick rotates the
+          // Space's config key and re-encrypts the manifest to it, so the key in
+          // an older backup can no longer open it. Measured by the space-kick
+          // harness scenario, which saw this surface to the user as
+          // `Unexpected token 'D', "Decryption"... is not valid JSON` — the raw
+          // JSON.parse error from the SDK's failure string. Accurate, useless.
+          const raw = e instanceof Error ? e.message : String(e);
+          const looksLikeDecryptFailure =
+            /decryption|is not valid JSON|aead/i.test(raw);
           failed.push({
             spaceId: space.spaceId,
-            reason: e instanceof Error ? e.message : String(e),
+            reason: looksLikeDecryptFailure
+              ? 'you no longer have access to this Space — its keys were changed, ' +
+                'which happens when a member is removed'
+              : raw,
           });
         }
       }

--- a/src/services/ConfigService.ts
+++ b/src/services/ConfigService.ts
@@ -395,30 +395,58 @@ export class ConfigService {
             initialization_vector: string;
             associated_data: string;
           };
-          const manifest = JSON.parse(
-            Buffer.from(
-              JSON.parse(
-                ch.js_decrypt_inbox_message(
-                  JSON.stringify({
-                    inbox_private_key: [
-                      ...new Uint8Array(
-                        Buffer.from(config.privateKey, 'hex')
-                      ),
-                    ],
-                    ephemeral_public_key: [
-                      ...new Uint8Array(
-                        Buffer.from(
-                          manifestPayload.data.ephemeral_public_key,
-                          'hex'
-                        )
-                      ),
-                    ],
-                    ciphertext: ciphertext,
-                  })
+          // Decrypt in its OWN try, so "we cannot open this manifest" can be
+          // told apart from every other way this block can fail.
+          //
+          // This used to be reported by pattern-matching the outer catch's error
+          // text for /decryption|is not valid JSON|aead/. That is far too broad:
+          // the outer try also covers two API calls and two other JSON.parse
+          // calls, so an outage returning HTML would fail with "is not valid
+          // JSON" and be reported as "you no longer have access to this Space".
+          // Telling someone a RECOVERABLE Space is permanently gone is worse
+          // than the raw error it replaced, because they stop retrying.
+          //
+          // Scope, not pattern: only a failure here means the key cannot open
+          // the manifest, which is what being removed from a Space looks like.
+          let manifest: Space;
+          try {
+            manifest = JSON.parse(
+              Buffer.from(
+                JSON.parse(
+                  ch.js_decrypt_inbox_message(
+                    JSON.stringify({
+                      inbox_private_key: [
+                        ...new Uint8Array(
+                          Buffer.from(config.privateKey, 'hex')
+                        ),
+                      ],
+                      ephemeral_public_key: [
+                        ...new Uint8Array(
+                          Buffer.from(
+                            manifestPayload.data.ephemeral_public_key,
+                            'hex'
+                          )
+                        ),
+                      ],
+                      ciphertext: ciphertext,
+                    })
+                  )
                 )
-              )
-            ).toString('utf-8')
-          ) as Space;
+              ).toString('utf-8')
+            ) as Space;
+          } catch (decryptError) {
+            logger.warn(
+              t`Could not decrypt Space manifest — key no longer opens it`,
+              decryptError
+            );
+            failed.push({
+              spaceId: space.spaceId,
+              reason:
+                'you no longer have access to this Space — its keys were changed, ' +
+                'which happens when a member is removed',
+            });
+            continue;
+          }
 
           // Written only once the manifest has decrypted — i.e. once we know
           // this Space can actually be rebuilt. Saving them earlier left
@@ -545,15 +573,13 @@ export class ConfigService {
           // harness scenario, which saw this surface to the user as
           // `Unexpected token 'D', "Decryption"... is not valid JSON` — the raw
           // JSON.parse error from the SDK's failure string. Accurate, useless.
-          const raw = e instanceof Error ? e.message : String(e);
-          const looksLikeDecryptFailure =
-            /decryption|is not valid JSON|aead/i.test(raw);
+          // Reported verbatim. The one failure worth translating — the manifest
+          // not opening — is caught at its own call site above, so anything
+          // reaching here is a genuine error the user should see as-is rather
+          // than have guessed at.
           failed.push({
             spaceId: space.spaceId,
-            reason: looksLikeDecryptFailure
-              ? 'you no longer have access to this Space — its keys were changed, ' +
-                'which happens when a member is removed'
-              : raw,
+            reason: e instanceof Error ? e.message : String(e),
           });
         }
       }

--- a/src/services/ConfigService.ts
+++ b/src/services/ConfigService.ts
@@ -332,7 +332,21 @@ export class ConfigService {
     const failed: { spaceId: string; reason: string }[] = [];
 
     for (const space of spaceKeys) {
-      const existingSpace = await this.messageDB.getSpace(space.spaceId);
+      // Inside its own try: this read used to sit outside the per-Space catch
+      // below, so a single transient IndexedDB failure threw straight out of
+      // adoptSpaces and discarded the results of every Space already processed
+      // and persisted — the exact opposite of the isolation the catch promises.
+      let existingSpace: Space | null;
+      try {
+        existingSpace = await this.messageDB.getSpace(space.spaceId);
+      } catch (e) {
+        failed.push({
+          spaceId: space.spaceId,
+          reason: e instanceof Error ? e.message : String(e),
+        });
+        continue;
+      }
+
       if (existingSpace) {
         // The additive guarantee. Counted rather than silently ignored so a
         // restore can report "3 already present" instead of implying it did
@@ -376,6 +390,14 @@ export class ConfigService {
           );
           if (!manifestPayload) {
             logger.warn(t`Could not obtain manifest for Space`);
+            // Reported, like every other failure branch in this loop. Without
+            // this the Space fell out of restored/alreadyPresent/failed alike and
+            // vanished from the restore report — while its keys, saved a few
+            // lines above, were already on disk with no `spaces` row to render.
+            failed.push({
+              spaceId: space.spaceId,
+              reason: 'could not fetch Space manifest',
+            });
             continue;
           }
 

--- a/src/services/ConfigService.ts
+++ b/src/services/ConfigService.ts
@@ -113,173 +113,8 @@ export class ConfigService {
       config.items = validateItems(config.items);
     }
 
-    for (const space of config.spaceKeys ?? []) {
-      const existingSpace = await this.messageDB.getSpace(space.spaceId);
-      if (!existingSpace) {
-        try {
-          const config = space.keys.find((k) => k.keyId == 'config');
-          if (!config) {
-            logger.warn(t`Decrypted Space with no known config key`);
-            continue;
-          }
-
-          const hub = space.keys.find((k) => k.keyId == 'hub');
-          if (!hub) {
-            logger.warn(t`Decrypted Space with no known hub key`);
-            continue;
-          }
-
-          for (const key of space.keys) {
-            // Per-device-signing flip (Option A): a fresh device no longer
-            // adopts the shared `signing` slot. It signs with its own
-            // per-device `inbox` key (getSigningKey falls through to it) and
-            // announces that key via announce-keys. Skipping the synced
-            // `signing` key here — and NOT deriving one from `inbox` below —
-            // is what puts a fresh second device on its own key. Devices set
-            // up before this flip keep any previously-saved `signing` slot
-            // untouched (getSigningKey still reads it), so nothing regresses.
-            if (key.keyId === 'signing') continue;
-            await this.messageDB.saveSpaceKey(key);
-          }
-
-          const reg = (await this.apiClient.getSpace(space.spaceId)).data;
-          this.spaceInfo.current[space.spaceId] = reg;
-
-          const manifestPayload = await this.apiClient.getSpaceManifest(
-            space.spaceId
-          );
-          if (!manifestPayload) {
-            logger.warn(t`Could not obtain manifest for Space`);
-            continue;
-          }
-
-          const ciphertext = JSON.parse(
-            manifestPayload.data.space_manifest
-          ) as {
-            ciphertext: string;
-            initialization_vector: string;
-            associated_data: string;
-          };
-          const manifest = JSON.parse(
-            Buffer.from(
-              JSON.parse(
-                ch.js_decrypt_inbox_message(
-                  JSON.stringify({
-                    inbox_private_key: [
-                      ...new Uint8Array(
-                        Buffer.from(config.privateKey, 'hex')
-                      ),
-                    ],
-                    ephemeral_public_key: [
-                      ...new Uint8Array(
-                        Buffer.from(
-                          manifestPayload.data.ephemeral_public_key,
-                          'hex'
-                        )
-                      ),
-                    ],
-                    ciphertext: ciphertext,
-                  })
-                )
-              )
-            ).toString('utf-8')
-          ) as Space;
-
-          const ip = ch.js_generate_ed448();
-          const inboxPair = JSON.parse(ip);
-          const ih = await sha256.digest(
-            Buffer.from(new Uint8Array(inboxPair.public_key))
-          );
-          const inboxAddress = base58btc.baseEncode(ih.bytes);
-
-          await this.messageDB.saveSpace(manifest);
-          await this.messageDB.saveEncryptionState(
-            { ...space.encryptionState, inboxId: inboxAddress },
-            true
-          );
-
-          await this.apiClient.postHubAdd({
-            hub_address: hub.address!,
-            hub_public_key: hub.publicKey,
-            hub_signature: Buffer.from(
-              JSON.parse(
-                ch.js_sign_ed448(
-                  Buffer.from(hub.privateKey, 'hex').toString('base64'),
-                  Buffer.from(
-                    new Uint8Array([
-                      ...new Uint8Array(
-                        Buffer.from(
-                          'add' +
-                            Buffer.from(
-                              new Uint8Array(inboxPair.public_key)
-                            ).toString('hex'),
-                          'utf-8'
-                        )
-                      ),
-                    ])
-                  ).toString('base64')
-                )
-              ),
-              'base64'
-            ).toString('hex'),
-            inbox_public_key: Buffer.from(
-              new Uint8Array(inboxPair.public_key)
-            ).toString('hex'),
-            inbox_signature: Buffer.from(
-              JSON.parse(
-                ch.js_sign_ed448(
-                  Buffer.from(new Uint8Array(inboxPair.private_key)).toString(
-                    'base64'
-                  ),
-                  Buffer.from(
-                    new Uint8Array([
-                      ...new Uint8Array(
-                        Buffer.from('add' + hub.publicKey, 'utf-8')
-                      ),
-                    ])
-                  ).toString('base64')
-                )
-              ),
-              'base64'
-            ).toString('hex'),
-          });
-
-          this.enqueueOutbound(async () => [
-            JSON.stringify({
-              type: 'listen',
-              inbox_addresses: [inboxAddress],
-            }),
-          ]);
-
-          await this.messageDB.saveSpaceKey({
-            spaceId: space.spaceId,
-            keyId: 'inbox',
-            address: inboxAddress,
-            publicKey: Buffer.from(
-              new Uint8Array(inboxPair.public_key)
-            ).toString('hex'),
-            privateKey: Buffer.from(
-              new Uint8Array(inboxPair.private_key)
-            ).toString('hex'),
-          });
-
-          this.enqueueOutbound(async () => [
-            await this.sendHubMessage(
-              space.spaceId,
-              JSON.stringify({
-                type: 'control',
-                message: {
-                  type: 'sync',
-                  inboxAddress: inboxAddress,
-                },
-              })
-            ),
-          ]);
-        } catch (e) {
-          console.error(t`Could not add Space`, e);
-        }
-      }
-    }
+    // Additive by construction: adoptSpaces skips any Space already present.
+    await this.adoptSpaces({ spaceKeys: config.spaceKeys ?? [] });
 
     // Merge deviceNames: additive union so names from all devices survive concurrent saves
     const deviceNamesMerge = mergeDeviceNames(
@@ -464,6 +299,224 @@ export class ConfigService {
       () => config
     );
     return config;
+  }
+
+  /**
+   * Adopt Spaces from key material, skipping any that already exist locally.
+   *
+   * Extracted from getConfig so the backup restore path can reuse it verbatim
+   * rather than reimplement it. Restoring a Space from a `.qmbak` is the SAME
+   * operation as adopting one from a synced config — only the source of the key
+   * bundle differs — and this is the version that has run on every multi-device
+   * login for months.
+   *
+   * **Additive by construction.** The `if (!existingSpace)` guard is the whole
+   * safety property: a Space this device already holds is never touched, so its
+   * keys cannot be overwritten by an older bundle. Any caller relying on that
+   * (the backup import does) must not bypass this method.
+   *
+   * The Space *definition* is re-fetched from the API, never taken from the
+   * caller — only key material is trusted from the bundle.
+   */
+  async adoptSpaces({
+    spaceKeys,
+  }: {
+    spaceKeys: NonNullable<UserConfig['spaceKeys']>;
+  }): Promise<{
+    restored: string[];
+    alreadyPresent: string[];
+    failed: { spaceId: string; reason: string }[];
+  }> {
+    const restored: string[] = [];
+    const alreadyPresent: string[] = [];
+    const failed: { spaceId: string; reason: string }[] = [];
+
+    for (const space of spaceKeys) {
+      const existingSpace = await this.messageDB.getSpace(space.spaceId);
+      if (existingSpace) {
+        // The additive guarantee. Counted rather than silently ignored so a
+        // restore can report "3 already present" instead of implying it did
+        // nothing.
+        alreadyPresent.push(space.spaceId);
+      }
+      if (!existingSpace) {
+        try {
+          const config = space.keys.find((k) => k.keyId == 'config');
+          if (!config) {
+            logger.warn(t`Decrypted Space with no known config key`);
+            failed.push({ spaceId: space.spaceId, reason: 'missing config key' });
+            continue;
+          }
+
+          const hub = space.keys.find((k) => k.keyId == 'hub');
+          if (!hub) {
+            logger.warn(t`Decrypted Space with no known hub key`);
+            failed.push({ spaceId: space.spaceId, reason: 'missing hub key' });
+            continue;
+          }
+
+          for (const key of space.keys) {
+            // Per-device-signing flip (Option A): a fresh device no longer
+            // adopts the shared `signing` slot. It signs with its own
+            // per-device `inbox` key (getSigningKey falls through to it) and
+            // announces that key via announce-keys. Skipping the synced
+            // `signing` key here — and NOT deriving one from `inbox` below —
+            // is what puts a fresh second device on its own key. Devices set
+            // up before this flip keep any previously-saved `signing` slot
+            // untouched (getSigningKey still reads it), so nothing regresses.
+            if (key.keyId === 'signing') continue;
+            await this.messageDB.saveSpaceKey(key);
+          }
+
+          const reg = (await this.apiClient.getSpace(space.spaceId)).data;
+          this.spaceInfo.current[space.spaceId] = reg;
+
+          const manifestPayload = await this.apiClient.getSpaceManifest(
+            space.spaceId
+          );
+          if (!manifestPayload) {
+            logger.warn(t`Could not obtain manifest for Space`);
+            continue;
+          }
+
+          const ciphertext = JSON.parse(
+            manifestPayload.data.space_manifest
+          ) as {
+            ciphertext: string;
+            initialization_vector: string;
+            associated_data: string;
+          };
+          const manifest = JSON.parse(
+            Buffer.from(
+              JSON.parse(
+                ch.js_decrypt_inbox_message(
+                  JSON.stringify({
+                    inbox_private_key: [
+                      ...new Uint8Array(
+                        Buffer.from(config.privateKey, 'hex')
+                      ),
+                    ],
+                    ephemeral_public_key: [
+                      ...new Uint8Array(
+                        Buffer.from(
+                          manifestPayload.data.ephemeral_public_key,
+                          'hex'
+                        )
+                      ),
+                    ],
+                    ciphertext: ciphertext,
+                  })
+                )
+              )
+            ).toString('utf-8')
+          ) as Space;
+
+          const ip = ch.js_generate_ed448();
+          const inboxPair = JSON.parse(ip);
+          const ih = await sha256.digest(
+            Buffer.from(new Uint8Array(inboxPair.public_key))
+          );
+          const inboxAddress = base58btc.baseEncode(ih.bytes);
+
+          await this.messageDB.saveSpace(manifest);
+          await this.messageDB.saveEncryptionState(
+            { ...space.encryptionState, inboxId: inboxAddress },
+            true
+          );
+
+          await this.apiClient.postHubAdd({
+            hub_address: hub.address!,
+            hub_public_key: hub.publicKey,
+            hub_signature: Buffer.from(
+              JSON.parse(
+                ch.js_sign_ed448(
+                  Buffer.from(hub.privateKey, 'hex').toString('base64'),
+                  Buffer.from(
+                    new Uint8Array([
+                      ...new Uint8Array(
+                        Buffer.from(
+                          'add' +
+                            Buffer.from(
+                              new Uint8Array(inboxPair.public_key)
+                            ).toString('hex'),
+                          'utf-8'
+                        )
+                      ),
+                    ])
+                  ).toString('base64')
+                )
+              ),
+              'base64'
+            ).toString('hex'),
+            inbox_public_key: Buffer.from(
+              new Uint8Array(inboxPair.public_key)
+            ).toString('hex'),
+            inbox_signature: Buffer.from(
+              JSON.parse(
+                ch.js_sign_ed448(
+                  Buffer.from(new Uint8Array(inboxPair.private_key)).toString(
+                    'base64'
+                  ),
+                  Buffer.from(
+                    new Uint8Array([
+                      ...new Uint8Array(
+                        Buffer.from('add' + hub.publicKey, 'utf-8')
+                      ),
+                    ])
+                  ).toString('base64')
+                )
+              ),
+              'base64'
+            ).toString('hex'),
+          });
+
+          this.enqueueOutbound(async () => [
+            JSON.stringify({
+              type: 'listen',
+              inbox_addresses: [inboxAddress],
+            }),
+          ]);
+
+          await this.messageDB.saveSpaceKey({
+            spaceId: space.spaceId,
+            keyId: 'inbox',
+            address: inboxAddress,
+            publicKey: Buffer.from(
+              new Uint8Array(inboxPair.public_key)
+            ).toString('hex'),
+            privateKey: Buffer.from(
+              new Uint8Array(inboxPair.private_key)
+            ).toString('hex'),
+          });
+
+          this.enqueueOutbound(async () => [
+            await this.sendHubMessage(
+              space.spaceId,
+              JSON.stringify({
+                type: 'control',
+                message: {
+                  type: 'sync',
+                  inboxAddress: inboxAddress,
+                },
+              })
+            ),
+          ]);
+
+          restored.push(space.spaceId);
+        } catch (e) {
+          console.error(t`Could not add Space`, e);
+          // Counted, not rethrown: one unreachable Space must not abandon the
+          // rest of the batch. Unchanged behaviour — only now it is reportable
+          // instead of visible solely in the console.
+          failed.push({
+            spaceId: space.spaceId,
+            reason: e instanceof Error ? e.message : String(e),
+          });
+        }
+      }
+    }
+
+    return { restored, alreadyPresent, failed };
   }
 
   /**

--- a/src/services/InvitationService.ts
+++ b/src/services/InvitationService.ts
@@ -764,6 +764,10 @@ export class InvitationService {
       });
       // Clear any tombstones from a previous join to allow messages to sync
       await this.messageDB.clearTombstonesForSpace(space.spaceId);
+      // Same reasoning one level up: the user is in this Space again, so any
+      // record of having left it is no longer true and must not keep blocking a
+      // backup restore of it.
+      await this.messageDB.clearSpaceDeparture(space.spaceId);
       await this.messageDB.saveSpace(space);
       let config = await this.getConfig({
         address: currentPasskeyInfo.address,

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -5636,6 +5636,15 @@ export class MessageService {
                     () => userConfig
                   );
                   await this.messageDB.deleteSpace(spaceId);
+                  // Departure tombstone: we were removed. Without this a later
+                  // backup restore re-adds the Space and calls postHubAdd, so a
+                  // kicked user silently re-announces to the Space that removed
+                  // them — the same class of mistake as the convergence timer
+                  // below, just delayed by however long until they restore.
+                  await this.messageDB.markSpaceDeparted({
+                    spaceId,
+                    reason: 'removed',
+                  });
                   // The space is gone from under us. Any armed convergence
                   // timer would fire ~20s from now against a deleted space and
                   // broadcast a sync-request into a space we were just removed

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -5635,13 +5635,14 @@ export class MessageService {
                     buildConfigKey({ userAddress: self_address }),
                     () => userConfig
                   );
-                  await this.messageDB.deleteSpace(spaceId);
-                  // Departure tombstone: we were removed. Without this a later
-                  // backup restore re-adds the Space and calls postHubAdd, so a
-                  // kicked user silently re-announces to the Space that removed
-                  // them — the same class of mistake as the convergence timer
-                  // below, just delayed by however long until they restore.
-                  await this.messageDB.markSpaceDeparted({
+                  // Deletion and departure record in ONE transaction. Without
+                  // the record a later backup restore re-adds the Space and
+                  // calls postHubAdd, so a kicked user re-announces to the
+                  // Space that removed them — the same class of mistake as the
+                  // convergence timer below, delayed until they restore. Two
+                  // sequential writes would leave a crash window that produces
+                  // exactly that state; see deleteSpaceAsDeparture.
+                  await this.messageDB.deleteSpaceAsDeparture({
                     spaceId,
                     reason: 'removed',
                   });

--- a/src/services/SpaceService.ts
+++ b/src/services/SpaceService.ts
@@ -682,12 +682,11 @@ export class SpaceService {
       buildConfigKey({ userAddress: this.selfAddress }),
       () => userConfig
     );
-    await this.messageDB.deleteSpace(spaceId);
-    // Departure tombstone: a genuine leave/delete, so a later backup restore
-    // must not re-add this Space or re-register with its hub. Recorded here
-    // rather than inside deleteSpace, which is also used for a space-address
-    // migration — see markSpaceDeparted.
-    await this.messageDB.markSpaceDeparted({ spaceId, reason: 'left' });
+    // Deletion and departure record in ONE transaction. Two sequential writes
+    // leave a window where an interruption deletes the Space without recording
+    // why, and a later backup restore would then re-add it and re-register with
+    // its hub. See deleteSpaceAsDeparture.
+    await this.messageDB.deleteSpaceAsDeparture({ spaceId, reason: 'left' });
     // The sidebar and the Spaces list read the ['Spaces'] query, not the
     // config query updated above, so without this they keep serving the
     // cached pre-delete list until a page reload. createSpace already does

--- a/src/services/SpaceService.ts
+++ b/src/services/SpaceService.ts
@@ -683,6 +683,11 @@ export class SpaceService {
       () => userConfig
     );
     await this.messageDB.deleteSpace(spaceId);
+    // Departure tombstone: a genuine leave/delete, so a later backup restore
+    // must not re-add this Space or re-register with its hub. Recorded here
+    // rather than inside deleteSpace, which is also used for a space-address
+    // migration — see markSpaceDeparted.
+    await this.messageDB.markSpaceDeparted({ spaceId, reason: 'left' });
     // The sidebar and the Spaces list read the ['Spaces'] query, not the
     // config query updated above, so without this they keep serving the
     // cached pre-delete list until a page reload. createSpace already does

--- a/src/services/SyncService.ts
+++ b/src/services/SyncService.ts
@@ -228,6 +228,21 @@ export class SyncService {
     const channelId = space?.defaultChannelId || spaceId;
     const inboxKey = await this.messageDB.getSpaceKey(spaceId, 'inbox');
 
+    // The Space can disappear between a sync being armed and it firing — being
+    // kicked deletes the Space and all its keys, and an already-scheduled sync
+    // then lands here with nothing to sign with. `inboxKey.address!` below
+    // asserts non-null, so this threw an UNHANDLED rejection rather than
+    // failing quietly. Surfaced by the space-kick harness scenario.
+    //
+    // Returning matches what this method already does when there are no sync
+    // candidates: there is nothing to sync into a Space we are no longer in.
+    if (!inboxKey) {
+      logger.log(
+        `[SyncService] initiateSync: no inbox key for ${spaceId} — Space is gone, skipping`
+      );
+      return;
+    }
+
     // Get peer IDs
     const encryptionState = await this.messageDB.getEncryptionStates({
       conversationId: spaceId + '/' + spaceId,


### PR DESCRIPTION
A `.qmbak` backup could not restore a single Space, including Spaces the user created and owns.

The export took Space key material from `user_config.spaceKeys`, a snapshot `saveConfig` only assembles inside the `allowSync` branch. `getDefaultUserConfig` initialises it to `[]`, so a user who never enabled sync exported a file containing a list of space ids and no key material for any of them: no config key, no hub key, and no `owner` key, which is the sole proof of Space ownership and has no other copy anywhere. Precisely the users with no server-side fallback got the emptiest file.

## What changed

**Export reads the stores that own the data.** `space_keys` and `spaces` are read directly rather than through the config snapshot, so the export is identical whether sync is on, off, or has never been on. Format bumped to v2 with per-domain presence flags; v1 files still import; a file from a newer format is refused rather than half-restored.

**Restore is additive.** Space adoption reuses the path a synced login already runs, whose `if (!existingSpace)` guard is the whole safety property: a Space this device holds is never touched. That single rule makes a stale backup, a backup restored onto the wrong device, and a second import of the same file all safe without reasoning about the file's age.

**A restore cannot undo a deletion.** Additive protects state the user changed; it says nothing about state the user removed. Deleting a whole chat wrote no tombstones at all (only the single-message path did), so restoring an older backup silently resurrected deleted conversations. Adds tombstones for bulk message deletion, conversation deletion (`deleted_conversations`, DB v16), and Space departures (`departed_spaces`, DB v15).

**The restore says what it did, and what it did not.** Per-domain counts: Spaces restored, Spaces left untouched because already present, messages and conversations withheld as deleted, Spaces skipped with a readable reason, plus the "this file predates Space keys" case.

**Size.** A real account exported 17.6 MB. The config snapshot embeds each Space's encryption state, so the multi-megabyte eval pool shipped twice in every backup; that duplicate is gone. Orphaned encryption states are skipped too. Measured on a second account: 10.05 MB, against roughly 17.8 MB for the same data on the current code.

## Verification

Four safety properties are mutation-verified, each turning specific tests red when removed: the additive guard, the DM tombstone gate, the conversation tombstone gate, and the departure gate.

A headless harness scenario (`yarn harness space-kick`) runs two bots against a live relay: a member reads a post, is kicked, cannot read the next post, and restoring their pre-kick backup onto a wiped device returns `restored=0 failed=1`. Kicking rotates the Space config key and re-encrypts the manifest to it, so an older backup's key cannot open it and the adopt aborts before any hub announcement.

That scenario also surfaced a pre-existing crash: a sync armed before a kick fires after it and dereferences a Space key the kick deleted, throwing an unhandled rejection. Guarded.

1207 tests, typecheck clean.

## Notes for review

- **Two schema bumps (v15, v16), so rollback is not available.** Once a client opens this build its database is at v16 and an older build cannot open it. Forward-fix only.
- **Touches paths outside backup**: `saveConversation` now writes to two stores (runs on every inbound DM), DM deletions now write tombstone rows, and the key-save reorder in `adoptSpaces` also affects multi-device sync login.
- DM ratchet state is deliberately never restored. A restored conversation is immediately usable because the first send starts a fresh session, so nothing is rewound and no message key can be re-derived.
