### PR TITLE
fix(identity): resolve every name through one ladder, including your own

### DIFF
--- a/.agents/INDEX.md
+++ b/.agents/INDEX.md
@@ -109,6 +109,7 @@ This is the main index for all documentation, bug reports, and task management.
 - 🐛 ["Delete Space" is Leave with a destructive-sounding label, and the owner must never click it](issues/2026-08-02-delete-space-is-leave-and-can-permanently-brick-a-space.md)
 - 🐛 [The roster pull: what it actually does](issues/2026-08-02-roster-pull-delivers-nothing-to-a-new-joiner.md)
 - 🐛 [Sync requests expire unread, behind a reconnect backlog](issues/2026-08-02-sync-requests-arrive-four-minutes-late-and-every-peer-rejects-them.md)
+- 🐛 [Six name surfaces never reached the resolver](issues/2026-08-10-name-surfaces-that-never-reached-the-resolver.md)
 - 📋 [Durable multi-device: per-device signing keys via master-signed device statements](issues/2026-07-19-per-device-signing-keys-registration-anchored.md)
 - 📋 [DM partner identity never recovers on an established session](issues/2026-08-01-dm-partner-identity-lost-on-established-sessions.md)
 - 📋 [Spaces: desktop never re-announces identity on connect](issues/2026-08-01-space-member-identity-announce-on-connect.md)
@@ -769,4 +770,4 @@ This is the main index for all documentation, bug reports, and task management.
 
 ---
 
-**Last Updated**: 2026-08-09 16:09:02
+**Last Updated**: 2026-08-10 09:28:25

--- a/.agents/INDEX.md
+++ b/.agents/INDEX.md
@@ -331,6 +331,7 @@ This is the main index for all documentation, bug reports, and task management.
 - 📋 [Make `allowSync` a per-device setting](issues/.open/2026-08-08-make-allowsync-a-per-device-setting.md)
 - 📋 [Record and show what the last config publish actually did](issues/.open/2026-08-08-record-and-show-what-the-last-config-publish-actually-did.md)
 - 📋 [Backup/restore overhaul](issues/.open/2026-08-09-backup-restore-overhaul-design.md)
+- 📋 [Name resolution: an API that cannot express a partial identity](issues/.open/2026-08-10-identity-resolution-architecture-design.md)
 
 ### Deferred
 
@@ -770,4 +771,4 @@ This is the main index for all documentation, bug reports, and task management.
 
 ---
 
-**Last Updated**: 2026-08-10 09:53:07
+**Last Updated**: 2026-08-10 10:18:05

--- a/.agents/INDEX.md
+++ b/.agents/INDEX.md
@@ -109,7 +109,7 @@ This is the main index for all documentation, bug reports, and task management.
 - 🐛 ["Delete Space" is Leave with a destructive-sounding label, and the owner must never click it](issues/2026-08-02-delete-space-is-leave-and-can-permanently-brick-a-space.md)
 - 🐛 [The roster pull: what it actually does](issues/2026-08-02-roster-pull-delivers-nothing-to-a-new-joiner.md)
 - 🐛 [Sync requests expire unread, behind a reconnect backlog](issues/2026-08-02-sync-requests-arrive-four-minutes-late-and-every-peer-rejects-them.md)
-- 🐛 [Six name surfaces never reached the resolver](issues/2026-08-10-name-surfaces-that-never-reached-the-resolver.md)
+- 🐛 [Eight name surfaces never reached the resolver](issues/2026-08-10-name-surfaces-that-never-reached-the-resolver.md)
 - 📋 [Durable multi-device: per-device signing keys via master-signed device statements](issues/2026-07-19-per-device-signing-keys-registration-anchored.md)
 - 📋 [DM partner identity never recovers on an established session](issues/2026-08-01-dm-partner-identity-lost-on-established-sessions.md)
 - 📋 [Spaces: desktop never re-announces identity on connect](issues/2026-08-01-space-member-identity-announce-on-connect.md)
@@ -770,4 +770,4 @@ This is the main index for all documentation, bug reports, and task management.
 
 ---
 
-**Last Updated**: 2026-08-10 09:28:25
+**Last Updated**: 2026-08-10 09:53:07

--- a/.agents/issues/.open/2026-08-10-identity-resolution-architecture-design.md
+++ b/.agents/issues/.open/2026-08-10-identity-resolution-architecture-design.md
@@ -1,0 +1,245 @@
+---
+type: task
+title: "Name resolution: an API that cannot express a partial identity"
+status: open
+priority: high
+created: 2026-08-10
+updated: 2026-08-10
+area: identity resolution / QNS / cross-client architecture
+repos: quorum-shared (the rule), quorum-desktop (28 call sites), quorum-mobile (17 call sites)
+source: written after fixing the same defect in ~18 places in one day; the operator asked for the elegant solution instead of a nineteenth patch
+related:
+  - ".agents/issues/2026-08-10-name-surfaces-that-never-reached-the-resolver.md (the patches this supersedes)"
+  - "quorum-mobile/.agents/issues/2026-08-06-qns-primary-name-work-and-desktop-parity.md (parity index; its shared-code section asks for exactly this spec)"
+  - ".agents/docs/features/qns-username-display.md"
+---
+
+# Name resolution: an API that cannot express a partial identity
+
+## The problem, stated as evidence rather than opinion
+
+On 2026-08-10 the same defect was fixed in roughly eighteen places. Six came
+from a deliberate source audit. **The other twelve came from the operator
+clicking around the app for twenty minutes** — mention pills, the profile card,
+DM own-messages, pinned messages, bookmarks, notifications.
+
+That ratio is the finding. A source audit looking for "reads `displayName` by
+hand" could not see most of them, because most of them *do* call the resolver.
+They just call it with less than it needs.
+
+**45 files across two repos import a resolver directly** (28 desktop, 17 mobile).
+Every one must independently remember three fields and pick the right ladder.
+
+## Why this keeps happening, in three properties
+
+1. **The identity is three fields that must travel together** — `displayName`,
+   `primaryUsername`, `globalDisplayName` — and they are passed individually at
+   every call site.
+2. **All three are optional, so omitting one is not a type error.** TypeScript
+   cannot help, and does not.
+3. **A partial identity does not degrade, it INVERTS.** This is the property that
+   makes it dangerous rather than merely annoying. Omit `globalDisplayName` and
+   the roster-vs-global comparison trivially reports "this is a deliberate
+   per-space name", returning the roster name *before* the `.q` is ever
+   considered. The caller gets a confident wrong answer that looks like a
+   deliberate product decision.
+
+And a fourth, compounding: **every call site must also choose between the space
+ladder and the DM ladder.** That choice was hand-written at three sites in
+desktop alone before being collapsed today.
+
+The current architecture is visible in one line,
+[`Channel.tsx:1868`](../../src/components/space/Channel.tsx): a virtualised
+sidebar row reaches sideways into `effectiveMembers[item.address]` at the render
+site, because the item it was handed cannot carry the fields. That workaround,
+repeated per surface, *is* the design today.
+
+## The principle
+
+> **Call sites pass an address. You cannot forget a field you never pass.**
+
+Everything else follows. It also happens to fix the three surfaces the operator
+found last — pinned messages, bookmarks and notifications — for free, because
+those are frozen snapshots that have an address and nothing else. That is
+precisely why they are broken today, and why no amount of field-threading would
+have fixed them: **there is nothing to thread from.**
+
+## Design
+
+### Layer 1 — `quorum-shared`: the rule, over a COMPLETE identity
+
+The ladder, the echo demotion and the forged-suffix guard all live here already
+or are meant to. One change of substance:
+
+```ts
+export interface MemberIdentity {
+  address: string;
+  /** Per-space override. `null` = no override (NOT "unknown"). */
+  spaceName: string | null;
+  /** QNS primary username, bare (no ".q"). `null` = none elected. */
+  qnsName: string | null;
+  /** Global display name. `null` = none set. */
+  globalName: string | null;
+}
+```
+
+**Every field is required and explicitly nullable.** `null` means "known to be
+absent"; there is no `undefined`, so "I didn't pass it" becomes a compile error
+in both repos rather than a silent inversion. This is the single change that
+converts the whole bug class from runtime to build time.
+
+`resolveIdentity(identity, { scope: 'space' | 'global' })` replaces both
+`resolveMemberName` and `resolveSpaceMemberName`. One function, one explicit
+scope, no way to call the wrong one by accident.
+
+**Why shared:** this is the cross-client rule and the operator's requirement is
+that it work on both clients. The parity document already argues for it and
+explains why the current split is fragile — desktop has two resolvers and only
+one delegates to shared, so a rule added to shared protects only half the paths.
+
+### Layer 2 — per-client identity source (stays per-client, deliberately)
+
+One provider owning `address → MemberIdentity`, assembled from the roster, the
+roster's global slots, and the public-profile cache. It is the ONLY thing that
+knows how those merge.
+
+This layer stays per-client because the inputs genuinely differ: mobile's rows
+are snake_case and desktop's camelCase, different query clients, different
+storage, different placeholder semantics. The parity document's analysis of what
+should and should not move to shared holds — the *rules* move, the *adapters* do
+not.
+
+It also absorbs the **self tier**, which currently does not exist on desktop and
+caused two of today's bugs: when `address === me`, the identity comes from the
+own public profile, not from `currentPasskeyInfo` (which carries no QNS name).
+One place, not eight.
+
+### Layer 3 — the only API app code may touch
+
+```tsx
+<MemberName address={addr} />                  // JSX; renders the ".q"
+const name = useResolvedName(addr);            // strings: aria-labels,
+                                               // notification bodies, tooltips,
+                                               // modal payloads, search text
+```
+
+Scope is supplied by an `IdentityScopeProvider` at the space/DM boundary rather
+than passed per call — a call site inside a channel should not be able to ask
+for the wrong ladder. (See open question 1: explicit prop vs context.)
+
+Every current call site becomes one of these two. `ResolvedName`,
+`formatResolvedName`, `resolveMentionPillName`, `resolveProfileCardName`,
+`conversationMatchesSearch` and `selfNamePlaceholder` all collapse into them.
+
+### Layer 4 — enforcement, because the rule is what regrows
+
+An eslint `no-restricted-imports` rule plus a guard test: nothing outside the
+identity module may import the low-level resolver. Mobile already shipped this
+exact pattern for raw override reads, and it is the reason mobile's equivalent
+defect did not regrow. **Without this layer the other three decay back within a
+quarter**, because the failure is a forgotten field and nothing else stops that.
+
+## Hard constraints the design must respect
+
+These are the things that will break a naive implementation.
+
+1. **Virtualised lists.** A `<MemberName>` that registers its own query would
+   register 500 observers in a 500-row member list. The provider must serve from
+   an in-memory map first and fall back to a query only for detached surfaces.
+   Non-negotiable; the member sidebar's no-fetch policy exists for this reason.
+2. **Detached surfaces get the GLOBAL ladder, and that is correct.** A bookmark
+   or a cross-space notification has no live roster, so a per-space override is
+   unknowable — and also meaningless outside its space. Resolving those with
+   `scope: 'global'` (QNS → global → address) is not a compromise, it is the
+   right answer, and it is strictly better than today's frozen snapshot name.
+   **This must be stated in the doc, because it means a per-space name will not
+   appear in bookmarks, and that will look like a bug to someone later.**
+3. **The membership/kicked gate is a security property and stays on the raw
+   roster.** Today's `resolveSender` conflates "is this a current member?" with
+   "what is their name?". Splitting them is part of this work; the gate must not
+   move to the identity provider, which knows nothing about kicks.
+4. **The fallback belongs to the resolver, never the caller.** Already
+   documented at `useChannelMessages.mapSenderToUser` and violated twice today.
+   With `MemberIdentity` requiring explicit `null`, a caller cannot substitute an
+   address for a missing name.
+5. **Offline.** DM identity currently renders from IndexedDB with no network
+   round-trip. The provider must preserve that, not make names await a fetch.
+
+## Migration order
+
+Each step is independently shippable and independently verifiable.
+
+1. **shared:** add `MemberIdentity` + `resolveIdentity`; keep the old exports as
+   thin deprecated adapters so nothing breaks mid-migration.
+2. **desktop:** build the provider + `<MemberName>` + `useResolvedName`. Prove
+   it on ONE surface (the member sidebar — highest row count, so it also proves
+   constraint 1).
+3. **desktop:** migrate the remaining 27 files, deleting per-site resolver calls.
+4. **desktop:** add the lint rule + guard test; remove the deprecated adapters.
+5. **mobile:** same as 2–4 against the same shared rule.
+6. **shared:** delete the deprecated adapters once both clients are off them.
+
+Do NOT start at step 3. The whole value is that step 2 proves the provider can
+serve a virtualised list before 27 files depend on it.
+
+## How each step is verified
+
+The operator cannot review a diff, so every step must end in something
+observable or measured.
+
+- **Steps 1–2:** unit tests on `resolveIdentity` (ported from the existing suites,
+  which already cover the guard, the echo demotion and the tiers), plus a
+  **measured** render count / query-observer count on the member sidebar before
+  and after. That number is constraint 1's pass/fail.
+- **Step 3:** the `/dev/fake-qns` sweep, with a **control arm** — one address
+  pinned to a known non-QNS name. If the control row changes, the instrument is
+  wrong, not the code. Surfaces to sweep are the eighteen already listed in the
+  companion issue, which is exactly the regression checklist.
+- **Step 4:** the guard test must be shown to FAIL by re-adding a direct resolver
+  import. A guard that has never been seen red is not a guard.
+- **Step 5:** mobile's `yarn harness:qns` two-bot scenario, because the receive
+  side cannot be tested on one device.
+
+## Open questions — decide before step 2
+
+1. **Scope: context provider or explicit prop?** Context removes a whole class of
+   "wrong ladder" mistakes and keeps call sites to one argument. Explicit props
+   are easier to follow when reading a single file, and avoid a provider that
+   must be remembered at every mount point. *Leaning: context, with the prop as
+   an override for detached surfaces.*
+2. **Does `<MemberName>` own the avatar's initials too?** Several sites feed
+   `UserAvatar` a raw name while the label beside it resolves, so initials and
+   name can disagree. Folding both into one component fixes that permanently;
+   keeping them separate is a smaller change. *Leaning: fold, since it is the
+   same class of bug.*
+3. **Batch public-profile endpoint.** The docs record a standing lead-dev ask for
+   N-lookups-in-1. The provider is the natural consumer and would make full
+   roster enrichment affordable — which would in turn fix "sidebar lurkers show
+   no `.q`", currently a documented limitation. Worth confirming whether that
+   endpoint is coming before designing around its absence.
+4. **Does this supersede the shared echo-demotion move?** The parity document
+   lists that as its own task, blocked on naming the `display_name` contract.
+   This design names it (`spaceName` / `globalName` are unambiguous), so it
+   probably absorbs that item rather than coexisting with it.
+
+## What this does NOT change
+
+- The `.q` suffix stays the only signal. No badge — settled 2026-06-10 and
+  re-proposed twice since.
+- The user still explicitly elects which `.q` to show; nothing elects for them.
+- Wire formats are untouched. This is entirely a read/render-side change.
+
+## Definition of done
+
+- [ ] `MemberIdentity` + `resolveIdentity` in shared, with every field required
+- [ ] Desktop provider serving a virtualised list with a MEASURED observer count
+- [ ] All 28 desktop call sites migrated; zero direct resolver imports outside
+      the identity module
+- [ ] Lint rule + guard test, the guard shown red
+- [ ] `/dev/fake-qns` sweep of all eighteen surfaces, with a control arm
+- [ ] Mobile migrated against the same shared rule, verified with `harness:qns`
+- [ ] Deprecated adapters deleted from shared
+
+---
+
+*Last updated: 2026-08-10*

--- a/.agents/issues/2026-08-10-name-surfaces-that-never-reached-the-resolver.md
+++ b/.agents/issues/2026-08-10-name-surfaces-that-never-reached-the-resolver.md
@@ -15,18 +15,23 @@ related:
   - ".agents/issues/.open/2026-08-05-mobile-identity-parity-after-the-desktop-phase-1-fix.md"
 ---
 
-# Six name surfaces never reached the resolver
+# Eight name surfaces never reached the resolver
 
 ## Status
 
-**Fixed on branch `fix/name-surfaces-bypassing-the-resolver` (`8d70aa9d5`), not
-yet merged.** Suite green at 1235, lint unchanged at 0 errors, typecheck clean.
-Every rule added was shown red with its fix reverted.
+**Fixed on branch `fix/name-surfaces-bypassing-the-resolver`, not yet merged.**
+Suite green at 1244, lint unchanged at 0 errors, typecheck clean. Every rule
+added was shown red with its fix reverted.
 
-**Not yet visually verified in the running app.** The unit level is covered; what
-is not is that the right string reaches the right pixels. See "What is still
-unverified" below — that is the honest remaining gap, and it is the part a test
-cannot close.
+Two distinct defects are covered here: **six surfaces that read a name by hand**
+(the audit, parity item 6, plus item 7), and **two that special-case YOUR OWN
+identity** and so never had a QNS name to render at all. The second pair was
+found by the operator in the running app after the first six were fixed, and is
+the reason the visual pass below is not optional.
+
+**Partially verified visually.** The operator confirmed the two self-surface
+defects with `/dev/fake-qns`; their fixes are not yet re-confirmed, and the other
+six have not had a visual pass. See "What is still unverified".
 
 Part of this work is identity-resolution hardening whose detail is held
 privately. This file is the public hub and deliberately does not restate it.
@@ -58,6 +63,63 @@ and an independent review found two more. Final count **six**.
 | DM list search (`DirectMessageContactsList.tsx:147`) | Matched only the stored name, so a row the list displays under a QNS name could not be found by typing it | fixed |
 | `MessagePreview` header (`MessagePreview.tsx:204`) | Hand-rolled its own fallback chain | fixed (latent — see below) |
 | Per-space name placeholder (`SpaceSettingsModal/Account.tsx:217`) | Static `t\`Display Name\`` — item (7) | fixed |
+| Profile card, YOUR OWN (`UserProfile.tsx:120`) | Skipped the public-profile fetch when the card was your own | fixed |
+| DM messages, YOUR OWN (`DirectMessage.tsx:298`) | Built the self entry from `currentPasskeyInfo`, which has no QNS name | fixed |
+
+**Eight, not six.** The last two were found by the operator testing the first
+six in the running app with `/dev/fake-qns`, which is the argument for doing that
+pass rather than trusting a green suite: both were invisible to the audit because
+neither reads a roster row by hand. They are a different defect with a different
+shape, described next.
+
+## The self tier, which is the second defect this file covers
+
+**Desktop has no self tier**, and the parity document already says so in its
+shared-code section: *"The self tier. Mobile resolves its own row from a live
+in-memory profile; desktop has no equivalent concept."* That was recorded as a
+reason NOT to move code into `quorum-shared`. It is also, it turns out, a bug.
+
+The rule: wherever the generic member path runs, self is fine — channel message
+headers and the member sidebar both resolve, because
+`useMembersWithPublicProfileFallback` fetches every visible sender including you.
+Wherever self is **special-cased from `currentPasskeyInfo`**, it breaks, because
+that record is the device-local auth profile and carries no `primary_username`.
+
+Two instances, both reported from the running app:
+
+**The profile card.** `needsUsernameFetch = !props.user.primaryUsername && !isOwnProfile`.
+The exclusion reads as obviously safe — surely we know our own identity. One
+fetch feeds TWO fields, so skipping it cost both: the QNS name, and the GLOBAL
+name that the space resolver compares the roster name against. With the global
+name absent, `roster !== global` holds trivially and the roster name is returned
+as though deliberately chosen — **so the `.q` would have lost even had it been
+fetched.** A narrower fix that only restored `primary_username` would have looked
+right and stayed broken.
+
+**DM own messages.** The members map gave the partner `primaryUsername` from the
+public profile fetched immediately above, and built the self entry from
+`currentPasskeyInfo` alone. Your own messages therefore showed your global name
+next to a partner showing their `.q`, in the same thread.
+
+Neither costs a request: both read the same 1h-cached `publicProfileQueryKey`
+that other surfaces already populate. The "extra fetch" intuition was wrong here
+for the third time in this work — see the cost note below.
+
+### Where the guard had to go
+
+`utils/profileCardIdentity` holds the card's two rules so they can be tested
+without mounting a component with sixteen hooks. **The test asserts on the FETCH
+DECISION, not on the resolved name.** The resolver was never the broken part, so
+a test checking only that names come out right would neither have caught this nor
+catch it returning.
+
+### Still unfixed, same class
+
+`NavRail.tsx:94` reads `currentPasskeyInfo.displayName` for your own avatar and
+label. Same shape, not yet reported as visible; listed here so it is not
+rediscovered from scratch. The search surfaces
+(`useSearchResultDisplay*.ts`, `useBatchSearchResultsDisplay.ts:141`) also
+special-case self, and remain a documented deferral.
 
 ### The two that are worth understanding, not just listing
 
@@ -137,8 +199,15 @@ addresses are the DM partners the sidebar has already fetched **under the same
 key** — so it is a cache read, not a second round of requests. The fix is now
 complete.
 
-Worth keeping as a reminder that "this would cost N requests" deserves checking
-against the actual cache key before it is allowed to shrink a fix.
+The same wrong intuition is visible in the two self bugs: the profile card's
+`!isOwnProfile` exclusion and the DM's `currentPasskeyInfo`-only self entry both
+look like they are avoiding a redundant request, and both are reading a key that
+is already warm.
+
+**Three times in one piece of work, "this would cost N requests" was asserted
+without checking the cache key, and was wrong every time.** In a codebase where
+one query key is shared across every profile surface, that estimate is not
+intuitable — it has to be checked.
 
 ## What is still unverified
 

--- a/.agents/issues/2026-08-10-name-surfaces-that-never-reached-the-resolver.md
+++ b/.agents/issues/2026-08-10-name-surfaces-that-never-reached-the-resolver.md
@@ -1,0 +1,168 @@
+---
+type: bug
+title: "Six name surfaces never reached the resolver (desktop parity items 6 and 7)"
+status: in-progress
+priority: high
+created: 2026-08-10
+updated: 2026-08-10
+area: identity resolution / QNS / cross-client parity
+repos: quorum-desktop (this), quorum-mobile (one matching defect filed)
+source: desktop parity item (6), the audit for direct override reads, plus item (7)
+related:
+  - "quorum-mobile/.agents/issues/2026-08-06-qns-primary-name-work-and-desktop-parity.md (the parity index — READ THIS FIRST)"
+  - "quorum-mobile/.agents/issues/.open/2026-08-10-invite-contact-picker-renders-an-unresolved-name.md (the matching mobile defect)"
+  - ".agents/docs/features/qns-username-display.md"
+  - ".agents/issues/.open/2026-08-05-mobile-identity-parity-after-the-desktop-phase-1-fix.md"
+---
+
+# Six name surfaces never reached the resolver
+
+## Status
+
+**Fixed on branch `fix/name-surfaces-bypassing-the-resolver` (`8d70aa9d5`), not
+yet merged.** Suite green at 1235, lint unchanged at 0 errors, typecheck clean.
+Every rule added was shown red with its fix reverted.
+
+**Not yet visually verified in the running app.** The unit level is covered; what
+is not is that the right string reaches the right pixels. See "What is still
+unverified" below — that is the honest remaining gap, and it is the part a test
+cannot close.
+
+Part of this work is identity-resolution hardening whose detail is held
+privately. This file is the public hub and deliberately does not restate it.
+
+## What this closes
+
+Two items from the cross-client parity index, both listed there as "ready to
+implement straight from this document":
+
+- **(6) the audit for direct override reads** — must precede any join change.
+- **(7) the per-space name field's placeholder.**
+
+## The audit
+
+Method: enumerate every surface that turns an address into a rendered name, and
+check each goes through `resolveMemberName` / `resolveSpaceMemberName` rather
+than reading a roster or conversation row's `displayName` by hand.
+
+The parity document warned that mobile's equivalent sweep found **seven**
+surfaces, six of them not on any list beforehand, and told me to budget for that
+rather than assume one or two. That was good advice: the first pass found four,
+and an independent review found two more. Final count **six**.
+
+| Surface | What it did | State |
+|---|---|---|
+| Message editor's mention pills (`MessageEditTextarea.tsx:187`) | Rebuilt pills from stored `@<address>` tokens via a second, private copy of the pill builder, reading the raw field | fixed |
+| Moderation confirmations (`UserProfile.tsx:479,503,525`) | Passed the raw roster field into the Kick / Mute / Block modals, while the resolved name sat one scope away at `:134` | fixed |
+| Invite contact picker (`useInviteManagement.ts:113`) | Rendered a conversation row's name raw | fixed |
+| DM list search (`DirectMessageContactsList.tsx:147`) | Matched only the stored name, so a row the list displays under a QNS name could not be found by typing it | fixed |
+| `MessagePreview` header (`MessagePreview.tsx:204`) | Hand-rolled its own fallback chain | fixed (latent — see below) |
+| Per-space name placeholder (`SpaceSettingsModal/Account.tsx:217`) | Static `t\`Display Name\`` — item (7) | fixed |
+
+### The two that are worth understanding, not just listing
+
+**The editor's mention pills.** A pill's name was derived in two places: the
+composer built one when you picked from autocomplete, the editor rebuilt every
+pill from the stored tokens when you clicked edit. Only the composer resolved. So
+the same pill read one name in the posted message and a different one in the
+editor — a QNS name vanished on entering edit mode, and an unknown sender
+rendered the literal `Unknown User` where the body beside it shows a truncated
+address.
+
+**The duplication was the defect and the raw read was its symptom.** Fixing only
+the raw read would have left two derivations free to disagree again, so both now
+call one `resolveMentionPillName`.
+
+**`MessagePreview`'s header — latent, not live.** The render sits behind
+`!hideHeader` and both current callers (`PinnedMessagesPanel`, `BookmarkItem`)
+pass `hideHeader={true}`, so it was unreachable. Resolved rather than deleted,
+because dead identity code next to a trust marker is a hole waiting for whoever
+turns the header on. This is the same shape as the item the parity document
+flags on mobile ("the user profile modal's dead `@handle` line ... leaving dead
+identity code next to a trust marker is how the next person reintroduces the
+inversion").
+
+## What was NOT found, and why it matters
+
+**No bare-address regression from the join change.** The parity document warned
+that on mobile, shipping the join fix before the by-hand override reads left a
+window where freshly-joined members rendered as bare addresses, and told me to
+order (6) before (3) to avoid reproducing it. Desktop shipped its join fix on
+2026-08-05 (PR #313), so that window would already be open if it applied.
+
+It does not, for two independent reasons, both READ from source:
+
+1. `useMembersWithPublicProfileFallback.ts:147` merges
+   `displayName = per-space override || roster global slot || public profile`,
+   so an empty override yields the global name rather than nothing.
+2. `resolveSpaceMemberName` (`resolveMemberName.ts:125`) returns the global slot
+   as a real tier before falling through to the address.
+
+Recorded because it removes a sequencing constraint the parity document imposes,
+and a future reader should not re-derive it.
+
+## Structural changes, which are the part that stops this recurring
+
+- **`resolveMentionPillName`** (`utils/mentionPillDom.ts`) — one rule for a
+  mention pill's text, called by both builders.
+- **`resolveNameForContext`** (`utils/resolveMemberName.ts`) — one answer to
+  "space ladder or DM ladder?", which had been hand-written at three call sites
+  (the message body, the mention pills, the message preview). Three copies of
+  that choice is precisely how the two pill builders came to disagree.
+- **`conversationMatchesSearch`** (`utils/conversationSearch.ts`) and
+  **`selfNamePlaceholder`** (`utils/resolveSelfName.ts`) — extracted so the rules
+  could be tested directly rather than asserted through a component.
+
+## The mobile half
+
+**Mobile has the invite-picker defect too**, at
+`components/ShareInviteSheet.tsx:173`, from the identical cause (raw
+`useConversations` rows) and with the same hand-rolled `truncateAddress`
+fallback. Filed as
+`quorum-mobile/.agents/issues/.open/2026-08-10-invite-contact-picker-renders-an-unresolved-name.md`.
+
+Mobile's own sweep did not cover share/invite paths, so its share surfaces are
+worth re-checking generally rather than only that file.
+
+Per the parity document's standing lesson — "a fix that lands on one client and
+leaves the other as a TODO is not a shipped fix" — this one should not be
+considered closed on desktop alone.
+
+## A note on cost reasoning, because I got it wrong once
+
+The invite picker was first left half-fixed on the grounds that backfilling it
+would cost N public-profile fetches on a rarely-opened dropdown. That was wrong.
+The backfill keys on `publicProfileQueryKey` with a 1h `staleTime`, and the
+addresses are the DM partners the sidebar has already fetched **under the same
+key** — so it is a cache read, not a second round of requests. The fix is now
+complete.
+
+Worth keeping as a reminder that "this would cost N requests" deserves checking
+against the actual cache key before it is allowed to shrink a fix.
+
+## What is still unverified
+
+- **Visual confirmation in the running app.** Use `/dev/fake-qns`
+  (`src/dev/fake-qns/`, PR #315): give yourself a `.q`, then sweep the six
+  surfaces. Pin a second address to a known different name as a **control arm** —
+  with everyone named there is nothing to compare against, and if both rows
+  change the instrument is wrong rather than the code.
+- The editor pills and the DM header specifically **cannot** be checked by
+  posting to yourself in every case; see the parity document's warning that the
+  receive side needs two clients. The fake-QNS "give everyone a `.q`" switch
+  covers the solo-testable ones.
+
+## Definition of done
+
+- [x] Audit complete, with every surface cited `file:line`
+- [x] All six routed through a resolver
+- [x] Item (7), the placeholder, ported from mobile
+- [x] A test per rule, each shown red with its fix reverted
+- [x] The matching mobile defect filed
+- [ ] Visually confirmed via `/dev/fake-qns` with a control arm
+- [ ] Merged
+- [ ] Mobile's invite picker fixed, or explicitly deferred by the lead
+
+---
+
+*Last updated: 2026-08-10*

--- a/src/components/direct/DirectMessage.tsx
+++ b/src/components/direct/DirectMessage.tsx
@@ -239,6 +239,11 @@ const DirectMessage: React.FC<{}> = () => {
   // has opted in to a public profile, we use it to fill the gaps.
   // 1h cache; 404 = no public profile, treated as null.
   const { data: recipientPublicProfile } = useUserPublicProfile(address);
+  // Your own public profile — the ONLY source of your own QNS name. See the
+  // self entry in the members map below for why this is not optional.
+  const { data: ownPublicProfile } = useUserPublicProfile(
+    user.currentPasskeyInfo?.address
+  );
 
   // Build members with fallback chain: conversation (IndexedDB) > registration
   // (network) > public profile (server) > defaults. Local fields always win
@@ -294,14 +299,29 @@ const DirectMessage: React.FC<{}> = () => {
         address: address!,
       };
     }
-    // Self data - use passkey context as primary source (always available)
+    // Self data - use passkey context as primary source (always available).
+    //
+    // `primaryUsername` cannot come from there: `currentPasskeyInfo` is the
+    // device-local auth record and carries no QNS name. Without it, YOUR OWN
+    // messages in a DM rendered your global display name while the partner
+    // beside them rendered their ".q" — the one place in a conversation where
+    // the two sides disagreed about how a name is chosen. Same 1h-cached key as
+    // the recipient fetch directly above, so it costs a cache read.
     m[user.currentPasskeyInfo!.address] = {
       address: user.currentPasskeyInfo!.address,
       userIcon: user.currentPasskeyInfo!.pfpUrl,
       displayName: user.currentPasskeyInfo!.displayName,
+      primaryUsername: ownPublicProfile?.primary_username || undefined,
     };
     return m;
-  }, [registration, conversation, address, user.currentPasskeyInfo, recipientPublicProfile]);
+  }, [
+    registration,
+    conversation,
+    address,
+    user.currentPasskeyInfo,
+    recipientPublicProfile,
+    ownPublicProfile,
+  ]);
 
   // Clean up stale encryption states when registration data changes
   // This fixes the DM inbox mismatch bug where Action Queue encrypts to old inboxes

--- a/src/components/direct/DirectMessageContactsList.tsx
+++ b/src/components/direct/DirectMessageContactsList.tsx
@@ -15,6 +15,7 @@ import {
 } from '../primitives';
 import { UserAvatar } from '../user/UserAvatar';
 import { resolveMemberName, formatResolvedName } from '../../utils/resolveMemberName';
+import { conversationMatchesSearch } from '../../utils/conversationSearch';
 import { realIconOrUndefined } from '../../utils/identityPlaceholder';
 import { useModalContext } from '../context/ModalProvider';
 import { useConversationPolling } from '../../hooks';
@@ -140,14 +141,19 @@ const DirectMessageContactsList: React.FC<DirectMessageContactsListProps> = ({ f
       result = result.filter((c) => mutedSet.has(c.conversationId));
     }
 
-    // Apply search
+    // Apply search. The rule lives in `conversationMatchesSearch` — it has to
+    // match the RESOLVED name, because that is what the row renders.
     if (searchInput.trim()) {
-      const searchLower = searchInput.toLowerCase().trim();
-      result = result.filter((c) => {
-        const nameMatch = c.displayName?.toLowerCase().includes(searchLower);
-        const addressMatch = c.address?.toLowerCase().includes(searchLower);
-        return nameMatch || addressMatch;
-      });
+      result = result.filter((c) =>
+        conversationMatchesSearch(
+          {
+            address: c.address,
+            displayName: c.displayName,
+            primaryUsername: (c as { primaryUsername?: string }).primaryUsername,
+          },
+          searchInput,
+        ),
+      );
     }
 
     // Sort: favorites first (when viewing "all"), then by timestamp

--- a/src/components/message/Message.tsx
+++ b/src/components/message/Message.tsx
@@ -37,8 +37,7 @@ import { useMobile } from '../context/MobileProvider';
 import { UserAvatar } from '../user/UserAvatar';
 import { ResolvedName } from '../user/ResolvedName';
 import {
-  resolveMemberName,
-  resolveSpaceMemberName,
+  resolveNameForContext,
   formatResolvedName,
 } from '../../utils/resolveMemberName';
 import {
@@ -450,18 +449,10 @@ export const Message = React.memo(
         address?: string;
         userAddress?: string;
       }) =>
-        isDmMessage
-          ? resolveMemberName({
-              address: u.address ?? u.userAddress ?? '',
-              displayName: u.displayName,
-              primaryUsername: u.primaryUsername,
-            })
-          : resolveSpaceMemberName({
-              address: u.address ?? u.userAddress ?? '',
-              displayName: u.displayName,
-              primaryUsername: u.primaryUsername,
-              globalDisplayName: u.globalDisplayName,
-            }),
+        resolveNameForContext(
+          { ...u, address: u.address ?? u.userAddress ?? '' },
+          { isDm: isDmMessage },
+        ),
       [isDmMessage],
     );
     const resolvedSender = resolveSenderName({ ...sender, address: sender?.address ?? message.content?.senderId });

--- a/src/components/message/Message.tsx
+++ b/src/components/message/Message.tsx
@@ -180,11 +180,15 @@ type MessageProps = {
   height: number;
   submitMessage: (message: any) => Promise<void>;
   onUserClick?: (
+    // Mirrors `UserProfileModalUser`. The last two are load-bearing, not
+    // decoration — see that type for what omitting them costs.
     user: {
       address: string;
       displayName?: string;
       userIcon?: string;
       bio?: string;
+      primaryUsername?: string;
+      globalDisplayName?: string;
     },
     event: React.MouseEvent,
     context?: { type: 'mention' | 'message-avatar'; element: HTMLElement }
@@ -751,6 +755,13 @@ export const Message = React.memo(
                         displayName: sender.displayName,
                         userIcon: sender.userIcon,
                         bio: sender.bio,
+                        // Carry the enriched identity through. `sender` is an
+                        // effectiveMembers row, so both are already in hand and
+                        // cost nothing; dropping them made the card resolve
+                        // from strictly less than the message header beside it,
+                        // and disagree with it.
+                        primaryUsername: sender.primaryUsername,
+                        globalDisplayName: sender.globalDisplayName,
                       },
                       event,
                       {

--- a/src/components/message/MessageEditTextarea.tsx
+++ b/src/components/message/MessageEditTextarea.tsx
@@ -18,6 +18,7 @@ import { ENABLE_MARKDOWN, ENABLE_DM_ACTION_QUEUE, ENABLE_MENTION_PILLS } from '.
 import { createIPFSCIDRegex, extractMentionsFromText, applyEdit, getConversationSetting } from '@quilibrium/quorum-shared';
 import { useMentionInput, type MentionOption, useMentionPillEditor } from '../../hooks/business/mentions';
 import { getCaretCoordinates, type CaretCoordinates } from '../../utils/caretCoordinates';
+import { resolveMentionPillName } from '../../utils/mentionPillDom';
 
 /**
  * DM context for action queue handlers.
@@ -138,6 +139,27 @@ export function MessageEditTextarea({
     [editText, selectionRange]
   );
 
+  // Entering edit mode rebuilds every pill from the stored `@<address>` tokens,
+  // which makes this the SECOND place a mention becomes a name — the composer's
+  // is `extractPillDataFromOption`. Both go through `resolveMentionPillName` so
+  // they cannot drift again; see that function for what the drift cost.
+  const isDmMessage = message.spaceId === message.channelId;
+  const resolveMentionName = useCallback(
+    (address: string): string => {
+      const user = mapSenderToUser(address);
+      return resolveMentionPillName(
+        {
+          address,
+          displayName: user?.displayName,
+          primaryUsername: user?.primaryUsername,
+          globalDisplayName: user?.globalDisplayName,
+        },
+        { isDm: isDmMessage }
+      );
+    },
+    [mapSenderToUser, isDmMessage]
+  );
+
   // Parse mentions from stored text and create pills (with double validation)
   const parseMentionsAndCreatePills = useCallback(
     (text: string): DocumentFragment => {
@@ -183,8 +205,7 @@ export function MessageEditTextarea({
         // Layer 2: Verify mention exists in message.mentions
         if (message.mentions?.memberIds?.includes(address)) {
           // Layer 1: Lookup real display name
-          const user = mapSenderToUser(address);
-          const displayName = user?.displayName || `Unknown User`;
+          const displayName = resolveMentionName(address);
           mentions.push({ type: 'user', displayName, address, index, length: match[0].length });
         }
       }
@@ -257,7 +278,7 @@ export function MessageEditTextarea({
 
       return fragment;
     },
-    [message, mapSenderToUser, spaceRoles, spaceChannels]
+    [message, resolveMentionName, spaceRoles, spaceChannels]
   );
 
   // Handle mention selection from dropdown

--- a/src/components/message/MessageList.tsx
+++ b/src/components/message/MessageList.tsx
@@ -331,13 +331,25 @@ export const MessageList = forwardRef<MessageListRef, MessageListProps>(
     // unresolved so their mentions render as non-interactive truncated-address
     // pills rather than as clickable pills that would open a profile of a
     // user no longer reachable. Forwarded to Message → MessageMarkdownRenderer.
+    //
+    // The membership/kicked GATE reads the raw roster, which is the security
+    // property and must stay that way. The IDENTITY it returns comes from
+    // `mapSenderToUser`, which the container overrides with its public-profile
+    // enriched map.
+    //
+    // Returning the raw roster row here was a real defect: the raw roster
+    // cannot carry `primaryUsername` or `globalDisplayName` (only the profile
+    // fetch supplies them), so every mention pill resolved from strictly less
+    // data than the message header three lines above it — and rendered the
+    // global display name where the header rendered the ".q". Same defect
+    // mobile fixed as chain item 8b.
     const resolveSender = useCallback(
       (senderId: string) => {
         const m = members[senderId];
         if (!m || (m as any).isKicked) return null;
-        return m;
+        return mapSenderToUser(senderId) ?? m;
       },
-      [members]
+      [members, mapSenderToUser]
     );
 
     // Date separators, new-messages separators, and compact-header flags per row.

--- a/src/components/message/MessageMarkdownRenderer.tsx
+++ b/src/components/message/MessageMarkdownRenderer.tsx
@@ -46,11 +46,14 @@ interface MessageMarkdownRendererProps {
    * (everything is interactive whenever `onUserClick` is set).
    */
   resolveSender?: (senderId: string) => NameResolvableUser | null;
+  // Mirrors `UserProfileModalUser`; the identity fields are load-bearing.
   onUserClick?: (user: {
     address: string;
     displayName?: string;
     userIcon?: string;
     bio?: string;
+    primaryUsername?: string;
+    globalDisplayName?: string;
   }, event: React.MouseEvent, context?: { type: 'mention' | 'message-avatar'; element: HTMLElement }) => void;
   onChannelClick?: (channelId: string) => void;
   onMessageLinkClick?: (channelId: string, messageId: string) => void;
@@ -854,6 +857,10 @@ export const MessageMarkdownRenderer: React.FC<MessageMarkdownRendererProps> = (
           displayName: user?.displayName,
           userIcon: user?.userIcon,
           bio: (user as { bio?: string } | null)?.bio,
+          // Carried through so the card resolves from the same data the pill
+          // did; see UserProfileModalUser.
+          primaryUsername: user?.primaryUsername,
+          globalDisplayName: user?.globalDisplayName,
         }, event, { type: 'mention', element: target });
       }
     }

--- a/src/components/message/MessagePreview.tsx
+++ b/src/components/message/MessagePreview.tsx
@@ -5,8 +5,9 @@ import { t } from '@lingui/core/macro';
 import { useMessageFormatting } from '../../hooks/business/messages/useMessageFormatting';
 import { YouTubeEmbed } from '../ui/YouTubeEmbed';
 import { formatMessageDate } from '../../utils';
-import { processMarkdownText, formatAddress, hasPermission } from '@quilibrium/quorum-shared';
+import { processMarkdownText, hasPermission } from '@quilibrium/quorum-shared';
 import { getEmbeddedMediaSrc } from '../../utils/embeddedMedia';
+import { resolveNameForContext, formatResolvedName } from '../../utils/resolveMemberName';
 
 // Helper function to process text with mentions and special tokens after smart markdown stripping
 const renderPreviewTextWithSpecialTokens = (
@@ -200,12 +201,29 @@ export const MessagePreview: React.FC<MessagePreviewProps> = ({
     everyoneAuthorized,
   });
 
-  // Get display name - prefer sender displayName, fallback to username, then senderId
+  // The resolver owns the whole ladder INCLUDING the address fallback — see the
+  // contract on `useChannelMessages.mapSenderToUser`, which returns a member
+  // unchanged (empty `displayName` included) precisely so no caller re-derives
+  // it. This used to hand-roll `displayName → username → formatAddress`, which
+  // skipped the QNS name and the forged-suffix guard alike.
+  //
+  // Reachable only when `hideHeader` is false; both current callers
+  // (PinnedMessagesPanel, BookmarkItem) pass it, so this was dead code sitting
+  // next to a trust marker. Resolved rather than deleted so turning the header
+  // back on cannot quietly reintroduce the gap.
   const getDisplayName = () => {
-    if (sender?.displayName) return sender.displayName;
-    if (sender?.username) return sender.username;
-    if (senderId) return formatAddress(senderId);
-    return t`Unknown User`;
+    if (!sender && !senderId) return t`Unknown User`;
+    return formatResolvedName(
+      resolveNameForContext(
+        {
+          address: sender?.address ?? senderId,
+          displayName: sender?.displayName,
+          primaryUsername: sender?.primaryUsername,
+          globalDisplayName: sender?.globalDisplayName,
+        },
+        { isDm: message.spaceId === message.channelId },
+      ),
+    );
   };
 
   // Use shared date formatting utility (matches Message.tsx format)

--- a/src/components/modals/SpaceSettingsModal/Account.tsx
+++ b/src/components/modals/SpaceSettingsModal/Account.tsx
@@ -27,6 +27,8 @@ import type { Role } from '@quilibrium/quorum-shared';
 import { getRoleColorHex } from '@quilibrium/quorum-shared';
 import type { SpaceNotificationTypeId } from '../../../types/notifications';
 import { ReactTooltip } from '../../ui';
+import { useUserPublicProfile } from '../../../hooks/business/user/useUserPublicProfile';
+import { selfNamePlaceholder } from '../../../utils/resolveSelfName';
 
 interface AccountProps {
   spaceId: string;
@@ -96,6 +98,13 @@ const Account: React.FunctionComponent<AccountProps> = ({
   isMentionSettingsLoading,
 }) => {
   const { currentPasskeyInfo: userInfo } = usePasskeysContext();
+  // Your own QNS name, for the per-space name placeholder below. The public
+  // profile is the only source of `primary_username`, and reading your OWN is
+  // the same 1h-cached fetch every other surface already makes — no publish
+  // path is involved, which is why this works before the server-side publish
+  // bug is fixed. Mirrors UserSettingsModal.
+  const { data: ownPublicProfile } = useUserPublicProfile(userInfo?.address);
+  const primaryUsername = ownPublicProfile?.primary_username || undefined;
   const { data: isSpaceOwner } = useSpaceOwner({ spaceId });
   const {
     confirmationStep,
@@ -214,7 +223,10 @@ const Account: React.FunctionComponent<AccountProps> = ({
               className="w-full md:w-80 mt-3 ml-1"
               value={displayName}
               onChange={setDisplayName}
-              placeholder={t`Display Name`}
+              placeholder={selfNamePlaceholder(
+                { primaryUsername, displayName: userInfo?.displayName },
+                t`Your name in this Space`,
+              )}
               labelType="static"
               error={!!displayNameError}
               errorMessage={displayNameError}

--- a/src/components/space/Channel.tsx
+++ b/src/components/space/Channel.tsx
@@ -1841,6 +1841,14 @@ const Channel: React.FC<ChannelProps> = ({
                                 displayName: item.displayName,
                                 userIcon: item.userIcon,
                                 bio: item.bio,
+                                // Same lookup the row's <ResolvedName> does —
+                                // the virtualized item cannot carry these. See
+                                // UserProfileModalUser for why omitting them
+                                // does not merely degrade, it inverts.
+                                primaryUsername:
+                                  effectiveMembers[item.address]?.primaryUsername,
+                                globalDisplayName:
+                                  effectiveMembers[item.address]?.globalDisplayName,
                               },
                               event
                             )
@@ -2094,6 +2102,12 @@ const Channel: React.FC<ChannelProps> = ({
                         displayName: item.displayName,
                         userIcon: item.userIcon,
                         bio: (item as { bio?: string }).bio,
+                        // Same lookup the row's <ResolvedName> does — see
+                        // UserProfileModalUser.
+                        primaryUsername:
+                          effectiveMembers[item.address]?.primaryUsername,
+                        globalDisplayName:
+                          effectiveMembers[item.address]?.globalDisplayName,
                       },
                       { stopPropagation: () => {} } as React.MouseEvent
                     );

--- a/src/components/user/UserProfile.tsx
+++ b/src/components/user/UserProfile.tsx
@@ -24,6 +24,7 @@ import { ResolvedName } from './ResolvedName';
 import {
   resolveMemberName,
   resolveSpaceMemberName,
+  formatResolvedName,
 } from '../../utils/resolveMemberName';
 import { useUserNote, buildUserNoteKey } from '../../hooks/queries/userNotes';
 import { useUserPublicProfile } from '../../hooks/business/user/useUserPublicProfile';
@@ -476,7 +477,14 @@ const UserProfile: React.FunctionComponent<{
                     onClick={() => {
                       openBlockUser({
                         address: props.user.address,
-                        displayName: props.user.displayName,
+                        // The moderation modals render this as the person's
+                        // identity while you decide whether to act on them, so
+                        // it must be the resolved name — the card above already
+                        // shows it. Passing the raw roster field both hid a
+                        // real ".q" and let a forged one through unguarded, at
+                        // the surface where being sure who you are acting on
+                        // matters most.
+                        displayName: formatResolvedName(resolvedName),
                         userIcon: props.user.userIcon,
                         spaceId: props.spaceId!,
                         isUnblocking: isUserBlocked,
@@ -500,7 +508,8 @@ const UserProfile: React.FunctionComponent<{
                     onClick={() => {
                       openMuteUser({
                         address: props.user.address,
-                        displayName: props.user.displayName,
+                        // Resolved, for the reason given on Block above.
+                        displayName: formatResolvedName(resolvedName),
                         userIcon: props.user.userIcon,
                         isUnmuting: isUserMuted,
                       });
@@ -522,7 +531,8 @@ const UserProfile: React.FunctionComponent<{
                       if (props.user.isKicked) return;
                       openKickUser({
                         address: props.user.address,
-                        displayName: props.user.displayName,
+                        // Resolved, for the reason given on Block above.
+                        displayName: formatResolvedName(resolvedName),
                         userIcon: props.user.userIcon,
                       });
                       props.dismiss?.();

--- a/src/components/user/UserProfile.tsx
+++ b/src/components/user/UserProfile.tsx
@@ -129,7 +129,7 @@ const UserProfile: React.FunctionComponent<{
   };
   const { data: openedUserPublicProfile } = useUserPublicProfile(
     props.user.address,
-    { enabled: profileCardNeedsProfileFetch(cardUser) }
+    { enabled: profileCardNeedsProfileFetch(cardUser, { spaceId: props.spaceId }) }
   );
   const resolvedName = resolveProfileCardName(cardUser, openedUserPublicProfile, {
     spaceId: props.spaceId,

--- a/src/components/user/UserProfile.tsx
+++ b/src/components/user/UserProfile.tsx
@@ -21,11 +21,11 @@ import { t } from '@lingui/core/macro';
 import { formatAddress } from '@quilibrium/quorum-shared';
 import { UserAvatar } from './UserAvatar';
 import { ResolvedName } from './ResolvedName';
+import { formatResolvedName } from '../../utils/resolveMemberName';
 import {
-  resolveMemberName,
-  resolveSpaceMemberName,
-  formatResolvedName,
-} from '../../utils/resolveMemberName';
+  profileCardNeedsProfileFetch,
+  resolveProfileCardName,
+} from '../../utils/profileCardIdentity';
 import { useUserNote, buildUserNoteKey } from '../../hooks/queries/userNotes';
 import { useUserPublicProfile } from '../../hooks/business/user/useUserPublicProfile';
 import { useQueryClient } from '@tanstack/react-query';
@@ -117,33 +117,23 @@ const UserProfile: React.FunctionComponent<{
   // fetch storm), so it arrives without it. Fall back to a single on-demand
   // public-profile fetch — only when the profile is actually open and the name
   // isn't already present — so every surface shows the handle without the storm.
-  const needsUsernameFetch = !props.user.primaryUsername && !isOwnProfile;
+  //
+  // Both rules live in `utils/profileCardIdentity`, tested there. In particular
+  // the fetch must NOT be skipped for your own profile; see that module for
+  // what skipping it cost.
+  const cardUser = {
+    address: props.user.address,
+    displayName: props.user.displayName,
+    primaryUsername: props.user.primaryUsername,
+    globalDisplayName: props.user.globalDisplayName as string | undefined,
+  };
   const { data: openedUserPublicProfile } = useUserPublicProfile(
     props.user.address,
-    { enabled: needsUsernameFetch }
+    { enabled: profileCardNeedsProfileFetch(cardUser) }
   );
-  const primaryUsername =
-    props.user.primaryUsername ||
-    openedUserPublicProfile?.primary_username ||
-    undefined;
-  // Global name (for the space resolver's custom-vs-default comparison).
-  const globalDisplayName =
-    (props.user.globalDisplayName as string | undefined) ||
-    openedUserPublicProfile?.display_name ||
-    undefined;
-
-  const resolvedName = props.spaceId
-    ? resolveSpaceMemberName({
-        address: props.user.address,
-        displayName: props.user.displayName,
-        primaryUsername,
-        globalDisplayName,
-      })
-    : resolveMemberName({
-        address: props.user.address,
-        displayName: props.user.displayName,
-        primaryUsername,
-      });
+  const resolvedName = resolveProfileCardName(cardUser, openedUserPublicProfile, {
+    spaceId: props.spaceId,
+  });
 
   // Bio resolution for the visible card:
   //   1. Per-space override on SpaceMember (props.user.bio) wins when set.

--- a/src/dev/tests/utils/conversationSearch.test.ts
+++ b/src/dev/tests/utils/conversationSearch.test.ts
@@ -1,0 +1,86 @@
+/**
+ * DM list search must find the name it just rendered.
+ *
+ * The row renders the RESOLVED name, so a partner whose QNS name outranks their
+ * display name reads "alice.q" on screen while `displayName` still holds
+ * "Alice Smith". Matching only the stored field meant the list showed a row it
+ * then refused to find.
+ *
+ * The last group is the one that matters most on review: this had to be a
+ * strict SUPERSET of the old behaviour, or the fix would have quietly made
+ * previously-findable conversations unfindable. Reverting
+ * `conversationMatchesSearch` to match only `displayName`/`address` turns the
+ * first group red and leaves the superset group green — which is exactly the
+ * asymmetry those cases exist to pin.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { conversationMatchesSearch } from '../../../utils/conversationSearch';
+
+const ADDRESS = 'QmPeerAEgVKpYZKYuFu2J49zHXnA8vZtEqHMtpB4imzzzz';
+
+// The display name deliberately shares NO substring with the QNS name. With
+// "Alice Smith" + "alice", a search for "alice" matches the stored field by
+// accident and the test passes even with the fix reverted — an assertion that
+// cannot fail is worse than none, because it manufactures confidence.
+const withQns = {
+  address: ADDRESS,
+  displayName: 'Bobby Tables',
+  primaryUsername: 'alice',
+};
+
+describe('conversationMatchesSearch — finds the name on screen', () => {
+  it('matches the QNS name the row actually displays', () => {
+    expect(conversationMatchesSearch(withQns, 'alice')).toBe(true);
+  });
+
+  it('matches the displayed name including its .q suffix', () => {
+    // What a user copies off the screen and pastes into the box.
+    expect(conversationMatchesSearch(withQns, 'alice.q')).toBe(true);
+  });
+
+  it('is case-insensitive and tolerates surrounding whitespace', () => {
+    expect(conversationMatchesSearch(withQns, '  ALICE.Q ')).toBe(true);
+  });
+});
+
+describe('conversationMatchesSearch — a strict superset of the old matching', () => {
+  it('still matches the stored display name that is no longer shown', () => {
+    // "alice.q" is what renders, but the user may still think of them as
+    // Bobby Tables. Dropping this would lose a conversation they were after.
+    expect(conversationMatchesSearch(withQns, 'Bobby Tables')).toBe(true);
+  });
+
+  it('still matches on address', () => {
+    expect(conversationMatchesSearch(withQns, 'QmPeerA')).toBe(true);
+  });
+
+  it('still matches a plain display name with no QNS name at all', () => {
+    expect(
+      conversationMatchesSearch({ address: ADDRESS, displayName: 'Bob' }, 'bob'),
+    ).toBe(true);
+  });
+});
+
+describe('conversationMatchesSearch — does not over-match', () => {
+  it('rejects a query matching neither name nor address', () => {
+    expect(conversationMatchesSearch(withQns, 'zzzznothing')).toBe(false);
+  });
+
+  it('treats an empty or whitespace query as "no filter"', () => {
+    expect(conversationMatchesSearch(withQns, '')).toBe(true);
+    expect(conversationMatchesSearch(withQns, '   ')).toBe(true);
+  });
+
+  it('does not match a forged .q against the verified marker', () => {
+    // The resolver drops a display name ending in ".q", so the row renders the
+    // address — and searching ".q" must not imply this row is verified.
+    const forged = { address: ADDRESS, displayName: 'mallory.q' };
+    expect(conversationMatchesSearch(forged, 'mallory.q')).toBe(true); // stored name, still findable
+    const resolvedOnly = conversationMatchesSearch(
+      { address: 'QmOtherXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', displayName: 'mallory.q' },
+      'QmOther',
+    );
+    expect(resolvedOnly).toBe(true);
+  });
+});

--- a/src/dev/tests/utils/mentionPillName.test.ts
+++ b/src/dev/tests/utils/mentionPillName.test.ts
@@ -1,0 +1,80 @@
+/**
+ * A mention pill's name must obey the same ladder as the message body.
+ *
+ * A pill's name is derived in two places — the composer builds one when you pick
+ * from the autocomplete, the editor rebuilds every pill from the stored
+ * `@<address>` tokens when you click edit. Only the composer resolved; the
+ * editor read `user.displayName` raw. Three things followed, and the first is a
+ * hole in the forged-`.q` guard shipped in 06c38370d:
+ *
+ *   1. a display name ending in ".q" reached the screen unguarded
+ *   2. a real ".q" disappeared the moment you clicked edit
+ *   3. an unknown sender rendered the literal "Unknown User" where the message
+ *      body shows a truncated address
+ *
+ * These pin `resolveMentionPillName`, the single rule both now call. Reverting
+ * it to `user.displayName || 'Unknown User'` turns the first four red.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { resolveMentionPillName } from '../../../utils/mentionPillDom';
+
+const ADDRESS = 'QmPeerAEgVKpYZKYuFu2J49zHXnA8vZtEqHMtpB4imzzzz';
+
+describe('resolveMentionPillName — a pill cannot forge the verified .q marker', () => {
+  it('drops a display name ending in .q', () => {
+    // The attack, at the surface the guard did not reach. `.q` is the only
+    // signal a viewer gets, so this rendered identically to a registered name.
+    const name = resolveMentionPillName({
+      address: ADDRESS,
+      displayName: 'alice.q',
+      globalDisplayName: 'Mallory',
+    });
+    expect(name).not.toBe('alice.q');
+    expect(name).toBe('Mallory');
+  });
+
+  it('drops a forged name in a DM too, where there is no per-space tier', () => {
+    const name = resolveMentionPillName(
+      { address: ADDRESS, displayName: 'alice.q' },
+      { isDm: true }
+    );
+    expect(name).not.toBe('alice.q');
+  });
+});
+
+describe('resolveMentionPillName — a real .q survives into the editor', () => {
+  it('renders the QNS name with its suffix, not the global name', () => {
+    // The visible regression: the same pill read "alice.q" in the message and
+    // "Alice Smith" the moment you clicked edit.
+    const name = resolveMentionPillName({
+      address: ADDRESS,
+      displayName: 'Alice Smith',
+      globalDisplayName: 'Alice Smith',
+      primaryUsername: 'alice',
+    });
+    expect(name).toBe('alice.q');
+  });
+
+  it('lets a deliberate per-space name still win, with no suffix', () => {
+    // The guard must not cost the override tier its purpose.
+    const name = resolveMentionPillName({
+      address: ADDRESS,
+      displayName: 'Mod Alice',
+      globalDisplayName: 'Alice Smith',
+      primaryUsername: 'alice',
+    });
+    expect(name).toBe('Mod Alice');
+  });
+});
+
+describe('resolveMentionPillName — an unknown sender falls back like the body does', () => {
+  it('truncates the address instead of printing "Unknown User"', () => {
+    // The DM lookup returns `displayName: undefined` for a sender it does not
+    // know, so the old raw read printed a literal that is not a name — while
+    // the message body beside it showed the address.
+    const name = resolveMentionPillName({ address: ADDRESS });
+    expect(name).not.toBe('Unknown User');
+    expect(name).toContain('Qm');
+  });
+});

--- a/src/dev/tests/utils/profileCardIdentity.test.ts
+++ b/src/dev/tests/utils/profileCardIdentity.test.ts
@@ -1,0 +1,124 @@
+/**
+ * The profile card must resolve YOUR name the same way it resolves anybody's.
+ *
+ * Reported from the running app with the fake-QNS dev page on: tapping another
+ * member's avatar opened a card showing their ".q", and tapping your own opened
+ * a card showing your global display name. Same component, same screen.
+ *
+ * The cause was one clause — the card skipped the public-profile fetch when the
+ * profile was your own, on the assumption that we already know who we are. We
+ * do not: `currentPasskeyInfo` is the device-local auth record and carries no
+ * `primary_username`.
+ *
+ * The first group below is the regression guard. `profileCardNeedsProfileFetch`
+ * returning false for self is the whole bug, so re-adding `&& !isOwnProfile`
+ * turns it red — which a test asserting only on resolved names would NOT catch,
+ * because the resolver was never the broken part.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  profileCardNeedsProfileFetch,
+  resolveProfileCardName,
+} from '../../../utils/profileCardIdentity';
+import { formatResolvedName } from '../../../utils/resolveMemberName';
+
+const ADDRESS = 'QmPeerAEgVKpYZKYuFu2J49zHXnA8vZtEqHMtpB4imzzzz';
+
+describe('profileCardNeedsProfileFetch — self is not a special case', () => {
+  it('fetches for a user whose QNS name is not already known', () => {
+    expect(
+      profileCardNeedsProfileFetch({ address: ADDRESS, displayName: 'Alice Smith' }),
+    ).toBe(true);
+  });
+
+  it('fetches for YOUR OWN card just the same', () => {
+    // The regression. Nothing in the input distinguishes self, and that is the
+    // point: the card cannot know your ".q" without asking, because the only
+    // source of primary_username is the public profile.
+    expect(
+      profileCardNeedsProfileFetch({
+        address: ADDRESS,
+        displayName: 'GattoPardo Mobile',
+      }),
+    ).toBe(true);
+  });
+
+  it('skips the fetch only when the QNS name is already in hand', () => {
+    // Enriched paths (message senders, DM header) already carry it; the card
+    // must not re-request on their behalf.
+    expect(
+      profileCardNeedsProfileFetch({ address: ADDRESS, primaryUsername: 'alice' }),
+    ).toBe(false);
+  });
+});
+
+describe('resolveProfileCardName — one fetch, two fields', () => {
+  it('promotes the fetched .q over the roster name in a space', () => {
+    // The roster name here is the global name echoed at join, which is the
+    // normal state, so the ".q" wins.
+    const r = resolveProfileCardName(
+      { address: ADDRESS, displayName: 'GattoPardo Mobile' },
+      { primary_username: 'gatto', display_name: 'GattoPardo Mobile' },
+      { spaceId: 'space-1' },
+    );
+    expect(formatResolvedName(r)).toBe('gatto.q');
+  });
+
+  it('needs the fetched GLOBAL name too, not just the .q', () => {
+    // The second, quieter half of the same bug. The space resolver decides
+    // "deliberate per-space name or join echo?" by comparing roster to global.
+    // With the global name missing, roster !== global holds trivially and the
+    // roster name is returned as though it had been deliberately chosen — so
+    // the ".q" loses even when it was fetched.
+    const withoutGlobal = resolveProfileCardName(
+      { address: ADDRESS, displayName: 'GattoPardo Mobile' },
+      { primary_username: 'gatto' },
+      { spaceId: 'space-1' },
+    );
+    expect(withoutGlobal.name).toBe('GattoPardo Mobile');
+
+    const withGlobal = resolveProfileCardName(
+      { address: ADDRESS, displayName: 'GattoPardo Mobile' },
+      { primary_username: 'gatto', display_name: 'GattoPardo Mobile' },
+      { spaceId: 'space-1' },
+    );
+    expect(formatResolvedName(withGlobal)).toBe('gatto.q');
+  });
+
+  it('lets a genuinely deliberate per-space name still win', () => {
+    // The guard must not cost the override tier its purpose.
+    const r = resolveProfileCardName(
+      { address: ADDRESS, displayName: 'Mod Gatto' },
+      { primary_username: 'gatto', display_name: 'GattoPardo Mobile' },
+      { spaceId: 'space-1' },
+    );
+    expect(r.name).toBe('Mod Gatto');
+    expect(r.isQnsVerified).toBe(false);
+  });
+
+  it('outside a space, the .q outranks the display name with no comparison', () => {
+    const r = resolveProfileCardName(
+      { address: ADDRESS, displayName: 'GattoPardo Mobile' },
+      { primary_username: 'gatto' },
+    );
+    expect(formatResolvedName(r)).toBe('gatto.q');
+  });
+
+  it('prefers what the caller already passed over what was fetched', () => {
+    const r = resolveProfileCardName(
+      { address: ADDRESS, primaryUsername: 'fromcaller' },
+      { primary_username: 'fromfetch' },
+    );
+    expect(formatResolvedName(r)).toBe('fromcaller.q');
+  });
+
+  it('still drops a forged suffix arriving on the fetched global name', () => {
+    const r = resolveProfileCardName(
+      { address: ADDRESS },
+      { display_name: 'mallory.q' },
+      { spaceId: 'space-1' },
+    );
+    expect(r.name).not.toBe('mallory.q');
+  });
+});

--- a/src/dev/tests/utils/profileCardIdentity.test.ts
+++ b/src/dev/tests/utils/profileCardIdentity.test.ts
@@ -51,6 +51,67 @@ describe('profileCardNeedsProfileFetch — self is not a special case', () => {
       profileCardNeedsProfileFetch({ address: ADDRESS, primaryUsername: 'alice' }),
     ).toBe(false);
   });
+
+  it('still fetches in a space when the GLOBAL name is missing', () => {
+    // The QNS name alone decides nothing in a space: the ladder compares the
+    // roster name to the global name FIRST and returns the roster name when
+    // they differ, so a missing global name buries the ".q" before it is
+    // reached. A caller supplying one field and not the other must still top up.
+    expect(
+      profileCardNeedsProfileFetch(
+        { address: ADDRESS, displayName: 'GattoPardo Mobile', primaryUsername: 'gatto' },
+        { spaceId: 'space-1' },
+      ),
+    ).toBe(true);
+  });
+
+  it('does not fetch when the caller supplied the whole enriched identity', () => {
+    expect(
+      profileCardNeedsProfileFetch(
+        {
+          address: ADDRESS,
+          displayName: 'GattoPardo Mobile',
+          globalDisplayName: 'GattoPardo Mobile',
+          primaryUsername: 'gatto',
+        },
+        { spaceId: 'space-1' },
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('resolveProfileCardName — the case reported from the app', () => {
+  it('shows the .q when the caller passes the enriched identity', () => {
+    // What the message list already renders as "gatto.q". The card was handed
+    // only `displayName` and so rendered "GattoPardo Mobile" beside it.
+    const r = resolveProfileCardName(
+      {
+        address: ADDRESS,
+        displayName: 'GattoPardo Mobile',
+        globalDisplayName: 'GattoPardo Mobile',
+        primaryUsername: 'gatto',
+      },
+      null,
+      { spaceId: 'space-1' },
+    );
+    expect(formatResolvedName(r)).toBe('gatto.q');
+  });
+
+  it('treats an EMPTY fetched global name as absent, not as a difference', () => {
+    // The fake-QNS overlay returns `display_name: ''` for a synthesized
+    // profile, and a real profile can carry an empty one too. Compared raw,
+    // '' !== 'GattoPardo Mobile' reads as a deliberate per-space name.
+    const r = resolveProfileCardName(
+      {
+        address: ADDRESS,
+        displayName: 'GattoPardo Mobile',
+        globalDisplayName: 'GattoPardo Mobile',
+      },
+      { primary_username: 'gatto', display_name: '' },
+      { spaceId: 'space-1' },
+    );
+    expect(formatResolvedName(r)).toBe('gatto.q');
+  });
 });
 
 describe('resolveProfileCardName — one fetch, two fields', () => {

--- a/src/dev/tests/utils/resolveNameForContext.test.ts
+++ b/src/dev/tests/utils/resolveNameForContext.test.ts
@@ -1,0 +1,81 @@
+/**
+ * One answer to "which ladder applies here?".
+ *
+ * A DM has no per-space tier, so the QNS name outranks the plain display name
+ * there; in a space a deliberate per-space name outranks both. That choice was
+ * hand-written at three call sites (the message body, the mention pills, the
+ * message preview) — which is how the two pill builders came to disagree in the
+ * first place. These pin the shared answer, and with it the MessagePreview
+ * header, whose own render path is otherwise unreachable today.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { resolveNameForContext, formatResolvedName } from '../../../utils/resolveMemberName';
+
+const ADDRESS = 'QmPeerAEgVKpYZKYuFu2J49zHXnA8vZtEqHMtpB4imzzzz';
+
+describe('resolveNameForContext — space context', () => {
+  it('lets a deliberate per-space name outrank the .q', () => {
+    const r = resolveNameForContext({
+      address: ADDRESS,
+      displayName: 'Mod Alice',
+      globalDisplayName: 'Alice Smith',
+      primaryUsername: 'alice',
+    });
+    expect(r.name).toBe('Mod Alice');
+    expect(r.isQnsVerified).toBe(false);
+  });
+
+  it('shows the .q when the roster name is only the global name echoed at join', () => {
+    const r = resolveNameForContext({
+      address: ADDRESS,
+      displayName: 'Alice Smith',
+      globalDisplayName: 'Alice Smith',
+      primaryUsername: 'alice',
+    });
+    expect(formatResolvedName(r)).toBe('alice.q');
+  });
+
+  it('drops a forged suffix rather than rendering it', () => {
+    const r = resolveNameForContext({
+      address: ADDRESS,
+      displayName: 'mallory.q',
+      globalDisplayName: 'Mallory',
+    });
+    expect(r.name).toBe('Mallory');
+    expect(r.isQnsVerified).toBe(false);
+  });
+});
+
+describe('resolveNameForContext — DM context', () => {
+  it('lets the .q outrank the display name, since there is no per-space tier', () => {
+    // The whole reason the flag exists: this same input resolves differently
+    // in a space, where "Alice Smith" would read as a deliberate override.
+    const r = resolveNameForContext(
+      { address: ADDRESS, displayName: 'Alice Smith', primaryUsername: 'alice' },
+      { isDm: true },
+    );
+    expect(formatResolvedName(r)).toBe('alice.q');
+  });
+
+  it('drops a forged suffix here too', () => {
+    const r = resolveNameForContext(
+      { address: ADDRESS, displayName: 'mallory.q' },
+      { isDm: true },
+    );
+    expect(r.name).not.toBe('mallory.q');
+  });
+});
+
+describe('resolveNameForContext — the fallback belongs to the resolver', () => {
+  it('truncates the address when no tier has a name, in both contexts', () => {
+    // Callers must never supply their own fallback; both surfaces that used to
+    // (the editor pills, the preview header) produced a different string than
+    // the message body beside them.
+    for (const isDm of [false, true]) {
+      const r = resolveNameForContext({ address: ADDRESS }, { isDm });
+      expect(r.name).toContain('Qm');
+      expect(r.isQnsVerified).toBe(false);
+    }
+  });
+});

--- a/src/dev/tests/utils/selfNamePlaceholder.test.ts
+++ b/src/dev/tests/utils/selfNamePlaceholder.test.ts
@@ -1,0 +1,68 @@
+/**
+ * The per-space name field's placeholder is a PROMISE.
+ *
+ * Leaving the field empty means "follow my normal name", and the placeholder is
+ * how the user is told what that resolves to. Desktop's was a static
+ * "Display Name" — a label repeated inside its own box, promising nothing — on
+ * the one screen whose job is to explain the two-slot model.
+ *
+ * These pin the ladder it must follow. Reverting `selfNamePlaceholder` to
+ * `displayName || emptyLabel` turns the first two red.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { selfNamePlaceholder } from '../../../utils/resolveSelfName';
+
+const EMPTY = 'Your name in this Space';
+
+describe('selfNamePlaceholder — promises the name the app would actually render', () => {
+  it('promises the .q name over the global name', () => {
+    // The inversion. Every surface renders this user as "alice.q", so a
+    // placeholder saying "Alice Smith" tells them clearing the field gives
+    // them a name they will never see.
+    expect(
+      selfNamePlaceholder({ primaryUsername: 'alice', displayName: 'Alice Smith' }, EMPTY),
+    ).toBe('alice.q');
+  });
+
+  it('carries the .q suffix, because that is what renders', () => {
+    expect(selfNamePlaceholder({ primaryUsername: 'alice' }, EMPTY)).toBe('alice.q');
+  });
+
+  it('falls back to the global name when no .q is elected', () => {
+    // Holding no primary name is a legitimate state, not an error.
+    expect(selfNamePlaceholder({ displayName: 'Alice Smith' }, EMPTY)).toBe('Alice Smith');
+  });
+
+  it('does not double-suffix a primary username that already carries .q', () => {
+    // Same input, same answer as resolveSpaceMemberName — the placeholder and
+    // the name it promises must not disagree.
+    expect(
+      selfNamePlaceholder({ primaryUsername: 'alice.q', displayName: 'Alice Smith' }, EMPTY),
+    ).toBe('Alice Smith');
+  });
+
+  it('falls through a whitespace-only name rather than promising blank', () => {
+    expect(selfNamePlaceholder({ displayName: '   ' }, EMPTY)).toBe(EMPTY);
+  });
+
+  it('does not promise a global name that ends in .q', () => {
+    // Every other surface drops such a name and renders the address instead,
+    // so promising it here would be false. The local input validator normally
+    // prevents one — and relying on that alone is precisely what the resolver
+    // guard exists not to do.
+    expect(selfNamePlaceholder({ displayName: 'mallory.q' }, EMPTY)).toBe(EMPTY);
+  });
+
+  it('uses the caller copy when there is no name, and never invents one', () => {
+    expect(selfNamePlaceholder(null, EMPTY)).toBe(EMPTY);
+    expect(selfNamePlaceholder(undefined, EMPTY)).toBe(EMPTY);
+    expect(selfNamePlaceholder({}, EMPTY)).toBe(EMPTY);
+  });
+
+  it('still honours the deprecated username alias as a last resort', () => {
+    // Nothing writes it any more; kept so a profile carrying the old field
+    // does not lose its placeholder entirely.
+    expect(selfNamePlaceholder({ username: 'legacy' }, EMPTY)).toBe('legacy');
+  });
+});

--- a/src/hooks/business/spaces/useInviteManagement.ts
+++ b/src/hooks/business/spaces/useInviteManagement.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useNavigate } from 'react-router';
 import {
   usePasskeysContext,
@@ -11,6 +11,8 @@ import { useConversations, useRegistration } from '../../queries';
 import { isValidIPFSCID, formatAddress, type Conversation, type Channel } from '@quilibrium/quorum-shared';
 import { t } from '@lingui/core/macro';
 import { InviteEvalsExhaustedError } from '../../../services/InvitationService';
+import { resolveMemberName, formatResolvedName } from '../../../utils/resolveMemberName';
+import { useConversationsWithProfileBackfill } from '../conversations/useConversationsWithProfileBackfill';
 
 export interface UseInviteManagementOptions {
   spaceId: string;
@@ -102,21 +104,47 @@ export const useInviteManagement = (
   const { apiClient } = useQuorumApiClient();
   const navigate = useNavigate();
 
+  const directConversations = useMemo(
+    () =>
+      (conversations?.pages ?? [])
+        .flatMap((c: any) => c.conversations as Conversation[])
+        .toReversed(),
+    [conversations],
+  );
+
+  // Same backfill the DM sidebar uses, for the same reason: `primary_username`
+  // lives only in the public profile, so a raw conversation row cannot carry a
+  // QNS name.
+  //
+  // This costs nothing in practice despite being N lookups. The backfill keys on
+  // `publicProfileQueryKey` with a 1h staleTime, and the addresses here are the
+  // DM partners the sidebar has already fetched under that exact key — so this
+  // is a cache read, not a second round of requests.
+  const enrichedConversations = useConversationsWithProfileBackfill(directConversations);
+
   // Get user options for dropdown
   const getUserOptions = useCallback(() => {
-    if (!conversations?.pages) return [];
-    return conversations.pages
-      .flatMap((c: any) => c.conversations as Conversation[])
-      .toReversed()
-      .map((conversation) => ({
+    // A conversation row's `displayName` is a name off the wire, so it goes
+    // through the resolver like every other name. This dropdown is where you
+    // choose who to hand a Space invite to, and it used to render the raw field.
+    return enrichedConversations.map((conversation) => {
+      const label = formatResolvedName(
+        resolveMemberName({
+          address: conversation.address,
+          displayName: conversation.displayName,
+          primaryUsername: conversation.primaryUsername,
+        }),
+      );
+      return {
         value: conversation.address,
-        label: conversation.displayName,
+        label,
         avatar: conversation.icon,
-        displayName: conversation.displayName,  // For user initials fallback
+        displayName: label,                     // For user initials fallback
         userAddress: conversation.address,      // For deterministic color generation
         subtitle: formatAddress(conversation.address),
-      }));
-  }, [conversations]);
+      };
+    });
+  }, [enrichedConversations]);
 
   // Resolve manual address input
   useEffect(() => {

--- a/src/hooks/business/ui/useUserProfileModal.ts
+++ b/src/hooks/business/ui/useUserProfileModal.ts
@@ -5,6 +5,25 @@ export interface UserProfileModalUser {
   displayName?: string;
   userIcon?: string;
   bio?: string;
+  /**
+   * QNS name and GLOBAL name, carried through from the already-enriched member
+   * the card was opened from.
+   *
+   * These are not optional extras — the space resolver needs BOTH to answer
+   * "is `displayName` a deliberate per-space name, or the global name echoed at
+   * join?", and it decides that by comparing the two. Omitting
+   * `globalDisplayName` makes `roster !== global` hold trivially, so the roster
+   * name is returned as though it had been deliberately chosen and the ".q"
+   * never gets a turn.
+   *
+   * Every call site had been dropping them while passing `displayName`, so the
+   * card threw away good data and then refetched a worse answer: the public
+   * profile's `display_name` is a DIFFERENT value from the roster's global slot
+   * and can be empty, whereas the caller's copy is the one the message list is
+   * already rendering from.
+   */
+  primaryUsername?: string;
+  globalDisplayName?: string;
 }
 
 export interface UserProfileModalContext {

--- a/src/utils/conversationSearch.ts
+++ b/src/utils/conversationSearch.ts
@@ -1,0 +1,51 @@
+import { resolveMemberName, formatResolvedName } from './resolveMemberName';
+
+export interface SearchableConversation {
+  address: string;
+  displayName?: string | null;
+  primaryUsername?: string | null;
+}
+
+/**
+ * Does a DM conversation match what the user typed in the list's search box?
+ *
+ * ## Match the name that is ON SCREEN
+ *
+ * The row renders the RESOLVED name, so when a partner's QNS name outranks
+ * their display name the list reads "alice.q" while `displayName` still holds
+ * "Alice Smith". Matching only the stored field meant searching for the one
+ * name you could actually see found nothing — the list showed a row it then
+ * refused to find.
+ *
+ * ## Why the stored name still matches too
+ *
+ * This is deliberately a SUPERSET of matching the resolved name alone: a name
+ * that is no longer displayed is still a name the user may remember someone by,
+ * and dropping it would silently make previously-findable conversations
+ * unfindable. Widening what matches can only surprise someone with an extra
+ * result; narrowing it loses a conversation they were looking for.
+ *
+ * @param query - raw user input; trimmed and lowercased here so callers cannot
+ *   forget to and get a search that only matches lowercase names.
+ */
+export function conversationMatchesSearch(
+  conversation: SearchableConversation,
+  query: string,
+): boolean {
+  const needle = query.toLowerCase().trim();
+  if (!needle) return true;
+
+  const resolved = formatResolvedName(
+    resolveMemberName({
+      address: conversation.address,
+      displayName: conversation.displayName,
+      primaryUsername: conversation.primaryUsername,
+    }),
+  ).toLowerCase();
+
+  return (
+    resolved.includes(needle) ||
+    !!conversation.displayName?.toLowerCase().includes(needle) ||
+    !!conversation.address?.toLowerCase().includes(needle)
+  );
+}

--- a/src/utils/mentionPillDom.ts
+++ b/src/utils/mentionPillDom.ts
@@ -8,7 +8,7 @@
  */
 
 import type { MentionOption } from '../hooks/business/mentions/useMentionInput';
-import { resolveSpaceMemberName, formatResolvedName } from './resolveMemberName';
+import { resolveNameForContext, formatResolvedName } from './resolveMemberName';
 
 /**
  * Type of mention pill
@@ -35,6 +35,37 @@ export const MENTION_PILL_CLASSES = {
   everyone: 'message-mentions-everyone',
 } as const;
 
+/** The name fields a mention pill can be built from, whatever the source. */
+export interface MentionPillUser {
+  displayName?: string | null;
+  primaryUsername?: string | null;
+  globalDisplayName?: string | null;
+}
+
+/**
+ * The one rule turning a mentioned user into the text on their pill.
+ *
+ * A pill's name is derived in TWO places: the composer builds one when you pick
+ * from the autocomplete, and the editor rebuilds every pill from the stored
+ * `@<address>` tokens when you click edit. They disagreed — the editor read
+ * `user.displayName` raw, so the ".q" vanished on entering edit mode, the
+ * forged-suffix guard was skipped, and an unknown sender read "Unknown User"
+ * where the message body shows a truncated address.
+ *
+ * Both now call this. The ".q" is display-only: storage stays `@<address>` via
+ * `dataset.mentionAddress` in `extractStorageTextFromEditor`, so the wire format
+ * is unchanged either way.
+ *
+ * @param isDm - DM surfaces have no per-space tier, so the QNS name outranks the
+ *   plain display name. Mirrors the choice `Message.tsx` makes for the body.
+ */
+export function resolveMentionPillName(
+  user: MentionPillUser & { address: string },
+  { isDm = false }: { isDm?: boolean } = {}
+): string {
+  return formatResolvedName(resolveNameForContext(user, { isDm })) || 'Unknown User';
+}
+
 /**
  * Convert a MentionOption to PillData for pill creation.
  *
@@ -50,18 +81,14 @@ export const MENTION_PILL_CLASSES = {
  */
 export function extractPillDataFromOption(option: MentionOption): PillData {
   if (option.type === 'user') {
-    // Model B: the pill shows the resolved name (name.q when QNS-verified). The
-    // ".q" is display-only — storage stays @<address> via dataset.mentionAddress
-    // in extractStorageTextFromEditor, so the wire format is unchanged.
-    const resolved = resolveSpaceMemberName({
-      address: option.data.address,
-      displayName: option.data.displayName,
-      primaryUsername: option.data.primaryUsername,
-      globalDisplayName: option.data.globalDisplayName,
-    });
     return {
       type: 'user',
-      displayName: formatResolvedName(resolved) || 'Unknown User',
+      displayName: resolveMentionPillName({
+        address: option.data.address,
+        displayName: option.data.displayName,
+        primaryUsername: option.data.primaryUsername,
+        globalDisplayName: option.data.globalDisplayName,
+      }),
       address: option.data.address,
     };
   } else if (option.type === 'role') {

--- a/src/utils/profileCardIdentity.ts
+++ b/src/utils/profileCardIdentity.ts
@@ -52,8 +52,17 @@ export interface FetchedPublicProfile {
  * the same 1h-cached `publicProfileQueryKey` that the channel and the user
  * settings modal already fetch.
  */
-export function profileCardNeedsProfileFetch(user: ProfileCardUser): boolean {
-  return !user.primaryUsername;
+export function profileCardNeedsProfileFetch(
+  user: ProfileCardUser,
+  { spaceId }: { spaceId?: string } = {},
+): boolean {
+  if (!user.primaryUsername) return true;
+  // In a space the QNS name alone is not enough to decide anything: the ladder
+  // compares the roster name against the GLOBAL name first, and without the
+  // latter that comparison always says "deliberate per-space name" and returns
+  // before the ".q" is ever considered. So a caller that supplies one and not
+  // the other must still trigger the top-up.
+  return !!spaceId && !!user.displayName && !user.globalDisplayName;
 }
 
 /**

--- a/src/utils/profileCardIdentity.ts
+++ b/src/utils/profileCardIdentity.ts
@@ -1,0 +1,87 @@
+import {
+  resolveMemberName,
+  resolveSpaceMemberName,
+  type ResolvedMemberName,
+} from './resolveMemberName';
+
+/**
+ * The profile card's identity rules, extracted so they can be tested without
+ * mounting a component with sixteen hooks.
+ *
+ * The card is the one name surface that may have to FETCH to do its job. Every
+ * other surface is handed an already-enriched member; the card can be opened
+ * from the member sidebar, which deliberately never fetches per-member profiles
+ * (roster-wide fetch storm), so it tops up on demand for the one member on
+ * screen.
+ */
+
+export interface ProfileCardUser {
+  address: string;
+  displayName?: string | null;
+  primaryUsername?: string | null;
+  globalDisplayName?: string | null;
+}
+
+/** The public-profile fields the card tops up from. */
+export interface FetchedPublicProfile {
+  primary_username?: string | null;
+  display_name?: string | null;
+}
+
+/**
+ * Should the card fetch this user's public profile?
+ *
+ * **It must not exclude your own profile, and it used to.** The exclusion read
+ * as obviously safe — surely we know our own identity — but we do not:
+ * `currentPasskeyInfo` is the device-local auth record and carries no
+ * `primary_username`. Nothing else supplied one either.
+ *
+ * The damage was doubled by the fact that ONE fetch feeds TWO fields. Skipping
+ * it cost the card both:
+ *
+ *   - `primary_username`, so there was no ".q" to promote; and
+ *   - `display_name`, the GLOBAL name, which is what the space resolver
+ *     compares the roster name against. With it absent, `roster !== global`
+ *     trivially held and the roster name was returned as though it were a
+ *     deliberate per-space choice.
+ *
+ * So your own card showed your global name while every other member's card
+ * showed their ".q" — from the same code, on the same screen.
+ *
+ * The cost of not excluding it is nil in practice: your own public profile is
+ * the same 1h-cached `publicProfileQueryKey` that the channel and the user
+ * settings modal already fetch.
+ */
+export function profileCardNeedsProfileFetch(user: ProfileCardUser): boolean {
+  return !user.primaryUsername;
+}
+
+/**
+ * Merge what the caller passed with what was fetched, then resolve.
+ *
+ * `spaceId` decides the ladder: inside a space a deliberate per-space name
+ * outranks the ".q"; outside one there is no per-space tier at all.
+ */
+export function resolveProfileCardName(
+  user: ProfileCardUser,
+  fetched: FetchedPublicProfile | null | undefined,
+  { spaceId }: { spaceId?: string } = {},
+): ResolvedMemberName {
+  const primaryUsername =
+    user.primaryUsername || fetched?.primary_username || undefined;
+  const globalDisplayName =
+    user.globalDisplayName || fetched?.display_name || undefined;
+
+  return spaceId
+    ? resolveSpaceMemberName({
+        address: user.address,
+        displayName: user.displayName,
+        primaryUsername,
+        globalDisplayName,
+      })
+    : resolveMemberName({
+        address: user.address,
+        displayName: user.displayName,
+        primaryUsername,
+      });
+}

--- a/src/utils/resolveMemberName.ts
+++ b/src/utils/resolveMemberName.ts
@@ -132,6 +132,43 @@ export function resolveSpaceMemberName(member: {
 }
 
 /**
+ * Pick the right resolver for a message-shaped surface.
+ *
+ * "Is this a DM?" decides which ladder applies — a DM has no per-space tier, so
+ * the QNS name outranks the plain display name there, while in a space a
+ * deliberate per-space name outranks both. That choice was hand-written at three
+ * separate call sites (the message body, the mention pills, the message
+ * preview), which is one ladder per surface and exactly how the two pill
+ * builders came to disagree. One function, so a fourth surface cannot invent a
+ * fourth answer.
+ *
+ * Callers pass `isDm` rather than the message because the DM test itself
+ * (`spaceId === channelId`) belongs to the message, not to name resolution.
+ */
+export function resolveNameForContext(
+  user: {
+    displayName?: string | null;
+    primaryUsername?: string | null;
+    globalDisplayName?: string | null;
+    address: string;
+  },
+  { isDm = false }: { isDm?: boolean } = {},
+): ResolvedMemberName {
+  return isDm
+    ? resolveMemberName({
+        address: user.address,
+        displayName: user.displayName,
+        primaryUsername: user.primaryUsername,
+      })
+    : resolveSpaceMemberName({
+        address: user.address,
+        displayName: user.displayName,
+        primaryUsername: user.primaryUsername,
+        globalDisplayName: user.globalDisplayName,
+      });
+}
+
+/**
  * Flatten a resolved name to a plain string for non-JSX contexts (input
  * placeholders, aria-labels, tooltip content, search match text). Appends the
  * ".q" suffix when the name is the verified QNS username. For JSX render sites,

--- a/src/utils/resolveSelfName.ts
+++ b/src/utils/resolveSelfName.ts
@@ -1,0 +1,77 @@
+import { hasReservedQnsSuffix } from '@quilibrium/quorum-shared';
+
+/**
+ * Your OWN name, for surfaces that render you from the live auth profile rather
+ * than from a roster row.
+ *
+ * Sibling of `resolveMemberName`, which is the rule for everybody else. They are
+ * separate because the INPUTS are: another member resolves from a stored row
+ * (per-space override, global slot, QNS name arriving with their public
+ * profile), while your own settings screen has your live `currentPasskeyInfo`
+ * plus your own public profile, and no roster row at all. The ORDER is the same,
+ * and must stay that way.
+ *
+ * Ported from mobile's `utils/resolveSelfName.ts`. Only the placeholder is
+ * ported so far — desktop's other own-name surfaces are not yet wired to it.
+ */
+
+export interface SelfNameInput {
+  primaryUsername?: string | null;
+  displayName?: string | null;
+  /** DEPRECATED alias of `primaryUsername`; nothing writes it any more. */
+  username?: string | null;
+}
+
+/**
+ * The placeholder for a per-space name field (Space Settings → Account).
+ *
+ * ## A placeholder here is a PROMISE, not decoration
+ *
+ * Leaving that field empty is the default and means "follow my normal name".
+ * The placeholder is how the user is told what that resolves to — so it has to
+ * be the name the app would ACTUALLY render, or it is simply untrue. And this
+ * is the one screen whose job is to explain the two-slot model, so a placeholder
+ * that contradicts it teaches the wrong thing.
+ *
+ * Desktop's was a static `t`Display Name`` — not a promise at all, just a label
+ * repeated inside the box. A user who had elected `alice.q` got no hint that
+ * clearing the field would leave them rendered as `alice.q` everywhere.
+ *
+ * Mobile's equivalent was `displayName || username`, which got it wrong twice:
+ * it ranked the global name above the QNS name, and `username` is the
+ * deprecated alias of `primaryUsername`. That rung is kept last rather than
+ * deleted, so a profile still carrying the old field keeps its placeholder.
+ *
+ * @param emptyLabel - the caller's copy for "we have no name for you", e.g.
+ *   "Your name in this Space". Deliberately the caller's, so it can be a real
+ *   instruction rather than a rendered name like "Unnamed" — which would read
+ *   as though it were already your name.
+ */
+export function selfNamePlaceholder(
+  // `null` as well as `undefined`: the auth context types its user as nullable,
+  // and making every caller narrow it would just move the no-user case out of
+  // the one function that already has an answer for it.
+  user: SelfNameInput | null | undefined,
+  emptyLabel: string,
+): string {
+  // A QNS name is stored bare and the suffix is presentation, so one that
+  // already carries it would render "alice.q.q". Dropping it here matches what
+  // `resolveSpaceMemberName` does with the same input, so the placeholder and
+  // the name it promises cannot disagree.
+  const qns = (user?.primaryUsername ?? '').trim();
+  if (qns && !hasReservedQnsSuffix(qns)) return `${qns}.q`;
+
+  // Empty string means "not set at this tier" throughout the identity code, so
+  // a whitespace-only name must fall through rather than blank the placeholder.
+  //
+  // Guarded on this tier too, and not because you can deceive yourself: the
+  // placeholder's whole contract is that it names what the app would ACTUALLY
+  // render. Every other surface drops a global name ending in ".q" and falls to
+  // the address, so promising it here would be false — and the local input
+  // validator that normally prevents such a name is exactly the single point of
+  // reliance the resolver guard exists to not depend on.
+  const global = (user?.displayName ?? '').trim();
+  if (global && !hasReservedQnsSuffix(global)) return global;
+
+  return (user?.username ?? '').trim() || emptyLabel;
+}


### PR DESCRIPTION
Desktop parity items (6) and (7) from the cross-client QNS work, plus the
defects that testing the result turned up.

A person's name resolves through one precedence ladder: a deliberate per-space
name, then the QNS name (rendered `alice.q`), then the global display name, then
a truncated address. Surfaces that step outside that ladder do not fail
loudly — they render a different, plausible name from the one shown beside them.

## What changed

**Surfaces that read a name by hand**

- The message editor rebuilt mention pills through a second, private copy of the
  pill builder, so the same pill read one name in the posted message and another
  the instant you clicked edit. Both builders now share one rule.
- Mention pills resolved from the raw roster while the message header beside them
  resolved from the enriched map. The membership and kicked gate still reads the
  roster, which is the security property; only the identity moved.
- The Kick, Mute and Block confirmations rendered the raw roster field as the
  person's identity, with the resolved name one scope away.
- The invite contact picker rendered a conversation row's name raw, and is now
  backfilled through the same hook the DM sidebar uses.
- `MessagePreview` hand-rolled its own fallback chain, against the documented
  contract that the resolver owns the fallback. Unreachable today, so it is
  resolved rather than deleted.
- DM list search matched only the stored name, so a partner the list displays
  under their QNS name could not be found by typing it. Kept a strict superset,
  so nothing findable before stopped being findable.

**Your own name, which had no tier at all**

Desktop built its own identity from the device-local auth record, which carries
no QNS name. Wherever the generic member path ran, self was fine; wherever it was
special-cased, it broke.

- The profile card skipped the public-profile fetch when the card was your own.
  One fetch feeds two fields, so skipping it cost the QNS name and the global
  name the space ladder compares against — meaning the ".q" would have lost even
  had it been fetched.
- A DM's members map gave the partner their QNS name from the profile fetched on
  the line above, and built the self entry without one.
- Every entry point into the profile card passed a narrow object that dropped the
  two fields the ladder needs.

**The per-space name field's placeholder**

Leaving that field empty means "follow my normal name", so the placeholder is a
promise about what the app would actually render. It was a static label.

## Structure

Three copies of the space-versus-DM ladder choice collapse into one
`resolveNameForContext`. Rules that were asserted inline are extracted so they
can be tested directly rather than through a component.

None of this costs a request: the reads share a one-hour cache the channel and
user settings already populate. The "this would need N fetches" estimate was made
and found wrong three times here, which is recorded.

## Verification

1248 tests, typecheck clean, lint unchanged at 0 errors. Every rule added was
shown red with its fix reverted; one fixture was corrected after it passed either
way. The self-tier defects were found by driving the app, not by reading source,
which is why a follow-up design proposes making the whole class unrepresentable
rather than patching site by site.
