### PR TITLE
fix(emoji): the reaction picker stays open, and its emoji load in production

### DIFF
--- a/src/components/emoji-picker/emojiData.ts
+++ b/src/components/emoji-picker/emojiData.ts
@@ -39,6 +39,25 @@ const CATEGORY_ICON_CODES: Record<string, string> = {
 
 let cachedEmojis: EmojiItem[] | null = null;
 let cachedRockHand: EmojiItem | null = null;
+let cachedByUnified: Map<string, EmojiItem> | null = null;
+
+/**
+ * Look up an emoji by unified codepoint, case-insensitively.
+ *
+ * emoji-datasource-twitter stores `unified` uppercase and the picker records
+ * usage in that form, but entries migrated from the old emoji-picker-react
+ * store (`epr_suggested`) are lowercase and are carried across verbatim. An
+ * exact match drops those silently, leaving a short "Frequently Used" row for
+ * anyone who used the app before the picker rewrite.
+ */
+function findByUnified(unified: string): EmojiItem | undefined {
+  if (!cachedByUnified) {
+    cachedByUnified = new Map(
+      buildEmojiIndex().map((e) => [e.unified.toLowerCase(), e])
+    );
+  }
+  return cachedByUnified.get(unified.toLowerCase());
+}
 
 /** Convert unified codepoint string to native emoji character */
 export function unifiedToEmoji(unified: string): string {
@@ -142,9 +161,19 @@ export function buildRowData(
 
   // Frequently Used
   if (frequentUnifieds.length > 0) {
-    const freqEmojis = frequentUnifieds
-      .map((u) => emojis.find((e) => e.unified === u))
-      .filter((e): e is EmojiItem => e != null);
+    // Dedupe on the resolved emoji, not the stored key: a user who used the app
+    // both before and after the picker rewrite can hold "1f600" AND "1F600" for
+    // the same emoji, which case-insensitive lookup would otherwise list twice —
+    // and the row renders with `key={item.unified}`, so it would collide there too.
+    const seen = new Set<string>();
+    const freqEmojis: EmojiItem[] = [];
+    for (const u of frequentUnifieds) {
+      const match = findByUnified(u);
+      if (match && !seen.has(match.unified)) {
+        seen.add(match.unified);
+        freqEmojis.push(match);
+      }
+    }
 
     if (freqEmojis.length > 0) {
       categoryRowIndices.set('Frequently Used', rows.length);

--- a/src/components/message/MessageActions.tsx
+++ b/src/components/message/MessageActions.tsx
@@ -1,10 +1,8 @@
 import React, { useState } from 'react';
-import { parse as parseEmoji } from '@twemoji/parser';
 import type { Message as MessageType } from '@quilibrium/quorum-shared';
 import { Tooltip, Icon, type IconName } from '../primitives';
 import { useQuickReactions, useFrequentEmojis } from '../../hooks/business/messages';
 import { useShiftKey } from '../../hooks/ui/useShiftKey';
-import { emojiToUnified } from '../../utils/remarkTwemoji';
 import { t } from '@lingui/core/macro';
 
 interface MessageActionsProps {
@@ -214,18 +212,7 @@ export const MessageActions: React.FC<MessageActionsProps> = ({
           ) : (
             <>
               {/* Quick reactions - top 3 most frequently used emojis */}
-              {frequentEmojis.map(({ emoji, unified }) => {
-                // Resolve Twemoji image path from unified codepoint or native emoji
-                let twemojiSrc: string | null = null;
-                if (unified) {
-                  twemojiSrc = `/twitter/64/${unified}.png`;
-                } else {
-                  const entities = parseEmoji(emoji);
-                  if (entities.length > 0) {
-                    twemojiSrc = `/twitter/64/${emojiToUnified(entities[0].text)}.png`;
-                  }
-                }
-
+              {frequentEmojis.map(({ emoji, twemojiSrc }) => {
                 return (
                   <div
                     key={emoji}

--- a/src/components/message/MessageActionsDrawer.tsx
+++ b/src/components/message/MessageActionsDrawer.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
-import { parse as parseEmoji } from '@twemoji/parser';
 import { t } from '@lingui/core/macro';
 import type { Message as MessageType } from '@quilibrium/quorum-shared';
 import { MobileDrawer } from '../ui';
 import { Button, Icon } from '../primitives';
 import { useFrequentEmojis } from '../../hooks/business/messages';
-import { emojiToUnified } from '../../utils/remarkTwemoji';
 import './MessageActionsDrawer.scss';
 
 export interface MessageActionsDrawerProps {
@@ -144,17 +142,7 @@ const MessageActionsDrawer: React.FC<MessageActionsDrawerProps> = ({
   const reactionsContent = (
     <div className="message-actions-drawer__reactions">
       <div className="message-actions-drawer__reactions-row">
-        {frequentEmojis.map(({ emoji, unified }) => {
-          let twemojiSrc: string | null = null;
-          if (unified) {
-            twemojiSrc = `/twitter/64/${unified}.png`;
-          } else {
-            const entities = parseEmoji(emoji);
-            if (entities.length > 0) {
-              twemojiSrc = `/twitter/64/${emojiToUnified(entities[0].text)}.png`;
-            }
-          }
-
+        {frequentEmojis.map(({ emoji, twemojiSrc }) => {
           return (
             <Button
               key={emoji}

--- a/src/components/message/MessageActionsMenu.tsx
+++ b/src/components/message/MessageActionsMenu.tsx
@@ -1,11 +1,9 @@
 import React, { useMemo } from 'react';
-import { parse as parseEmoji } from '@twemoji/parser';
 import { t } from '@lingui/core/macro';
 import type { Message as MessageType } from '@quilibrium/quorum-shared';
 import { Button, Icon } from '../primitives';
 import { FloatingPopover, rectAnchor } from '../ui';
 import { useFrequentEmojis } from '../../hooks/business/messages';
-import { emojiToUnified } from '../../utils/remarkTwemoji';
 import './MessageActionsMenu.scss';
 
 // Delay for copy actions to show "Copied!" feedback
@@ -170,17 +168,7 @@ const MessageActionsMenu: React.FC<MessageActionsMenuProps> = ({
     >
       {/* Quick reactions row */}
         <div className="message-actions-menu__reactions">
-          {frequentEmojis.map(({ emoji, unified }) => {
-            let twemojiSrc: string | null = null;
-            if (unified) {
-              twemojiSrc = `/twitter/64/${unified}.png`;
-            } else {
-              const entities = parseEmoji(emoji);
-              if (entities.length > 0) {
-                twemojiSrc = `/twitter/64/${emojiToUnified(entities[0].text)}.png`;
-              }
-            }
-
+          {frequentEmojis.map(({ emoji, twemojiSrc }) => {
             return (
               <Button
                 key={emoji}

--- a/src/components/ui/FloatingPopover.tsx
+++ b/src/components/ui/FloatingPopover.tsx
@@ -216,12 +216,24 @@ export const FloatingPopover: React.FC<FloatingPopoverProps> = ({
   // Close on any scroll — for anchors inside a virtualized list whose items
   // move via transforms JS positioning can't track in lockstep. Capture phase
   // catches scrolls on nested scrollers (the message list), not just window.
+  //
+  // Scrolls from INSIDE the popover are exempt. Capture walks window →
+  // document → target, so this one listener also sees the popover's own
+  // scrollers even though it is portalled out of the anchor's subtree and
+  // scroll events don't bubble. Without the exemption, a popover with
+  // scrollable content dismisses itself the moment the user scrolls it — as
+  // the emoji picker did, both on wheel and on the programmatic scroll its
+  // category buttons issue.
   React.useEffect(() => {
     if (!open || !closeOnScroll) return;
-    const handleScroll = () => onCloseRef.current();
+    const handleScroll = (e: Event) => {
+      const target = e.target as Node | null;
+      if (target && refs.floating.current?.contains(target)) return;
+      onCloseRef.current();
+    };
     window.addEventListener('scroll', handleScroll, true);
     return () => window.removeEventListener('scroll', handleScroll, true);
-  }, [open, closeOnScroll]);
+  }, [open, closeOnScroll, refs.floating]);
 
   if (!open || !anchor) return null;
 

--- a/src/dev/tests/components/emojiPickerFrequentLookup.unit.test.ts
+++ b/src/dev/tests/components/emojiPickerFrequentLookup.unit.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { buildRowData } from '../../../components/emoji-picker/emojiData';
+import type { EmojiItem } from '../../../components/emoji-picker/types';
+
+/**
+ * The picker's "Frequently Used" row resolves stored codes against
+ * emoji-datasource-twitter, whose `unified` field is UPPERCASE ("1F600").
+ *
+ * Codes migrated from the old emoji-picker-react store (`epr_suggested`) are
+ * LOWERCASE and are copied across verbatim, so a case-sensitive match drops
+ * them: the row silently comes up short for anyone who used the app before the
+ * picker rewrite. Matching is therefore case-insensitive.
+ */
+
+const COLUMNS = 8;
+
+/** Flatten the emoji that actually render under the "Frequently Used" header. */
+function frequentlyUsedEmojis(frequentUnifieds: string[]): EmojiItem[] {
+  const { rows, categoryRowIndices } = buildRowData(COLUMNS, frequentUnifieds, []);
+  const start = categoryRowIndices.get('Frequently Used');
+  if (start == null) return [];
+
+  const out: EmojiItem[] = [];
+  // Walk forward from the header until the next header row.
+  for (let i = start + 1; i < rows.length; i++) {
+    const row = rows[i];
+    if (row.type === 'header') break;
+    if (row.type === 'emoji-row') out.push(...row.emojis);
+  }
+  return out;
+}
+
+describe('buildRowData — Frequently Used lookup', () => {
+  it('resolves the uppercase codes the current picker records', () => {
+    const found = frequentlyUsedEmojis(['1F600']);
+    expect(found.map((e) => e.unified)).toEqual(['1F600']);
+  });
+
+  it('resolves lowercase codes migrated from the legacy store', () => {
+    const found = frequentlyUsedEmojis(['1f600', '2764-fe0f']);
+    expect(found.map((e) => e.unified)).toEqual(['1F600', '2764-FE0F']);
+  });
+
+  it('does not list an emoji twice when both casings are stored', () => {
+    // A user who used the app before AND after the rewrite can hold both keys
+    // for the same emoji. They must collapse to one entry: the row renders with
+    // `key={item.unified}`, so a duplicate would also collide as a React key.
+    const found = frequentlyUsedEmojis(['1f600', '1F600']);
+    expect(found.map((e) => e.unified)).toEqual(['1F600']);
+  });
+
+  it('still drops codes that match no emoji at all', () => {
+    const found = frequentlyUsedEmojis(['ffffff-not-an-emoji']);
+    expect(found).toEqual([]);
+  });
+
+  it('omits the Frequently Used section entirely when nothing resolves', () => {
+    const { categoryRowIndices } = buildRowData(COLUMNS, ['ffffff-not-an-emoji'], []);
+    expect(categoryRowIndices.has('Frequently Used')).toBe(false);
+  });
+});

--- a/src/dev/tests/components/floatingPopoverCloseOnScroll.unit.test.tsx
+++ b/src/dev/tests/components/floatingPopoverCloseOnScroll.unit.test.tsx
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { i18n } from '@lingui/core';
+import { messages } from '@/i18n/en/messages';
+import { FloatingPopover, rectAnchor } from '../../../components/ui/FloatingPopover';
+import EmojiPicker from '../../../components/emoji-picker/EmojiPicker';
+
+/**
+ * `closeOnScroll` exists for surfaces anchored inside the virtualized message
+ * list: their anchor moves by CSS transform, which JS positioning cannot track
+ * in lockstep, so the surface closes rather than lag behind.
+ *
+ * It is implemented as a CAPTURE-phase scroll listener on `window`. Scroll
+ * events do not bubble, but capture still walks window → document → target, so
+ * that one listener sees scrolls from every scroller in the document —
+ * including scrollers inside the popover's own content.
+ *
+ * The emoji picker is such a surface: its grid is a react-virtuoso scroller,
+ * and its category buttons scroll it programmatically via scrollToIndex. Both
+ * fired the window listener and dismissed the picker the moment the user tried
+ * to use it. Scrolls originating inside the popover must be ignored.
+ */
+
+beforeAll(() => {
+  i18n.load('en', messages);
+  i18n.activate('en');
+
+  // floating-ui's autoUpdate observes size and layout shifts; jsdom ships
+  // neither observer. Stub both locally so this suite does not perturb others.
+  class NoopObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+    takeRecords() {
+      return [];
+    }
+  }
+  globalThis.ResizeObserver ??= NoopObserver as unknown as typeof ResizeObserver;
+  globalThis.IntersectionObserver ??=
+    NoopObserver as unknown as typeof IntersectionObserver;
+});
+
+function renderPopover(onClose: () => void) {
+  // An outside scroller standing in for the message list behind the popover.
+  const outside = document.createElement('div');
+  outside.setAttribute('data-testid', 'outside-scroller');
+  document.body.appendChild(outside);
+
+  render(
+    <FloatingPopover
+      open
+      onClose={onClose}
+      // A virtual anchor keeps FloatingFocusManager out of the way; the scroll
+      // behaviour under test is independent of the anchor kind.
+      anchor={rectAnchor({ x: 10, y: 10, width: 20, height: 20 })}
+      closeOnScroll
+    >
+      <div data-testid="popover-scroller">
+        <div data-testid="popover-child">emoji grid</div>
+      </div>
+    </FloatingPopover>
+  );
+
+  return { outside };
+}
+
+const scroll = (el: EventTarget) =>
+  el.dispatchEvent(new Event('scroll', { bubbles: false }));
+
+describe('FloatingPopover — closeOnScroll', () => {
+  it('stays open when the scroll came from inside the popover', () => {
+    const onClose = vi.fn();
+    renderPopover(onClose);
+
+    scroll(screen.getByTestId('popover-scroller'));
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('stays open when a nested descendant scrolls', () => {
+    const onClose = vi.fn();
+    renderPopover(onClose);
+
+    // react-virtuoso's scrollToIndex fires the event on its inner scroller,
+    // which sits several levels below the popover root.
+    scroll(screen.getByTestId('popover-child'));
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('closes when the scroll came from outside the popover', () => {
+    const onClose = vi.fn();
+    const { outside } = renderPopover(onClose);
+
+    scroll(outside);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes on a document-level scroll', () => {
+    const onClose = vi.fn();
+    renderPopover(onClose);
+
+    scroll(document);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('FloatingPopover — closeOnScroll with the real emoji picker', () => {
+  // The reported bug, at the actual pairing: the reaction picker is an
+  // EmojiPicker inside a closeOnScroll popover, and its grid is a react-virtuoso
+  // scroller. Asserting against that scroller (rather than a stand-in div)
+  // proves the exempt subtree really does cover where the events come from.
+  it('survives a scroll of the picker grid', () => {
+    const onClose = vi.fn();
+
+    render(
+      <FloatingPopover
+        open
+        onClose={onClose}
+        anchor={rectAnchor({ x: 10, y: 10, width: 20, height: 20 })}
+        closeOnScroll
+      >
+        <EmojiPicker onEmojiClick={() => {}} />
+      </FloatingPopover>
+    );
+
+    // react-virtuoso tags its scrollable element with this testid.
+    scroll(screen.getByTestId('virtuoso-scroller'));
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/src/dev/tests/hooks/frequentEmojiTwemojiSrc.unit.test.tsx
+++ b/src/dev/tests/hooks/frequentEmojiTwemojiSrc.unit.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useFrequentEmojis } from '../../../hooks/business/messages/useFrequentEmojis';
+import { FREQUENT_EMOJIS_KEY } from '../../../components/emoji-picker/useFrequentlyUsed';
+
+/**
+ * The quick-reaction row in the message toolbar reads its emoji from the
+ * emoji picker's "frequently used" localStorage map. The picker records usage
+ * keyed on emoji-datasource-twitter's `unified` field, which is UPPERCASE
+ * ("1F600"). The Twemoji PNGs shipped by that same package are named in
+ * lowercase ("1f600.png").
+ *
+ * A Windows dev box serves those files off a case-insensitive filesystem, so
+ * "/twitter/64/1F600.png" resolves there and the bug is invisible. Production
+ * serves from a case-sensitive filesystem, where the same URL 404s and every
+ * recently-used emoji renders as a broken image.
+ *
+ * These tests pin the casing at the hook — the single point every consumer
+ * (MessageActions, MessageActionsMenu, MessageActionsDrawer) reads from.
+ */
+
+const stored = (map: Record<string, { count: number; lastUsed: number }>) =>
+  window.localStorage.setItem(FREQUENT_EMOJIS_KEY, JSON.stringify(map));
+
+describe('useFrequentEmojis — Twemoji asset casing', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('lowercases the uppercase unified codes the emoji picker records', () => {
+    stored({
+      '1F600': { count: 5, lastUsed: 300 },
+      '2764-FE0F': { count: 4, lastUsed: 200 },
+      '1F44D': { count: 3, lastUsed: 100 },
+    });
+
+    const { result } = renderHook(() => useFrequentEmojis(3));
+
+    expect(result.current.map((e) => e.unified)).toEqual([
+      '1f600',
+      '2764-fe0f',
+      '1f44d',
+    ]);
+  });
+
+  it('builds asset paths that match the shipped lowercase PNG filenames', () => {
+    stored({ '1F600': { count: 1, lastUsed: 1 } });
+
+    const { result } = renderHook(() => useFrequentEmojis(1));
+
+    expect(result.current[0].twemojiSrc).toBe('/twitter/64/1f600.png');
+    // Guard the exact failure mode: an uppercase path 404s in production.
+    expect(result.current[0].twemojiSrc).not.toMatch(/[A-F]/);
+  });
+
+  it('resolves a path for the built-in defaults, which carry no unified code', () => {
+    const { result } = renderHook(() => useFrequentEmojis(3));
+
+    // Storage is empty, so all three slots come from DEFAULT_QUICK_EMOJIS.
+    expect(result.current).toHaveLength(3);
+    for (const entry of result.current) {
+      expect(entry.twemojiSrc).toMatch(/^\/twitter\/64\/[0-9a-f-]+\.png$/);
+    }
+    // ❤️ is the first default and carries the VS16 selector.
+    expect(result.current[0].twemojiSrc).toBe('/twitter/64/2764-fe0f.png');
+  });
+
+  it('keeps already-lowercase legacy keys untouched', () => {
+    // epr_suggested (emoji-picker-react) migration writes lowercase codes.
+    stored({ '1f525': { count: 2, lastUsed: 10 } });
+
+    const { result } = renderHook(() => useFrequentEmojis(1));
+
+    expect(result.current[0].unified).toBe('1f525');
+    expect(result.current[0].twemojiSrc).toBe('/twitter/64/1f525.png');
+  });
+});

--- a/src/hooks/business/messages/useFrequentEmojis.ts
+++ b/src/hooks/business/messages/useFrequentEmojis.ts
@@ -1,8 +1,10 @@
 import { useMemo, useSyncExternalStore } from 'react';
+import { parse as parseEmoji } from '@twemoji/parser';
 import {
   FREQUENT_EMOJIS_KEY,
   subscribeFrequentEmojis,
 } from '../../../components/emoji-picker/useFrequentlyUsed';
+import { emojiToUnified } from '../../../utils/remarkTwemoji';
 
 const DEFAULT_QUICK_EMOJIS = ['❤️', '👍', '🔥', '😂', '😢', '😮'];
 
@@ -11,12 +13,38 @@ interface FrequentEntry {
   lastUsed: number;
 }
 
+export interface FrequentEmoji {
+  /** Native emoji character, used as the reaction payload. */
+  emoji: string;
+  /**
+   * Unified codepoint, lowercased. The picker records usage keyed on
+   * emoji-datasource-twitter's `unified` field, which is UPPERCASE ("1F600"),
+   * while the PNGs that package ships are named lowercase ("1f600.png"). A
+   * case-insensitive dev filesystem hides the mismatch; production's does not.
+   */
+  unified: string;
+  /** Ready-to-use Twemoji asset path, or null if the emoji isn't recognised. */
+  twemojiSrc: string | null;
+}
+
 /** Convert unified codepoint string (e.g. "1f60d") to native emoji character. */
 function unifiedToNative(unified: string): string {
   return unified
     .split('-')
     .map((hex) => String.fromCodePoint(parseInt(hex, 16)))
     .join('');
+}
+
+/**
+ * Resolve the Twemoji PNG for an entry. Prefers the recorded unified code and
+ * falls back to parsing the native character, which is the only route open for
+ * the built-in defaults (they carry no recorded code).
+ */
+function twemojiSrcFor(emoji: string, unified: string): string | null {
+  if (unified) return `/twitter/64/${unified}.png`;
+  const entities = parseEmoji(emoji);
+  if (entities.length === 0) return null;
+  return `/twitter/64/${emojiToUnified(entities[0].text)}.png`;
 }
 
 /** Read the raw JSON string from localStorage for snapshot comparison. */
@@ -56,39 +84,43 @@ function subscribe(callback: () => void): () => void {
  * localStorage data, falling back to defaults (❤️, 👍, 🔥) when there
  * aren't enough entries.
  *
- * Each item includes the native emoji string and the unified codepoint
- * (for rendering as a Twemoji image).
+ * Each item includes the native emoji string, the (lowercased) unified
+ * codepoint, and the resolved Twemoji image path.
  */
-export function useFrequentEmojis(count = 3) {
+export function useFrequentEmojis(count = 3): FrequentEmoji[] {
   const raw = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 
   return useMemo(() => {
+    const withSrc = (emoji: string, unified: string): FrequentEmoji => ({
+      emoji,
+      unified,
+      twemojiSrc: twemojiSrcFor(emoji, unified),
+    });
+
     try {
       const map = JSON.parse(raw) as Record<string, FrequentEntry>;
       const sorted = Object.entries(map).sort(
         ([, a], [, b]) => b.lastUsed - a.lastUsed,
       );
-      const frequent = sorted.slice(0, count).map(([unified]) => ({
-        emoji: unifiedToNative(unified),
-        unified,
-      }));
+      const frequent = sorted
+        .slice(0, count)
+        // Lowercase here, at the one place every consumer reads from, so no
+        // call site can reintroduce the case mismatch against the PNG names.
+        .map(([unified]) => withSrc(unifiedToNative(unified), unified.toLowerCase()));
 
       // Fill remaining slots with defaults (skip any already present)
       if (frequent.length < count) {
         for (const fallback of DEFAULT_QUICK_EMOJIS) {
           if (frequent.length >= count) break;
           if (!frequent.some((f) => f.emoji === fallback)) {
-            frequent.push({ emoji: fallback, unified: '' });
+            frequent.push(withSrc(fallback, ''));
           }
         }
       }
 
       return frequent;
     } catch {
-      return DEFAULT_QUICK_EMOJIS.slice(0, count).map((emoji) => ({
-        emoji,
-        unified: '',
-      }));
+      return DEFAULT_QUICK_EMOJIS.slice(0, count).map((emoji) => withSrc(emoji, ''));
     }
   }, [raw, count]);
 }


### PR DESCRIPTION
Three fixes to the message-actions reaction picker, two of them user-reported.

### The picker dismissed itself on any interaction

`FloatingPopover`'s `closeOnScroll` was a capture-phase `scroll` listener on `window`. Scroll events don't bubble, but capture still walks window → document → target, so that one listener also fired for scrolls originating *inside* the popover, even though it's portalled out of the anchor's subtree.

The reaction picker is exactly that shape: an `EmojiPicker` whose grid is a react-virtuoso scroller. Scrolling the grid dismissed it, and so did clicking a category button, which scrolls the grid programmatically via `scrollToIndex`. The panel was unusable by any route except search. The composer's panel was unaffected because it isn't a popover.

Scrolls the floating element contains are now exempt. The original purpose is intact: the virtualized message list behind the popover is outside that subtree, so it still closes as before. The other `closeOnScroll` consumers (context menu, profile cards) render no internal scroller, so the exemption is inert for them.

### Recently-used reactions rendered as broken images, production only

`emoji-datasource-twitter` stores `unified` uppercase (`1F600`) and the picker records usage under that key, but every PNG the same package ships is named lowercase (`1f600.png`). Three components each built the URL straight from the stored key without lowercasing.

A dev filesystem is case-insensitive and resolves it; production's is case-sensitive and 404s. Only *recorded* emoji were affected, since the built-in defaults carry no stored code and went down a path that already lowercased. That split is also why this arrived with the custom picker: the store it replaced held lowercase codes, so identical URL-building code was correct until the key format changed underneath it.

The path is now resolved once in `useFrequentEmojis`, lowercased at the single point every consumer reads from, and the three duplicated copies of the logic are gone.

### Legacy codes silently dropped out of "Frequently Used"

The picker's own Frequently Used row matched stored codes against the dataset exactly. Codes migrated from the old `emoji-picker-react` store are lowercase and carried across verbatim, so they matched nothing and were filtered out: anyone who used the app before the picker rewrite saw a short or empty row.

Lookup is now case-insensitive, via an index built once alongside the emoji cache. It dedupes on the resolved emoji rather than the stored key, because someone who used the app on both sides of the rewrite can hold `1f600` **and** `1F600` for the same emoji, which would otherwise list twice and collide as a React key.

### Verification

Tests were written first and confirmed red, then green. Reverting each fix individually puts its tests back to red, with the "closes on outside scroll" cases holding green throughout as a control. One test drives the real `EmojiPicker` inside a `closeOnScroll` popover and scrolls Virtuoso's actual scroller, so the exemption is pinned against the real DOM shape rather than a stand-in.

Full suite: 1262 passing, 0 failing. The reaction picker was also exercised by hand in the running app.
