### PR TITLE
fix(identity): the profile card's avatar and bio follow the roster, not the published profile

### DIFF
--- a/.agents/issues/2026-08-11-profile-card-from-a-mention-pill-shows-a-stale-bio-and-no-avatar.md
+++ b/.agents/issues/2026-08-11-profile-card-from-a-mention-pill-shows-a-stale-bio-and-no-avatar.md
@@ -149,11 +149,21 @@ test file mocks it properly.
 - **DMs.** `props.spaceId` is absent there, so there is no roster to read and
   the ladder degrades to caller → public profile, exactly as before. The DM
   sidebar was not part of this report.
-- **Mobile parity.** Not checked. Mobile has its own
-  `useMembersWithPublicProfileFallback` and its own profile card; if its card
-  has an address-only entry point, it very likely has this bug too. Per the
-  standing lesson in the parity index, a fix that lands on one client and leaves
-  the other as a TODO is not a shipped fix.
+- **Mobile parity — checked, and it is a DIFFERENT bug.** Mobile's
+  `UserProfileModal` has no fallback chain and needs none: every caller hands it
+  an already-resolved identity. Its avatar goes through `resolveMemberAvatar`
+  (override → global slot) and is fine. Its **bio has no such resolver** — four
+  call sites read `member.bio` raw, i.e. the per-space override only, so the bio
+  disappears for any member the visible-senders merge never touched (most
+  visibly the space-settings member list, which never goes through that merge at
+  all). Filed as
+  `quorum-mobile/.agents/issues/.open/2026-08-11-profile-modal-bio-is-read-raw-so-it-vanishes-for-any-unmerged-member.md`.
+
+  Worth noting for anyone doing the next parity sweep: the two clients had the
+  same *class* of defect (a rendered identity field not going through a ladder)
+  with completely different *shapes* — desktop's was gated on which pill you
+  clicked, mobile's on whether the member had posted recently. Looking for
+  desktop's symptom on mobile would have found nothing.
 
 ## Definition of done
 
@@ -165,7 +175,7 @@ test file mocks it properly.
 - [x] Rebased onto the identity branch tip, clean
 - [x] The reported stale NAME resolved (closed above, not pursued)
 - [x] Visually confirmed in the running app, from both entry points
-- [ ] Mobile parity checked, or explicitly deferred
+- [x] Mobile parity checked (a different defect, filed on mobile)
 - [ ] Merged (stacked on the identity work, so it lands after that does)
 
 ---

--- a/.agents/issues/2026-08-11-profile-card-from-a-mention-pill-shows-a-stale-bio-and-no-avatar.md
+++ b/.agents/issues/2026-08-11-profile-card-from-a-mention-pill-shows-a-stale-bio-and-no-avatar.md
@@ -16,18 +16,29 @@ related:
 
 ## Status
 
-**Fixed on `fix/profile-card-mention-fields`, branched off the identity work
-(`d244903fe`), NOT off `main` — the code being fixed only exists on the identity
-branch.**
+**Fixed on `fix/profile-card-mention-fields`, rebased onto the identity work
+(`a01901f7d`), NOT off `main` — the code being fixed only exists on the identity
+branch, whose refactor of this card is what the fix builds on.**
 
 Verified: 8 new tests green, and **red on revert** — reverting only the component
 wiring makes the three component tests fail with the exact reported symptom
 (`"The bio I published to my public profile months ago."` where the roster bio
-belongs). Full suite 1384 passed / 1 unrelated load-induced timeout
-(`fetchSpaceReplies.unit.test.ts`, green in isolation). Typecheck and lint clean.
+belongs). Identity suite 247/247 on the rebased tree; full suite 1384 passed / 1
+unrelated load-induced timeout (`fetchSpaceReplies.unit.test.ts`, green in
+isolation). Typecheck and lint clean. Independent code review found nothing at
+or above its reporting bar, having re-run the red-on-revert check itself.
 
-Not yet verified: the visual pass in the running app, and the **reported stale
-NAME** (see "The name, which this does not explain").
+**No conflict with the identity branch, contrary to an early report.** The base
+was one commit behind `feat/identity-provider`, and that commit
+(`a01901f7d`, ReactionsModal + bookmarks) touches none of the files here. The
+rebase applied clean. The claim that this work needed re-deriving against a
+newer tree came from assuming the base predated the refactor; it did not.
+
+Not yet verified: **the visual pass in the running app.** The operator reported
+the card looking correct, but on a build of `feat/identity-provider`, which does
+not contain this fix — so that observation covers the identity branch's own name
+work, not this ladder. Bio and avatar from a mention pill still need one look
+once this branch is running.
 
 ## The report
 
@@ -116,9 +127,21 @@ bio and avatar. It passes. So:
   divergence is in the **sources**, not in the component — a different hunt,
   most likely the roster row the identity provider holds for that address.
 
-**Open question for the operator:** re-check the name specifically, with the
-same person, from both entry points, after the avatar/bio fix lands. It is
-possible the bio and the missing picture dominated the impression.
+**Closed, not pursued.** The operator could not recall the name specifically,
+and the identity branch's own work (the root provider gaining real rosters for
+every space, `d1f016d7`) covers the plausible source-side cause. The control arm
+stays in the test as the tripwire: if the name ever diverges between these two
+entry points, that assertion is what says so.
+
+## One thing to know if you touch the older card test
+
+`src/dev/tests/identity/migrated/UserProfile.test.tsx` (untouched here) mocks
+`messageDB` without a `getSpaceMembers` method. The card now queries the roster
+unconditionally, so in that file every render rejects that query, silently
+swallowed by react-query's `retry: false`. Harmless today — none of its fixtures
+exercise the per-space-override tier, and all five still pass — but a future
+edit there that assumes roster data flows through will be surprised. The new
+test file mocks it properly.
 
 ## Not covered
 
@@ -137,10 +160,12 @@ possible the bio and the missing picture dominated the impression.
 - [x] One ladder, shared with the surfaces that already had it right
 - [x] Tests green, and shown red with the fix reverted
 - [x] Full suite + typecheck + lint
+- [x] Independently code-reviewed in a fresh context
+- [x] Rebased onto the identity branch tip, clean
+- [x] The reported stale NAME resolved (closed above, not pursued)
 - [ ] Visually confirmed in the running app, from both entry points
-- [ ] The reported stale NAME re-checked, or filed separately
 - [ ] Mobile parity checked, or explicitly deferred
-- [ ] Merged (branched off the identity work, so it lands after that does)
+- [ ] Merged (stacked on the identity work, so it lands after that does)
 
 ---
 

--- a/.agents/issues/2026-08-11-profile-card-from-a-mention-pill-shows-a-stale-bio-and-no-avatar.md
+++ b/.agents/issues/2026-08-11-profile-card-from-a-mention-pill-shows-a-stale-bio-and-no-avatar.md
@@ -6,7 +6,7 @@ priority: medium
 created: 2026-08-11
 updated: 2026-08-11
 area: identity resolution / profile card
-repos: quorum-desktop (this), quorum-mobile (parity not yet checked)
+repos: quorum-desktop (this), quorum-mobile (a different defect, filed there)
 related:
   - ".agents/issues/2026-08-10-name-surfaces-that-never-reached-the-resolver.md"
   - ".agents/issues/.open/2026-08-10-identity-resolution-architecture-design.md"
@@ -39,7 +39,8 @@ build that contains the fix): the card opened from a mention pill now shows the
 right bio and the profile picture, matching the card opened from a message
 avatar.
 
-Still open: mobile parity, and the merge itself.
+Still open: the merge itself. Mobile parity is checked — it has a different
+defect, filed in that repo (see "Not covered").
 
 ## The report
 

--- a/.agents/issues/2026-08-11-profile-card-from-a-mention-pill-shows-a-stale-bio-and-no-avatar.md
+++ b/.agents/issues/2026-08-11-profile-card-from-a-mention-pill-shows-a-stale-bio-and-no-avatar.md
@@ -34,11 +34,12 @@ was one commit behind `feat/identity-provider`, and that commit
 rebase applied clean. The claim that this work needed re-deriving against a
 newer tree came from assuming the base predated the refactor; it did not.
 
-Not yet verified: **the visual pass in the running app.** The operator reported
-the card looking correct, but on a build of `feat/identity-provider`, which does
-not contain this fix — so that observation covers the identity branch's own name
-work, not this ladder. Bio and avatar from a mention pill still need one look
-once this branch is running.
+**Visually confirmed by the operator**, running the app from this worktree (the
+build that contains the fix): the card opened from a mention pill now shows the
+right bio and the profile picture, matching the card opened from a message
+avatar.
+
+Still open: mobile parity, and the merge itself.
 
 ## The report
 
@@ -163,7 +164,7 @@ test file mocks it properly.
 - [x] Independently code-reviewed in a fresh context
 - [x] Rebased onto the identity branch tip, clean
 - [x] The reported stale NAME resolved (closed above, not pursued)
-- [ ] Visually confirmed in the running app, from both entry points
+- [x] Visually confirmed in the running app, from both entry points
 - [ ] Mobile parity checked, or explicitly deferred
 - [ ] Merged (stacked on the identity work, so it lands after that does)
 

--- a/.agents/issues/2026-08-11-profile-card-from-a-mention-pill-shows-a-stale-bio-and-no-avatar.md
+++ b/.agents/issues/2026-08-11-profile-card-from-a-mention-pill-shows-a-stale-bio-and-no-avatar.md
@@ -1,0 +1,147 @@
+---
+type: bug
+title: "The profile card opened from a mention pill shows a stale bio and no avatar"
+status: in-progress
+priority: medium
+created: 2026-08-11
+updated: 2026-08-11
+area: identity resolution / profile card
+repos: quorum-desktop (this), quorum-mobile (parity not yet checked)
+related:
+  - ".agents/issues/2026-08-10-name-surfaces-that-never-reached-the-resolver.md"
+  - ".agents/issues/.open/2026-08-10-identity-resolution-architecture-design.md"
+---
+
+# The profile card opened from a mention pill shows a stale bio and no avatar
+
+## Status
+
+**Fixed on `fix/profile-card-mention-fields`, branched off the identity work
+(`d244903fe`), NOT off `main` — the code being fixed only exists on the identity
+branch.**
+
+Verified: 8 new tests green, and **red on revert** — reverting only the component
+wiring makes the three component tests fail with the exact reported symptom
+(`"The bio I published to my public profile months ago."` where the roster bio
+belongs). Full suite 1384 passed / 1 unrelated load-induced timeout
+(`fetchSpaceReplies.unit.test.ts`, green in isolation). Typecheck and lint clean.
+
+Not yet verified: the visual pass in the running app, and the **reported stale
+NAME** (see "The name, which this does not explain").
+
+## The report
+
+In a channel, the profile card opened from a **mention pill** showed a display
+name and a bio that were stale — editing them on that user's own device did not
+change them — and no profile picture at all. The same person's card opened from
+their **message avatar**, one click away, showed everything correctly and
+updated immediately.
+
+## The mechanism
+
+Both entry points render the identical component with identical props, except
+for the `user` payload:
+
+| Entry point | Payload | Source |
+|---|---|---|
+| Message avatar | the fully-merged member record | `Message.tsx`'s `onUserClick` |
+| Mention pill | `{ address }` and nothing else | `MessageMarkdownRenderer.tsx`'s `handleClick` |
+
+The address-only payload is deliberate, not an oversight: the NAME resolves from
+`src/identity` keyed on the address, so carrying a name snapshot through the
+click event would just be a second thing that can drift.
+
+The name survived that narrowing. **The avatar and bio did not.** They are not
+names, so the identity module deliberately does not carry them (design
+constraint 4), and the card's own address-keyed fallback was only two rungs
+deep:
+
+```
+bio  = props.user.bio      || publicProfile.bio            || ownConfig.bio
+icon = props.user.userIcon || publicProfile.profile_image
+```
+
+That skips the tier every other surface renders from: `space_members`'
+per-space override and its live-pushed `global_user_icon` / `global_bio` slots,
+written by the identity announce (`MessageDB.tsx`) and merged for message
+rendering by `useChannelData`. The published public profile is **opt-in**
+(so `profile_image` is normally empty), and cached for **an hour** (so the bio
+lags). With the caller's copy absent, the card fell straight through to it.
+
+So the defect is not "the card trusts the caller" — it is the opposite. The card
+resolves from the address correctly, and the source it resolves *to* was the
+worst one available.
+
+## The fix
+
+`useProfileCardIdentityFields` owns the whole ladder in one place:
+
+```
+caller pre-fill → per-space override → roster global slot → public profile
+                                                          → own config bio (self)
+```
+
+Identical to `useChannelData`'s merge and to `pickBookmarkSenderIcon`, which
+fixed this same class of bug for bookmarks in August. The precedence rules are
+pure functions (`pickProfileCardIcon`, `pickProfileCardBio`) so they can be
+tested without IndexedDB or a mounted component.
+
+**Cost: none in the channel case.** The roster read uses `buildSpaceMembersKey`
+— the key `Channel` (via `useSpaceMembers`) and `useMultiSpaceRosters` have
+already populated. A cache read, not a second IndexedDB round trip. Checking the
+key before asserting a cost is the standing lesson from
+`2026-08-10-name-surfaces-that-never-reached-the-resolver.md`, where the same
+"this would cost N requests" intuition was wrong three times in one piece of
+work.
+
+The caller pre-fill deliberately stays the top rung. It is itself a snapshot of
+the two member tiers below it, so it changes nothing about correctness — it only
+avoids a flash on the avatar path while the roster read settles.
+
+## The name, which this does NOT explain
+
+**The reported stale display name has no mechanism in this code.** Both cards
+call `useResolvedMemberName(props.user.address, { spaceId, enrich: true })`;
+neither reads `props.user.displayName` for the rendered name. Same hook, same
+address, same `<IdentityScopeProvider>` — the name cannot differ between the two
+entry points.
+
+The test therefore carries a **control arm**: the same two payloads are rendered
+against identical sources and asserted to agree on the name as well as on the
+bio and avatar. It passes. So:
+
+- if that assertion ever fails, the defect is in name resolution, not in this
+  ladder;
+- if it keeps passing while the running app still shows a difference, then the
+  divergence is in the **sources**, not in the component — a different hunt,
+  most likely the roster row the identity provider holds for that address.
+
+**Open question for the operator:** re-check the name specifically, with the
+same person, from both entry points, after the avatar/bio fix lands. It is
+possible the bio and the missing picture dominated the impression.
+
+## Not covered
+
+- **DMs.** `props.spaceId` is absent there, so there is no roster to read and
+  the ladder degrades to caller → public profile, exactly as before. The DM
+  sidebar was not part of this report.
+- **Mobile parity.** Not checked. Mobile has its own
+  `useMembersWithPublicProfileFallback` and its own profile card; if its card
+  has an address-only entry point, it very likely has this bug too. Per the
+  standing lesson in the parity index, a fix that lands on one client and leaves
+  the other as a TODO is not a shipped fix.
+
+## Definition of done
+
+- [x] Mechanism traced to `file:line`, with the two payloads compared
+- [x] One ladder, shared with the surfaces that already had it right
+- [x] Tests green, and shown red with the fix reverted
+- [x] Full suite + typecheck + lint
+- [ ] Visually confirmed in the running app, from both entry points
+- [ ] The reported stale NAME re-checked, or filed separately
+- [ ] Mobile parity checked, or explicitly deferred
+- [ ] Merged (branched off the identity work, so it lands after that does)
+
+---
+
+*Last updated: 2026-08-11*

--- a/src/components/user/UserProfile.tsx
+++ b/src/components/user/UserProfile.tsx
@@ -23,6 +23,7 @@ import { UserAvatar } from './UserAvatar';
 import { useResolvedMemberName } from '../../identity';
 import { useUserNote, buildUserNoteKey } from '../../hooks/queries/userNotes';
 import { useUserPublicProfile } from '../../hooks/business/user/useUserPublicProfile';
+import { useProfileCardIdentityFields } from '../../hooks/business/user/useProfileCardIdentityFields';
 import { useQueryClient } from '@tanstack/react-query';
 import { buildSpaceKey } from '../../hooks/queries/space/buildSpaceKey';
 import { buildConfigKey } from '../../hooks/queries/config/buildConfigKey';
@@ -129,15 +130,8 @@ const UserProfile: React.FunctionComponent<{
   // passed — see the regression this fixes in the module's test file.
   const { data: openedUserPublicProfile } = useUserPublicProfile(props.user.address);
 
-  // Bio resolution for the visible card:
-  //   1. Per-space override on SpaceMember (props.user.bio) wins when set —
-  //      a real per-space bio override, not a caller-supplied name fallback.
-  //   2. The fetched public profile's bio — the address-derived source that
-  //      makes this correct even when the caller passed nothing (e.g. a
-  //      mention-pill click, which only ever carries an address).
-  //   3. For the current user's own profile, fall back to UserConfig.bio
-  //      (the global bio) so deleting the per-space override reveals the
-  //      global one again instead of leaving an empty section.
+  // Your own GLOBAL bio — the last bio tier, so clearing a per-space override
+  // reveals it again instead of leaving an empty section.
   //
   // Subscribed via useQuery (not a getQueryData snapshot) so the card
   // re-renders if the global bio changes while it's open (e.g. user saves
@@ -152,16 +146,28 @@ const UserProfile: React.FunctionComponent<{
     enabled: isOwnProfile && !!currentPasskeyInfo?.address,
     networkMode: 'always',
   });
-  const resolvedBio =
-    (props.user.bio as string | undefined) ||
-    openedUserPublicProfile?.bio ||
-    ownConfig?.bio;
-
-  // Avatar: same address-derived top-up as bio. `resolvedName.name` (BARE,
-  // no ".q") — not `props.user.displayName` — so the initials fallback always
-  // agrees with the name actually rendered beside it (design constraint 4 of
-  // the identity migration: the avatar and the name must not disagree).
-  const resolvedUserIcon = (props.user.userIcon as string | undefined) || openedUserPublicProfile?.profile_image;
+  // Bio and avatar resolve from the ADDRESS, on the same ladder every other
+  // surface renders from: caller pre-fill → per-space override → the roster's
+  // live-pushed global slot → the published public profile (→ your own config
+  // bio, self only). The middle rung is the one that used to be missing:
+  // without it a card opened from a mention pill — which carries an address
+  // and nothing else — fell straight to the opt-in, hour-cached public profile
+  // and showed a stale bio and no avatar, while the same person's card opened
+  // from a message avatar showed both. See the hook for the full write-up.
+  //
+  // `resolvedName.name` (BARE, no ".q") — not `props.user.displayName` — is
+  // what feeds the initials fallback below, so it always agrees with the name
+  // actually rendered beside it (design constraint 4 of the identity
+  // migration: the avatar and the name must not disagree).
+  const { userIcon: resolvedUserIcon, bio: resolvedBio } = useProfileCardIdentityFields({
+    address: props.user.address,
+    spaceId: props.spaceId,
+    callerIcon: props.user.userIcon as string | undefined,
+    callerBio: props.user.bio as string | undefined,
+    publicProfileIcon: openedUserPublicProfile?.profile_image,
+    publicProfileBio: openedUserPublicProfile?.bio,
+    ownConfigBio: ownConfig?.bio,
+  });
   // The moderation modals (Block/Mute/Kick) now resolve the name themselves
   // from `address` via src/identity — no name payload is threaded through
   // `openBlockUser`/`openMuteUser`/`openKickUser` anymore (was

--- a/src/dev/tests/identity/profileCardRosterFields.test.tsx
+++ b/src/dev/tests/identity/profileCardRosterFields.test.tsx
@@ -1,0 +1,283 @@
+/**
+ * The profile card's avatar and bio must not depend on WHICH pill you clicked.
+ *
+ * Two entry points hand the card different payloads: a message-avatar click
+ * passes a fully-merged member record, a mention-pill click passes an address
+ * and nothing else (deliberate — the NAME resolves from `src/identity` either
+ * way). Before this fix the card's own address-keyed fallback for avatar/bio
+ * went straight to the published public profile, skipping `space_members`'
+ * per-space override and its live-pushed `global_user_icon`/`global_bio`
+ * slots — the tier `useChannelData` merges for every other surface, and where
+ * most members' avatar and bio actually live.
+ *
+ * Reported symptom: opening someone's card from a mention pill showed a stale
+ * bio and no profile picture; opening the same person's card from their
+ * message avatar, one click away, showed both correctly and updated live.
+ *
+ * The component test below carries a CONTROL ARM: the same two payloads are
+ * rendered against identical sources, and the NAME is asserted to match. The
+ * name never came from the caller (it resolves through
+ * `useResolvedMemberName`), so it must be identical from both entry points. If
+ * a future change makes the name diverge here, the control fails and says so;
+ * if the name diverges in the running app while this control stays green, the
+ * difference is in the SOURCES, not in this component.
+ */
+import * as React from 'react';
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { i18n } from '@lingui/core';
+import { messages } from '@/i18n/en/messages';
+import { IdentityScopeProvider } from '@/identity';
+import { DefaultImages } from '@/utils';
+import {
+  pickProfileCardBio,
+  pickProfileCardIcon,
+} from '@/hooks/business/user/useProfileCardIdentityFields';
+
+beforeAll(() => {
+  i18n.load('en', messages);
+  i18n.activate('en');
+});
+
+const getPublicProfile = vi.fn();
+vi.mock('@/api/baseTypes', () => ({
+  QuorumApiClient: class {
+    getPublicProfile(address: string) {
+      return getPublicProfile(address);
+    }
+  },
+  isHandledFetchError: () => false,
+}));
+
+const SELF_ADDR = 'QmSelf00000000000000000000000000000000';
+vi.mock('@quilibrium/quilibrium-js-sdk-channels', () => ({
+  channel: {},
+  usePasskeysContext: () => ({ currentPasskeyInfo: { address: SELF_ADDR } }),
+}));
+
+const getSpaceMembers = vi.fn();
+vi.mock('@/components/context/useMessageDB', () => ({
+  useMessageDB: () => ({
+    messageDB: {
+      getSpace: vi.fn().mockResolvedValue(null),
+      getUserConfig: vi.fn().mockResolvedValue(null),
+      getSpaceMembers: (spaceId: string) => getSpaceMembers(spaceId),
+      saveUserConfig: vi.fn(),
+      deleteUserNote: vi.fn(),
+      saveUserNote: vi.fn(),
+    },
+  }),
+}));
+
+vi.mock('@/components/context/ModalProvider', () => ({
+  useModals: () => ({ openMuteUser: vi.fn(), openKickUser: vi.fn(), openBlockUser: vi.fn() }),
+}));
+
+// See UserProfile.test.tsx: ClickToCopyContent pulls in react-tooltip, which
+// crashes under vitest with a duplicate-React "Invalid hook call".
+vi.mock('@/components/ui', () => ({
+  ClickToCopyContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/hooks/queries/spaceOwner', () => ({
+  useSpaceOwner: () => ({ data: false }),
+}));
+vi.mock('@/hooks/queries/mutedUsers', () => ({
+  useMutedUsers: () => ({ data: [] }),
+}));
+vi.mock('@/hooks/queries/userNotes', () => ({
+  useUserNote: () => ({ data: null }),
+  buildUserNoteKey: ({ targetAddress }: { targetAddress: string }) => ['user-note', targetAddress],
+}));
+vi.mock('@/hooks/business/user/useBlockUser', () => ({
+  useBlockUser: () => ({ isBlocked: () => false, blockUser: vi.fn(), unblockUser: vi.fn() }),
+}));
+
+vi.mock('@/hooks', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/hooks')>();
+  return {
+    ...actual,
+    useUserRoleManagement: () => ({ addRole: vi.fn(), removeRole: vi.fn(), loadingRoles: new Set() }),
+    useUserProfileActions: () => ({ sendMessage: vi.fn() }),
+    useUserRoleDisplay: () => ({ userRoles: [], availableRoles: [] }),
+  };
+});
+
+const ADDR = 'QmPeerUEgVKpYZKYuFu2J49zHXnA8vZtEqHMtpB4imzzzz';
+const SPACE_ID = 'space-1';
+
+const ROSTER_ICON = 'https://example.com/live-roster-avatar.png';
+const ROSTER_BIO = 'The bio I just edited on my other device.';
+const STALE_PUBLIC_BIO = 'The bio I published to my public profile months ago.';
+
+import UserProfile from '@/components/user/UserProfile';
+
+/**
+ * The member row as the identity announce leaves it under the two-slot model:
+ * no per-space override (its normal state), and the live global slots carrying
+ * the avatar and bio. The published public profile is deliberately WORSE — an
+ * empty `profile_image`, which is what a user who never opted into a public
+ * photo has, and a stale bio.
+ */
+const ROSTER_ROW = {
+  address: ADDR,
+  user_address: ADDR,
+  display_name: '',
+  global_display_name: 'Alice',
+  user_icon: '',
+  bio: '',
+  global_user_icon: ROSTER_ICON,
+  global_bio: ROSTER_BIO,
+};
+
+const PUBLIC_PROFILE = {
+  primary_username: 'alice',
+  display_name: 'Alice',
+  bio: STALE_PUBLIC_BIO,
+  profile_image: '',
+};
+
+function renderCard(user: Record<string, unknown>) {
+  getPublicProfile.mockResolvedValue({ data: PUBLIC_PROFILE });
+  getSpaceMembers.mockResolvedValue([ROSTER_ROW]);
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <IdentityScopeProvider
+        spaceId={SPACE_ID}
+        rostersBySpace={{
+          [SPACE_ID]: {
+            [ADDR]: {
+              display_name: ROSTER_ROW.display_name,
+              global_display_name: ROSTER_ROW.global_display_name,
+            },
+          },
+        }}
+        selfAddress={SELF_ADDR}
+      >
+        <UserProfile spaceId={SPACE_ID} user={user} dismiss={() => {}} />
+      </IdentityScopeProvider>
+    </QueryClientProvider>,
+  );
+}
+
+/** What `MessageMarkdownRenderer`'s mention-pill click passes: address only. */
+const MENTION_PAYLOAD = { address: ADDR };
+
+/** What `Message.tsx`'s avatar click passes: the merged member record, whose
+ *  `userIcon`/`bio` `useChannelData` already resolved off the global slots. */
+const AVATAR_PAYLOAD = {
+  address: ADDR,
+  displayName: 'Alice',
+  userIcon: ROSTER_ICON,
+  bio: ROSTER_BIO,
+};
+
+describe('profile card avatar/bio — the roster global slots are a tier', () => {
+  beforeEach(() => {
+    getPublicProfile.mockReset();
+    getSpaceMembers.mockReset();
+  });
+
+  it('renders the roster global bio, not the stale public-profile bio, from an address-only payload', async () => {
+    renderCard(MENTION_PAYLOAD);
+
+    await waitFor(() => {
+      expect(document.querySelector('.user-profile-bio-text')?.textContent).toBe(ROSTER_BIO);
+    });
+    expect(document.querySelector('.user-profile-bio-text')?.textContent).not.toBe(
+      STALE_PUBLIC_BIO,
+    );
+  });
+
+  it('renders the roster global avatar from an address-only payload, where the public profile has none', async () => {
+    renderCard(MENTION_PAYLOAD);
+
+    await waitFor(() => {
+      const img = document.querySelector<HTMLImageElement>('.user-profile-icon img');
+      expect(img?.src).toBe(ROSTER_ICON);
+    });
+  });
+
+  it('agrees with the message-avatar entry point on all three fields', async () => {
+    const mention = renderCard(MENTION_PAYLOAD);
+    await waitFor(() => {
+      expect(document.querySelector('.user-profile-bio-text')?.textContent).toBe(ROSTER_BIO);
+    });
+    const fromMention = {
+      name: document.querySelector('.user-profile-username')?.textContent,
+      bio: document.querySelector('.user-profile-bio-text')?.textContent,
+      icon: document.querySelector<HTMLImageElement>('.user-profile-icon img')?.src,
+    };
+    mention.unmount();
+
+    renderCard(AVATAR_PAYLOAD);
+    await waitFor(() => {
+      expect(document.querySelector('.user-profile-bio-text')?.textContent).toBe(ROSTER_BIO);
+    });
+    const fromAvatar = {
+      name: document.querySelector('.user-profile-username')?.textContent,
+      bio: document.querySelector('.user-profile-bio-text')?.textContent,
+      icon: document.querySelector<HTMLImageElement>('.user-profile-icon img')?.src,
+    };
+
+    // Control arm: the name never came from the caller, so it must already
+    // match — if THIS assertion is the one that fails, the defect is in name
+    // resolution, not in the avatar/bio ladder this file is about.
+    expect(fromMention.name).toBe(fromAvatar.name);
+    expect(fromMention.bio).toBe(fromAvatar.bio);
+    expect(fromMention.icon).toBe(fromAvatar.icon);
+  });
+});
+
+describe('the precedence rules themselves', () => {
+  it('prefers a per-space override over the global slot over the public profile', () => {
+    expect(
+      pickProfileCardIcon({
+        memberIcon: 'override.png',
+        memberGlobalIcon: 'global.png',
+        publicProfileIcon: 'public.png',
+      }),
+    ).toBe('override.png');
+    expect(
+      pickProfileCardIcon({ memberGlobalIcon: 'global.png', publicProfileIcon: 'public.png' }),
+    ).toBe('global.png');
+    expect(pickProfileCardIcon({ publicProfileIcon: 'public.png' })).toBe('public.png');
+  });
+
+  it('treats an empty per-space override as "follow global", not as "no value"', () => {
+    // The override being empty is its NORMAL state under the two-slot model,
+    // so `||`-style skipping is the whole point of the ladder.
+    expect(pickProfileCardIcon({ memberIcon: '', memberGlobalIcon: 'global.png' })).toBe(
+      'global.png',
+    );
+    expect(pickProfileCardBio({ memberBio: '   ', memberGlobalBio: 'global bio' })).toBe(
+      'global bio',
+    );
+  });
+
+  it('falls through the UNKNOWN_USER placeholder so initials can take over', () => {
+    // Same rule as useChannelData's pickAvatar: the default image counts as
+    // absent, otherwise a broken-looking placeholder renders instead of
+    // coloured initials.
+    expect(
+      pickProfileCardIcon({
+        memberIcon: DefaultImages.UNKNOWN_USER,
+        memberGlobalIcon: 'global.png',
+      }),
+    ).toBe('global.png');
+  });
+
+  it('keeps your own global config bio as the last bio tier', () => {
+    expect(pickProfileCardBio({ ownConfigBio: 'my global bio' })).toBe('my global bio');
+    expect(pickProfileCardBio({ memberGlobalBio: 'roster', ownConfigBio: 'config' })).toBe(
+      'roster',
+    );
+  });
+
+  it('returns undefined when nothing knows anything', () => {
+    expect(pickProfileCardIcon({})).toBeUndefined();
+    expect(pickProfileCardBio({})).toBeUndefined();
+  });
+});

--- a/src/hooks/business/user/useProfileCardIdentityFields.ts
+++ b/src/hooks/business/user/useProfileCardIdentityFields.ts
@@ -1,0 +1,177 @@
+// useProfileCardIdentityFields — the profile card's avatar and bio, resolved
+// from the ADDRESS rather than from whatever the caller happened to pass.
+//
+// The card has two entry points carrying different payloads: a message-avatar
+// click hands over a fully-merged member record (`Message.tsx`'s `onUserClick`),
+// a mention-pill click hands over an address and nothing else
+// (`MessageMarkdownRenderer.tsx`'s `handleClick` — deliberately, because the
+// NAME resolves from `src/identity` either way).
+//
+// The name survived that narrowing; the avatar and bio did not. They are not
+// names, so the identity module deliberately does not carry them (design
+// constraint 4 — `MemberName` takes `userIcon` as a caller-supplied prop), and
+// the card's own address-keyed fallback went straight to the published public
+// profile. That SKIPS the tier the rest of the app actually renders from:
+// `space_members`' per-space override and its live-pushed
+// `global_user_icon` / `global_bio` slots, written by the identity announce
+// (`MessageDB.tsx`) and merged for every other surface by `useChannelData`.
+// The public profile is opt-in, frequently absent, and cached for an hour — so
+// the same person's card opened from a mention showed a stale bio and, for
+// anyone who never published a public photo, no avatar at all, while their card
+// opened from a message avatar one click away showed both.
+//
+// The ladder below is the SAME one `useChannelData` applies when it builds that
+// member record, and the same one `pickBookmarkSenderIcon` applies for
+// bookmarks: local tiers first, because they are live-pushed and work for
+// members with no public profile at all; the public profile last.
+//
+// Cost: none in the channel case. The roster read below uses
+// `buildSpaceMembersKey`, the key `Channel` (via `useSpaceMembers`) and
+// `useMultiSpaceRosters` have already populated — a cache read, not a second
+// IndexedDB round trip. Checking the key before asserting a cost is the
+// standing lesson from the identity work; see
+// `.agents/issues/2026-08-10-name-surfaces-that-never-reached-the-resolver.md`.
+
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { DefaultImages } from '../../../utils';
+import { useMessageDB } from '../../../components/context/useMessageDB';
+import { buildSpaceMembersFetcher } from '../../queries/spaceMembers/buildSpaceMembersFetcher';
+import { buildSpaceMembersKey } from '../../queries/spaceMembers/buildSpaceMembersKey';
+
+/**
+ * One rung of the avatar ladder: a usable avatar, or `undefined` so the next
+ * rung — and ultimately the initials placeholder — can take over. Mirrors
+ * `useChannelData`'s `pickAvatar`; the default UNKNOWN_USER image counts as
+ * absent, because handing it on renders a broken-looking placeholder instead
+ * of initials.
+ */
+function pickAvatar(icon: string | undefined): string | undefined {
+  if (!icon) return undefined;
+  return icon.includes(DefaultImages.UNKNOWN_USER) ? undefined : icon;
+}
+
+/** Blank and whitespace-only strings are "no value", not a value. */
+function nn(value: string | undefined): string | undefined {
+  const trimmed = (value ?? '').trim();
+  return trimmed.length ? value : undefined;
+}
+
+/** Every place the card's avatar and bio can come from, already read. */
+export interface ProfileCardFieldSources {
+  /**
+   * What the caller passed on `props.user`. PRE-FILL ONLY: present on the
+   * message-avatar and sidebar paths, absent on the mention-pill path. It is
+   * itself a snapshot of the two member tiers below, so it ranks first purely
+   * to avoid a flash while the roster read settles — never as the only source.
+   */
+  callerIcon?: string;
+  callerBio?: string;
+  /** `space_members.user_icon` / `.bio` — the deliberate per-space override. */
+  memberIcon?: string;
+  memberBio?: string;
+  /** `space_members.global_user_icon` / `.global_bio` — the live-pushed global
+   *  identity. The tier that was missing, and where most members' avatar and
+   *  bio actually live under the two-slot model. */
+  memberGlobalIcon?: string;
+  memberGlobalBio?: string;
+  /** The published public profile: opt-in, often empty, cached one hour. */
+  publicProfileIcon?: string;
+  publicProfileBio?: string;
+  /** `UserConfig.bio` — self only, so clearing a per-space bio override
+   *  reveals your global one again instead of an empty section. */
+  ownConfigBio?: string;
+}
+
+/**
+ * Pure precedence rules, kept out of the hook so they can be tested without
+ * IndexedDB, the network, or mounting a component with sixteen hooks.
+ */
+export function pickProfileCardIcon(
+  sources: ProfileCardFieldSources
+): string | undefined {
+  return (
+    pickAvatar(sources.callerIcon) ??
+    pickAvatar(sources.memberIcon) ??
+    pickAvatar(sources.memberGlobalIcon) ??
+    pickAvatar(sources.publicProfileIcon)
+  );
+}
+
+export function pickProfileCardBio(
+  sources: ProfileCardFieldSources
+): string | undefined {
+  return (
+    nn(sources.callerBio) ??
+    nn(sources.memberBio) ??
+    nn(sources.memberGlobalBio) ??
+    nn(sources.publicProfileBio) ??
+    nn(sources.ownConfigBio)
+  );
+}
+
+export interface UseProfileCardIdentityFieldsArgs {
+  address: string;
+  /** Absent in a DM, where there is no roster to read — the caller value and
+   *  the public profile are then the only tiers, exactly as before. */
+  spaceId?: string;
+  callerIcon?: string;
+  callerBio?: string;
+  publicProfileIcon?: string;
+  publicProfileBio?: string;
+  ownConfigBio?: string;
+}
+
+export function useProfileCardIdentityFields({
+  address,
+  spaceId,
+  callerIcon,
+  callerBio,
+  publicProfileIcon,
+  publicProfileBio,
+  ownConfigBio,
+}: UseProfileCardIdentityFieldsArgs): { userIcon?: string; bio?: string } {
+  const { messageDB } = useMessageDB();
+
+  const { data: members } = useQuery({
+    queryKey: buildSpaceMembersKey({ spaceId: spaceId ?? '' }),
+    queryFn: buildSpaceMembersFetcher({ spaceId: spaceId ?? '', messageDB }),
+    enabled: !!spaceId,
+    networkMode: 'always', // IndexedDB, not the network
+    staleTime: 60 * 1000,
+  });
+
+  // `SpaceMemberRow` is the raw IndexedDB shape (SDK field names), NOT
+  // quorum-shared's `SpaceMember` — so `user_address`/`user_icon` here, never
+  // `address`/`profile_image`. That rawness is the point: this is the same
+  // row `useChannelData` reads, before any adapter mapping.
+  const member = useMemo(
+    () => members?.find((m) => m.user_address === address),
+    [members, address]
+  );
+
+  return useMemo(() => {
+    const sources: ProfileCardFieldSources = {
+      callerIcon,
+      callerBio,
+      memberIcon: member?.user_icon || undefined,
+      memberBio: member?.bio || undefined,
+      memberGlobalIcon: member?.global_user_icon || undefined,
+      memberGlobalBio: member?.global_bio || undefined,
+      publicProfileIcon,
+      publicProfileBio,
+      ownConfigBio,
+    };
+    return {
+      userIcon: pickProfileCardIcon(sources),
+      bio: pickProfileCardBio(sources),
+    };
+  }, [
+    member,
+    callerIcon,
+    callerBio,
+    publicProfileIcon,
+    publicProfileBio,
+    ownConfigBio,
+  ]);
+}


### PR DESCRIPTION
The profile card has two entry points that pass different payloads. A message-avatar click hands over a fully-merged member record; a mention-pill click hands over an address and nothing else, deliberately, because the name resolves from `src/identity` either way.

The name survived that narrowing. The avatar and bio did not: they are not names, so the identity module does not carry them, and the card's own address-keyed fallback went straight to the published public profile. That skips the tier every other surface renders from, `space_members`' per-space override and its live-pushed `global_user_icon` / `global_bio` slots. The public profile is opt-in, so it usually has no photo, and is cached for an hour, so its bio lags.

Result: opening someone's card from a mention pill showed a stale bio and no profile picture, while their card opened from their message avatar one click away showed both.

## What changed

- `useProfileCardIdentityFields` owns the ladder in one place: caller pre-fill → per-space override → roster global slot → public profile → own config bio (self only). Same ladder as `useChannelData` and `pickBookmarkSenderIcon`.
- The precedence rules are pure functions (`pickProfileCardIcon`, `pickProfileCardBio`), testable without IndexedDB or a mounted component.
- `UserProfile.tsx` calls the hook instead of its two inline expressions.

The roster read uses `buildSpaceMembersKey`, already populated by `Channel` via `useSpaceMembers`, so this is a cache read rather than a second IndexedDB round trip.

## Verification

Eight new tests. The three component tests were confirmed red with the wiring reverted, failing with the exact reported symptom. Identity suite 251/251 on this base, typecheck and lint clean. Confirmed visually in the running app from both entry points.

The test carries a control arm: the same two payloads rendered against identical sources must agree on the *name* too. The name never came from the caller, so it already matches — if that assertion ever fails, the defect is in name resolution rather than in this ladder.

## Follow-up

Mobile was checked and has a related but differently-shaped defect (its bio is read raw, so it vanishes for any member the visible-senders merge never touched). Filed in that repo; not addressed here.
