### PR TITLE
fix(styles): colour classes naming an undefined token now generate CSS

### DIFF
--- a/src/components/message/MessageActions.tsx
+++ b/src/components/message/MessageActions.tsx
@@ -111,7 +111,7 @@ export const MessageActions: React.FC<MessageActionsProps> = ({
   const dangerIconButtonClass =
     'text-center text-surface-9 hover:text-danger hover:scale-125 xl:hover:scale-150 transition duration-200 rounded-md flex items-center justify-center cursor-pointer';
   const separatorClass =
-    'w-2 mr-2 text-center flex flex-col border-r border-r-1 border-surface-5';
+    'w-2 mr-2 text-center flex flex-col border-r border-surface-5';
 
   // Build the Shift-mode quick-action list. Each entry is rendered only if a
   // handler is provided and the corresponding capability is granted.

--- a/src/components/message/MessageList.tsx
+++ b/src/components/message/MessageList.tsx
@@ -713,10 +713,10 @@ export const MessageList = forwardRef<MessageListRef, MessageListProps>(
 
         {/* Loading Hash Message Indicator */}
         {isLoadingHashMessage && (
-          <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 z-50 bg-chat-overlay rounded-lg p-4 shadow-lg">
+          <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 z-50 bg-modal rounded-lg p-4 shadow-lg">
             <div className="flex items-center space-x-3">
-              <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-primary" />
-              <span className="text-sm text-primary">
+              <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-accent" />
+              <span className="text-sm text-main">
                 <Trans>Loading message...</Trans>
               </span>
             </div>

--- a/src/components/message/MessageMarkdownRenderer.tsx
+++ b/src/components/message/MessageMarkdownRenderer.tsx
@@ -720,7 +720,7 @@ export const MessageMarkdownRenderer: React.FC<MessageMarkdownRendererProps> = (
     // Style blockquotes
     blockquote: ({ children, ...props }: any) => (
       <blockquote
-        className="border-l-4 border-accent/50 pl-4 py-1 my-2 text-subtle italic"
+        className="border-l-4 border-accent-rgb/50 pl-4 py-1 my-2 text-subtle italic"
         {...props}
       >
         {children}

--- a/src/components/modals/SpaceSettingsModal/Account.tsx
+++ b/src/components/modals/SpaceSettingsModal/Account.tsx
@@ -457,7 +457,7 @@ const Account: React.FunctionComponent<AccountProps> = ({
           <>
             <Spacer size="xl" direction="vertical" />
             <Callout variant="error" size="md">
-              <div className="text-md">
+              <div className="text-base">
                 <Trans>Leave this Space</Trans>
               </div>
               <div className="pt-2 text-sm">

--- a/src/components/modals/SpaceSettingsModal/Roles.tsx
+++ b/src/components/modals/SpaceSettingsModal/Roles.tsx
@@ -195,7 +195,7 @@ const Roles: React.FunctionComponent<RolesProps> = ({
                       >
                         <Icon
                           name={r.isPublic !== false ? "eye" : "eye-off"}
-                          className="cursor-pointer text-main hover:text-main-hover"
+                          className="cursor-pointer text-main hover:text-strong"
                           onClick={() => toggleRolePublic(i)}
                         />
                       </Tooltip>

--- a/src/components/modals/UserSettingsModal/Security.tsx
+++ b/src/components/modals/UserSettingsModal/Security.tsx
@@ -389,7 +389,7 @@ const Security: React.FunctionComponent<SecurityProps> = ({
                       <>
                         <input
                           autoFocus
-                          className="flex-1 min-w-0 bg-transparent border border-subtle rounded px-2 py-0.5 text-sm text-main outline-none focus:border-primary"
+                          className="flex-1 min-w-0 bg-transparent border border-subtle rounded px-2 py-0.5 text-sm text-main outline-none focus:border-accent"
                           value={editValue}
                           onChange={e => setEditValue(e.target.value)}
                           onKeyDown={handleEditKeyDown}

--- a/src/components/search/SearchResults.tsx
+++ b/src/components/search/SearchResults.tsx
@@ -275,7 +275,7 @@ const SearchResultsInner: React.FC<SearchResultsProps> = ({
                 )}
               />
               {results.length >= 500 && (
-                <div className="p-3 border-top">
+                <div className="p-3 border-t border-default">
                   <Callout variant="info" className="w-full">
                     {t`Showing first 500 results. Refine your search for more specific results.`}
                   </Callout>

--- a/src/components/space/Channel.tsx
+++ b/src/components/space/Channel.tsx
@@ -178,7 +178,7 @@ export const MemberListRowAvatarAndName: React.FC<{
         {/* No `enrich` — deliberate, see design decision 3: this list can be
             200+ rows and enriching would fire one public-profile fetch per
             rendered row on open. */}
-        <MemberName address={address} className="text-md font-bold truncate-user-name" />
+        <MemberName address={address} className="text-base font-bold truncate-user-name" />
         {joinedAt != null && Date.now() - joinedAt < 7 * 24 * 60 * 60 * 1000 && (
           <Icon name="seedling" size="sm" variant="filled" className="ml-1.5 text-success flex-shrink-0" />
         )}

--- a/src/dev/DevMainPage.tsx
+++ b/src/dev/DevMainPage.tsx
@@ -94,7 +94,7 @@ export const DevMainPage: React.FC = () => {
             <Link
               key={index}
               to={tool.path}
-              className="block h-full no-underline bg-surface-1 hover:bg-surface-2 rounded-lg p-5 border border-default hover:border-accent/50 hover:shadow-lg transition-all cursor-pointer"
+              className="block h-full no-underline bg-surface-1 hover:bg-surface-2 rounded-lg p-5 border border-default hover:border-accent-rgb/50 hover:shadow-lg transition-all cursor-pointer"
             >
               <div className="flex items-center gap-2 mb-2">
                 <Icon name={tool.icon} size="lg" className="text-accent" />

--- a/src/dev/components-audit/ComponentAuditViewer.tsx
+++ b/src/dev/components-audit/ComponentAuditViewer.tsx
@@ -596,7 +596,7 @@ export const ComponentAuditViewer: React.FC = () => {
 
         {/* Ready to Build Panel */}
         {data.mobile_strategy && (
-          <div className="bg-accent/10 rounded-lg p-4 border border-accent/30 mb-6">
+          <div className="bg-accent-rgb/10 rounded-lg p-4 border border-accent-rgb/30 mb-6">
             <Flex gap="sm" className="mb-3 items-center">
               <span className="text-base text-strong text-accent-700 dark:text-accent-300">
                 🚀 Ready to Build Now - {data.mobile_strategy.current_phase}
@@ -856,7 +856,7 @@ export const ComponentAuditViewer: React.FC = () => {
                 <tbody>
                   {filteredComponents.map(([key, component]) => (
                     <React.Fragment key={key}>
-                      <tr className="border-b border-default hover:bg-surface-2/50 transition-colors">
+                      <tr className="border-b border-default hover:bg-surface-2 transition-colors">
                         <td className="px-4 py-3">
                           <div>
                             <p className="font-medium text-strong">
@@ -901,7 +901,7 @@ export const ComponentAuditViewer: React.FC = () => {
                                 {component.dependencies
                                   .slice(0, 3)
                                   .map((dep, idx) => (
-                                    <span className="px-1.5 py-0.5 bg-accent/10 text-accent-600 dark:text-accent-400 rounded text-xs" key={idx} title={dep}>
+                                    <span className="px-1.5 py-0.5 bg-accent-rgb/10 text-accent-600 dark:text-accent-400 rounded text-xs" key={idx} title={dep}>
                                       {dep.length > 10
                                         ? dep.substring(0, 10) + '...'
                                         : dep}
@@ -946,7 +946,7 @@ export const ComponentAuditViewer: React.FC = () => {
                       </tr>
 
                       {expandedRows.has(key) && (
-                        <tr className="bg-surface-2/30 border-b border-default">
+                        <tr className="bg-surface-2 border-b border-default">
                           <td colSpan={10} className="px-4 py-4">
                             <div className="space-y-3">
                               <div>
@@ -967,7 +967,7 @@ export const ComponentAuditViewer: React.FC = () => {
                                     {component.hooks.map((hook, index) => (
                                       <span
                                         key={index}
-                                        className="px-2 py-1 bg-accent/10 text-accent-600 dark:text-accent-400 rounded text-xs"
+                                        className="px-2 py-1 bg-accent-rgb/10 text-accent-600 dark:text-accent-400 rounded text-xs"
                                       >
                                         {hook}
                                       </span>
@@ -1182,7 +1182,7 @@ export const ComponentAuditViewer: React.FC = () => {
                   subtitle: 'Native implementation complete',
                   filter: (comp: ComponentAudit) =>
                     ['done', 'ready'].includes(comp.native),
-                  color: 'bg-accent/10 border-accent/30',
+                  color: 'bg-accent-rgb/10 border-accent-rgb/30',
                   urgency: 'done',
                 },
               ];
@@ -1222,7 +1222,7 @@ export const ComponentAuditViewer: React.FC = () => {
                         {components.slice(0, 8).map(([key, component]) => (
                           <div
                             key={key}
-                            className="flex items-center justify-between p-4 bg-surface-0 rounded-lg border border-default hover:bg-surface-1/50 transition-colors"
+                            className="flex items-center justify-between p-4 bg-surface-0 rounded-lg border border-default hover:bg-surface-1 transition-colors"
                           >
                             <div className="flex-1">
                               <div className="flex items-center gap-4 mb-2">
@@ -1238,7 +1238,7 @@ export const ComponentAuditViewer: React.FC = () => {
                                   />
                                   {component.dependencies &&
                                     component.dependencies.length > 0 && (
-                                      <span className="text-xs bg-accent/10 text-accent px-2 py-1 rounded">
+                                      <span className="text-xs bg-accent-rgb/10 text-accent px-2 py-1 rounded">
                                         {component.dependencies.length} deps
                                       </span>
                                     )}

--- a/src/dev/db-inspector/DbInspector.tsx
+++ b/src/dev/db-inspector/DbInspector.tsx
@@ -210,7 +210,7 @@ export const DbInspector: React.FC = () => {
                         onClick={() => loadStore(storeName)}
                         className={`w-full text-left px-3 py-2 rounded-md transition-colors ${
                           isSelected
-                            ? 'bg-accent/20 border border-accent/50'
+                            ? 'bg-accent-rgb/20 border border-accent-rgb/50'
                             : 'hover:bg-surface-2 border border-transparent'
                         }`}
                       >

--- a/src/dev/dm-doctor/DmDoctor.tsx
+++ b/src/dev/dm-doctor/DmDoctor.tsx
@@ -318,7 +318,7 @@ export const DmDoctor: React.FC = () => {
                   {distribution.map(([spaceId, count]) => {
                     const isGhost = Boolean(ownAddress) && spaceId === ownAddress;
                     return (
-                      <tr key={spaceId} className="border-b border-default/50">
+                      <tr key={spaceId} className="border-b border-subtle">
                         <td className="py-1 pr-4 font-mono">{truncateAddress(spaceId)}</td>
                         <td className="py-1 pr-4">{count}</td>
                         <td className="py-1">
@@ -380,7 +380,7 @@ export const DmDoctor: React.FC = () => {
                 </thead>
                 <tbody>
                   {history.map((entry, i) => (
-                    <tr key={entry.id} className="border-b border-default/50">
+                    <tr key={entry.id} className="border-b border-subtle">
                       <td className="py-1 pr-4">{i + 1}</td>
                       <td className="py-1 pr-4 font-mono">{entry.atIso}</td>
                       <td className="py-1 pr-4">{entry.prefix}</td>
@@ -456,7 +456,7 @@ export const DmDoctor: React.FC = () => {
                 </thead>
                 <tbody>
                   {ghosts.map((row) => (
-                    <tr key={row.conversationId} className="border-b border-default/50">
+                    <tr key={row.conversationId} className="border-b border-subtle">
                       <td className="py-1 pr-4 font-mono">{truncateAddress(row.address)}</td>
                       <td className="py-1 pr-4">{row.displayName || '(none)'}</td>
                       <td className="py-1 pr-4 font-mono">
@@ -513,7 +513,7 @@ export const DmDoctor: React.FC = () => {
                       </tr>
                     )}
                     {inventory.rows.map((row) => (
-                      <tr key={`${row.conversationId}-${row.address}`} className="border-b border-default/50">
+                      <tr key={`${row.conversationId}-${row.address}`} className="border-b border-subtle">
                         <td className="py-1 pr-4 font-mono">{truncateAddress(row.conversationId)}</td>
                         <td className="py-1 pr-4 font-mono">{truncateAddress(row.address)}</td>
                         <td className="py-1 pr-4">{row.displayName}</td>

--- a/src/dev/docs/MarkdownViewer.tsx
+++ b/src/dev/docs/MarkdownViewer.tsx
@@ -195,7 +195,7 @@ export const MarkdownViewer: React.FC<MarkdownViewerProps> = ({
       .replace(
         /^> (.*$)/gm,
         (match, text) =>
-          `<blockquote class="border-l-4 border-accent/50 pl-4 py-2 my-4 bg-accent/5 italic text-subtle rounded-r-lg">${text}</blockquote>`
+          `<blockquote class="border-l-4 border-accent-rgb/50 pl-4 py-2 my-4 bg-accent-rgb/5 italic text-subtle rounded-r-lg">${text}</blockquote>`
       )
 
       // Horizontal rules

--- a/src/dev/docs/components/FilterableList.tsx
+++ b/src/dev/docs/components/FilterableList.tsx
@@ -456,7 +456,7 @@ const IssueGroups: React.FC<{ files: MarkdownFile[]; basePath: string }> = ({
                 ({epicFiles.length})
               </span>
             </Flex>
-            <div className="h-px bg-border mt-1" />
+            <div className="h-px bg-surface-5 mt-1" />
           </div>
           <ul className="space-y-2 mb-4">
             {epicFiles.map((file) => (
@@ -562,7 +562,7 @@ const FolderView: React.FC<{
           {capitalize(folder.name)}
         </span>
       </Flex>
-      <div className="h-px bg-border mt-1" />
+      <div className="h-px bg-surface-5 mt-1" />
     </div>
 
     {folder.files.length > 0 && (
@@ -590,7 +590,7 @@ function getStatusStyle(status: string): string {
     case 'done':
       return 'bg-success/20 text-success border border-success/30';
     case 'in-progress':
-      return 'bg-accent/20 text-accent border border-accent/30';
+      return 'bg-accent-rgb/20 text-accent border border-accent-rgb/30';
     case 'on-hold':
       return 'bg-warning/20 text-warning border border-warning/30';
     case 'open':
@@ -598,7 +598,7 @@ function getStatusStyle(status: string): string {
     case 'deferred':
       return 'bg-info/20 text-info border border-info/30';
     case 'archived':
-      return 'bg-muted/20 text-muted border border-muted/30';
+      return 'bg-surface-3 text-muted border border-subtle';
     default:
       return 'bg-surface-2 text-subtle border border-default';
   }
@@ -607,7 +607,7 @@ function getStatusStyle(status: string): string {
 function getTypeStyle(type: string): string {
   return type === 'bug'
     ? 'bg-danger/20 text-danger border border-danger/30'
-    : 'bg-accent/10 text-accent border border-accent/20';
+    : 'bg-accent-rgb/10 text-accent border border-accent-rgb/20';
 }
 
 function getPriorityStyle(priority: string): string {
@@ -615,7 +615,7 @@ function getPriorityStyle(priority: string): string {
     case 'low':
       return 'bg-success/20 text-success border border-success/30';
     case 'medium':
-      return 'bg-accent/20 text-accent border border-accent/30';
+      return 'bg-accent-rgb/20 text-accent border border-accent-rgb/30';
     case 'high':
       return 'bg-danger/20 text-danger border border-danger/30';
     default:

--- a/src/dev/identity-coverage/IdentityCoverage.tsx
+++ b/src/dev/identity-coverage/IdentityCoverage.tsx
@@ -130,7 +130,7 @@ const LiveResolutionDiagnostics: React.FC = () => {
               {state.events.slice(0, 20).map((e) => (
                 <tr
                   key={`${e.address}|${e.scope}|${e.spaceId ?? ''}|${e.reason}`}
-                  className="border-b border-default/50"
+                  className="border-b border-subtle"
                 >
                   <td className="py-1 pr-4 font-mono text-xs">{e.at}</td>
                   <td className="py-1 pr-4">{e.surface}</td>
@@ -482,7 +482,7 @@ export const IdentityCoverage: React.FC = () => {
                     {latest.spaces.map((space) => (
                       <tr
                         key={space.spaceId}
-                        className="border-b border-default/50"
+                        className="border-b border-subtle"
                       >
                         <td className="py-1 pr-4">
                           {space.spaceName}
@@ -569,7 +569,7 @@ export const IdentityCoverage: React.FC = () => {
                       {history.map((snapshot, index) => (
                         <tr
                           key={snapshot.atIso}
-                          className="border-b border-default/50"
+                          className="border-b border-subtle"
                         >
                           <td className="py-1 pr-4">{index + 1}</td>
                           <td className="py-1 pr-4 font-mono text-xs">

--- a/src/dev/tests/components/tailwindClassesGenerate.test.ts
+++ b/src/dev/tests/components/tailwindClassesGenerate.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'fs';
+import { join } from 'path';
+import postcss from 'postcss';
+import tailwindcss from 'tailwindcss';
+// @ts-ignore - plain JS config, no types
+import tailwindConfig from '../../../../tailwind.config.js';
+
+/**
+ * A Tailwind class that names a colour the theme does not define generates no
+ * CSS at all. Nothing errors: the class stays on the element, the build passes,
+ * and the element silently falls back to whatever it inherits. That failure is
+ * invisible in review and usually plausible on screen, which is why these
+ * accumulate.
+ *
+ * `border-default` is the case that makes the point. `theme.borderColor.DEFAULT`
+ * names the bare `border` utility, not `border-default`, so ~90 call sites wrote
+ * a class that never existed. It looked correct only because Tailwind's preflight
+ * paints every element's border with that same variable anyway.
+ *
+ * Others found by the first run of this test, all silently wrong for months:
+ * `hover:text-main-hover`, `text-primary` / `border-primary` / `bg-chat-overlay`
+ * on the message-loading card, `focus:border-primary`, `text-md` (Tailwind has
+ * `text-base`, never `text-md`), and every `-accent/<opacity>` class — an opacity
+ * modifier cannot apply to a bare `var()` value, which is what `accent-rgb`
+ * exists for.
+ *
+ * See `.agents/issues/.done/2026-08-12-hover-text-utilities-generate-no-css.md`.
+ *
+ * Related: `cssColourVariableFormat.test.ts` catches the neighbouring defect,
+ * where the class does generate but its `rgb(var(--x))` value is invalid CSS.
+ */
+
+/** Namespaces where a bad value yields no rule rather than a build error. */
+const NAMESPACES =
+  'text|bg|border|divide|from|via|to|ring|outline|decoration|placeholder|caret|fill|stroke|shadow|accent';
+const CANDIDATE = new RegExp(`^(?:[a-z0-9-]+:)*!?(?:${NAMESPACES})-`);
+
+const collectFiles = (dir: string, match: RegExp): string[] => {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name !== 'node_modules') out.push(...collectFiles(full, match));
+    } else if (match.test(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+};
+
+/** `.\32 xl\:text-xl` -> `2xl:text-xl` */
+const unescapeSelector = (selector: string) =>
+  selector
+    .replace(/\\([0-9a-fA-F]{1,6})[ ]?/g, (_, hex) =>
+      String.fromCodePoint(parseInt(hex, 16))
+    )
+    .replace(/\\(.)/g, '$1');
+
+/**
+ * Class-list string literals, one line at a time. Scanning across lines drifts
+ * out of phase on the first apostrophe in JSX prose ("don't") and then reports
+ * fragments of markup as class names.
+ */
+const STRING_LITERAL = /(["'`])((?:\\.|(?!\1)[^\\\n])*)\1/g;
+
+/** `className`, `iconClassName`, `nameWrapperClassName`, plain `class`, ... */
+const CLASS_ATTR =
+  /\b(?:[a-zA-Z]*[cC]lassName|class)\s*=\s*(?:"([^"\n]*)"|'([^'\n]*)')/g;
+
+const rel = (file: string) => file.replace(/\\/g, '/');
+
+/**
+ * Comments must go before any string scan. Prose in a doc comment quotes class
+ * names in backticks, which reads as a template literal — this very file's
+ * comment above mentions `text-md`, and without this the test reports itself.
+ * The `[^:]` guard keeps `https://` out of the line-comment rule.
+ */
+const stripComments = (source: string) =>
+  source
+    .replace(/\/\*[\s\S]*?\*\//g, (block) => block.replace(/[^\n]/g, ' '))
+    .replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+
+describe('tailwind classes generate css', () => {
+  it('every colour utility written in source produces a rule', async () => {
+    // 1. Exactly the utilities Tailwind would ship for this repo, built from the
+    //    real config so the test cannot drift from the build.
+    const { css: utilities } = await postcss([
+      tailwindcss(tailwindConfig),
+    ]).process('@tailwind utilities;', { from: undefined });
+
+    // Matching stops at an unescaped `:`, so `.hover\:text-danger:hover` yields
+    // the class `hover:text-danger` rather than the whole selector.
+    const generated = new Set<string>();
+    for (const match of utilities.matchAll(/\.((?:\\.|[\w-])+)/g)) {
+      generated.add(unescapeSelector(match[1]));
+    }
+    expect(generated.size).toBeGreaterThan(500); // the scan itself still works
+
+    // 2. Hand-written SCSS classes are legitimate too (`text-label`, `bg-onboarding`).
+    const scssClasses = new Set<string>();
+    for (const file of collectFiles('src', /\.(scss|css)$/)) {
+      for (const match of readFileSync(file, 'utf8').matchAll(
+        /\.(-?[A-Za-z_][A-Za-z0-9_-]*)/g
+      )) {
+        scssClasses.add(match[1]);
+      }
+    }
+
+    const isKnown = (cls: string) => generated.has(cls) || scssClasses.has(cls);
+
+    // 3. Every candidate class written in source must resolve to one of those.
+    const dead = new Map<string, Set<string>>();
+
+    const inspect = (
+      chunk: string,
+      file: string,
+      source: string,
+      index: number
+    ) => {
+      const tokens = chunk
+        .replace(/\$\{[^}]*\}/g, ' ')
+        .split(/\s+/)
+        .filter(Boolean);
+      for (const token of tokens) {
+        if (!CANDIDATE.test(token) || isKnown(token)) continue;
+        // Arbitrary values (`text-[var(--x)]`) escape too many ways to compare
+        // as plain strings, and a wrong one is a CSS error rather than a no-op.
+        if (token.includes('[')) continue;
+        const line = source.slice(0, index).split('\n').length;
+        if (!dead.has(token)) dead.set(token, new Set());
+        dead.get(token)!.add(`${rel(file)}:${line}`);
+      }
+    };
+
+    for (const file of collectFiles('src', /\.(tsx?|jsx?)$/)) {
+      // Block comments are blanked rather than removed so reported line numbers
+      // still match the file on disk.
+      const source = stripComments(readFileSync(file, 'utf8'));
+
+      // A `className="..."` value is a class list by definition, even when it
+      // holds a single token (`className="text-md"`).
+      for (const match of source.matchAll(CLASS_ATTR)) {
+        inspect(match[1] ?? match[2] ?? '', file, source, match.index!);
+      }
+
+      // Class lists also get built in helpers and returned as plain strings.
+      // Treat a literal as one only when two or more of its tokens are real
+      // classes: a single hit misfires on CSS values such as the transition
+      // `'border-color 0.15s ease-in-out'`, where `ease-in-out` is also a class.
+      for (const match of source.matchAll(STRING_LITERAL)) {
+        const chunk = match[2];
+        if (chunk.includes('<') || chunk.includes('>')) continue; // markup
+        const tokens = chunk.split(/\s+/).filter(Boolean);
+        if (tokens.filter(isKnown).length < 2) continue;
+        inspect(chunk, file, source, match.index!);
+      }
+    }
+
+    const report = [...dead]
+      .sort()
+      .map(
+        ([cls, where]) =>
+          `  ${cls}\n${[...where]
+            .sort()
+            .map((w) => `      ${w}`)
+            .join('\n')}`
+      )
+      .join('\n');
+
+    expect(
+      dead.size,
+      dead.size
+        ? `${dead.size} class(es) generate no CSS — the theme defines no such colour:\n${report}\n`
+        : ''
+    ).toBe(0);
+  }, 60_000);
+});

--- a/src/dev/tests/identity/identitySidebarFetch.test.tsx
+++ b/src/dev/tests/identity/identitySidebarFetch.test.tsx
@@ -100,7 +100,7 @@ function Sidebar({ addrs, selfAddress = null }: { addrs: string[]; selfAddress?:
   return (
     <IdentityScopeProvider spaceId={SPACE_ID} rostersBySpace={{ [SPACE_ID]: rosterRows }} selfAddress={selfAddress}>
       {addrs.map((address, i) => (
-        <MemberName key={i} address={address} className="text-md font-bold truncate-user-name" />
+        <MemberName key={i} address={address} className="text-base font-bold truncate-user-name" />
       ))}
     </IdentityScopeProvider>
   );

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -99,6 +99,12 @@ export default {
 
       borderColor: {
         DEFAULT: 'var(--color-border-default)',
+        // `DEFAULT` only names the bare `border` utility and the preflight rule
+        // that colours every element's border. It does NOT create `border-default`,
+        // which ~90 call sites here write explicitly. Without this key that class
+        // generates nothing; it went unnoticed for so long because preflight
+        // already paints the same colour, so the dead class looked like it worked.
+        default: 'var(--color-border-default)',
         subtle: 'var(--color-border-subtle)',
         strong: 'var(--color-border-strong)',
         stronger: 'var(--color-border-stronger)',


### PR DESCRIPTION
A Tailwind class that names a colour the theme does not define generates no CSS
at all. The class stays on the element, the build passes, and the element falls
back to whatever it inherits — invisible in review, and usually plausible on
screen. Twenty-four of these were live in the app.

This started as an investigation into a bug report claiming no `hover:text-*`
utility generated CSS. **That report was wrong** — all 14 of them generate, with
valid values. Its evidence came from a `grep` that silently fails to match a
literal backslash on Git Bash for Windows:

```bash
grep -o  'hover\:text-danger' bundle.css   # -> 0   (what the report used)
grep -oF 'hover\:text-danger'  bundle.css   # -> 1   (correct)
```

The same broken pattern also reports `hover:bg-danger` as missing, yet the
report cited it as present — the two halves of its contrast were gathered by
different methods, and only one worked. Reading the bundle with Node instead
turned up the real defect, of the same shape but elsewhere.

### Fixed

| Class | Sites | Fix |
|---|---|---|
| `border-default` | 86 | `theme.borderColor.default` added |
| `divide-default` | 1 | same (divide colours derive from `borderColor`) |
| `hover:text-main-hover` | 1 | → `hover:text-strong` |
| `bg-chat-overlay`, `border-primary`, `text-primary` | 3 | → `bg-modal`, `border-accent`, `text-main` |
| `focus:border-primary` | 1 | → `focus:border-accent` |
| `text-md` | 3 | → `text-base` |
| `border-r-1`, `border-top` | 2 | removed / → `border-t border-default` |
| `-accent/<opacity>` family | 10 | → `-accent-rgb/<opacity>` |
| `bg-surface-N/<opacity>`, `bg-border`, `bg-muted/20`, `border-muted/30`, `border-default/50` | 15 | existing surface/subtle tokens (dev pages) |

Two worth calling out:

- **`border-default` hid because it looked right.** `theme.borderColor.DEFAULT`
  names the bare `border` utility and the preflight rule that colours *every*
  element's border. It never created `border-default`. Since preflight already
  paints `var(--color-border-default)`, 86 dead classes rendered exactly the
  colour their author intended. Defining the key changes no pixels.
- **`-accent/<opacity>` cannot work.** An opacity modifier needs a numeric
  triplet, and `--accent` holds a bare `var()`. That is what `accent-rgb`
  exists for. One production site (the markdown blockquote border); the rest
  were `/dev` pages.

### Regression guard

`src/dev/tests/components/tailwindClassesGenerate.test.ts` builds the utility
CSS from the real `tailwind.config.js`, collects every class written in `src`
(from `className` attributes and from class-list strings returned by helpers),
and fails on any colour-namespace class matching neither a generated utility nor
a hand-written SCSS class. It is the sibling of `cssColourVariableFormat.test.ts`,
which catches the neighbouring defect where the class generates but its
`rgb(var(--x))` value is invalid CSS.

**Confirmed it can fail rather than merely passing:** reverting three of the
fixes above turns it red naming exactly the four expected classes, and restoring
them turns it green.

Two false-positive traps are handled, both found by running it: comments are
blanked first (prose quotes class names in backticks, which reads as a template
literal — it reported its own doc comment otherwise), and a helper-returned
string counts as a class list only when two or more tokens are real classes
(the transition value `'border-color 0.15s ease-in-out'` contains `ease-in-out`).

### Verification

- `yarn test:run` — 151 files, 1409 tests, all pass
- `npx tsc --noEmit --jsx react-jsx --skipLibCheck` — clean
- `yarn lint` — 0 errors
- `yarn build` — succeeds; post-build bundle confirmed to contain every
  replacement rule and none of the replaced classes

### Visible changes

Most of the diff is deliberately invisible (`border-default`). What does change:
the roles eye icon now brightens on hover; the markdown blockquote border is
accent-tinted; the "Loading message…" card has a background at all; the username
field shows an accent focus border; the search footer divider draws at ≥500
results; assorted `/dev` badge tints. Rendering was not verified in a browser —
the claim is that the CSS exists and is valid, which is what was measured.
