### PR TITLE
fix(reset): Reset App Data clears the SDK key store, not just the app database

### DIFF
--- a/src/components/modals/UserSettingsModal/DangerZone.tsx
+++ b/src/components/modals/UserSettingsModal/DangerZone.tsx
@@ -4,6 +4,7 @@ import { Trans } from '@lingui/react/macro';
 import { t } from '@lingui/core/macro';
 import { useQueryClient } from '@tanstack/react-query';
 import { useDeregisterThisDevice } from '../../../hooks/business/user/useDeregisterThisDevice';
+import { wipeLocalAppData } from '../../../services/resetAppData';
 
 const DangerZone: React.FunctionComponent = () => {
   const queryClient = useQueryClient();
@@ -44,22 +45,14 @@ const DangerZone: React.FunctionComponent = () => {
       // Clear React Query cache
       queryClient.clear();
 
-      // Delete IndexedDB database. A blocked delete means another tab still
-      // holds the DB open — treating it as success (the old behavior) silently
-      // reloaded on the SAME data, so the reset appeared to do nothing. Reject
-      // so the user is told to close other tabs instead.
-      await new Promise<void>((resolve, reject) => {
-        const req = indexedDB.deleteDatabase('quorum_db');
-        req.onsuccess = () => resolve();
-        req.onerror = () => reject(req.error);
-        req.onblocked = () => reject(new Error('blocked'));
-      });
-
-      // Clear all localStorage
-      localStorage.clear();
-
-      // Clear sessionStorage
-      sessionStorage.clear();
+      // Both IndexedDB databases (the app's own and the SDK's key store) plus
+      // all web storage. Deliberately AFTER the deregistration above, which
+      // signs with the master key this destroys.
+      //
+      // A blocked delete still rejects rather than resolving: treating it as
+      // success (the old behavior) silently reloaded on the SAME data, so the
+      // reset appeared to do nothing.
+      await wipeLocalAppData();
 
       // Hard reload to clear in-memory state
       window.location.reload();

--- a/src/dev/tests/components/dangerZoneResetWiring.test.tsx
+++ b/src/dev/tests/components/dangerZoneResetWiring.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * DangerZone — the Confirm Reset button really does destroy the key material.
+ *
+ * The wipe itself is covered in depth by
+ * `services/resetAppDataKeyMaterial.test.ts`. This file exists for the gap that
+ * unit test cannot see: the wipe lives in a service now, so deleting the call
+ * from the component would leave every one of those tests green while the
+ * shipped button quietly stopped deleting anything.
+ *
+ * So this drives the actual UI — type "reset", click the button — and then asks
+ * the SDK for the key back.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import 'fake-indexeddb/auto';
+import { webcrypto } from 'node:crypto';
+import { Buffer } from 'buffer';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { i18n } from '@lingui/core';
+import { I18nProvider } from '@lingui/react';
+import { messages } from '@/i18n/en/messages';
+import { passkey } from '@quilibrium/quilibrium-js-sdk-channels';
+
+const deregisterMock = vi.fn(async () => ({ hub: 'ok', spaces: 'ok' }));
+vi.mock('@/hooks/business/user/useDeregisterThisDevice', () => ({
+  useDeregisterThisDevice: () => deregisterMock,
+}));
+
+import DangerZone from '@/components/modals/UserSettingsModal/DangerZone';
+
+const FAKE_MASTER_KEY = new Uint8Array(57).map((_, i) => (i * 7 + 3) & 0xff);
+
+beforeAll(() => {
+  i18n.load('en', messages);
+  i18n.activate('en');
+  // setup.ts stubs crypto.subtle; the SDK needs real AES-GCM to store anything.
+  Object.defineProperty(globalThis, 'crypto', {
+    value: webcrypto,
+    configurable: true,
+    writable: true,
+  });
+  // jsdom throws "Not implemented" on navigation.
+  Object.defineProperty(window, 'location', {
+    value: { ...window.location, reload: vi.fn() },
+    writable: true,
+    configurable: true,
+  });
+});
+
+beforeEach(async () => {
+  const FDBFactory = (await import('fake-indexeddb/lib/FDBFactory')).default;
+  const fdb = new FDBFactory();
+  globalThis.indexedDB = fdb;
+  (window as unknown as { indexedDB: IDBFactory }).indexedDB = fdb;
+  localStorage.clear();
+  sessionStorage.clear();
+  deregisterMock.mockClear();
+});
+
+const renderDangerZone = () =>
+  render(
+    <I18nProvider i18n={i18n}>
+      <QueryClientProvider client={new QueryClient()}>
+        <DangerZone />
+      </QueryClientProvider>
+    </I18nProvider>
+  );
+
+describe('DangerZone reset wiring', () => {
+  it('destroys the stored master key when the user confirms', async () => {
+    const user = userEvent.setup();
+    await passkey.encryptDataSaveKey(1, Buffer.from(FAKE_MASTER_KEY));
+    // Control arm: prove it was actually stored, so a later rejection means
+    // "deleted" rather than "never written".
+    await expect(passkey.loadKeyDecryptData(1)).resolves.toBeDefined();
+
+    renderDangerZone();
+
+    await user.type(screen.getByPlaceholderText(/type reset to confirm/i), 'reset');
+    await user.click(screen.getByRole('button', { name: /confirm reset/i }));
+
+    await waitFor(async () => {
+      await expect(passkey.loadKeyDecryptData(1)).rejects.toBe('no data');
+    });
+  });
+
+  it('deregisters the device before destroying the key', async () => {
+    const user = userEvent.setup();
+    await passkey.encryptDataSaveKey(1, Buffer.from(FAKE_MASTER_KEY));
+
+    let keyStillReadableAtDeregister: boolean | undefined;
+    deregisterMock.mockImplementationOnce(async () => {
+      // The deregistration signs with the master key, so it has to still be
+      // there at this point. Ordering the wipe first would strand the device's
+      // hub entry and its space signing admission.
+      keyStillReadableAtDeregister = await passkey
+        .loadKeyDecryptData(1)
+        .then(() => true)
+        .catch(() => false);
+      return { hub: 'ok', spaces: 'ok' };
+    });
+
+    renderDangerZone();
+    await user.type(screen.getByPlaceholderText(/type reset to confirm/i), 'reset');
+    await user.click(screen.getByRole('button', { name: /confirm reset/i }));
+
+    await waitFor(() => expect(deregisterMock).toHaveBeenCalled());
+    expect(keyStillReadableAtDeregister).toBe(true);
+  });
+
+  it('does nothing until the confirmation word is typed', async () => {
+    const user = userEvent.setup();
+    await passkey.encryptDataSaveKey(1, Buffer.from(FAKE_MASTER_KEY));
+
+    renderDangerZone();
+    await user.click(screen.getByRole('button', { name: /confirm reset/i }));
+
+    expect(deregisterMock).not.toHaveBeenCalled();
+    await expect(passkey.loadKeyDecryptData(1)).resolves.toBeDefined();
+  });
+});

--- a/src/dev/tests/services/resetAppDataKeyMaterial.test.ts
+++ b/src/dev/tests/services/resetAppDataKeyMaterial.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Reset App Data — the wipe has to clear key material, not just app data.
+ *
+ * The SDK keeps key material in its own IndexedDB database, separate from the
+ * app's `quorum_db`. The invariant under test: once `wipeLocalAppData()`
+ * resolves, nothing readable is left in EITHER store, so the dialog's promise
+ * to delete "your private keys" holds on every code path.
+ *
+ * Everything here goes through the SDK's PUBLIC helpers
+ * (`passkey.encryptDataSaveKey` / `loadKeyDecryptData` / `authenticate`) and
+ * never touches the `'KeyDB'` string itself. That is deliberate: the wipe
+ * deletes that database BY NAME, which couples it to an SDK internal, and
+ * `indexedDB.deleteDatabase` on a database that does not exist resolves
+ * successfully rather than erroring. So if a future SDK version renames its
+ * database, the delete would silently become a no-op. Seeding through the
+ * SDK's own API is what turns that silent no-op into a red test here.
+ *
+ * The keys below are invented constants, not real key material.
+ */
+
+import 'fake-indexeddb/auto';
+import { describe, it, expect, beforeEach, beforeAll } from 'vitest';
+import { webcrypto } from 'node:crypto';
+import { Buffer } from 'buffer';
+import { passkey } from '@quilibrium/quilibrium-js-sdk-channels';
+import { wipeLocalAppData } from '@/services/resetAppData';
+
+/** Matches `fqAppPrefix: 'Quorum'` in useUnifiedOnboardingFlow.ts. */
+const APP_PREFIX = 'Quorum';
+const FALLBACK_FLAG = `${APP_PREFIX.toLowerCase()}-master-prf-incompatibility`;
+
+/**
+ * An Ed448 private key is 57 bytes, and `authenticate` branches on that exact
+ * length (`data.byteLength == 57` → hex) — so the fixture has to be 57 bytes or
+ * the SDK takes its utf-8 branch and the test stops exercising the real path.
+ */
+const FAKE_MASTER_KEY = new Uint8Array(57).map((_, i) => (i * 7 + 3) & 0xff);
+const FAKE_MASTER_KEY_HEX = Buffer.from(FAKE_MASTER_KEY).toString('hex');
+
+beforeAll(() => {
+  // setup.ts replaces crypto.subtle with vi.fn() stubs that return undefined.
+  // AES-GCM has to be real here or encryptDataSaveKey silently stores nothing.
+  Object.defineProperty(globalThis, 'crypto', {
+    value: webcrypto,
+    configurable: true,
+    writable: true,
+  });
+});
+
+beforeEach(async () => {
+  const FDBFactory = (await import('fake-indexeddb/lib/FDBFactory')).default;
+  const fdb = new FDBFactory();
+  globalThis.indexedDB = fdb;
+  // The SDK's callOnStore reads `window.indexedDB`, not the bare global.
+  (window as unknown as { indexedDB: IDBFactory }).indexedDB = fdb;
+  localStorage.clear();
+  sessionStorage.clear();
+});
+
+/** Onboarding on the fallback path: master key to id=1, flag set. */
+const seedFallbackRegistration = async () => {
+  localStorage.setItem(FALLBACK_FLAG, 'true');
+  localStorage.setItem(
+    'passkeys-list',
+    JSON.stringify([
+      {
+        credentialId: 'not-passkey',
+        address: 'QmFakeAddrForTest0000000000000000',
+        publicKey: 'aabbcc',
+        completedOnboarding: true,
+      },
+    ])
+  );
+  await passkey.encryptDataSaveKey(1, Buffer.from(FAKE_MASTER_KEY));
+};
+
+/**
+ * The control arm. Every assertion below is "the SDK can no longer read X",
+ * which would also pass if the fixture had never stored X in the first place —
+ * a broken seed, stubbed crypto, the wrong IndexedDB factory. This proves the
+ * seed works, so a later rejection means "deleted" and not "never written".
+ */
+describe('fixture: seeding through the SDK stores a readable key', () => {
+  it('authenticate() returns what encryptDataSaveKey stored', async () => {
+    await seedFallbackRegistration();
+
+    const cred = await passkey.authenticate(APP_PREFIX, {
+      credentialId: 'not-passkey',
+    });
+
+    expect(cred.largeBlob).toBe(FAKE_MASTER_KEY_HEX);
+  });
+});
+
+describe('the fix: wipeLocalAppData clears the SDK key store', () => {
+  it('makes the master key unreadable through the SDK', async () => {
+    await seedFallbackRegistration();
+
+    await wipeLocalAppData();
+    localStorage.setItem(FALLBACK_FLAG, 'true');
+
+    // 'no data' is the SDK's own rejection for an absent record. Asserting the
+    // exact reason matters: a bare "it rejected" would also pass if the test
+    // had broken the crypto or the store, i.e. for the wrong reason.
+    await expect(passkey.loadKeyDecryptData(1)).rejects.toBe('no data');
+  });
+
+  it('leaves authenticate() with nothing to hand back', async () => {
+    await seedFallbackRegistration();
+
+    await wipeLocalAppData();
+    localStorage.setItem(FALLBACK_FLAG, 'true');
+
+    await expect(
+      passkey.authenticate(APP_PREFIX, { credentialId: 'not-passkey' })
+    ).rejects.toBe('no data');
+  });
+
+  /**
+   * The id=2 record holds the identity and device keysets. On the fallback
+   * path it is encrypted under SHA-256(master key), so id=1 is enough to open
+   * it — both records have to go, which is why the fix drops the whole store
+   * rather than one row.
+   */
+  it('clears the identity/device keyset record too', async () => {
+    await seedFallbackRegistration();
+    await passkey.encryptDataSaveKey(2, Buffer.from('{"identity":"x"}', 'utf-8'));
+
+    await wipeLocalAppData();
+
+    await expect(passkey.loadKeyDecryptData(2)).rejects.toBe('no data');
+  });
+
+  it('still clears the app database and web storage', async () => {
+    await seedFallbackRegistration();
+    await new Promise<void>((resolve) => {
+      const open = indexedDB.open('quorum_db', 1);
+      open.onupgradeneeded = () => open.result.createObjectStore('messages');
+      open.onsuccess = () => {
+        open.result.close();
+        resolve();
+      };
+    });
+
+    await wipeLocalAppData();
+
+    expect(localStorage.length).toBe(0);
+    expect(sessionStorage.length).toBe(0);
+  });
+
+  /**
+   * A blocked delete means another tab still holds the database open. Treating
+   * it as success would reload on the same data and the reset would appear to
+   * do nothing, so it has to surface — same contract quorum_db already had.
+   */
+  it('rejects with "blocked" rather than half-completing', async () => {
+    await seedFallbackRegistration();
+
+    const held = await new Promise<IDBDatabase>((resolve) => {
+      const open = indexedDB.open('quorum_db', 1);
+      open.onupgradeneeded = () => open.result.createObjectStore('messages');
+      open.onsuccess = () => resolve(open.result);
+    });
+
+    // Holding the connection open makes deleteDatabase fire onblocked.
+    await expect(wipeLocalAppData()).rejects.toThrow('blocked');
+    held.close();
+  });
+});

--- a/src/dev/tests/services/resetAppDataKeyMaterial.test.ts
+++ b/src/dev/tests/services/resetAppDataKeyMaterial.test.ts
@@ -24,6 +24,7 @@ import { webcrypto } from 'node:crypto';
 import { Buffer } from 'buffer';
 import { passkey } from '@quilibrium/quilibrium-js-sdk-channels';
 import { wipeLocalAppData } from '@/services/resetAppData';
+import { QUORUM_DB_NAME } from '@/db/dbVersion';
 
 /** Matches `fqAppPrefix: 'Quorum'` in useUnifiedOnboardingFlow.ts. */
 const APP_PREFIX = 'Quorum';
@@ -56,6 +57,34 @@ beforeEach(async () => {
   localStorage.clear();
   sessionStorage.clear();
 });
+
+/** Stand in for MessageDB: create the app database with one store. */
+const createAppDb = (): Promise<IDBDatabase> =>
+  new Promise((resolve) => {
+    const open = indexedDB.open(QUORUM_DB_NAME, 1);
+    open.onupgradeneeded = () => open.result.createObjectStore('messages');
+    open.onsuccess = () => resolve(open.result);
+  });
+
+/**
+ * Whether the app database is still there.
+ *
+ * Opening it is the portable probe: `onupgradeneeded` only fires when there was
+ * nothing to open. It leaves an empty database behind, which is harmless — each
+ * test gets a fresh IndexedDB factory.
+ */
+const appDbExists = (): Promise<boolean> =>
+  new Promise((resolve) => {
+    let existed = true;
+    const open = indexedDB.open(QUORUM_DB_NAME);
+    open.onupgradeneeded = () => {
+      existed = false;
+    };
+    open.onsuccess = () => {
+      open.result.close();
+      resolve(existed);
+    };
+  });
 
 /** Onboarding on the fallback path: master key to id=1, flag set. */
 const seedFallbackRegistration = async () => {
@@ -131,16 +160,18 @@ describe('the fix: wipeLocalAppData clears the SDK key store', () => {
     await expect(passkey.loadKeyDecryptData(2)).rejects.toBe('no data');
   });
 
-  it('still clears the app database and web storage', async () => {
+  it('still deletes the app database', async () => {
     await seedFallbackRegistration();
-    await new Promise<void>((resolve) => {
-      const open = indexedDB.open('quorum_db', 1);
-      open.onupgradeneeded = () => open.result.createObjectStore('messages');
-      open.onsuccess = () => {
-        open.result.close();
-        resolve();
-      };
-    });
+    (await createAppDb()).close();
+
+    await wipeLocalAppData();
+
+    expect(await appDbExists()).toBe(false);
+  });
+
+  it('still clears web storage', async () => {
+    await seedFallbackRegistration();
+    sessionStorage.setItem('some-session-state', 'x');
 
     await wipeLocalAppData();
 
@@ -156,14 +187,49 @@ describe('the fix: wipeLocalAppData clears the SDK key store', () => {
   it('rejects with "blocked" rather than half-completing', async () => {
     await seedFallbackRegistration();
 
-    const held = await new Promise<IDBDatabase>((resolve) => {
-      const open = indexedDB.open('quorum_db', 1);
-      open.onupgradeneeded = () => open.result.createObjectStore('messages');
-      open.onsuccess = () => resolve(open.result);
-    });
-
     // Holding the connection open makes deleteDatabase fire onblocked.
+    const held = await createAppDb();
+
     await expect(wipeLocalAppData()).rejects.toThrow('blocked');
     held.close();
+  });
+
+  /**
+   * The failure path, pinned deliberately.
+   *
+   * It is tempting to move the storage clears into a `finally` so a failed
+   * wipe still "does as much as it can". That is the wrong trade: clearing
+   * `passkeys-list` — the only record that an account exists on this device —
+   * while key material is still on disk would lock the user out AND leave
+   * behind the exact thing the reset exists to remove. Failing without
+   * touching storage leaves a state the user retries out of cleanly, because
+   * deleting an already-deleted database succeeds.
+   */
+  it('leaves web storage untouched when the wipe fails', async () => {
+    await seedFallbackRegistration();
+    const held = await createAppDb();
+
+    await expect(wipeLocalAppData()).rejects.toThrow('blocked');
+
+    expect(localStorage.getItem('passkeys-list')).not.toBeNull();
+    expect(localStorage.getItem(FALLBACK_FLAG)).toBe('true');
+    held.close();
+  });
+
+  /**
+   * Retrying after a blocked reset has to converge, otherwise the error the
+   * user is shown ("close your other tabs, then try again") is a dead end.
+   */
+  it('completes on retry once the blocking connection closes', async () => {
+    await seedFallbackRegistration();
+    const held = await createAppDb();
+    await expect(wipeLocalAppData()).rejects.toThrow('blocked');
+
+    held.close();
+    await wipeLocalAppData();
+
+    expect(await appDbExists()).toBe(false);
+    expect(localStorage.length).toBe(0);
+    await expect(passkey.loadKeyDecryptData(1)).rejects.toBe('no data');
   });
 });

--- a/src/services/resetAppData.ts
+++ b/src/services/resetAppData.ts
@@ -9,8 +9,7 @@
  * master key, and this is what destroys the master key.
  */
 
-/** The app's own store: messages, spaces, config. */
-const APP_DB = 'quorum_db';
+import { QUORUM_DB_NAME } from '../db/dbVersion';
 
 /**
  * The SDK's key store (`@quilibrium/quilibrium-js-sdk-channels`, `callOnStore`).
@@ -47,11 +46,19 @@ const deleteDatabase = (name: string): Promise<void> =>
  * Order is deliberate. `quorum_db` is the one held open long-term (MessageDB),
  * so it is the one that realistically blocks — attempting it first means a
  * blocked reset aborts having deleted nothing, instead of destroying the key
- * store and then failing. The user closes the other tab and retries onto a
- * consistent state.
+ * store and then failing. The key store is opened and closed per operation by
+ * the SDK, so it is the far less likely of the two to block.
+ *
+ * The storage clears deliberately do NOT run on failure. Clearing them anyway
+ * would drop `passkeys-list` — the only record that an account exists here —
+ * while key material was still on disk, which locks the user out AND keeps the
+ * thing the reset was supposed to remove. Failing without touching storage
+ * leaves a state the user can simply retry out of, since deleting an
+ * already-deleted database succeeds. `resetAppDataKeyMaterial.test.ts` pins
+ * this, so please don't "tidy" it into a `finally`.
  */
 export const wipeLocalAppData = async (): Promise<void> => {
-  await deleteDatabase(APP_DB);
+  await deleteDatabase(QUORUM_DB_NAME);
   await deleteDatabase(SDK_KEY_DB);
   localStorage.clear();
   sessionStorage.clear();

--- a/src/services/resetAppData.ts
+++ b/src/services/resetAppData.ts
@@ -1,0 +1,58 @@
+/**
+ * The destructive half of "Reset App Data".
+ *
+ * Split out of DangerZone so the wipe can be tested directly — the guarantee
+ * this has to make (no key material survives) is not something you want
+ * resting on a component test that could pass for the wrong reason.
+ *
+ * Callers must run the device deregistration BEFORE this: it signs with the
+ * master key, and this is what destroys the master key.
+ */
+
+/** The app's own store: messages, spaces, config. */
+const APP_DB = 'quorum_db';
+
+/**
+ * The SDK's key store (`@quilibrium/quilibrium-js-sdk-channels`, `callOnStore`).
+ *
+ * Reaching for this by name couples us to an SDK internal — it is a string
+ * literal in the SDK, not part of its exported API — and the coupling fails
+ * QUIETLY, because `deleteDatabase` on a database that does not exist resolves
+ * successfully. If a future SDK version renames it, this stops deleting
+ * anything and says nothing.
+ *
+ * `resetAppDataKeyMaterial.test.ts` is the tripwire: it seeds through the
+ * SDK's own `encryptDataSaveKey` and asserts the key is gone afterwards, so a
+ * rename breaks the test instead of breaking users. If the SDK ever exposes
+ * something like `passkey.clearStoredKeys()`, use that and drop this constant.
+ */
+const SDK_KEY_DB = 'KeyDB';
+
+const deleteDatabase = (name: string): Promise<void> =>
+  new Promise((resolve, reject) => {
+    const req = indexedDB.deleteDatabase(name);
+    req.onsuccess = () => resolve();
+    req.onerror = () => reject(req.error);
+    // Blocked means another tab still holds the database open. The old code
+    // treated this as success, which silently reloaded on the SAME data and
+    // made the reset look like it had done nothing. Reject so the user is
+    // told to close other tabs.
+    req.onblocked = () => reject(new Error('blocked'));
+  });
+
+/**
+ * Erase every local trace of the account: both IndexedDB databases and all web
+ * storage.
+ *
+ * Order is deliberate. `quorum_db` is the one held open long-term (MessageDB),
+ * so it is the one that realistically blocks — attempting it first means a
+ * blocked reset aborts having deleted nothing, instead of destroying the key
+ * store and then failing. The user closes the other tab and retries onto a
+ * consistent state.
+ */
+export const wipeLocalAppData = async (): Promise<void> => {
+  await deleteDatabase(APP_DB);
+  await deleteDatabase(SDK_KEY_DB);
+  localStorage.clear();
+  sessionStorage.clear();
+};


### PR DESCRIPTION
"Reset App Data" deleted the app's own IndexedDB database and web storage, but the SDK keeps key material in a separate database that nothing was clearing. The dialog promises to delete "your private keys", so the wipe now covers both stores.

## What changed

- New `src/services/resetAppData.ts` exporting `wipeLocalAppData()`, so the destructive sequence can be tested directly instead of only through the component.
- `DangerZone` calls it. Deregistration still runs first, since it signs with the key the wipe destroys, and the blocked-delete contract is unchanged: a blocked delete rejects rather than resolving.
- The app database name now comes from `QUORUM_DB_NAME` rather than a second hardcoded literal.

## On the hardcoded database name

The wipe names the SDK's database directly, because the SDK exposes no clear function. This couples us to an internal, and the coupling would fail *quietly*: `deleteDatabase` resolves successfully on a database that does not exist, so a rename upstream would stop the wipe deleting anything and say nothing.

The tests seed and verify through the SDK's public helpers rather than touching that name, so a rename produces a red test instead of a silent no-op. Verified that the version pinned in `yarn.lock` and the local development copy agree on the name.

## Testing

12 tests across two new files, all revert-checked rather than assumed:

- removing the key-store delete turns 5 red
- removing the app-database delete turns 4 red
- removing the call from `DangerZone` turns 1 red

A failed wipe deliberately leaves web storage alone, and a retry converges once the blocking connection closes. Both are pinned by tests, with a comment explaining why moving the storage clears into a `finally` would be the wrong trade.

Full suite: 152 files, 1420 tests passing. Typecheck and lint clean.

## Commits

- fix(reset): Reset App Data clears the SDK key store, not just the app database
- fix(reset): cover the app database delete too, and pin the failure path
