### PR TITLE
fix(debug): debug globals stay out of production builds, enforced by lint and a build check

### DIFF
--- a/.agents/docs/features/action-queue.md
+++ b/.agents/docs/features/action-queue.md
@@ -632,6 +632,14 @@ Some handlers are safe to retry by design:
 
 ## Debugging
 
+> **Development builds only (since 2026-08-12).** `window.__actionQueue` and
+> `window.__messageDB` are gated behind `import.meta.env?.DEV` and are
+> `undefined` in production. They previously shipped to production unguarded,
+> which exposed the account's private keys (via
+> `__actionQueue.getUserKeyset()`) and the whole database to any script on the
+> page. The guards live in `src/components/context/MessageDB.tsx` — do not
+> remove them.
+
 ```javascript
 // Check queue stats
 await window.__actionQueue.getStats()

--- a/.agents/docs/features/action-queue.md
+++ b/.agents/docs/features/action-queue.md
@@ -632,13 +632,11 @@ Some handlers are safe to retry by design:
 
 ## Debugging
 
-> **Development builds only (since 2026-08-12).** `window.__actionQueue` and
-> `window.__messageDB` are gated behind `import.meta.env?.DEV` and are
-> `undefined` in production. They previously shipped to production unguarded,
-> which exposed the account's private keys (via
-> `__actionQueue.getUserKeyset()`) and the whole database to any script on the
-> page. The guards live in `src/components/context/MessageDB.tsx` — do not
-> remove them.
+> **Development builds only.** `window.__actionQueue` and `window.__messageDB`
+> are gated behind `import.meta.env?.DEV` and are `undefined` in production —
+> `__actionQueue` reaches the user and device keysets via `getUserKeyset()`,
+> and `__messageDB` is a read/write handle to the whole database. The guards
+> live in `src/components/context/MessageDB.tsx`; do not remove them.
 
 ```javascript
 // Check queue stats

--- a/.agents/issues/.done/2026-03-19-standalone-delivery-ack-unreliable.md
+++ b/.agents/issues/.done/2026-03-19-standalone-delivery-ack-unreliable.md
@@ -55,7 +55,7 @@ The standalone acks appeared more broken than piggybacked acks because piggyback
 
 1. Add logging to the `sendDeliveryAck` handler execute method to confirm it runs
 2. Add logging after `encryptAndSendDm` completes to confirm encryption succeeds
-3. Check Action Queue stats (`window.__actionQueue.getStats()` — development builds only since 2026-08-12, the global is now `import.meta.env?.DEV`-gated) for failed `send-delivery-ack` tasks
+3. Check Action Queue stats (`window.__actionQueue.getStats()` — development builds only, the global is `import.meta.env?.DEV`-gated) for failed `send-delivery-ack` tasks
 4. Check if the encrypted ack actually appears in WebSocket traffic (Network tab)
 5. On the sender side, check if the ack message arrives at `handleNewMessage` at all
 

--- a/.agents/issues/.done/2026-03-19-standalone-delivery-ack-unreliable.md
+++ b/.agents/issues/.done/2026-03-19-standalone-delivery-ack-unreliable.md
@@ -55,7 +55,7 @@ The standalone acks appeared more broken than piggybacked acks because piggyback
 
 1. Add logging to the `sendDeliveryAck` handler execute method to confirm it runs
 2. Add logging after `encryptAndSendDm` completes to confirm encryption succeeds
-3. Check Action Queue stats (`window.__actionQueue.getStats()`) for failed `send-delivery-ack` tasks
+3. Check Action Queue stats (`window.__actionQueue.getStats()` — development builds only since 2026-08-12, the global is now `import.meta.env?.DEV`-gated) for failed `send-delivery-ack` tasks
 4. Check if the encrypted ack actually appears in WebSocket traffic (Network tab)
 5. On the sender side, check if the ack message arrives at `handleNewMessage` at all
 

--- a/.agents/issues/.done/2026-05-18-typing-dm-ratchet-investigation.md
+++ b/.agents/issues/.done/2026-05-18-typing-dm-ratchet-investigation.md
@@ -19,7 +19,7 @@ The PR-level code review of the typing-indicators feature flagged that every DM 
 
 Source: `src/services/MessageService.ts` `encryptAndSendDm` (called by `sendEphemeralDMControl`) calls `DoubleRatchetInboxEncrypt` and then `messageDB.saveEncryptionState(newEncryptionState, true)` for each target inbox session.
 
-The reviewer's concern: with active typing in a DM, a user generates roughly one ratchet advance every 5 seconds (the throttle window). Over time this could bloat the encryption-states table. The reviewer cited the existing known bloat issue (see the `window.__messageDB.analyzeEncryptionStates()` debug helper in `MessageDB.tsx` — development builds only since 2026-08-12, the global is now `import.meta.env?.DEV`-gated) and recommended switching to a piggyback-only model like delivery-acks use.
+The reviewer's concern: with active typing in a DM, a user generates roughly one ratchet advance every 5 seconds (the throttle window). Over time this could bloat the encryption-states table. The reviewer cited the existing known bloat issue (see the `window.__messageDB.analyzeEncryptionStates()` debug helper in `MessageDB.tsx` — development builds only, the global is `import.meta.env?.DEV`-gated) and recommended switching to a piggyback-only model like delivery-acks use.
 
 ## Open questions before any code changes
 

--- a/.agents/issues/.done/2026-05-18-typing-dm-ratchet-investigation.md
+++ b/.agents/issues/.done/2026-05-18-typing-dm-ratchet-investigation.md
@@ -19,7 +19,7 @@ The PR-level code review of the typing-indicators feature flagged that every DM 
 
 Source: `src/services/MessageService.ts` `encryptAndSendDm` (called by `sendEphemeralDMControl`) calls `DoubleRatchetInboxEncrypt` and then `messageDB.saveEncryptionState(newEncryptionState, true)` for each target inbox session.
 
-The reviewer's concern: with active typing in a DM, a user generates roughly one ratchet advance every 5 seconds (the throttle window). Over time this could bloat the encryption-states table. The reviewer cited the existing known bloat issue (see the `window.__messageDB.analyzeEncryptionStates()` debug helper in `MessageDB.tsx`) and recommended switching to a piggyback-only model like delivery-acks use.
+The reviewer's concern: with active typing in a DM, a user generates roughly one ratchet advance every 5 seconds (the throttle window). Over time this could bloat the encryption-states table. The reviewer cited the existing known bloat issue (see the `window.__messageDB.analyzeEncryptionStates()` debug helper in `MessageDB.tsx` — development builds only since 2026-08-12, the global is now `import.meta.env?.DEV`-gated) and recommended switching to a piggyback-only model like delivery-acks use.
 
 ## Open questions before any code changes
 

--- a/.agents/issues/.done/background-action-queue.md
+++ b/.agents/issues/.done/background-action-queue.md
@@ -1338,7 +1338,9 @@ await actionQueueService.enqueue('action-type', context, dedupKey);
 
 ## Testing
 
-Debug commands available in browser console:
+Debug commands available in browser console (**development builds only since
+2026-08-12** — `window.__actionQueue` and `window.__messageDB` are now gated
+behind `import.meta.env?.DEV` and are `undefined` in production):
 ```javascript
 // Check queue stats
 await window.__actionQueue.getStats()

--- a/.agents/issues/.done/background-action-queue.md
+++ b/.agents/issues/.done/background-action-queue.md
@@ -1338,9 +1338,9 @@ await actionQueueService.enqueue('action-type', context, dedupKey);
 
 ## Testing
 
-Debug commands available in browser console (**development builds only since
-2026-08-12** — `window.__actionQueue` and `window.__messageDB` are now gated
-behind `import.meta.env?.DEV` and are `undefined` in production):
+Debug commands available in browser console (**development builds only** —
+`window.__actionQueue` and `window.__messageDB` are gated behind
+`import.meta.env?.DEV` and are `undefined` in production):
 ```javascript
 // Check queue stats
 await window.__actionQueue.getStats()

--- a/.agents/issues/.open/2025-12-09-encryption-state-evals-bloat.md
+++ b/.agents/issues/.open/2025-12-09-encryption-state-evals-bloat.md
@@ -109,7 +109,8 @@ tells the truth loudly.
 ## Compounding bug 2026-07-19 — space deletion LEAKS the bloated state (garbage accumulation)
 
 Found while cleaning a real test account. The diagnostic
-(`window.__messageDB.analyzeEncryptionStates()`) showed **10 bloated ~2MB
+(`window.__messageDB.analyzeEncryptionStates()` — development builds only since
+2026-08-12, the global is now `import.meta.env?.DEV`-gated) showed **10 bloated ~2MB
 created-space states = 19.4MB local**, while the UI showed only **2 created
 spaces**. So ~8 created-space encryption states (~16MB) were orphaned debris
 from spaces "deleted" earlier — the space vanished from the UI but its ~2MB

--- a/.agents/issues/.open/2025-12-09-encryption-state-evals-bloat.md
+++ b/.agents/issues/.open/2025-12-09-encryption-state-evals-bloat.md
@@ -109,8 +109,8 @@ tells the truth loudly.
 ## Compounding bug 2026-07-19 — space deletion LEAKS the bloated state (garbage accumulation)
 
 Found while cleaning a real test account. The diagnostic
-(`window.__messageDB.analyzeEncryptionStates()` — development builds only since
-2026-08-12, the global is now `import.meta.env?.DEV`-gated) showed **10 bloated ~2MB
+(`window.__messageDB.analyzeEncryptionStates()` — development builds only, the
+global is `import.meta.env?.DEV`-gated) showed **10 bloated ~2MB
 created-space states = 19.4MB local**, while the UI showed only **2 created
 spaces**. So ~8 created-space encryption states (~16MB) were orphaned debris
 from spaces "deleted" earlier — the space vanished from the UI but its ~2MB

--- a/.agents/reports/action-queue/011-dm-debug-console-snippets.md
+++ b/.agents/reports/action-queue/011-dm-debug-console-snippets.md
@@ -55,10 +55,10 @@ A collection of browser console snippets for debugging DM delivery issues.
 > | `window.__actionQueue` | Same: dev builds only. |
 > | `window.__keyset` | **Removed outright.** Snippets using it return `undefined` everywhere. |
 >
-> All three previously shipped to production unguarded, which published the
-> account's private keys and the whole database to any script running on the
-> page. The two debug handles were kept because real debugging workflows depend
-> on them, but they are now gated. **Do not remove those guards, and do not
+> Debug handles are development-only: anything on `window` in a production
+> build is readable by every script in the page. The two below were kept
+> because real debugging workflows depend on them; `__keyset` was dropped
+> because nothing needed it. **Do not remove those guards, and do not
 > reintroduce `window.__keyset`.**
 >
 > Where a snippet below needs `__keyset` (the local device inbox address), the

--- a/.agents/reports/action-queue/011-dm-debug-console-snippets.md
+++ b/.agents/reports/action-queue/011-dm-debug-console-snippets.md
@@ -47,6 +47,34 @@ A collection of browser console snippets for debugging DM delivery issues.
 
 ---
 
+> **⚠️ Note (2026-08-12): these snippets are now DEVELOPMENT-ONLY, and one global was removed.**
+>
+> | Global | Status |
+> |---|---|
+> | `window.__messageDB` | Still available, but **only in `yarn dev` builds** (gated behind `import.meta.env?.DEV`). `undefined` in production. |
+> | `window.__actionQueue` | Same: dev builds only. |
+> | `window.__keyset` | **Removed outright.** Snippets using it return `undefined` everywhere. |
+>
+> All three previously shipped to production unguarded, which published the
+> account's private keys and the whole database to any script running on the
+> page. The two debug handles were kept because real debugging workflows depend
+> on them, but they are now gated. **Do not remove those guards, and do not
+> reintroduce `window.__keyset`.**
+>
+> Where a snippet below needs `__keyset` (the local device inbox address), the
+> only supported way to get it is to add a temporary DEV-gated handle while you
+> debug, following `src/dev/db-inspector/dbDumpUtil.ts:494`:
+>
+> ```ts
+> if (typeof window !== 'undefined' && import.meta.env?.DEV) {
+>   (window as any).__keyset = { deviceKeyset, userKeyset };
+> }
+> ```
+>
+> Do not commit it. Note that the API side of the comparison
+> (`/users/<address>` → `device_registrations`) still works unchanged, so only
+> the local half of each identity check needs this.
+
 ## Snippets
 
 ### 1. Identity Check
@@ -60,6 +88,8 @@ const tx = db.transaction('user_config', 'readonly');
 const store = tx.objectStore('user_config');
 const config = await new Promise(r => { const req = store.getAll(); req.onsuccess = () => r(req.result); });
 const myAddr = config[0]?.address;
+// REMOVED: window.__keyset no longer exists (see note at top of this file).
+// Add a temporary DEV-gated handle to run this line locally.
 const myInbox = window.__keyset?.deviceKeyset?.inbox_keyset?.inbox_address;
 
 console.log('=== IDENTITY CHECK ===');
@@ -125,6 +155,8 @@ Checks receiver's encryption state for the sender. **Navigate to DM conversation
 // === RECEIVER DIAGNOSTIC ===
 const otherAddr = location.pathname.split('/messages/')[1]?.split('/')[0]
   || location.pathname.split('/dm/')[1]?.split('/')[0];
+// REMOVED: window.__keyset no longer exists (see note at top of this file).
+// Add a temporary DEV-gated handle to run this line locally.
 const myInbox = window.__keyset?.deviceKeyset?.inbox_keyset?.inbox_address;
 console.log('=== Receiver Diagnostic ===');
 console.log('My device inbox:', myInbox);

--- a/.agents/reports/action-queue/INDEX.md
+++ b/.agents/reports/action-queue/INDEX.md
@@ -72,6 +72,11 @@ The Quorum network can experience intermittent issues unrelated to our code:
 
 ## Common Diagnostic Commands
 
+> **Development builds only (since 2026-08-12).** `window.__actionQueue` and
+> `window.__messageDB` are gated behind `import.meta.env?.DEV` and are
+> `undefined` in production. See
+> [action-queue.md → Debugging](../../docs/features/action-queue.md#debugging).
+
 ```javascript
 // Check queue stats
 await window.__actionQueue.getStats()

--- a/.agents/reports/action-queue/INDEX.md
+++ b/.agents/reports/action-queue/INDEX.md
@@ -72,10 +72,9 @@ The Quorum network can experience intermittent issues unrelated to our code:
 
 ## Common Diagnostic Commands
 
-> **Development builds only (since 2026-08-12).** `window.__actionQueue` and
-> `window.__messageDB` are gated behind `import.meta.env?.DEV` and are
-> `undefined` in production. See
-> [action-queue.md → Debugging](../../docs/features/action-queue.md#debugging).
+> **Development builds only.** `window.__actionQueue` and `window.__messageDB`
+> are gated behind `import.meta.env?.DEV` and are `undefined` in production.
+> See [action-queue.md → Debugging](../../docs/features/action-queue.md#debugging).
 
 ```javascript
 // Check queue stats

--- a/eslint-rules/no-ungated-debug-globals.js
+++ b/eslint-rules/no-ungated-debug-globals.js
@@ -1,0 +1,130 @@
+/**
+ * Forbid assigning a `__`-prefixed debug global to `window` / `globalThis`
+ * unless it sits inside a development-only guard.
+ *
+ * Anything reachable from `window` in a production build is readable by every
+ * script running in the page, including browser extensions and any injected
+ * or compromised third-party code. Debug handles tend to expose far more than
+ * their name suggests — a service object reaches whatever that service holds —
+ * so they belong in development builds only.
+ *
+ * What counts as a guard
+ * ----------------------
+ * An enclosing `if` whose test mentions either `import.meta.env…DEV` (the Vite
+ * idiom used by src/dev/db-inspector/dbDumpUtil.ts) or `NODE_ENV` with
+ * `production` (used by src/identity/diagnostics.ts). Both are verified to
+ * strip from a production bundle. The test is matched on source text rather
+ * than AST shape so that `import.meta.env.DEV`, `import.meta.env?.DEV` and
+ * `typeof window !== 'undefined' && import.meta.env?.DEV` all pass.
+ *
+ * Being under src/dev/ is NOT a guard. Nothing stops a production module
+ * importing such a file, which pulls the assignment into the bundle with it.
+ *
+ * Only `__`-prefixed properties are restricted, that being the convention for
+ * debug handles. `window.Buffer` in src/App.tsx is a real production polyfill
+ * and is intentionally allowed.
+ *
+ * scripts/check-bundle-globals.mjs is the other half of this guard: it checks
+ * the built artifact, catching cases where the source is correct but the
+ * output is not.
+ */
+
+/** Unwrap `(window as any)`, `(window as unknown as T)`, `window!`, `(window)`. */
+function baseObject(node) {
+  let current = node;
+  for (;;) {
+    if (!current) return null;
+    switch (current.type) {
+      case 'TSAsExpression':
+      case 'TSNonNullExpression':
+      case 'TSTypeAssertion':
+      case 'ChainExpression':
+        current = current.expression;
+        break;
+      default:
+        return current;
+    }
+  }
+}
+
+/** `window.__x` -> "__x", `window['__x']` -> "__x", otherwise null. */
+function propertyName(memberExpression) {
+  const { property, computed } = memberExpression;
+  if (!computed && property.type === 'Identifier') return property.name;
+  if (computed && property.type === 'Literal' && typeof property.value === 'string') {
+    return property.value;
+  }
+  return null;
+}
+
+const GUARD_PATTERNS = [
+  /import\s*\.\s*meta\s*\.\s*env\s*\??\.\s*DEV/,
+  /NODE_ENV[\s\S]*production/,
+];
+
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Debug globals on window must be behind a development-only guard, ' +
+        'so they cannot reach a production bundle.',
+    },
+    schema: [],
+    messages: {
+      ungated:
+        "'{{name}}' is assigned to {{target}} without a development guard, so it " +
+        'reaches production builds and is readable by any script on the page. ' +
+        "Wrap it in `if (typeof window !== 'undefined' && import.meta.env?.DEV) " +
+        '{ … }` — see src/dev/db-inspector/dbDumpUtil.ts — or delete it. Check what ' +
+        'the exposed object can reach before assuming it is harmless.',
+    },
+  },
+
+  create(context) {
+    const sourceCode = context.sourceCode ?? context.getSourceCode();
+
+    /** True when an ancestor `if` guards this node with a dev-only test. */
+    function isDevGuarded(node) {
+      for (let current = node; current; current = current.parent) {
+        const parent = current.parent;
+        if (
+          parent &&
+          parent.type === 'IfStatement' &&
+          // Only the consequent is guarded. An `else` branch runs in production.
+          parent.consequent === current
+        ) {
+          const test = sourceCode.getText(parent.test);
+          if (GUARD_PATTERNS.some((pattern) => pattern.test(test))) return true;
+        }
+      }
+      return false;
+    }
+
+    return {
+      AssignmentExpression(node) {
+        if (node.left.type !== 'MemberExpression') return;
+
+        const name = propertyName(node.left);
+        if (!name || !name.startsWith('__')) return;
+
+        const base = baseObject(node.left.object);
+        if (
+          !base ||
+          base.type !== 'Identifier' ||
+          (base.name !== 'window' && base.name !== 'globalThis')
+        ) {
+          return;
+        }
+
+        if (isDevGuarded(node)) return;
+
+        context.report({
+          node,
+          messageId: 'ungated',
+          data: { name, target: base.name },
+        });
+      },
+    };
+  },
+};

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,6 +4,18 @@ import react from 'eslint-plugin-react';
 import reactHooks from 'eslint-plugin-react-hooks';
 import reactRefresh from 'eslint-plugin-react-refresh';
 import tseslint from 'typescript-eslint';
+import noUngatedDebugGlobals from './eslint-rules/no-ungated-debug-globals.js';
+
+// Debug globals (`window.__something = …`) must be behind a development-only
+// guard. Applied to every file, including src/dev/ — dev tooling is exactly
+// where these are written, and being under src/dev/ is a convention, not a
+// mechanism that keeps code out of the bundle.
+const quorumPlugin = {
+  rules: { 'no-ungated-debug-globals': noUngatedDebugGlobals },
+};
+const debugGlobalRules = {
+  'quorum/no-ungated-debug-globals': 'error',
+};
 
 // Nothing outside src/identity/ may resolve a name itself. Call sites use
 // <MemberName> / useResolvedName, which take an ADDRESS — you cannot forget
@@ -132,6 +144,7 @@ export default [
       react,
       'react-hooks': reactHooks,
       'react-refresh': reactRefresh,
+      quorum: quorumPlugin,
     },
     rules: {
       ...js.configs.recommended.rules,
@@ -139,6 +152,7 @@ export default [
       ...react.configs['jsx-runtime'].rules,
       ...reactHooks.configs.recommended.rules,
       ...noResolverImportsRules,
+      ...debugGlobalRules,
       'react/jsx-no-target-blank': 'off',
       'react/prop-types': 'off', // TypeScript already validates prop types
       'react-refresh/only-export-components': [
@@ -175,6 +189,7 @@ export default [
       'react-hooks': reactHooks,
       'react-refresh': reactRefresh,
       '@typescript-eslint': tseslint.plugin,
+      quorum: quorumPlugin,
     },
     rules: {
       ...js.configs.recommended.rules,
@@ -183,6 +198,7 @@ export default [
       ...reactHooks.configs.recommended.rules,
       ...tseslint.configs.recommended[1]?.rules,
       ...noResolverImportsRules,
+      ...debugGlobalRules,
       'react/jsx-no-target-blank': 'off',
       'react-refresh/only-export-components': [
         'warn',

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "scripts": {
     "dev": "vite --config web/vite.config.ts",
     "dev:clean": "rimraf node_modules/.vite && vite --config web/vite.config.ts",
-    "build": "vite build --config web/vite.config.ts",
+    "build": "vite build --config web/vite.config.ts && yarn check:bundle",
+    "check:bundle": "node scripts/check-bundle-globals.mjs",
     "build:preview": "yarn build && yarn preview --config web/vite.config.ts",
     "electron:dev": "cross-env NODE_ENV=development electron web/electron/main.cjs",
     "electron:build": "yarn build && electron-builder",

--- a/scripts/check-bundle-globals.mjs
+++ b/scripts/check-bundle-globals.mjs
@@ -1,0 +1,126 @@
+/**
+ * Fail the build if a debug global reached the production bundle.
+ *
+ * Second half of the guard whose first half is the ESLint rule
+ * `quorum/no-ungated-debug-globals`. The lint rule reads the source; this
+ * reads the artifact users actually download. Both exist because source can
+ * be correct while output is not — a guard that does not strip, a dependency
+ * re-exposing something, a bundler config change.
+ *
+ * How the watchlist is built
+ * --------------------------
+ * NOT a hardcoded denylist, which would go stale as soon as someone adds a
+ * new global. Every `__`-prefixed global assigned to `window`/`globalThis`
+ * anywhere in src/ or web/ is discovered by scanning the source, then
+ * asserted absent from the bundle. Add a new dev-only global and it is
+ * covered automatically, with no edit here.
+ *
+ * DELETED_GLOBALS is the one hardcoded part: names removed outright, which by
+ * definition no longer appear in source and so cannot be rediscovered. They
+ * are listed so they cannot quietly return.
+ *
+ * Usage: node scripts/check-bundle-globals.mjs [bundleDir]
+ * Runs automatically after `yarn build`.
+ */
+
+import { readdirSync, readFileSync, statSync, existsSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = fileURLToPath(new URL('..', import.meta.url));
+const bundleDir = process.argv[2]
+  ? join(repoRoot, process.argv[2])
+  : join(repoRoot, 'dist');
+const sourceDirs = ['src', 'web'].map((d) => join(repoRoot, d));
+
+/** Removed outright. Not discoverable from source, so listed explicitly. */
+const DELETED_GLOBALS = ['__keyset'];
+
+/** Third-party globals that legitimately appear in a production bundle. */
+const ALLOWED = [
+  '__REACT_DEVTOOLS_GLOBAL_HOOK__',
+  '__vite__',
+  '__VITE_',
+  '__esModule',
+];
+
+function walk(dir, extensions) {
+  if (!existsSync(dir)) return [];
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (entry === 'node_modules' || entry === '.git') continue;
+    if (statSync(full).isDirectory()) out.push(...walk(full, extensions));
+    else if (extensions.some((e) => entry.endsWith(e))) out.push(full);
+  }
+  return out;
+}
+
+// `(window as any).__x =`, `window.__x =`, `globalThis.__x =`,
+// `window['__x'] =`, `(window as unknown as {…}).__x =`
+const SOURCE_GLOBAL = /(?:window|globalThis)[^\n;]{0,200}?\.\s*(__[A-Za-z0-9_]+)\s*=[^=]|(?:window|globalThis)\s*\[\s*['"](__[A-Za-z0-9_]+)['"]\s*\]\s*=[^=]/g;
+
+function discoverFromSource() {
+  const names = new Set(DELETED_GLOBALS);
+  for (const dir of sourceDirs) {
+    for (const file of walk(dir, ['.ts', '.tsx', '.js', '.jsx', '.cjs', '.mjs'])) {
+      const text = readFileSync(file, 'utf8');
+      for (const m of text.matchAll(SOURCE_GLOBAL)) {
+        const name = m[1] ?? m[2];
+        if (name && !ALLOWED.some((a) => name.startsWith(a))) names.add(name);
+      }
+    }
+  }
+  return [...names].sort();
+}
+
+const watchlist = discoverFromSource();
+const bundleFiles = walk(bundleDir, ['.js', '.mjs']);
+
+if (bundleFiles.length === 0) {
+  console.error(
+    `[check-bundle-globals] No bundle found under ${relative(repoRoot, bundleDir) || bundleDir}.\n` +
+      '  Run `yarn build` first. Refusing to report success on an unbuilt tree —\n' +
+      '  a check that passes because it looked at nothing is worse than no check.'
+  );
+  process.exit(1);
+}
+
+const violations = [];
+for (const file of bundleFiles) {
+  const text = readFileSync(file, 'utf8');
+  for (const name of watchlist) {
+    // Property names survive minification, so a literal search is sound.
+    let index = text.indexOf(name);
+    while (index !== -1) {
+      violations.push({
+        file: relative(repoRoot, file),
+        name,
+        excerpt: text.slice(Math.max(0, index - 40), index + 60).replace(/\n/g, ' '),
+      });
+      break; // one report per name per file is enough
+    }
+  }
+}
+
+if (violations.length > 0) {
+  console.error('\n[check-bundle-globals] DEBUG GLOBALS FOUND IN THE PRODUCTION BUNDLE\n');
+  for (const v of violations) {
+    console.error(`  ✗ ${v.name}  in ${v.file}`);
+    console.error(`      …${v.excerpt}…`);
+  }
+  console.error(
+    '\n  These are readable by any script running in the page, including browser\n' +
+      '  extensions and injected or compromised third-party code. Check what the\n' +
+      '  exposed object can reach before assuming it is harmless.\n\n' +
+      "  Fix: wrap the assignment in `if (typeof window !== 'undefined' &&\n" +
+      '  import.meta.env?.DEV) { … }` (see src/dev/db-inspector/dbDumpUtil.ts),\n' +
+      '  or delete it. Do not add it to the allowlist in this script.\n'
+  );
+  process.exit(1);
+}
+
+console.log(
+  `[check-bundle-globals] OK — ${watchlist.length} debug global(s) checked ` +
+    `against ${bundleFiles.length} bundle file(s), none present: ${watchlist.join(', ')}`
+);

--- a/src/components/context/MessageDB.tsx
+++ b/src/components/context/MessageDB.tsx
@@ -293,10 +293,14 @@ type MessageDBContextProps = {
 const MessageDBProvider: FC<MessageDBContextProps> = ({ children }) => {
   const messageDB = useMemo(() => {
     const db = new MessageDB();
-    // Expose for debugging bloated encryption states
-    // Usage: await window.__messageDB.analyzeEncryptionStates()
-    // Usage: await window.__messageDB.cleanBloatedEncryptionStates({ dryRun: false })
-    (window as any).__messageDB = db;
+    // Dev-only console handle for the debug utilities in src/db/messages.ts
+    // (analyzeEncryptionStates, deleteBloatedEncryptionState, ...).
+    // MUST stay behind this guard: unguarded, it ships to production and hands
+    // the whole database to any script on the page. Same pattern as
+    // src/dev/db-inspector/dbDumpUtil.ts.
+    if (typeof window !== 'undefined' && import.meta.env?.DEV) {
+      (window as any).__messageDB = db;
+    }
     return db;
   }, []);
   const queryClient = useQueryClient();
@@ -1146,8 +1150,14 @@ const MessageDBProvider: FC<MessageDBContextProps> = ({ children }) => {
   // ActionQueueService (depends on all other services)
   const actionQueueService = useMemo(() => {
     const service = new ActionQueueService(messageDB);
-    // Expose for debugging: window.__actionQueue
-    (window as any).__actionQueue = service;
+    // Dev-only console handle (getStats(), processQueue(), ...).
+    // MUST stay behind this guard: the service holds the user and device
+    // keysets and exposes them through getUserKeyset(), so an unguarded
+    // assignment publishes the account's private keys to any script on the
+    // page. Same pattern as src/dev/db-inspector/dbDumpUtil.ts.
+    if (typeof window !== 'undefined' && import.meta.env?.DEV) {
+      (window as any).__actionQueue = service;
+    }
     return service;
   }, [messageDB]);
 

--- a/src/components/context/MessageDB.tsx
+++ b/src/components/context/MessageDB.tsx
@@ -295,9 +295,9 @@ const MessageDBProvider: FC<MessageDBContextProps> = ({ children }) => {
     const db = new MessageDB();
     // Dev-only console handle for the debug utilities in src/db/messages.ts
     // (analyzeEncryptionStates, deleteBloatedEncryptionState, ...).
-    // MUST stay behind this guard: unguarded, it ships to production and hands
-    // the whole database to any script on the page. Same pattern as
-    // src/dev/db-inspector/dbDumpUtil.ts.
+    // Keep the guard: this is a read/write handle to the whole database, and
+    // anything on `window` in a production build is readable by any script on
+    // the page. Same pattern as src/dev/db-inspector/dbDumpUtil.ts.
     if (typeof window !== 'undefined' && import.meta.env?.DEV) {
       (window as any).__messageDB = db;
     }
@@ -1151,10 +1151,9 @@ const MessageDBProvider: FC<MessageDBContextProps> = ({ children }) => {
   const actionQueueService = useMemo(() => {
     const service = new ActionQueueService(messageDB);
     // Dev-only console handle (getStats(), processQueue(), ...).
-    // MUST stay behind this guard: the service holds the user and device
-    // keysets and exposes them through getUserKeyset(), so an unguarded
-    // assignment publishes the account's private keys to any script on the
-    // page. Same pattern as src/dev/db-inspector/dbDumpUtil.ts.
+    // Keep the guard: this service holds the user and device keysets and
+    // exposes them via getUserKeyset(), so it must never reach a production
+    // bundle. Same pattern as src/dev/db-inspector/dbDumpUtil.ts.
     if (typeof window !== 'undefined' && import.meta.env?.DEV) {
       (window as any).__actionQueue = service;
     }

--- a/src/components/context/RegistrationPersister.tsx
+++ b/src/components/context/RegistrationPersister.tsx
@@ -213,11 +213,6 @@ const RegistrationProvider: FC<RegistrationContextProps> = ({ children }) => {
                   deviceKeyset: senderDevice,
                   userKeyset: senderIdent,
                 });
-                // Expose for debugging: window.__keyset.deviceKeyset.inbox_keyset.inbox_address
-                (window as any).__keyset = {
-                  deviceKeyset: senderDevice,
-                  userKeyset: senderIdent,
-                };
                 const userConfig = await getConfig({
                   address: currentPasskeyInfo!.address,
                   userKey: senderIdent,

--- a/src/db/messages.ts
+++ b/src/db/messages.ts
@@ -3194,9 +3194,9 @@ export class MessageDB {
   //   await window.__messageDB.deleteBloatedEncryptionState(conversationId, inboxId)
   //
   // `window.__messageDB` is assigned in src/components/context/MessageDB.tsx
-  // behind an `import.meta.env?.DEV` guard. It was previously unguarded and
-  // shipped to production, which handed the whole database to any script on
-  // the page. Do not remove that guard.
+  // behind an `import.meta.env?.DEV` guard. Keep it there: this is a
+  // read/write handle to the whole database, and anything on `window` in a
+  // production build is readable by any script on the page.
 
   /**
    * Analyzes all encryption states and returns a report of their sizes and structure.

--- a/src/db/messages.ts
+++ b/src/db/messages.ts
@@ -3189,9 +3189,14 @@ export class MessageDB {
   // ============================================
   // See: 2025-12-09-encryption-state-evals-bloat.md under .agents/issues/
   //
-  // Usage (browser console):
+  // Usage (browser console, DEVELOPMENT BUILDS ONLY):
   //   await window.__messageDB.analyzeEncryptionStates()
   //   await window.__messageDB.deleteBloatedEncryptionState(conversationId, inboxId)
+  //
+  // `window.__messageDB` is assigned in src/components/context/MessageDB.tsx
+  // behind an `import.meta.env?.DEV` guard. It was previously unguarded and
+  // shipped to production, which handed the whole database to any script on
+  // the page. Do not remove that guard.
 
   /**
    * Analyzes all encryption states and returns a report of their sizes and structure.
@@ -3312,7 +3317,7 @@ export class MessageDB {
   /**
    * Deletes a specific bloated encryption state entirely.
    * WARNING: This will require re-establishing the encryption session for that space/conversation.
-   * Use from browser console: await window.__messageDB.deleteBloatedEncryptionState(conversationId, inboxId)
+   * Use from browser console in development only: await window.__messageDB.deleteBloatedEncryptionState(conversationId, inboxId)
    */
   async deleteBloatedEncryptionState(conversationId: string, inboxId: string): Promise<boolean> {
     await this.init();

--- a/src/dev/dm-doctor/warningCounters.ts
+++ b/src/dev/dm-doctor/warningCounters.ts
@@ -93,7 +93,7 @@ export function installDmWarningCounters(): DmWarningCounterState {
     };
   });
 
-  if (typeof window !== 'undefined') {
+  if (typeof window !== 'undefined' && import.meta.env?.DEV) {
     (window as unknown as { __dmWarningCounters: () => DmWarningCounterState }).__dmWarningCounters =
       getDmWarningState;
   }

--- a/src/dev/scrollDebug.ts
+++ b/src/dev/scrollDebug.ts
@@ -462,6 +462,6 @@ function fmt(v: number | undefined): string {
 
 export const scrollDebug = new ScrollDebug();
 
-if (typeof window !== 'undefined') {
+if (typeof window !== 'undefined' && import.meta.env?.DEV) {
   (window as any).__scrollDebug = scrollDebug;
 }


### PR DESCRIPTION
Debug console handles were being assigned to `window` with no environment guard, so they were present in production bundles as well as development ones. Anything on `window` in a shipped build is readable by every script running in the page, and some of these handles reach further than their names suggest.

## What changed

- `window.__keyset` is removed outright. Nothing read it.
- `window.__actionQueue` and `window.__messageDB` are kept, but now behind `import.meta.env?.DEV`. Real debugging workflows depend on them (`getStats()`, `processQueue()`, `analyzeEncryptionStates()`), so gating beat deleting.
- `__scrollDebug` and `__dmWarningCounters` were gated too. Both were absent from production only because nothing in a production path imported them, which is not a guarantee.

The guard is the one already used by `src/dev/db-inspector/dbDumpUtil.ts`, whose globals are verifiably absent from a production build.

## Preventing a repeat

Two independent checks, since each has a blind spot the other covers:

- **`quorum/no-ungated-debug-globals`** (`eslint-rules/`) rejects an ungated `__`-prefixed assignment to `window`/`globalThis`. It reads the source, so it fires while the code is being written, and it unwraps `(window as any)`, `(window as unknown as T)` and `window['__x']`.
- **`scripts/check-bundle-globals.mjs`** scans the built bundle and fails `yarn build` if one is present. It reads the artifact, so it still catches a guard that fails to strip. Its watchlist is discovered by scanning `src/` and `web/` rather than hardcoded, so new globals are covered without editing the script.

The lint rule is what found the two extra assignments above.

## Verification

Checked in both directions, since a check that cannot fail is worthless:

| | global reintroduced | fix in place |
|---|---|---|
| lint rule | errors at the assignment | 0 errors |
| bundle check | exits 1 | passes, 10 globals checked |

Production bundle went from one occurrence each of `__keyset` / `__messageDB` / `__actionQueue` to zero, while a development build still has the two dev handles. `getUserKeyset` remains in the production bundle as a control, confirming the build did not simply strip everything.

`tsc --noEmit` clean, lint 0 errors (warning count unchanged at 276), 1421 tests across 153 files passing.

Docs that teach these globals were updated to say development-only.
