### PR TITLE
fix(tooling): close two blind spots in the debug-global guard

### DIFF
--- a/eslint-rules/no-ungated-debug-globals.js
+++ b/eslint-rules/no-ungated-debug-globals.js
@@ -57,10 +57,115 @@ function propertyName(memberExpression) {
   return null;
 }
 
-const GUARD_PATTERNS = [
-  /import\s*\.\s*meta\s*\.\s*env\s*\??\.\s*DEV/,
-  /NODE_ENV[\s\S]*production/,
-];
+/** Strip wrappers that do not change what an expression evaluates to. */
+function unwrap(node) {
+  let current = node;
+  while (
+    current &&
+    (current.type === 'ChainExpression' ||
+      current.type === 'TSNonNullExpression' ||
+      current.type === 'TSAsExpression')
+  ) {
+    current = current.expression;
+  }
+  return current;
+}
+
+/** Does this member expression read `<object>.<name>`? */
+function reads(node, name) {
+  const target = unwrap(node);
+  if (!target || target.type !== 'MemberExpression') return false;
+  const { property, computed } = target;
+  if (!computed) return property.type === 'Identifier' && property.name === name;
+  return property.type === 'Literal' && property.value === name;
+}
+
+/** `import.meta.env` (optional chaining allowed at any link). */
+function isImportMetaEnv(node) {
+  const target = unwrap(node);
+  if (!target || target.type !== 'MemberExpression') return false;
+  if (!reads(target, 'env')) return false;
+  const base = unwrap(target.object);
+  return (
+    base &&
+    base.type === 'MetaProperty' &&
+    base.meta.name === 'import' &&
+    base.property.name === 'meta'
+  );
+}
+
+/** `process.env.NODE_ENV` */
+function isProcessEnvNodeEnv(node) {
+  const target = unwrap(node);
+  if (!target || !reads(target, 'NODE_ENV')) return false;
+  const env = unwrap(target.object);
+  return env && reads(env, 'env') && unwrap(env.object)?.name === 'process';
+}
+
+function isStringLiteral(node, value) {
+  const target = unwrap(node);
+  return target && target.type === 'Literal' && target.value === value;
+}
+
+/**
+ * Is this expression, on its own, sufficient to prove we are NOT in a
+ * production build?
+ *
+ * The `&&` / `||` handling is the load-bearing part, and the asymmetry is the
+ * whole point:
+ *   `DEV && somethingElse`  — narrowing. The branch cannot run unless DEV is
+ *                             true, so ONE dev operand is enough.
+ *   `DEV || somethingElse`  — widening. `somethingElse` alone can open the
+ *                             branch in production, so EVERY operand must
+ *                             itself prove dev.
+ * Matching the guard as source text instead treats both the same, which is how
+ * `if (import.meta.env.DEV || someFlag)` used to pass while shipping the global
+ * whenever `someFlag` was true.
+ */
+function provesDevelopment(node) {
+  const target = unwrap(node);
+  if (!target) return false;
+
+  // import.meta.env.DEV
+  if (isImportMetaEnv(target?.object) && reads(target, 'DEV')) return true;
+
+  // !import.meta.env.PROD
+  if (target.type === 'UnaryExpression' && target.operator === '!') {
+    const arg = unwrap(target.argument);
+    if (arg && isImportMetaEnv(arg.object) && reads(arg, 'PROD')) return true;
+    return false;
+  }
+
+  // process.env.NODE_ENV !== 'production' / === 'development'
+  if (target.type === 'BinaryExpression') {
+    const { operator, left, right } = target;
+    const nodeEnv = isProcessEnvNodeEnv(left)
+      ? right
+      : isProcessEnvNodeEnv(right)
+        ? left
+        : null;
+    if (!nodeEnv) return false;
+    if (operator === '!==' || operator === '!=') {
+      return isStringLiteral(nodeEnv, 'production');
+    }
+    if (operator === '===' || operator === '==') {
+      return isStringLiteral(nodeEnv, 'development');
+    }
+    return false;
+  }
+
+  if (target.type === 'LogicalExpression') {
+    if (target.operator === '&&') {
+      return provesDevelopment(target.left) || provesDevelopment(target.right);
+    }
+    if (target.operator === '||') {
+      return provesDevelopment(target.left) && provesDevelopment(target.right);
+    }
+    return false; // ?? — cannot reason about it
+  }
+
+  return false;
+}
 
 export default {
   meta: {
@@ -82,8 +187,6 @@ export default {
   },
 
   create(context) {
-    const sourceCode = context.sourceCode ?? context.getSourceCode();
-
     /** True when an ancestor `if` guards this node with a dev-only test. */
     function isDevGuarded(node) {
       for (let current = node; current; current = current.parent) {
@@ -92,10 +195,10 @@ export default {
           parent &&
           parent.type === 'IfStatement' &&
           // Only the consequent is guarded. An `else` branch runs in production.
-          parent.consequent === current
+          parent.consequent === current &&
+          provesDevelopment(parent.test)
         ) {
-          const test = sourceCode.getText(parent.test);
-          if (GUARD_PATTERNS.some((pattern) => pattern.test(test))) return true;
+          return true;
         }
       }
       return false;

--- a/scripts/check-bundle-globals.mjs
+++ b/scripts/check-bundle-globals.mjs
@@ -1,23 +1,36 @@
+#!/usr/bin/env node
 /**
  * Fail the build if a debug global reached the production bundle.
  *
  * Second half of the guard whose first half is the ESLint rule
  * `quorum/no-ungated-debug-globals`. The lint rule reads the source; this
  * reads the artifact users actually download. Both exist because source can
- * be correct while output is not — a guard that does not strip, a dependency
- * re-exposing something, a bundler config change.
+ * be correct while output is not — a guard that does not strip, a bundler
+ * config change, or a lint rule that was disabled with a comment.
  *
- * How the watchlist is built
- * --------------------------
- * NOT a hardcoded denylist, which would go stale as soon as someone adds a
- * new global. Every `__`-prefixed global assigned to `window`/`globalThis`
- * anywhere in src/ or web/ is discovered by scanning the source, then
- * asserted absent from the bundle. Add a new dev-only global and it is
- * covered automatically, with no edit here.
+ * What it looks for
+ * -----------------
+ * Assignments of a `__`-prefixed property onto the global object, **in the
+ * built output**:
  *
- * DELETED_GLOBALS is the one hardcoded part: names removed outright, which by
- * definition no longer appear in source and so cannot be rediscovered. They
- * are listed so they cannot quietly return.
+ *     window.__x = …        globalThis.__x = …        window['__x'] = …
+ *     const w = window; w.__x = …          (alias, see below)
+ *
+ * It deliberately does NOT decide what to look for by scanning `src/`. An
+ * earlier version did, which made it blind by construction to anything the
+ * source-side regex could not express — notably assignment through a local
+ * alias, where the secret shipped and this check still reported OK. Reading
+ * only the artifact removes that whole class, and also stops a code comment
+ * that happens to mention `window.__something` from being mistaken for a real
+ * assignment.
+ *
+ * Aliases: minifiers keep `window` as-is (it is a global) but rename locals,
+ * so `const w = window; w.__x = y` emits as `const a=window;a.__x=y`. The
+ * scan therefore collects identifiers assigned from `window`/`globalThis` and
+ * checks property writes on those too. Measured against the real bundle this
+ * adds zero false positives.
+ *
+ * Property names survive minification, which is what makes any of this sound.
  *
  * Usage: node scripts/check-bundle-globals.mjs [bundleDir]
  * Runs automatically after `yarn build`.
@@ -31,51 +44,68 @@ const repoRoot = fileURLToPath(new URL('..', import.meta.url));
 const bundleDir = process.argv[2]
   ? join(repoRoot, process.argv[2])
   : join(repoRoot, 'dist');
-const sourceDirs = ['src', 'web'].map((d) => join(repoRoot, d));
 
-/** Removed outright. Not discoverable from source, so listed explicitly. */
-const DELETED_GLOBALS = ['__keyset'];
+const SCANNED_EXTENSIONS = ['.js', '.mjs', '.cjs', '.html'];
 
-/** Third-party globals that legitimately appear in a production bundle. */
-const ALLOWED = [
-  '__REACT_DEVTOOLS_GLOBAL_HOOK__',
-  '__vite__',
-  '__VITE_',
-  '__esModule',
-];
+/**
+ * Third-party globals that legitimately appear in a production bundle.
+ * EXACT names only, never prefixes: a `startsWith` test let a crafted name
+ * like `__vite__mySecret` inherit an entry's trust silently.
+ */
+const ALLOWED = new Set([
+  '__reactRouterVersion', // react-router, sets this on window by design
+]);
 
-function walk(dir, extensions) {
+/**
+ * Names removed outright, which must never reappear in any form. Matched as a
+ * bare substring rather than as an assignment, because for these the bar is
+ * "does not occur at all".
+ */
+const FORBIDDEN_ANYWHERE = ['__keyset'];
+
+function walk(dir) {
   if (!existsSync(dir)) return [];
   const out = [];
   for (const entry of readdirSync(dir)) {
-    const full = join(dir, entry);
     if (entry === 'node_modules' || entry === '.git') continue;
-    if (statSync(full).isDirectory()) out.push(...walk(full, extensions));
-    else if (extensions.some((e) => entry.endsWith(e))) out.push(full);
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...walk(full));
+    else if (SCANNED_EXTENSIONS.some((e) => entry.endsWith(e))) out.push(full);
   }
   return out;
 }
 
-// `(window as any).__x =`, `window.__x =`, `globalThis.__x =`,
-// `window['__x'] =`, `(window as unknown as {…}).__x =`
-const SOURCE_GLOBAL = /(?:window|globalThis)[^\n;]{0,200}?\.\s*(__[A-Za-z0-9_]+)\s*=[^=]|(?:window|globalThis)\s*\[\s*['"](__[A-Za-z0-9_]+)['"]\s*\]\s*=[^=]/g;
+const escape = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
-function discoverFromSource() {
-  const names = new Set(DELETED_GLOBALS);
-  for (const dir of sourceDirs) {
-    for (const file of walk(dir, ['.ts', '.tsx', '.js', '.jsx', '.cjs', '.mjs'])) {
-      const text = readFileSync(file, 'utf8');
-      for (const m of text.matchAll(SOURCE_GLOBAL)) {
-        const name = m[1] ?? m[2];
-        if (name && !ALLOWED.some((a) => name.startsWith(a))) names.add(name);
+/** Identifiers that hold `window` / `globalThis`, so `a.__x =` is caught too. */
+function collectAliases(text) {
+  const aliases = new Set();
+  const pattern =
+    /(?:^|[;,{}()\s=])([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*(?:window|globalThis)\b(?!\s*\.)/g;
+  for (const match of text.matchAll(pattern)) aliases.add(match[1]);
+  return aliases;
+}
+
+/** Every `<base>.__name =` / `<base>['__name'] =` write in this text. */
+function findGlobalWrites(text) {
+  const bases = ['window', 'globalThis', ...collectAliases(text)];
+  const found = [];
+  for (const base of bases) {
+    const b = escape(base);
+    const patterns = [
+      new RegExp(`\\b${b}\\s*\\.\\s*(__[A-Za-z0-9_$]{1,60})\\s*=(?!=)`, 'g'),
+      new RegExp(`\\b${b}\\s*\\[\\s*["'](__[A-Za-z0-9_$]{1,60})["']\\s*\\]\\s*=(?!=)`, 'g'),
+    ];
+    for (const pattern of patterns) {
+      for (const match of text.matchAll(pattern)) {
+        found.push({ name: match[1], base, index: match.index ?? 0 });
       }
     }
   }
-  return [...names].sort();
+  return found;
 }
 
-const watchlist = discoverFromSource();
-const bundleFiles = walk(bundleDir, ['.js', '.mjs']);
+const bundleFiles = walk(bundleDir);
 
 if (bundleFiles.length === 0) {
   console.error(
@@ -87,26 +117,44 @@ if (bundleFiles.length === 0) {
 }
 
 const violations = [];
+const seen = new Set();
+
 for (const file of bundleFiles) {
   const text = readFileSync(file, 'utf8');
-  for (const name of watchlist) {
-    // Property names survive minification, so a literal search is sound.
-    let index = text.indexOf(name);
-    while (index !== -1) {
-      violations.push({
-        file: relative(repoRoot, file),
-        name,
-        excerpt: text.slice(Math.max(0, index - 40), index + 60).replace(/\n/g, ' '),
-      });
-      break; // one report per name per file is enough
-    }
+  const shortPath = relative(repoRoot, file);
+
+  for (const { name, base, index } of findGlobalWrites(text)) {
+    if (ALLOWED.has(name)) continue;
+    const key = `${shortPath}::${name}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    violations.push({
+      file: shortPath,
+      name,
+      detail: `assigned to \`${base}\``,
+      excerpt: text.slice(Math.max(0, index - 40), index + 60).replace(/\s+/g, ' '),
+    });
+  }
+
+  for (const name of FORBIDDEN_ANYWHERE) {
+    const index = text.indexOf(name);
+    if (index === -1) continue;
+    const key = `${shortPath}::${name}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    violations.push({
+      file: shortPath,
+      name,
+      detail: 'removed outright, must not appear in any form',
+      excerpt: text.slice(Math.max(0, index - 40), index + 60).replace(/\s+/g, ' '),
+    });
   }
 }
 
 if (violations.length > 0) {
   console.error('\n[check-bundle-globals] DEBUG GLOBALS FOUND IN THE PRODUCTION BUNDLE\n');
   for (const v of violations) {
-    console.error(`  ✗ ${v.name}  in ${v.file}`);
+    console.error(`  ✗ ${v.name}  (${v.detail})  in ${v.file}`);
     console.error(`      …${v.excerpt}…`);
   }
   console.error(
@@ -121,6 +169,6 @@ if (violations.length > 0) {
 }
 
 console.log(
-  `[check-bundle-globals] OK — ${watchlist.length} debug global(s) checked ` +
-    `against ${bundleFiles.length} bundle file(s), none present: ${watchlist.join(', ')}`
+  `[check-bundle-globals] OK — ${bundleFiles.length} bundle file(s) scanned, ` +
+    'no ungated debug globals on window/globalThis.'
 );


### PR DESCRIPTION
An independent review of the guard added in #334 found two blind spots, each demonstrated with a working bypass rather than argued. Both are fixed here.

Neither file is imported by application code or present in any bundle, so this changes no runtime behaviour. It only makes the development-time checks harder to slip past.

## 1. The lint rule accepted a guard that does not guard

The dev guard was matched as source text, so this passed:

```ts
if (import.meta.env.DEV || someFlag) {
  (window as any).__handle = secret;   // ships whenever someFlag is true
}
```

Adding `|| debugFlag` to a guard is an ordinary thing to do, and the rule was actively endorsing it.

The check is now structural rather than textual. `&&` needs one operand that proves development (it can only narrow); `||` needs every operand to prove it (any one can open the branch). It also recognises `!import.meta.env.PROD` and the `NODE_ENV` comparisons.

Verified against 6 bypasses (all now caught) and 6 legitimate guards including the repo's own `typeof window !== 'undefined' && import.meta.env?.DEV` (all still pass).

## 2. The bundle check was blind by construction

It decided *what to look for* by regex-scanning `src/`, so anything that regex could not express was never checked in the artifact. A local alias defeated both layers together:

```ts
const w = window;
w.__handle = secret;    // lint missed it, and the bundle check never looked for it
```

The reviewer put the secret verbatim in a bundle fixture and the check still reported OK.

It now reads only the built output, matching `__`-prefixed property writes on `window`/`globalThis` and on identifiers assigned from them. Minifiers keep `window` as-is and preserve property names, so this holds after minification. Measured zero false positives against the real bundle.

Three things fall out of dropping source-scanning:

- A comment mentioning `window.__something` can no longer be mistaken for a real assignment. This had already caused a spurious build failure during review, and a check that fails for fake reasons gets deleted by whoever it annoys.
- The allowlist is exact-match instead of prefix, so a crafted name cannot inherit an existing entry's trust.
- `.html` is scanned, so an inline `<script>` is no longer invisible.

## Verification

Fixture bundle containing five known bypasses — all five caught, including the alias and the inline HTML script. `window.__reactRouterVersion` (a genuine react-router global) and `__esModule` / `__wbg_*` on ordinary objects correctly ignored. Missing or empty output directory still exits 1 rather than reporting success on nothing.

`tsc --noEmit` clean, lint 0 errors (276 warnings, unchanged from baseline), 1421 tests across 153 files passing, `yarn build` green with the check wired in.
