### PR TITLE
fix(sync): remove the "Syncing..." toast that fired on every refresh

### DIFF
--- a/.agents/INDEX.md
+++ b/.agents/INDEX.md
@@ -338,6 +338,7 @@ This is the main index for all documentation, bug reports, and task management.
 - 📋 [Dependabot's 78 alerts, triaged against what actually ships](issues/.open/2026-08-12-dependabot-78-alerts-triage-react-router-bump.md)
 - 📋 [Pre-existing key-handling items for the lead](issues/.open/2026-08-12-pre-existing-key-handling-items-for-the-lead.md)
 - 📋 [Unshipped security branches (local, not pushed)](issues/.open/2026-08-12-unshipped-security-branches.md)
+- 📋 [Rebuild the sync indicator on a per-space "behind by N" signal](issues/.open/2026-08-13-sync-indicator-needs-a-per-space-behind-by-signal.md)
 
 ### Deferred
 
@@ -786,4 +787,4 @@ This is the main index for all documentation, bug reports, and task management.
 
 ---
 
-**Last Updated**: 2026-08-13 10:00:06
+**Last Updated**: 2026-08-13 12:35:41

--- a/.agents/issues/.done/sync-toast-notifications.md
+++ b/.agents/issues/.done/sync-toast-notifications.md
@@ -12,6 +12,14 @@ updated: '2026-05-18'
 
 > **⚠️ AI-Generated**: May contain errors. Verify before use.
 
+> **SUPERSEDED 2026-08-13 — the toast described here no longer exists.** It was removed
+> because the 2026-05-18 trigger below fires on sync *intent* (`requestSync`, once per
+> space per connect), so it appeared on every refresh regardless of whether anything
+> needed syncing, and it was a single global toast rather than per-space. The rebuild,
+> and the measurement it is gated on, are in
+> `.agents/issues/.open/2026-08-13-sync-indicator-needs-a-per-space-behind-by-signal.md`.
+> Kept for the protocol history, which is still accurate and still useful.
+
 ## 2026-05-18 — Reworked (current behavior)
 
 The original implementation below was reworked because the toast almost never fired in practice. Root cause: the trigger was a per-chunk message-count threshold (`>= 20`), but the new manifest/delta sync protocol chunks by byte size (5MB), so most syncs arrive as a single delta with a wide range of message counts and the threshold check produced non-deterministic results. It also fired late (after data verification, inside the receive handler), missing the user-anxious window between login and first delta arrival.

--- a/.agents/issues/.open/2026-08-13-sync-indicator-needs-a-per-space-behind-by-signal.md
+++ b/.agents/issues/.open/2026-08-13-sync-indicator-needs-a-per-space-behind-by-signal.md
@@ -1,0 +1,138 @@
+---
+type: task
+title: "Rebuild the sync indicator on a per-space \"behind by N\" signal (measure the signal first)"
+status: open
+priority: medium
+created: 2026-08-13
+updated: 2026-08-13
+area: sync / UX feedback
+---
+
+# Rebuild the sync indicator on a per-space "behind by N" signal
+
+The global "Syncing..." toast was **removed** on 2026-08-13 (see "What was removed").
+This task is the rebuild, and it is deliberately **gated on a measurement** rather than
+starting with an implementation, because three previous attempts each shipped a trigger
+that seemed right by reading and was wrong in practice.
+
+## The UX goal (stated by the user, 2026-08-13)
+
+> "You are in this space, but there are still messages that are arriving, and you don't
+> see them yet. Don't worry, they will arrive."
+
+Two properties follow, and both were missing before:
+
+1. It must fire **while the user waits**, not after the data lands.
+2. It must be **per-space**. A global indicator covering all spaces is noise, because
+   sync for a space you are not looking at tells you nothing.
+
+## Why the old one was wrong
+
+It fired on sync **intent**, not on need. `showSyncToast()` was the first statement of
+`SyncService.requestSync()`, before anything was known about whether the client was
+behind. `requestSync` runs once per space on every connect, so the toast appeared on
+every refresh, including when the channel was already fully rendered.
+
+Second defect: the arrival side could not tell a real sync from a no-op either. The
+`sync-delta` handler called `noteSyncActivity()` under `if (envelope.message.messageDelta)`,
+which is true for an **empty** delta. The `if (channelIdsToRefetch.size === 0)` fallback
+directly above it exists precisely because empty deltas arrive.
+
+Third defect: `SYNC_TOAST_ID` was a single hardcoded `'sync'`, so all spaces shared one
+toast. Per-space was not merely unimplemented, it was structurally impossible.
+
+### Why the previous attempts failed
+
+They kept relocating the trigger — `requestSync` → `initiateSync` → chunk arrival — but
+**every one of those points fires on a no-op sync**, so none of them could ever
+distinguish "you are behind" from "a sync ran". The original implementation did compare
+peer count against local count, but behind a `>= 20` per-chunk threshold; when the
+protocol moved to byte-sized (5MB) chunking that threshold became non-deterministic and
+the 2026-05-18 rework discarded the comparison entirely in favour of firing on intent.
+The comparison was the valuable part, and it was the part that got thrown away.
+
+History: `.agents/issues/.done/sync-toast-notifications.md`.
+
+## The lead: `sync-info` already carries a per-space peer message count
+
+`MessageService.ts`, the `sync-info` branch. A peer answering a sync request advertises
+`envelope.message.messageCount` (and `memberCount`, and a `summary`) **for one space**,
+and it arrives during the handshake, **before** any message data. That is the right shape
+and the right moment for "more is coming":
+
+- per-space already (the handler derives `spaceId` from `conversationId`)
+- arrives before the payload, so it can fire while the user waits
+- no prior attempt used it at this point
+
+Note it already survives an expired session: `noteAdvertisedRoster` is called *outside*
+the session gate deliberately (see the long comment in that branch), so what a peer
+advertises is learned even when we cannot sync from the offer.
+
+## STEP 1 — Measure before building. Do not skip this.
+
+**The load-bearing assumption:** that `peer messageCount - local count` is a trustworthy
+"behind by N" for a space.
+
+**Why it is genuinely in doubt:** it is unclear whether the two numbers are even
+comparable. Candidate skews, each of which would make the difference meaningless or
+negative: messages across channels the client does not subscribe to; deleted messages and
+tombstones counted on one side but not the other; the peer being behind *us*; several
+peers advertising different counts in the same window.
+
+This is the same class of assumption that killed the `>= 20` threshold. Prove it before
+writing UI.
+
+**How to measure.** The repo already has the instrument — the scenario harness under
+`src/dev/tests/harness/` (`*.scenario.test.ts`, plus captured `space-backlog` logs).
+Add a scenario, or extend a backlog one, that records at each `sync-info`:
+
+| Field | Why |
+|---|---|
+| advertised `messageCount` | the peer's claim |
+| local count for the same space | our side of the subtraction |
+| the delta actually delivered afterwards | ground truth |
+
+Then answer:
+
+- [ ] Does `advertised - local` **predict** the number of messages actually delivered?
+- [ ] Is it ever negative or wildly wrong (peer behind us, different channel scope)?
+- [ ] With several peers answering, does taking the max behave sensibly?
+- [ ] On a **clean refresh with nothing to sync**, is the difference reliably ~0?
+      This is the case that must produce no indicator, and it is the one the old
+      implementation got wrong every single time.
+
+**Include a control arm:** a space that should show nothing. If both the backlog space
+and the control space light up, the signal is broken rather than the code.
+
+## STEP 2 — Only if the measurement holds
+
+- [ ] Key the indicator by `spaceId`; drop the single global `'sync'` id.
+- [ ] Show it only for the space the user is **currently viewing**.
+- [ ] Raise it when `behind > 0` for that space; clear it when the local count catches up,
+      with a hard timeout as a backstop (peers can vanish mid-sync — that failure mode is
+      what forced the old two-timer dismiss system).
+- [ ] Reuse `showPersistentToast` / `dismissToast` in `src/utils/toast.ts`; they were kept
+      when the sync layer was deleted and are not sync-specific.
+- [ ] Consider an inline indicator in the message list rather than a toast. It is closer
+      to "these messages are still arriving" than a corner notification is.
+
+**If the measurement does not hold:** say so and stop. Leaving no indicator is the correct
+outcome — a wrong one is worse than none, which is why the old one was removed.
+
+## What was removed (2026-08-13)
+
+| File | Change |
+|---|---|
+| `src/utils/toast.ts` | deleted `showSyncToast`, `noteSyncActivity`, both timers, `SYNC_TOAST_*` constants. `showPersistentToast` / `dismissToast` kept. |
+| `src/services/SyncService.ts` | deleted the `showSyncToast(t\`Syncing...\`)` call in `requestSync()` and the now-unused `toast` + `@lingui` imports |
+| `src/services/MessageService.ts` | deleted both `noteSyncActivity()` calls; trimmed the toast import |
+| `src/components/ui/OfflineBanner.tsx` | doc comment no longer references the toast |
+
+Verified at removal: `tsc --noEmit` exit 0; full suite 1440 passed / 155 files.
+
+The `Syncing...` string was left in the `.po` catalogues rather than re-extracted across
+30 locales; a future `yarn i18n:extract` will drop it, and it is inert until then.
+
+---
+
+*Last updated: 2026-08-13*

--- a/.agents/issues/2026-08-10-identity-resolution-architecture-plan.md
+++ b/.agents/issues/2026-08-10-identity-resolution-architecture-plan.md
@@ -4,7 +4,7 @@ title: "Implementation plan: an identity API that cannot express a partial ident
 status: in-progress
 priority: high
 created: 2026-08-10
-updated: 2026-08-11
+updated: 2026-08-13
 area: identity resolution / QNS / cross-client architecture
 repos: quorum-shared, quorum-desktop, quorum-mobile
 source: writing-plans, from the design at 2026-08-10-identity-resolution-architecture-design.md
@@ -50,7 +50,7 @@ Still open:
 
 ## File Structure
 
-**quorum-shared** (at `D:/GitHub/Quilibrium/quorum-shared`)
+**quorum-shared** (at `E:/GitHub/Quilibrium/quorum-shared`)
 
 | File | Responsibility |
 |---|---|
@@ -79,13 +79,13 @@ Do not delegate. This is the design-bearing change and everything depends on its
 ### Task 1: `MemberIdentity` + `resolveIdentity` in shared
 
 **Files:**
-- Modify: `D:/GitHub/Quilibrium/quorum-shared/src/utils/resolveDisplayName.ts`
-- Test: `D:/GitHub/Quilibrium/quorum-shared/src/utils/resolveIdentity.test.ts`
+- Modify: `E:/GitHub/Quilibrium/quorum-shared/src/utils/resolveDisplayName.ts`
+- Test: `E:/GitHub/Quilibrium/quorum-shared/src/utils/resolveIdentity.test.ts`
 
 - [ ] **Step 1: Branch in shared**
 
 ```bash
-cd /d/GitHub/Quilibrium/quorum-shared
+cd /e/GitHub/Quilibrium/quorum-shared
 git checkout master && git pull
 git checkout -b feat/resolve-identity
 ```
@@ -221,7 +221,7 @@ describe('resolveIdentity — whitespace is absence', () => {
 
 - [ ] **Step 3: Run it and watch it fail**
 
-Run: `cd /d/GitHub/Quilibrium/quorum-shared && npx vitest --run src/utils/resolveIdentity.test.ts`
+Run: `cd /e/GitHub/Quilibrium/quorum-shared && npx vitest --run src/utils/resolveIdentity.test.ts`
 Expected: FAIL — `resolveIdentity` is not exported.
 
 - [ ] **Step 4: Implement**

--- a/.claude/skills/migrate-to-shared/SKILL.md
+++ b/.claude/skills/migrate-to-shared/SKILL.md
@@ -11,9 +11,34 @@ Guide for migrating code from `quorum-desktop` to `@quilibrium/quorum-shared` so
 
 ## Prerequisites
 
+### Resolve the two repo paths first
+
+Commands in this guide use `$REPO` and `$SHARED` rather than absolute paths, so they
+work on any machine and any OS. Set them once per shell, from anywhere inside
+quorum-desktop:
+
+```bash
+# The quorum-desktop checkout you are working in (worktree-aware).
+REPO=$(git rev-parse --show-toplevel)
+
+# The quorum-shared sibling checkout. Derived from the MAIN checkout, not the
+# current one, so it stays correct inside a linked worktree.
+SHARED="$(dirname "$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")")/quorum-shared"
+```
+
+`quorum-shared` is expected to sit **beside** the quorum-desktop repo root — that is
+what `"link:../quorum-shared"` in `package.json` means. If `$SHARED` doesn't exist,
+ask where quorum-shared is checked out rather than resolving via `node -e` (Windows
+quoting makes that brittle).
+
+> **Why `--git-common-dir` for `$SHARED` but `--show-toplevel` for `$REPO`:** inside a
+> linked worktree those differ. Desktop commands must run against *your* checkout, but
+> the `link:` target is a single shared checkout beside the main one, so resolving it
+> relative to your worktree would point at nothing.
+
 Before starting any migration:
 
-1. **Confirm `link:` dependency is active** in `d:/GitHub/Quilibrium/quorum-desktop/package.json`:
+1. **Confirm `link:` dependency is active** in `$REPO/package.json`:
    ```json
    "@quilibrium/quorum-shared": "link:../quorum-shared"
    ```
@@ -23,7 +48,7 @@ Before starting any migration:
 
 3. **Confirm quorum-shared builds cleanly** before making changes (this is the baseline you'll compare against):
    ```bash
-   cd d:/GitHub/Quilibrium/quorum-shared && yarn build
+   cd $SHARED && yarn build
    ```
 
 ---
@@ -51,10 +76,10 @@ For each candidate file, check:
 
 ```bash
 # What does this file import?
-grep "^import" d:/GitHub/Quilibrium/quorum-desktop/src/<path-to-file>
+grep "^import" $REPO/src/<path-to-file>
 
 # What imports this file?
-grep -r "from.*<module-name>" d:/GitHub/Quilibrium/quorum-desktop/src/ --include="*.ts" --include="*.tsx" -l
+grep -r "from.*<module-name>" $REPO/src/ --include="*.ts" --include="*.tsx" -l
 ```
 
 Classify imports into:
@@ -128,8 +153,8 @@ For components with `.web.tsx` / `.native.tsx` splits:
 
 If the migrated files need npm packages not yet in shared:
 
-1. Check exact versions in `d:/GitHub/Quilibrium/quorum-desktop/package.json`
-2. Add to `d:/GitHub/Quilibrium/quorum-shared/package.json` with matching versions
+1. Check exact versions in `$REPO/package.json`
+2. Add to `$SHARED/package.json` with matching versions
 3. Run `yarn install` in quorum-shared
 4. Verify build: `yarn build`
 
@@ -171,7 +196,7 @@ export { default as dayjs } from './dayjs';
 ### 3e. Verify Build
 
 ```bash
-cd d:/GitHub/Quilibrium/quorum-shared
+cd $SHARED
 yarn build
 ```
 
@@ -188,7 +213,7 @@ Expected: 0 errors. All 3 outputs generated (index.mjs, index.js, index.native.j
 Find all files that import from the migrated local paths:
 
 ```bash
-grep -r "from.*utils/<migrated-module>" d:/GitHub/Quilibrium/quorum-desktop/src/ --include="*.ts" --include="*.tsx" -l
+grep -r "from.*utils/<migrated-module>" $REPO/src/ --include="*.ts" --include="*.tsx" -l
 ```
 
 Update each to import from `@quilibrium/quorum-shared`:
@@ -235,34 +260,34 @@ Run these checks in order:
 
 ### 5a. quorum-shared build
 ```bash
-cd d:/GitHub/Quilibrium/quorum-shared && yarn build
+cd $SHARED && yarn build
 ```
 
 ### 5b. quorum-desktop web build
 ```bash
-cd d:/GitHub/Quilibrium/quorum-desktop && yarn build
+cd $REPO && yarn build
 ```
 
 ### 5c. quorum-desktop dev server
 ```bash
-cd d:/GitHub/Quilibrium/quorum-desktop && yarn dev
+cd $REPO && yarn dev
 ```
 Verify the app loads in browser — check for blank pages (ESM import failures are silent).
 
 ### 5d. Mobile compatibility (if applicable)
 ```bash
-cd d:/GitHub/Quilibrium/quorum-desktop && yarn mobile
+cd $REPO && yarn mobile
 ```
 Check Metro bundles without errors. If it fails, look for ESM-only packages (Phase 2d).
 
 ### 5e. Check for DOM API leaks
 ```bash
-grep -r "window\.\|document\.\|navigator\." d:/GitHub/Quilibrium/quorum-shared/src/ --include="*.ts" --include="*.tsx" | grep -v "typeof window" | grep -v "typeof document" | grep -v ".native."
+grep -r "window\.\|document\.\|navigator\." $SHARED/src/ --include="*.ts" --include="*.tsx" | grep -v "typeof window" | grep -v "typeof document" | grep -v ".native."
 ```
 
 ### 5f. Run tests
 ```bash
-cd d:/GitHub/Quilibrium/quorum-desktop && yarn test
+cd $REPO && yarn test
 ```
 Compare results with previous run — no NEW failures should be introduced.
 
@@ -331,6 +356,4 @@ Documentation upkeep that goes in the desktop PR (not a separate one):
 
 ---
 
-*Last updated: 2026-05-20 — after typing migration. Added: services folder layout (mirror `src/sync/`), vitest mock type strictness gotcha, `@/` alias rewrite reminder, accurate commit/PR/version-bump workflow (squash-merge, version-in-PR, desktop keeps `link:`), `git mv` of done task files, README upkeep notes.*
-
-*Previously: 2026-03-18 — initial skill.*
+*Last updated: 2026-08-13*

--- a/.claude/skills/update-shared/SKILL.md
+++ b/.claude/skills/update-shared/SKILL.md
@@ -20,7 +20,17 @@ The shared package is linked locally via `package.json`:
 "@quilibrium/quorum-shared": "link:../quorum-shared"
 ```
 
-The conventional sibling path is `d:/GitHub/Quilibrium/quorum-shared` (Windows) or `/mnt/data/GitHub/Quilibrium/quorum-shared` (Fedora). If that path doesn't exist, ask the user where quorum-shared is located rather than trying to resolve via `node -e` (Windows quoting makes that brittle).
+It is checked out as a **sibling of the quorum-desktop repo root** — that is what
+`link:../quorum-shared` means. Resolve it without hardcoding any machine path:
+
+```bash
+SHARED="$(dirname "$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")")/quorum-shared"
+```
+
+`--git-common-dir` (rather than `--show-toplevel`) makes this resolve correctly from a
+linked worktree too, where the `link:` target is still the one checkout beside the
+**main** repo. If `$SHARED` doesn't exist, ask the user where quorum-shared is located
+rather than trying to resolve via `node -e` (Windows quoting makes that brittle).
 
 ## Workflow
 
@@ -127,7 +137,7 @@ When a feature stabilizes and its types should be shared:
 4. Build
 5. In the consuming repo, import: `import { useMyHook } from '@quilibrium/quorum-shared'`
 
-Important: most desktop hooks are NOT shareable yet — the hooks migration is blocked on mobile codebase access (see `.agents/tasks/quorum-shared-migration/designs/2026-03-19-hooks-design.md`). Only add a hook to shared if it has zero context dependencies (no `useMessageDB`, no `usePasskeysContext`, etc.) and zero DOM coupling.
+Important: most desktop hooks are NOT shareable yet — the hooks migration is blocked on mobile codebase access (see `.agents/issues/quorum-shared-migration/designs/`, currently `2026-05-28-hooks-audit-refresh.md`). Only add a hook to shared if it has zero context dependencies (no `useMessageDB`, no `usePasskeysContext`, etc.) and zero DOM coupling.
 
 ### Adding a util
 
@@ -161,3 +171,7 @@ yarn test:run
 ```
 
 No separate test-imports list to maintain — Vitest picks up `*.test.ts` files automatically.
+
+---
+
+*Last updated: 2026-08-13*

--- a/src/components/ui/OfflineBanner.tsx
+++ b/src/components/ui/OfflineBanner.tsx
@@ -5,8 +5,8 @@
  * - User is offline (shows queued actions count)
  * - User hasn't dismissed it this session
  *
- * Does NOT display when online - action queue processing happens silently
- * and "Syncing Space..." toast handles sync feedback separately.
+ * Does NOT display when online - action queue processing happens silently.
+ * (There is no sync toast any more; it was removed on 2026-08-13.)
  *
  * Dismiss behavior:
  * - User can close with X button

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -72,7 +72,7 @@ import {
 import { t } from '@lingui/core/macro';
 import { DefaultImages } from '../utils';
 import { QuorumApiClient } from '../api/baseTypes';
-import { showWarning, noteSyncActivity } from '../utils/toast';
+import { showWarning } from '../utils/toast';
 import { notificationService } from './NotificationService';
 import type { ActionQueueService } from './ActionQueueService';
 import type { ReceiptService, ReceiptEnvelopeFields } from '@quilibrium/quorum-shared';
@@ -6077,8 +6077,6 @@ export class MessageService {
                     spaceId: conversationId.split('/')[0],
                   }),
                 });
-
-                noteSyncActivity();
               }
             }
           } else if (envelope.message.type === 'sync-manifest') {
@@ -6156,8 +6154,6 @@ export class MessageService {
                   }),
                 });
               }
-
-              noteSyncActivity();
             }
 
             // Apply member delta

--- a/src/services/SyncService.ts
+++ b/src/services/SyncService.ts
@@ -20,8 +20,6 @@ import {
   PeerEntry,
 } from '@quilibrium/quorum-shared';
 import { IndexedDBAdapter } from '../adapters/indexedDbAdapter';
-import { showSyncToast } from '../utils/toast';
-import { t } from '@lingui/core/macro';
 import type { Ref } from '../types/ref';
 import type { SyncInfoMap } from '../types/spaceRefs';
 
@@ -485,7 +483,6 @@ export class SyncService {
    */
   async requestSync(spaceId: string): Promise<boolean> {
     logger.log(`[SyncService] requestSync called for space ${spaceId}`);
-    showSyncToast(t`Syncing...`);
     try {
       const space = await this.messageDB.getSpace(spaceId);
       const channelId = space?.defaultChannelId || spaceId;

--- a/src/utils/toast.ts
+++ b/src/utils/toast.ts
@@ -124,51 +124,12 @@ export const dismissToast = (id: string): void => {
   );
 };
 
-// ---- Sync toast lifecycle ----
-// The "Syncing..." toast is shown when SyncService.requestSync() runs.
-// It must be dismissed in one of three ways:
-//   1. Happy path: 5s after the last sync-delta/sync-messages chunk arrives.
-//   2. Fallback: a hard timeout from when the toast was shown, in case no peer
-//      ever responds (e.g. lone-member space, all peers offline).
-// Both timers are tracked here so any caller can reset/clear them safely.
-
-const SYNC_TOAST_ID = 'sync';
-const SYNC_TOAST_MAX_LIFETIME_MS = 15_000;
-const SYNC_TOAST_IDLE_DISMISS_MS = 5_000;
-
-let syncIdleTimer: NodeJS.Timeout | undefined;
-let syncFallbackTimer: NodeJS.Timeout | undefined;
-
-const clearSyncTimers = (): void => {
-  clearTimeout(syncIdleTimer);
-  clearTimeout(syncFallbackTimer);
-  syncIdleTimer = undefined;
-  syncFallbackTimer = undefined;
-};
-
-/**
- * Show the global "Syncing..." toast and arm a fallback dismiss in case
- * no sync chunks ever arrive (lone-member space, all peers offline, etc.).
- */
-export const showSyncToast = (message: string): void => {
-  showPersistentToast(SYNC_TOAST_ID, message, 'info');
-  clearTimeout(syncFallbackTimer);
-  syncFallbackTimer = setTimeout(() => {
-    dismissToast(SYNC_TOAST_ID);
-    clearSyncTimers();
-  }, SYNC_TOAST_MAX_LIFETIME_MS);
-};
-
-/**
- * Called when a sync chunk arrives. Cancels the fallback timer and arms the
- * 5s idle-dismiss timer (resets on each chunk).
- */
-export const noteSyncActivity = (): void => {
-  clearTimeout(syncFallbackTimer);
-  syncFallbackTimer = undefined;
-  clearTimeout(syncIdleTimer);
-  syncIdleTimer = setTimeout(() => {
-    dismissToast(SYNC_TOAST_ID);
-    syncIdleTimer = undefined;
-  }, SYNC_TOAST_IDLE_DISMISS_MS);
-};
+// NOTE: the global "Syncing..." toast was removed on 2026-08-13. It fired from
+// SyncService.requestSync(), which runs once per space on every connect, so it
+// appeared on every refresh whether or not anything needed syncing — and it was
+// a single global toast, not per-space. See
+// .agents/issues/.open/2026-08-13-sync-indicator-needs-a-per-space-behind-by-signal.md
+// for the diagnosis and the signal a future implementation should use.
+//
+// showPersistentToast / dismissToast above are deliberately kept: they are a
+// general capability, not sync-specific.


### PR DESCRIPTION
Removes the global "Syncing..." toast, and makes the two quorum-shared skills usable by anyone rather than only on one machine.

## Sync toast

The toast fired on sync *intent*, not on need: `showSyncToast()` was the first statement of `SyncService.requestSync()`, which runs once per space on every connect. So it appeared on every refresh whether or not the client was behind, including in channels already fully rendered.

Two further defects made it unfixable by relocating the trigger:

- The arrival side could not tell a real sync from a no-op either. The `sync-delta` handler called `noteSyncActivity()` under `if (messageDelta)`, which is true for an **empty** delta — the `channelIdsToRefetch.size === 0` fallback just above it exists precisely because empty deltas arrive.
- `SYNC_TOAST_ID` was a single hardcoded string, so every space shared one toast. Per-space was structurally impossible, not merely unimplemented.

Every candidate trigger point (`requestSync`, `initiateSync`, chunk arrival) fires on a no-op sync, which is why successive reworks kept moving it without fixing it. A wrong indicator is worse than none.

`showPersistentToast` / `dismissToast` are kept — they are a general capability, not sync-specific.

The rebuild is filed as a task, gated on first measuring whether a peer's `sync-info` `messageCount` minus the local count is a trustworthy per-space "behind by N". That comparison is the signal the original implementation had and the 2026-05-18 rework discarded.

## Skills

`update-shared` and `migrate-to-shared` hardcoded absolute paths to the two repos, so their commands were wrong for anyone else who invoked them. They now resolve both locations at runtime:

```
REPO=$(git rev-parse --show-toplevel)
SHARED="$(dirname "$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")")/quorum-shared"
```

`REPO` uses `--show-toplevel` so desktop commands run against the checkout you are actually in; `SHARED` uses `--git-common-dir` so it still resolves to the sibling beside the main checkout from inside a linked worktree, which is where the `link:` target lives. Verified from the main root, a subdirectory, and a worktree. Also repoints a dead reference to a hooks design doc that no longer exists.

## Verification

`tsc --noEmit` exit 0. Full suite: 1440 passed / 155 files.

## Commits

- docs(skills): resolve quorum-shared by git, not by hardcoded machine paths
- docs(issues): point the identity-resolution plan at the current repo location
- fix(sync): remove the "Syncing..." toast that fired on every refresh
