### PR TITLE
feat(messages): put Edit in the hover toolbar and simplify the edit layout

### DIFF
--- a/src/components/message/Message.scss
+++ b/src/components/message/Message.scss
@@ -145,17 +145,20 @@
 }
 
 /* === MESSAGE EDIT UI === */
+/* Deliberately chrome-free: the message row itself carries the highlight
+   (`bg-chat-hover`, applied in Message.tsx while editing), so the editor adds
+   no box of its own — the post simply turns into a textarea in place. */
 .message-edit-container {
   margin-top: $s-2;
-  padding: $s-3;
-  background-color: var(--surface-2);
-  border-radius: $rounded-md;
-  border: 1px solid var(--surface-4);
 }
 
 .message-edit-textarea {
   width: 100%;
-  min-height: 60px;
+  /* Exactly one line plus its padding, so a single-line edit sits centered in
+     the box instead of hugging the top of a fixed 60px well. Taller content
+     grows the box from here. */
+  line-height: $leading-5;
+  min-height: calc(#{$leading-5} + #{$s-2} * 2);
   max-height: 200px;
   padding: $s-2;
   background-color: var(--color-field-bg);
@@ -167,21 +170,22 @@
   cursor: text; /* Show text cursor */
   resize: none;
   outline: none;
-  transition: all $duration-150 $ease-in-out;
 
   &::placeholder {
     color: var(--color-field-placeholder);
   }
 
-  &:hover:not(:focus) {
-    background-color: var(--color-field-bg-focus);
-    border-color: var(--color-field-border-hover);
+  /* No accent border or focus ring: this input is already the sole focus of
+     the highlighted row, so the usual field focus treatment only adds noise.
+     `:focus-visible` needs suppressing explicitly — the global accent ring in
+     `_base.scss` matches text inputs and contentEditable on plain mouse focus,
+     not just keyboard, so dropping the field box-shadow alone leaves it. */
+  &:focus {
+    border-color: var(--color-field-border);
   }
 
-  &:focus {
-    border-color: var(--color-field-border-focus);
-    background-color: var(--color-field-bg-focus);
-    box-shadow: 0 0 0 $s-1 var(--color-field-focus-shadow);
+  &:focus-visible {
+    outline: none;
   }
 }
 

--- a/src/components/message/Message.tsx
+++ b/src/components/message/Message.tsx
@@ -667,6 +667,10 @@ export const Message = React.memo(
           (isCompact ? 'message-compact ' : '') +
           // Desktop: hover effect; Touch: no extra styling (gap/border handled by .message-row wrapper)
           (isTouchDevice() ? '' : 'hover:bg-chat-hover ') +
+          // While editing, hold the same background the row gets on hover so the
+          // message being edited stays visually singled out even as the pointer
+          // moves away to the textarea.
+          (editingMessageId === message.messageId ? 'bg-chat-hover ' : '') +
           (highlightClassName ? ` ${highlightClassName}` : '')
         }
         // Desktop mouse interaction

--- a/src/components/message/MessageActions.tsx
+++ b/src/components/message/MessageActions.tsx
@@ -139,7 +139,7 @@ export const MessageActions: React.FC<MessageActionsProps> = ({
   if (canEdit && onEdit) {
     shiftActions.push({
       id: 'edit',
-      icon: 'edit',
+      icon: 'pencil',
       onClick: () => onEdit(),
     });
   }
@@ -259,6 +259,19 @@ export const MessageActions: React.FC<MessageActionsProps> = ({
                 <Icon name="reply" size="md" className="xl:hidden" />
                 <Icon name="reply" size="lg" className="hidden xl:block" />
               </div>
+
+              {/* Edit — promoted out of the dots menu: on your own posts this is
+                  the most common action, so it sits in the toolbar directly. */}
+              {canEdit && onEdit && (
+                <div
+                  onClick={() => onEdit()}
+                  onMouseEnter={() => setHoveredAction('edit')}
+                  className={iconButtonClassMr}
+                >
+                  <Icon name="pencil" size="md" className="xl:hidden" />
+                  <Icon name="pencil" size="lg" className="hidden xl:block" />
+                </div>
+              )}
 
               {/* Dots — open context menu */}
               <div

--- a/src/components/message/MessageActionsDrawer.tsx
+++ b/src/components/message/MessageActionsDrawer.tsx
@@ -221,7 +221,7 @@ const MessageActionsDrawer: React.FC<MessageActionsDrawerProps> = ({
             onClick={handleEdit}
             className="mobile-drawer__action-item"
           >
-            <Icon name="edit" />
+            <Icon name="pencil" />
             <span>{t`Edit message`}</span>
           </div>
         )}

--- a/src/components/message/MessageActionsMenu.tsx
+++ b/src/components/message/MessageActionsMenu.tsx
@@ -230,7 +230,7 @@ const MessageActionsMenu: React.FC<MessageActionsMenuProps> = ({
 
           {canEdit && onEdit && (
             <button onClick={handleEdit} className="message-actions-menu__item">
-              <Icon name="edit" size="sm" />
+              <Icon name="pencil" size="sm" />
               {t`Edit`}
             </button>
           )}

--- a/src/components/message/MessageEditTextarea.tsx
+++ b/src/components/message/MessageEditTextarea.tsx
@@ -53,6 +53,27 @@ interface MessageEditTextareaProps {
 }
 
 /**
+ * Nearest ancestor that actually scrolls vertically — the message list's
+ * scroller in practice. Checks scrollHeight too, so a merely `overflow: auto`
+ * wrapper that never overflows is skipped rather than silently swallowing the
+ * scroll adjustment.
+ */
+function findScrollableParent(element: HTMLElement): HTMLElement | null {
+  let node = element.parentElement;
+  while (node) {
+    const { overflowY } = window.getComputedStyle(node);
+    if (
+      (overflowY === 'auto' || overflowY === 'scroll') &&
+      node.scrollHeight > node.clientHeight
+    ) {
+      return node;
+    }
+    node = node.parentElement;
+  }
+  return null;
+}
+
+/**
  * Message edit textarea with markdown toolbar
  * Extracted from Message.tsx for better maintainability
  */
@@ -419,6 +440,42 @@ export function MessageEditTextarea({
       }, 50);
     }
   }, []);
+
+  // Grow upward, not downward.
+  //
+  // The editor lives inside the virtualized message list, so expanding it the
+  // normal way pushes everything below it down — and when the edit starts near
+  // the bottom of the viewport that means the editor pushes its own hint line
+  // (and often the caret) behind the composer. Nudging the scroller by each
+  // height delta pins the editor's BOTTOM edge where it already was and lets
+  // the top edge rise instead, which is what "grows upward" looks like.
+  //
+  // Writing scrollTop directly is how the list's own scroll snapping works
+  // (see MessageList.tsx), so this doesn't fight Virtuoso.
+  useEffect(() => {
+    const input = ENABLE_MENTION_PILLS ? editorRef.current : editTextareaRef.current;
+    if (!input) return;
+
+    const scroller = findScrollableParent(input);
+    if (!scroller) return;
+
+    // Seeded before observing so the ResizeObserver's initial callback — which
+    // fires immediately with the current size — is a no-op rather than a jump.
+    let previousHeight = input.getBoundingClientRect().height;
+
+    const observer = new ResizeObserver(() => {
+      const height = input.getBoundingClientRect().height;
+      const delta = height - previousHeight;
+      previousHeight = height;
+      if (delta !== 0) {
+        scroller.scrollTop += delta;
+      }
+    });
+
+    observer.observe(input);
+    return () => observer.disconnect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // Refs are stable; the observed element never swaps for a given edit
 
   const handleSaveEdit = async () => {
     const editNonce = crypto.randomUUID();


### PR DESCRIPTION
Refines the edit-post flow: the Edit affordance is easier to reach, and the editor itself loses the chrome that made it read as a separate widget stacked inside the message.

### Reaching Edit

- The hover toolbar renders Edit directly on your own posts, between Reply and the dots, instead of hiding it one click deep in the dots menu. It stays in the dots menu and the mobile drawer too.
- The icon is now a plain pen (`IconPencil`) everywhere it appears, replacing the boxed `IconEdit`.

### The editor

- The surrounding box is gone. The message row instead holds the same background it gets on hover for as long as the edit is open, so the post being edited stays singled out once the pointer moves away, and the post simply turns into a textarea in place.
- No accent focus ring. Removing the field `box-shadow` was not enough on its own: the ring came from the global `:focus-visible` rule in `_base.scss`, which browsers apply to text inputs on plain mouse focus rather than keyboard focus only. Suppressed for this input specifically.
- Single-line edits sit centered. The input was a fixed 60px well with the text pinned to the top; it is now one line-height plus its padding, and taller content grows from there.
- The editor grows upward. A `ResizeObserver` feeds each height delta to the message list's scroller, pinning the editor's bottom edge and letting the top edge rise, so editing a post at the bottom of the viewport no longer pushes its own hint line behind the composer. Writing `scrollTop` directly is how the list's own scroll snapping already works, so this does not fight Virtuoso.

The "Esc to CANCEL - Enter to SAVE - Shift+Enter for new line" hint is unchanged.

### Verification

Typecheck clean, lint reports no new errors, and the existing message tests pass. The layout and the focus ring were confirmed visually in the running app; the centering and upward-growth behaviour were checked in the UI by hand.
