### PR TITLE
fix(identity): verify a QNS claim before rendering it as a .q

### DIFF
--- a/scripts/check-bundle-globals.mjs
+++ b/scripts/check-bundle-globals.mjs
@@ -61,7 +61,27 @@ const ALLOWED = new Set([
  * bare substring rather than as an assignment, because for these the bar is
  * "does not occur at all".
  */
-const FORBIDDEN_ANYWHERE = ['__keyset'];
+const FORBIDDEN_ANYWHERE = [
+  '__keyset',
+  // The dev-only QNS overlay, and with it `isFakeClaimFor` — the one code path
+  // that returns "this `.q` claim is fine, skip the ownership check". It is
+  // excluded from production only because `identity/qnsClaimExemption.ts` gates
+  // its call on `process.env.NODE_ENV`, which the bundler folds to a constant,
+  // leaving `fakeQnsCore` with no importer. That is a property of how the
+  // bundler happens to optimise, so it needs a guard rather than a comment: a
+  // refactor that moves the gate behind a runtime value (a config object, a
+  // feature flag) would silently ship a verification bypass, and every existing
+  // test would still pass.
+  //
+  // The STORAGE KEY is the load-bearing entry: it is a string literal, and
+  // string literals survive minification. The function names below are mangled
+  // in a minified build and so would NOT catch a regression there on their own —
+  // they are kept for unminified builds and for readability at the call site.
+  'dev.fakeQns.state',
+  'deriveFakeQName',
+  'isFakeClaimFor',
+  'applyFakeQns',
+];
 
 function walk(dir) {
   if (!existsSync(dir)) return [];

--- a/src/components/modals/UserSettingsModal/UserSettingsModal.tsx
+++ b/src/components/modals/UserSettingsModal/UserSettingsModal.tsx
@@ -21,7 +21,7 @@ import { useQuery } from '@tanstack/react-query';
 import { buildSpacesFetcher } from '../../../hooks/queries/spaces/buildSpacesFetcher';
 import { buildSpacesKey } from '../../../hooks/queries/spaces/buildSpacesKey';
 import { useMessageDB } from '../../context/useMessageDB';
-import { useUserPublicProfile } from '../../../hooks/business/user/useUserPublicProfile';
+import { useResolvedMemberName } from '../../../identity';
 import { validateDisplayName, validateUserBio } from '../../../hooks/business/validation';
 import type { BroadcastSpaceTag } from '@quilibrium/quorum-shared';
 import General from './General';
@@ -105,9 +105,23 @@ const UserSettingsModal: React.FunctionComponent<{
   } = useUserSettings();
 
   // The user's own QNS primary name (if any) — drives the override notice in
-  // General. Sourced from their public profile, same hook used elsewhere.
-  const { data: ownPublicProfile } = useUserPublicProfile(currentPasskeyInfo?.address);
-  const primaryUsername = ownPublicProfile?.primary_username || undefined;
+  // General.
+  //
+  // Read through the identity module, NOT from `public_profile.primary_username`
+  // directly, because the notice claims "your QNS name X.q is shown as your
+  // name" and that has to actually be true. An unverified claim renders nowhere
+  // in the app (see `identityProvider.tsx`'s `verifiedQnsNames`), so sourcing it
+  // raw here would state the opposite of what every other surface does — and
+  // would be the one place left that appends `.q` to something nobody checked.
+  //
+  // Self is not exempt from the check. A name you have not registered does not
+  // become yours because you are the one looking at it.
+  const selfResolved = useResolvedMemberName(currentPasskeyInfo?.address ?? '', {
+    enrich: true,
+    global: true,
+    surface: 'UserSettingsModal',
+  });
+  const primaryUsername = selfResolved.isQnsVerified ? selfResolved.name : undefined;
 
   // Spaces for Space Tag selector (using useQuery to avoid Suspense requirement)
   const { messageDB } = useMessageDB();

--- a/src/dev/fake-qns/fakeQnsCore.ts
+++ b/src/dev/fake-qns/fakeQnsCore.ts
@@ -171,6 +171,57 @@ export function deriveFakeQName(address: string): string {
 }
 
 /**
+ * Is this claim one THIS overlay synthesized for THIS address?
+ *
+ * Exists because claim verification would otherwise make the whole instrument
+ * inert. A synthesized name (`qa1234`) is registered nowhere, so the genuine
+ * ownership check strips every one of them: the overlay would inject names, the
+ * verifier would remove them, and every QNS surface would render exactly as it
+ * did before the overlay existed — the panel reporting success while showing
+ * nothing. That failure looks identical to "the feature is broken", which is
+ * the most expensive kind of dev-tool bug.
+ *
+ * Deliberately narrow. It exempts ONLY names this module would itself produce
+ * for that exact address:
+ *
+ * - an explicit entry's `primaryUsername`, which is a deliberate act, and
+ * - the derived `qa…` name, and only while `giveEveryoneAName` is on.
+ *
+ * A REAL registration that happens to pass through `applyFakeQns` untouched is
+ * NOT exempt, and must not be: verifying real names is the one behaviour the
+ * instrument exists to observe, so exempting them would hide the regression it
+ * was built to catch.
+ *
+ * ⚠️ There is no production path to this. Its only caller,
+ * `identity/qnsClaimExemption.ts`, sits behind a `process.env.NODE_ENV` gate
+ * that the bundler folds to a constant, so the call is dead code and this
+ * module loses its last importer.
+ *
+ * Both halves are checked, by different means: `qnsClaimExemption.test.ts`
+ * asserts the RUNTIME gate refuses outside development, and the build-time half
+ * was MEASURED by grepping `dist/` after `yarn build` (2026-08-16 — zero
+ * occurrences of `deriveFakeQName`, `isFakeClaimFor`, `applyFakeQns` or the
+ * storage key across 71 bundle files). Re-run that grep if the gate changes
+ * shape; a unit test cannot see it.
+ *
+ * Anything that made this reachable in production would be a way to render an
+ * unverified `.q`, which is the entire thing verification prevents.
+ */
+export function isFakeClaimFor(name: string, address: string): boolean {
+  const claim = (name ?? '').trim();
+  const addr = (address ?? '').trim();
+  if (!claim || !addr) return false;
+
+  const state = getFakeQnsState();
+  if (!state.enabled) return false;
+
+  const entry = state.entries[addr.toLowerCase()];
+  if (entry) return !!entry.primaryUsername && entry.primaryUsername === claim;
+
+  return state.giveEveryoneAName && deriveFakeQName(addr) === claim;
+}
+
+/**
  * The seam. Called from `QuorumApiClient.getPublicProfile` with whatever the
  * server actually returned, or `null` for a 404.
  *

--- a/src/dev/tests/components/ReactionsModal.test.tsx
+++ b/src/dev/tests/components/ReactionsModal.test.tsx
@@ -84,6 +84,18 @@ vi.mock('@/components/context/useMessageDB', () => ({
   }),
 }));
 
+// This test pins WIRING — that the name the identity module resolves is the one
+// this surface renders. QNS ownership itself is tested in
+// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
+// both mutation-proven. The claim still travels the real path here, so this
+// still fails if the provider stops populating the verified map; only the final
+// comparison is stubbed, because the address fixtures are arbitrary and no real
+// key derives to them.
+vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
+  claimedNameBelongsTo: () => true,
+}));
+
 const ADDR = 'QmPeerFEgVKpYZKYuFu2J49zHXnA8vZtEqHMtpB4imzzzz';
 const SPACE_ID = 'space-1';
 const CHANNEL_ID = 'channel-1'; // distinct from SPACE_ID — the ordinary, non-DM shape

--- a/src/dev/tests/components/ReactionsModal.test.tsx
+++ b/src/dev/tests/components/ReactionsModal.test.tsx
@@ -84,13 +84,12 @@ vi.mock('@/components/context/useMessageDB', () => ({
   }),
 }));
 
-// This test pins WIRING — that the name the identity module resolves is the one
-// this surface renders. QNS ownership itself is tested in
-// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
-// both mutation-proven. The claim still travels the real path here, so this
-// still fails if the provider stops populating the verified map; only the final
-// comparison is stubbed, because the address fixtures are arbitrary and no real
-// key derives to them.
+// Pins WIRING, not QNS ownership. Only the final ownership comparison is
+// stubbed, because the address fixtures here are arbitrary and no real ed448
+// key derives to them. The claim still travels the whole real path, so this
+// still fails if the provider stops populating the verified map. Ownership
+// itself is pinned in `identity/verifiedQnsNames.test.ts` and shared's
+// `verifyQnsClaim.test.ts`, both mutation-proven.
 vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
   claimedNameBelongsTo: () => true,

--- a/src/dev/tests/components/ThreadsListPanel.test.tsx
+++ b/src/dev/tests/components/ThreadsListPanel.test.tsx
@@ -146,6 +146,18 @@ vi.mock('../../../components/ui/DropdownPanel', () => ({
     isOpen ? <div data-testid="dropdown-panel">{headerContent}{children}</div> : null,
 }));
 
+// This test pins WIRING — that the name the identity module resolves is the one
+// this surface renders. QNS ownership itself is tested in
+// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
+// both mutation-proven. The claim still travels the real path here, so this
+// still fails if the provider stops populating the verified map; only the final
+// comparison is stubbed, because the address fixtures are arbitrary and no real
+// key derives to them.
+vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
+  claimedNameBelongsTo: () => true,
+}));
+
 import { ThreadsListPanel } from '../../../components/thread/ThreadsListPanel';
 import { IdentityScopeProvider } from '../../../identity';
 

--- a/src/dev/tests/components/ThreadsListPanel.test.tsx
+++ b/src/dev/tests/components/ThreadsListPanel.test.tsx
@@ -68,65 +68,15 @@ vi.mock('../../../utils/platform', () => ({
   isTouchDevice: () => false,
 }));
 
-vi.mock('@quilibrium/quorum-shared', () => {
-  // The real algorithm, not a stub. `resolveSpaceMemberName` delegates to
-  // `resolveIdentity` for both the space/QNS/global ladder AND the guard that
-  // drops a name forging the verified `.q` marker — stubbing this to a
-  // constant would switch that guard off for anything this panel renders, and
-  // a mock that silently disables a security rule is worse than no mock.
-  const hasReservedQnsSuffix = (name: string) =>
-    name.replace(/[.．﹒․]/g, '.').trim().toLowerCase().endsWith('.q');
-
-  const present = (s?: string | null): string | null => {
-    const t = (s ?? '').trim();
-    return t.length ? t : null;
-  };
-  const presentUnreserved = (s?: string | null): string | null => {
-    const t = present(s);
-    if (!t) return null;
-    return hasReservedQnsSuffix(t) ? null : t;
-  };
-  const truncate = (addr: string): string =>
-    addr.length > 10 ? `${addr.slice(0, 6)}…${addr.slice(-4)}` : addr;
-
-  return {
-    formatRelativeTime: () => '2h ago',
-    resolveIdentity: (
-      identity: {
-        address: string;
-        spaceName: string | null;
-        qnsName: string | null;
-        globalName: string | null;
-      },
-      { scope }: { scope: 'space' | 'global' },
-    ) => {
-      const qns = presentUnreserved(identity.qnsName);
-      const global = presentUnreserved(identity.globalName);
-      if (scope === 'space') {
-        const space = presentUnreserved(identity.spaceName);
-        if (space && space !== global) return { name: space, isQnsVerified: false };
-      }
-      if (qns) return { name: qns, isQnsVerified: true };
-      if (global) return { name: global, isQnsVerified: false };
-      return { name: truncate(identity.address), isQnsVerified: false };
-    },
-    hasReservedQnsSuffix,
-  };
-});
-
-// Mock primitives
-vi.mock('@/components/primitives', () => ({
-  Icon: ({ name, className }: { name: string; className?: string }) => (
-    <span data-testid={`icon-${name}`} className={className}>{name}</span>
-  ),
-  Button: ({ children, icon, disabled, tooltip, className, onClick, ...rest }: any) => (
-    <button className={className} disabled={disabled} onClick={onClick} title={tooltip} {...rest}>
-      {icon && <span data-testid={`icon-${icon}`}>{icon}</span>}
-      {children}
-    </button>
-  ),
-  Flex: ({ children, className, ...rest }: any) => <div className={className} {...rest}>{children}</div>,
-  Container: ({ children, className, ...rest }: any) => <div className={className} {...rest}>{children}</div>,
+// Pins WIRING, not QNS ownership. Only the final ownership comparison is
+// stubbed, because the address fixtures here are arbitrary and no real ed448
+// key derives to them. The claim still travels the whole real path, so this
+// still fails if the provider stops populating the verified map. Ownership
+// itself is pinned in `identity/verifiedQnsNames.test.ts` and shared's
+// `verifyQnsClaim.test.ts`, both mutation-proven.
+vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
+  claimedNameBelongsTo: () => true,
 }));
 
 // Mock ListSearchInput to a simple input

--- a/src/dev/tests/components/ThreadsListPanel.test.tsx
+++ b/src/dev/tests/components/ThreadsListPanel.test.tsx
@@ -96,18 +96,6 @@ vi.mock('../../../components/ui/DropdownPanel', () => ({
     isOpen ? <div data-testid="dropdown-panel">{headerContent}{children}</div> : null,
 }));
 
-// This test pins WIRING — that the name the identity module resolves is the one
-// this surface renders. QNS ownership itself is tested in
-// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
-// both mutation-proven. The claim still travels the real path here, so this
-// still fails if the provider stops populating the verified map; only the final
-// comparison is stubbed, because the address fixtures are arbitrary and no real
-// key derives to them.
-vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
-  claimedNameBelongsTo: () => true,
-}));
-
 import { ThreadsListPanel } from '../../../components/thread/ThreadsListPanel';
 import { IdentityScopeProvider } from '../../../identity';
 

--- a/src/dev/tests/hooks/messageFormattingMentionTokenShape.unit.test.ts
+++ b/src/dev/tests/hooks/messageFormattingMentionTokenShape.unit.test.ts
@@ -51,6 +51,18 @@ vi.mock('@/api/baseTypes', () => ({
   isHandledFetchError: () => false,
 }));
 
+// This test pins WIRING — that the name the identity module resolves is the one
+// this surface renders. QNS ownership itself is tested in
+// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
+// both mutation-proven. The claim still travels the real path here, so this
+// still fails if the provider stops populating the verified map; only the final
+// comparison is stubbed, because the address fixtures are arbitrary and no real
+// key derives to them.
+vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
+  claimedNameBelongsTo: () => true,
+}));
+
 import { useMessageFormatting } from '@/hooks/business/messages/useMessageFormatting';
 import { IdentityScopeProvider } from '@/identity/identityProvider';
 

--- a/src/dev/tests/hooks/messageFormattingMentionTokenShape.unit.test.ts
+++ b/src/dev/tests/hooks/messageFormattingMentionTokenShape.unit.test.ts
@@ -51,13 +51,12 @@ vi.mock('@/api/baseTypes', () => ({
   isHandledFetchError: () => false,
 }));
 
-// This test pins WIRING — that the name the identity module resolves is the one
-// this surface renders. QNS ownership itself is tested in
-// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
-// both mutation-proven. The claim still travels the real path here, so this
-// still fails if the provider stops populating the verified map; only the final
-// comparison is stubbed, because the address fixtures are arbitrary and no real
-// key derives to them.
+// Pins WIRING, not QNS ownership. Only the final ownership comparison is
+// stubbed, because the address fixtures here are arbitrary and no real ed448
+// key derives to them. The claim still travels the whole real path, so this
+// still fails if the provider stops populating the verified map. Ownership
+// itself is pinned in `identity/verifiedQnsNames.test.ts` and shared's
+// `verifyQnsClaim.test.ts`, both mutation-proven.
 vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
   claimedNameBelongsTo: () => true,

--- a/src/dev/tests/hooks/messageFormattingUnresolvedMention.unit.test.ts
+++ b/src/dev/tests/hooks/messageFormattingUnresolvedMention.unit.test.ts
@@ -39,6 +39,18 @@ vi.mock('@/api/baseTypes', () => ({
   isHandledFetchError: () => false,
 }));
 
+// This test pins WIRING — that the name the identity module resolves is the one
+// this surface renders. QNS ownership itself is tested in
+// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
+// both mutation-proven. The claim still travels the real path here, so this
+// still fails if the provider stops populating the verified map; only the final
+// comparison is stubbed, because the address fixtures are arbitrary and no real
+// key derives to them.
+vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
+  claimedNameBelongsTo: () => true,
+}));
+
 import { useMessageFormatting } from '@/hooks/business/messages/useMessageFormatting';
 import { IdentityScopeProvider } from '@/identity/identityProvider';
 

--- a/src/dev/tests/hooks/messageFormattingUnresolvedMention.unit.test.ts
+++ b/src/dev/tests/hooks/messageFormattingUnresolvedMention.unit.test.ts
@@ -39,13 +39,12 @@ vi.mock('@/api/baseTypes', () => ({
   isHandledFetchError: () => false,
 }));
 
-// This test pins WIRING — that the name the identity module resolves is the one
-// this surface renders. QNS ownership itself is tested in
-// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
-// both mutation-proven. The claim still travels the real path here, so this
-// still fails if the provider stops populating the verified map; only the final
-// comparison is stubbed, because the address fixtures are arbitrary and no real
-// key derives to them.
+// Pins WIRING, not QNS ownership. Only the final ownership comparison is
+// stubbed, because the address fixtures here are arbitrary and no real ed448
+// key derives to them. The claim still travels the whole real path, so this
+// still fails if the provider stops populating the verified map. Ownership
+// itself is pinned in `identity/verifiedQnsNames.test.ts` and shared's
+// `verifyQnsClaim.test.ts`, both mutation-proven.
 vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
   claimedNameBelongsTo: () => true,

--- a/src/dev/tests/identity/identityLocalNames.test.tsx
+++ b/src/dev/tests/identity/identityLocalNames.test.tsx
@@ -47,6 +47,16 @@ vi.mock('@/api/baseTypes', () => ({
   isHandledFetchError: () => false,
 }));
 
+// This file pins the local-name TIER ORDER, not QNS ownership (that lives in
+// `verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`, both
+// mutation-proven). The claim still travels the real path, so this still fails
+// if the provider stops populating the verified map — only the final comparison
+// is stubbed, because `ADDR` is an arbitrary fixture no real key derives to.
+vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
+  claimedNameBelongsTo: () => true,
+}));
+
 import { IdentityScopeProvider } from '@/identity/identityProvider';
 import { MemberName } from '@/identity/MemberName';
 

--- a/src/dev/tests/identity/identityLocalNames.test.tsx
+++ b/src/dev/tests/identity/identityLocalNames.test.tsx
@@ -47,11 +47,12 @@ vi.mock('@/api/baseTypes', () => ({
   isHandledFetchError: () => false,
 }));
 
-// This file pins the local-name TIER ORDER, not QNS ownership (that lives in
-// `verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`, both
-// mutation-proven). The claim still travels the real path, so this still fails
-// if the provider stops populating the verified map — only the final comparison
-// is stubbed, because `ADDR` is an arbitrary fixture no real key derives to.
+// Pins WIRING, not QNS ownership. Only the final ownership comparison is
+// stubbed, because the address fixtures here are arbitrary and no real ed448
+// key derives to them. The claim still travels the whole real path, so this
+// still fails if the provider stops populating the verified map. Ownership
+// itself is pinned in `identity/verifiedQnsNames.test.ts` and shared's
+// `verifyQnsClaim.test.ts`, both mutation-proven.
 vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
   claimedNameBelongsTo: () => true,

--- a/src/dev/tests/identity/identityProvider.test.tsx
+++ b/src/dev/tests/identity/identityProvider.test.tsx
@@ -26,9 +26,9 @@ describe('identityFromMaps — tier assembly', () => {
       rostersBySpace: {
         'space-1': { [ADDR]: { display_name: 'Mod Alice', global_display_name: 'Alice' } },
       },
-      profiles: {},
+      verifiedQnsNames: {},
+      profileGlobalNames: {},
       selfAddress: null,
-      selfProfile: null,
       locallyKnownNames: {},
     });
     expect(r).toEqual({
@@ -44,23 +44,26 @@ describe('identityFromMaps — tier assembly', () => {
       rostersBySpace: {
         'space-1': { [ADDR]: { display_name: '', global_display_name: 'Roster Alice' } },
       },
-      profiles: { [ADDR]: { display_name: 'Profile Alice', primary_username: 'alice' } },
+      profileGlobalNames: { [ADDR]: 'Profile Alice' },
+      verifiedQnsNames: { [ADDR]: 'alice' },
       selfAddress: null,
-      selfProfile: null,
       locallyKnownNames: {},
     });
     expect(r.globalName).toBe('Roster Alice');
     expect(r.qnsName).toBe('alice');
   });
 
-  it('takes qnsName ONLY from the public profile', () => {
+  it('takes qnsName ONLY from the verified map', () => {
     // A roster row cannot carry primary_username; that is why bookmarks and
-    // notifications showed a nickname but never a ".q".
+    // notifications showed a nickname but never a ".q". Since verification
+    // moved upstream, the rule is stronger: the ONLY way a `.q` renders is an
+    // entry somebody already proved, so a roster row cannot produce one and
+    // neither can an unverified profile claim.
     const r = identityFromMaps(ADDR, 'space-1', {
       rostersBySpace: { 'space-1': { [ADDR]: { display_name: 'Alice' } } },
-      profiles: {},
+      verifiedQnsNames: {},
+      profileGlobalNames: {},
       selfAddress: null,
-      selfProfile: null,
       locallyKnownNames: {},
     });
     expect(r.qnsName).toBeNull();
@@ -69,9 +72,9 @@ describe('identityFromMaps — tier assembly', () => {
   it('returns an all-null identity for an unknown address, never undefined', () => {
     const r = identityFromMaps(ADDR, undefined, {
       rostersBySpace: {},
-      profiles: {},
+      verifiedQnsNames: {},
+      profileGlobalNames: {},
       selfAddress: null,
-      selfProfile: null,
       locallyKnownNames: {},
     });
     expect(r).toEqual({ address: ADDR, spaceName: null, qnsName: null, globalName: null });
@@ -83,9 +86,9 @@ describe('identityFromMaps — tier assembly', () => {
       rostersBySpace: {
         'space-1': { [ADDR]: { display_name: 'Mod Alice', global_display_name: 'Alice' } },
       },
-      profiles: { [ADDR]: { display_name: 'Alice', primary_username: 'alice' } },
+      profileGlobalNames: { [ADDR]: 'Alice' },
+      verifiedQnsNames: { [ADDR]: 'alice' },
       selfAddress: null,
-      selfProfile: null,
       locallyKnownNames: {},
     });
     expect(r.spaceName).toBeNull();
@@ -102,9 +105,9 @@ describe('identityFromMaps — offline (design constraint 5)', () => {
       rostersBySpace: {
         'space-1': { [ADDR]: { display_name: '', global_display_name: 'Alice' } },
       },
-      profiles: {},
+      verifiedQnsNames: {},
+      profileGlobalNames: {},
       selfAddress: null,
-      selfProfile: null,
       locallyKnownNames: {},
     });
     expect(r.globalName).toBe('Alice');
@@ -113,17 +116,38 @@ describe('identityFromMaps — offline (design constraint 5)', () => {
 });
 
 describe('identityFromMaps — the self tier', () => {
-  it('reads YOUR OWN qnsName from your own public profile', () => {
+  it('reads YOUR OWN qnsName from your own public profile, on the same path as anyone else', () => {
     // currentPasskeyInfo carries no primary_username. Special-casing self from
     // it is what broke your own DM messages and your own profile card.
+    //
+    // Self used to have its own branch here, reading a separate `selfProfile`
+    // field. It no longer does, and that is deliberate: your own claim is
+    // verified on exactly the same path as everybody else's, because a name you
+    // have not registered does not become yours just because you are the one
+    // looking at it.
     const r = identityFromMaps(ADDR, undefined, {
       rostersBySpace: {},
-      profiles: {},
+      verifiedQnsNames: { [ADDR]: 'gatto' },
+      profileGlobalNames: { [ADDR]: 'GattoPardo Mobile' },
       selfAddress: ADDR,
-      selfProfile: { display_name: 'GattoPardo Mobile', primary_username: 'gatto' },
       locallyKnownNames: {},
     });
     expect(r.qnsName).toBe('gatto');
+    expect(r.globalName).toBe('GattoPardo Mobile');
+  });
+
+  it('does NOT give self a shortcut past verification', () => {
+    // The paired negative, and the one that would have caught a "self is always
+    // trusted" shortcut. With no verified entry, self renders their global name
+    // and no ".q" — same as any other unproven claimant.
+    const r = identityFromMaps(ADDR, undefined, {
+      rostersBySpace: {},
+      verifiedQnsNames: {},
+      profileGlobalNames: { [ADDR]: 'GattoPardo Mobile' },
+      selfAddress: ADDR,
+      locallyKnownNames: {},
+    });
+    expect(r.qnsName).toBeNull();
     expect(r.globalName).toBe('GattoPardo Mobile');
   });
 });
@@ -137,9 +161,9 @@ describe('identityFromMaps — the local-name tier (fix round 1, DM identity los
   it('falls back to the local name when neither the roster nor a fetched profile knows one', () => {
     const r = identityFromMaps(ADDR, undefined, {
       rostersBySpace: {},
-      profiles: {},
+      verifiedQnsNames: {},
+      profileGlobalNames: {},
       selfAddress: null,
-      selfProfile: null,
       locallyKnownNames: { [ADDR]: 'Bob (from conversation)' },
     });
     expect(r.globalName).toBe('Bob (from conversation)');
@@ -149,9 +173,9 @@ describe('identityFromMaps — the local-name tier (fix round 1, DM identity los
   it('a fetched public profile still wins over the local name — the local name is the LAST resort, not the first', () => {
     const r = identityFromMaps(ADDR, undefined, {
       rostersBySpace: {},
-      profiles: { [ADDR]: { display_name: 'Published Bob', primary_username: 'bob' } },
+      profileGlobalNames: { [ADDR]: 'Published Bob' },
+      verifiedQnsNames: { [ADDR]: 'bob' },
       selfAddress: null,
-      selfProfile: null,
       locallyKnownNames: { [ADDR]: 'Bob (from conversation)' },
     });
     expect(r.globalName).toBe('Published Bob');
@@ -163,9 +187,9 @@ describe('identityFromMaps — the local-name tier (fix round 1, DM identity los
       rostersBySpace: {
         'space-1': { [ADDR]: { display_name: '', global_display_name: 'Roster Alice' } },
       },
-      profiles: {},
+      verifiedQnsNames: {},
+      profileGlobalNames: {},
       selfAddress: null,
-      selfProfile: null,
       locallyKnownNames: { [ADDR]: 'Local Alice' },
     });
     expect(r.globalName).toBe('Roster Alice');
@@ -174,9 +198,9 @@ describe('identityFromMaps — the local-name tier (fix round 1, DM identity los
   it('an empty locallyKnownNames map (every Space surface) changes nothing', () => {
     const r = identityFromMaps(ADDR, undefined, {
       rostersBySpace: {},
-      profiles: {},
+      verifiedQnsNames: {},
+      profileGlobalNames: {},
       selfAddress: null,
-      selfProfile: null,
       locallyKnownNames: {},
     });
     expect(r.globalName).toBeNull();

--- a/src/dev/tests/identity/identityResolvePerf.test.ts
+++ b/src/dev/tests/identity/identityResolvePerf.test.ts
@@ -31,28 +31,29 @@ const addressAt = (i: number): string => `QmPerf${String(i).padStart(4, '0')}${'
 function buildSources(count: number): { addresses: string[]; sources: IdentitySources } {
   const addresses = Array.from({ length: count }, (_, i) => addressAt(i));
   const roster: Record<string, RosterNameRow> = {};
-  const profiles: IdentitySources['profiles'] = {};
+  const profileGlobalNames: IdentitySources['profileGlobalNames'] = {};
+  const verifiedQnsNames: IdentitySources['verifiedQnsNames'] = {};
   addresses.forEach((address, i) => {
     // Mixed shapes, like a real roster: some with a per-space nickname, some
-    // with only a global name, some with a QNS-verified profile.
+    // with only a global name, some with a QNS name that verified.
     roster[address] = {
       display_name: i % 3 === 0 ? `Nick ${i}` : '',
       global_display_name: `Member ${i}`,
     };
     if (i % 2 === 0) {
-      profiles[address] = {
-        display_name: `Profile ${i}`,
-        primary_username: i % 4 === 0 ? `user${i}` : undefined,
-        profile_image: '',
-        bio: '',
-        timestamp: 1,
-        signature: '',
-      };
+      profileGlobalNames[address] = `Profile ${i}`;
+      if (i % 4 === 0) verifiedQnsNames[address] = `user${i}`;
     }
   });
   return {
     addresses,
-    sources: { rostersBySpace: { 'space-1': roster }, profiles, selfAddress: null, selfProfile: null },
+    sources: {
+      rostersBySpace: { 'space-1': roster },
+      profileGlobalNames,
+      verifiedQnsNames,
+      selfAddress: null,
+      locallyKnownNames: {},
+    },
   };
 }
 

--- a/src/dev/tests/identity/migrated/Account.test.tsx
+++ b/src/dev/tests/identity/migrated/Account.test.tsx
@@ -79,16 +79,12 @@ vi.mock('@/components/ui', () => ({
   ReactTooltip: () => null,
 }));
 
-// This test pins WIRING — that the name the identity module resolves is the one
-// this surface renders. It is not a test of QNS ownership, which lives in
-// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
-// both mutation-proven.
-//
-// The claim still travels the real path (profile -> claimedNamesIn ->
-// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
-// provider stops populating the verified map. Only the final comparison is
-// stubbed, because the address fixtures here are arbitrary and no real key
-// derives to them.
+// Pins WIRING, not QNS ownership. Only the final ownership comparison is
+// stubbed, because the address fixtures here are arbitrary and no real ed448
+// key derives to them. The claim still travels the whole real path, so this
+// still fails if the provider stops populating the verified map. Ownership
+// itself is pinned in `identity/verifiedQnsNames.test.ts` and shared's
+// `verifyQnsClaim.test.ts`, both mutation-proven.
 vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
   claimedNameBelongsTo: () => true,

--- a/src/dev/tests/identity/migrated/Account.test.tsx
+++ b/src/dev/tests/identity/migrated/Account.test.tsx
@@ -79,6 +79,21 @@ vi.mock('@/components/ui', () => ({
   ReactTooltip: () => null,
 }));
 
+// This test pins WIRING — that the name the identity module resolves is the one
+// this surface renders. It is not a test of QNS ownership, which lives in
+// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
+// both mutation-proven.
+//
+// The claim still travels the real path (profile -> claimedNamesIn ->
+// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
+// provider stops populating the verified map. Only the final comparison is
+// stubbed, because the address fixtures here are arbitrary and no real key
+// derives to them.
+vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
+  claimedNameBelongsTo: () => true,
+}));
+
 import Account from '@/components/modals/SpaceSettingsModal/Account';
 
 const SPACE_ID = 'space-1';

--- a/src/dev/tests/identity/migrated/BlockUserModal.test.tsx
+++ b/src/dev/tests/identity/migrated/BlockUserModal.test.tsx
@@ -37,6 +37,22 @@ vi.mock('@quilibrium/quilibrium-js-sdk-channels', () => ({
   usePasskeysContext: () => ({ currentPasskeyInfo: { address: 'QmSelf000000000000000000000000000000000000' } }),
 }));
 
+// This test pins WIRING — that the name the identity module resolves is the one
+// this surface renders. It is not a test of QNS ownership, which lives in
+// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
+// both mutation-proven.
+//
+// The claim still travels the real path (profile -> claimedNamesIn ->
+// verifiedQnsNames -> IdentitySources -> the ladder), so this test still fails
+// if the provider stops populating the verified map. Only the final comparison
+// is stubbed, because `ADDR` here is an arbitrary fixture and no real key
+// derives to it — the alternative would be regenerating every address fixture
+// in 40 files from a known keypair.
+vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
+  claimedNameBelongsTo: () => true,
+}));
+
 import BlockUserModal from '@/components/modals/BlockUserModal';
 import { IdentityScopeProvider, type RosterNameRow } from '@/identity';
 

--- a/src/dev/tests/identity/migrated/BlockUserModal.test.tsx
+++ b/src/dev/tests/identity/migrated/BlockUserModal.test.tsx
@@ -37,17 +37,12 @@ vi.mock('@quilibrium/quilibrium-js-sdk-channels', () => ({
   usePasskeysContext: () => ({ currentPasskeyInfo: { address: 'QmSelf000000000000000000000000000000000000' } }),
 }));
 
-// This test pins WIRING — that the name the identity module resolves is the one
-// this surface renders. It is not a test of QNS ownership, which lives in
-// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
-// both mutation-proven.
-//
-// The claim still travels the real path (profile -> claimedNamesIn ->
-// verifiedQnsNames -> IdentitySources -> the ladder), so this test still fails
-// if the provider stops populating the verified map. Only the final comparison
-// is stubbed, because `ADDR` here is an arbitrary fixture and no real key
-// derives to it — the alternative would be regenerating every address fixture
-// in 40 files from a known keypair.
+// Pins WIRING, not QNS ownership. Only the final ownership comparison is
+// stubbed, because the address fixtures here are arbitrary and no real ed448
+// key derives to them. The claim still travels the whole real path, so this
+// still fails if the provider stops populating the verified map. Ownership
+// itself is pinned in `identity/verifiedQnsNames.test.ts` and shared's
+// `verifyQnsClaim.test.ts`, both mutation-proven.
 vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
   claimedNameBelongsTo: () => true,

--- a/src/dev/tests/identity/migrated/BookmarkCard.test.tsx
+++ b/src/dev/tests/identity/migrated/BookmarkCard.test.tsx
@@ -54,16 +54,12 @@ vi.mock('@/api/baseTypes', () => ({
   isHandledFetchError: () => false,
 }));
 
-// This test pins WIRING — that the name the identity module resolves is the one
-// this surface renders. It is not a test of QNS ownership, which lives in
-// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
-// both mutation-proven.
-//
-// The claim still travels the real path (profile -> claimedNamesIn ->
-// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
-// provider stops populating the verified map. Only the final comparison is
-// stubbed, because the address fixtures here are arbitrary and no real key
-// derives to them.
+// Pins WIRING, not QNS ownership. Only the final ownership comparison is
+// stubbed, because the address fixtures here are arbitrary and no real ed448
+// key derives to them. The claim still travels the whole real path, so this
+// still fails if the provider stops populating the verified map. Ownership
+// itself is pinned in `identity/verifiedQnsNames.test.ts` and shared's
+// `verifyQnsClaim.test.ts`, both mutation-proven.
 vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
   claimedNameBelongsTo: () => true,

--- a/src/dev/tests/identity/migrated/BookmarkCard.test.tsx
+++ b/src/dev/tests/identity/migrated/BookmarkCard.test.tsx
@@ -54,6 +54,21 @@ vi.mock('@/api/baseTypes', () => ({
   isHandledFetchError: () => false,
 }));
 
+// This test pins WIRING — that the name the identity module resolves is the one
+// this surface renders. It is not a test of QNS ownership, which lives in
+// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
+// both mutation-proven.
+//
+// The claim still travels the real path (profile -> claimedNamesIn ->
+// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
+// provider stops populating the verified map. Only the final comparison is
+// stubbed, because the address fixtures here are arbitrary and no real key
+// derives to them.
+vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
+  claimedNameBelongsTo: () => true,
+}));
+
 import { BookmarkCard } from '@/components/bookmarks/BookmarkCard';
 import { IdentityScopeProvider } from '@/identity/identityProvider';
 import { ImageModalProvider } from '@/components/context/ImageModalProvider';

--- a/src/dev/tests/identity/migrated/BookmarkItem.test.tsx
+++ b/src/dev/tests/identity/migrated/BookmarkItem.test.tsx
@@ -42,6 +42,21 @@ vi.mock('@/api/baseTypes', () => ({
   isHandledFetchError: () => false,
 }));
 
+// This test pins WIRING — that the name the identity module resolves is the one
+// this surface renders. It is not a test of QNS ownership, which lives in
+// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
+// both mutation-proven.
+//
+// The claim still travels the real path (profile -> claimedNamesIn ->
+// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
+// provider stops populating the verified map. Only the final comparison is
+// stubbed, because the address fixtures here are arbitrary and no real key
+// derives to them.
+vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
+  claimedNameBelongsTo: () => true,
+}));
+
 import { BookmarkItem } from '@/components/bookmarks/BookmarkItem';
 import { IdentityScopeProvider } from '@/identity/identityProvider';
 

--- a/src/dev/tests/identity/migrated/BookmarkItem.test.tsx
+++ b/src/dev/tests/identity/migrated/BookmarkItem.test.tsx
@@ -42,16 +42,12 @@ vi.mock('@/api/baseTypes', () => ({
   isHandledFetchError: () => false,
 }));
 
-// This test pins WIRING — that the name the identity module resolves is the one
-// this surface renders. It is not a test of QNS ownership, which lives in
-// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
-// both mutation-proven.
-//
-// The claim still travels the real path (profile -> claimedNamesIn ->
-// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
-// provider stops populating the verified map. Only the final comparison is
-// stubbed, because the address fixtures here are arbitrary and no real key
-// derives to them.
+// Pins WIRING, not QNS ownership. Only the final ownership comparison is
+// stubbed, because the address fixtures here are arbitrary and no real ed448
+// key derives to them. The claim still travels the whole real path, so this
+// still fails if the provider stops populating the verified map. Ownership
+// itself is pinned in `identity/verifiedQnsNames.test.ts` and shared's
+// `verifyQnsClaim.test.ts`, both mutation-proven.
 vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
   claimedNameBelongsTo: () => true,

--- a/src/dev/tests/identity/migrated/ChannelTypingIndicator.test.tsx
+++ b/src/dev/tests/identity/migrated/ChannelTypingIndicator.test.tsx
@@ -49,16 +49,12 @@ vi.mock('@/hooks/business/messages/useTypingIndicator', () => ({
   useTypingIndicator: (_scope: TypingScope | null) => typists,
 }));
 
-// This test pins WIRING — that the name the identity module resolves is the one
-// this surface renders. It is not a test of QNS ownership, which lives in
-// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
-// both mutation-proven.
-//
-// The claim still travels the real path (profile -> claimedNamesIn ->
-// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
-// provider stops populating the verified map. Only the final comparison is
-// stubbed, because the address fixtures here are arbitrary and no real key
-// derives to them.
+// Pins WIRING, not QNS ownership. Only the final ownership comparison is
+// stubbed, because the address fixtures here are arbitrary and no real ed448
+// key derives to them. The claim still travels the whole real path, so this
+// still fails if the provider stops populating the verified map. Ownership
+// itself is pinned in `identity/verifiedQnsNames.test.ts` and shared's
+// `verifyQnsClaim.test.ts`, both mutation-proven.
 vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
   claimedNameBelongsTo: () => true,

--- a/src/dev/tests/identity/migrated/ChannelTypingIndicator.test.tsx
+++ b/src/dev/tests/identity/migrated/ChannelTypingIndicator.test.tsx
@@ -49,6 +49,21 @@ vi.mock('@/hooks/business/messages/useTypingIndicator', () => ({
   useTypingIndicator: (_scope: TypingScope | null) => typists,
 }));
 
+// This test pins WIRING — that the name the identity module resolves is the one
+// this surface renders. It is not a test of QNS ownership, which lives in
+// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
+// both mutation-proven.
+//
+// The claim still travels the real path (profile -> claimedNamesIn ->
+// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
+// provider stops populating the verified map. Only the final comparison is
+// stubbed, because the address fixtures here are arbitrary and no real key
+// derives to them.
+vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
+  claimedNameBelongsTo: () => true,
+}));
+
 import { ChannelTypingIndicator } from '@/components/space/Channel';
 
 function renderWith(rosterRow?: Record<string, unknown>) {

--- a/src/dev/tests/identity/migrated/ConversationSettingsModal.test.tsx
+++ b/src/dev/tests/identity/migrated/ConversationSettingsModal.test.tsx
@@ -78,6 +78,21 @@ vi.mock('@/hooks/business/dm/useDMConversationSettings', () => ({
   }),
 }));
 
+// This test pins WIRING — that the name the identity module resolves is the one
+// this surface renders. It is not a test of QNS ownership, which lives in
+// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
+// both mutation-proven.
+//
+// The claim still travels the real path (profile -> claimedNamesIn ->
+// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
+// provider stops populating the verified map. Only the final comparison is
+// stubbed, because the address fixtures here are arbitrary and no real key
+// derives to them.
+vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
+  claimedNameBelongsTo: () => true,
+}));
+
 // react-tooltip crashes under vitest ("Invalid hook call") the same way
 // noted in UserProfile.test.tsx / DirectMessageContactsList.test.tsx —
 // stub it, keep the rest of primitives real.

--- a/src/dev/tests/identity/migrated/ConversationSettingsModal.test.tsx
+++ b/src/dev/tests/identity/migrated/ConversationSettingsModal.test.tsx
@@ -78,16 +78,12 @@ vi.mock('@/hooks/business/dm/useDMConversationSettings', () => ({
   }),
 }));
 
-// This test pins WIRING — that the name the identity module resolves is the one
-// this surface renders. It is not a test of QNS ownership, which lives in
-// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
-// both mutation-proven.
-//
-// The claim still travels the real path (profile -> claimedNamesIn ->
-// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
-// provider stops populating the verified map. Only the final comparison is
-// stubbed, because the address fixtures here are arbitrary and no real key
-// derives to them.
+// Pins WIRING, not QNS ownership. Only the final ownership comparison is
+// stubbed, because the address fixtures here are arbitrary and no real ed448
+// key derives to them. The claim still travels the whole real path, so this
+// still fails if the provider stops populating the verified map. Ownership
+// itself is pinned in `identity/verifiedQnsNames.test.ts` and shared's
+// `verifyQnsClaim.test.ts`, both mutation-proven.
 vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
   claimedNameBelongsTo: () => true,

--- a/src/dev/tests/identity/migrated/DMUserProfileSidebar.test.tsx
+++ b/src/dev/tests/identity/migrated/DMUserProfileSidebar.test.tsx
@@ -56,6 +56,21 @@ vi.mock('@/components/ui', () => ({
   ClickToCopyContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
+// This test pins WIRING — that the name the identity module resolves is the one
+// this surface renders. It is not a test of QNS ownership, which lives in
+// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
+// both mutation-proven.
+//
+// The claim still travels the real path (profile -> claimedNamesIn ->
+// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
+// provider stops populating the verified map. Only the final comparison is
+// stubbed, because the address fixtures here are arbitrary and no real key
+// derives to them.
+vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
+  claimedNameBelongsTo: () => true,
+}));
+
 import { DMUserProfileSidebar } from '@/components/direct/DMUserProfileSidebar';
 import { IdentityScopeProvider } from '@/identity/identityProvider';
 

--- a/src/dev/tests/identity/migrated/DMUserProfileSidebar.test.tsx
+++ b/src/dev/tests/identity/migrated/DMUserProfileSidebar.test.tsx
@@ -56,16 +56,12 @@ vi.mock('@/components/ui', () => ({
   ClickToCopyContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
-// This test pins WIRING — that the name the identity module resolves is the one
-// this surface renders. It is not a test of QNS ownership, which lives in
-// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
-// both mutation-proven.
-//
-// The claim still travels the real path (profile -> claimedNamesIn ->
-// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
-// provider stops populating the verified map. Only the final comparison is
-// stubbed, because the address fixtures here are arbitrary and no real key
-// derives to them.
+// Pins WIRING, not QNS ownership. Only the final ownership comparison is
+// stubbed, because the address fixtures here are arbitrary and no real ed448
+// key derives to them. The claim still travels the whole real path, so this
+// still fails if the provider stops populating the verified map. Ownership
+// itself is pinned in `identity/verifiedQnsNames.test.ts` and shared's
+// `verifyQnsClaim.test.ts`, both mutation-proven.
 vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
   claimedNameBelongsTo: () => true,

--- a/src/dev/tests/identity/migrated/DirectMessage.test.tsx
+++ b/src/dev/tests/identity/migrated/DirectMessage.test.tsx
@@ -182,16 +182,12 @@ vi.mock('@/components/message/TypingIndicator', () => ({
   ),
 }));
 
-// This test pins WIRING — that the name the identity module resolves is the one
-// this surface renders. It is not a test of QNS ownership, which lives in
-// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
-// both mutation-proven.
-//
-// The claim still travels the real path (profile -> claimedNamesIn ->
-// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
-// provider stops populating the verified map. Only the final comparison is
-// stubbed, because the address fixtures here are arbitrary and no real key
-// derives to them.
+// Pins WIRING, not QNS ownership. Only the final ownership comparison is
+// stubbed, because the address fixtures here are arbitrary and no real ed448
+// key derives to them. The claim still travels the whole real path, so this
+// still fails if the provider stops populating the verified map. Ownership
+// itself is pinned in `identity/verifiedQnsNames.test.ts` and shared's
+// `verifyQnsClaim.test.ts`, both mutation-proven.
 vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
   claimedNameBelongsTo: () => true,

--- a/src/dev/tests/identity/migrated/DirectMessage.test.tsx
+++ b/src/dev/tests/identity/migrated/DirectMessage.test.tsx
@@ -182,6 +182,21 @@ vi.mock('@/components/message/TypingIndicator', () => ({
   ),
 }));
 
+// This test pins WIRING — that the name the identity module resolves is the one
+// this surface renders. It is not a test of QNS ownership, which lives in
+// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
+// both mutation-proven.
+//
+// The claim still travels the real path (profile -> claimedNamesIn ->
+// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
+// provider stops populating the verified map. Only the final comparison is
+// stubbed, because the address fixtures here are arbitrary and no real key
+// derives to them.
+vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
+  claimedNameBelongsTo: () => true,
+}));
+
 // react-tooltip crashes under vitest ("Invalid hook call") — same as other
 // migrated tests; stub the primitive, keep the rest of the barrel real.
 vi.mock('@/components/primitives', async (importOriginal) => {

--- a/src/dev/tests/identity/migrated/DirectMessageContact.test.tsx
+++ b/src/dev/tests/identity/migrated/DirectMessageContact.test.tsx
@@ -35,6 +35,21 @@ vi.mock('@/api/baseTypes', () => ({
   isHandledFetchError: () => false,
 }));
 
+// This test pins WIRING — that the name the identity module resolves is the one
+// this surface renders. It is not a test of QNS ownership, which lives in
+// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
+// both mutation-proven.
+//
+// The claim still travels the real path (profile -> claimedNamesIn ->
+// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
+// provider stops populating the verified map. Only the final comparison is
+// stubbed, because the address fixtures here are arbitrary and no real key
+// derives to them.
+vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
+  claimedNameBelongsTo: () => true,
+}));
+
 import DirectMessageContact from '@/components/direct/DirectMessageContact';
 import { IdentityScopeProvider } from '@/identity/identityProvider';
 

--- a/src/dev/tests/identity/migrated/DirectMessageContact.test.tsx
+++ b/src/dev/tests/identity/migrated/DirectMessageContact.test.tsx
@@ -35,16 +35,12 @@ vi.mock('@/api/baseTypes', () => ({
   isHandledFetchError: () => false,
 }));
 
-// This test pins WIRING — that the name the identity module resolves is the one
-// this surface renders. It is not a test of QNS ownership, which lives in
-// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
-// both mutation-proven.
-//
-// The claim still travels the real path (profile -> claimedNamesIn ->
-// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
-// provider stops populating the verified map. Only the final comparison is
-// stubbed, because the address fixtures here are arbitrary and no real key
-// derives to them.
+// Pins WIRING, not QNS ownership. Only the final ownership comparison is
+// stubbed, because the address fixtures here are arbitrary and no real ed448
+// key derives to them. The claim still travels the whole real path, so this
+// still fails if the provider stops populating the verified map. Ownership
+// itself is pinned in `identity/verifiedQnsNames.test.ts` and shared's
+// `verifyQnsClaim.test.ts`, both mutation-proven.
 vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
   claimedNameBelongsTo: () => true,

--- a/src/dev/tests/identity/migrated/DirectMessageContactsList.test.tsx
+++ b/src/dev/tests/identity/migrated/DirectMessageContactsList.test.tsx
@@ -122,6 +122,21 @@ vi.mock('@/hooks/business/conversations/useConversationsWithProfileBackfill', ()
   useConversationsWithProfileBackfill: (conversations: unknown[]) => conversations,
 }));
 
+// This test pins WIRING — that the name the identity module resolves is the one
+// this surface renders. It is not a test of QNS ownership, which lives in
+// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
+// both mutation-proven.
+//
+// The claim still travels the real path (profile -> claimedNamesIn ->
+// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
+// provider stops populating the verified map. Only the final comparison is
+// stubbed, because the address fixtures here are arbitrary and no real key
+// derives to them.
+vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
+  claimedNameBelongsTo: () => true,
+}));
+
 // Bypasses useConversations' useSuspenseInfiniteQuery (backed by
 // messageDB.getConversations, IndexedDB machinery unrelated to this test) —
 // feed the list directly, same as the rest of this file's mocks feed the

--- a/src/dev/tests/identity/migrated/DirectMessageContactsList.test.tsx
+++ b/src/dev/tests/identity/migrated/DirectMessageContactsList.test.tsx
@@ -122,16 +122,12 @@ vi.mock('@/hooks/business/conversations/useConversationsWithProfileBackfill', ()
   useConversationsWithProfileBackfill: (conversations: unknown[]) => conversations,
 }));
 
-// This test pins WIRING — that the name the identity module resolves is the one
-// this surface renders. It is not a test of QNS ownership, which lives in
-// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
-// both mutation-proven.
-//
-// The claim still travels the real path (profile -> claimedNamesIn ->
-// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
-// provider stops populating the verified map. Only the final comparison is
-// stubbed, because the address fixtures here are arbitrary and no real key
-// derives to them.
+// Pins WIRING, not QNS ownership. Only the final ownership comparison is
+// stubbed, because the address fixtures here are arbitrary and no real ed448
+// key derives to them. The claim still travels the whole real path, so this
+// still fails if the provider stops populating the verified map. Ownership
+// itself is pinned in `identity/verifiedQnsNames.test.ts` and shared's
+// `verifyQnsClaim.test.ts`, both mutation-proven.
 vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
   claimedNameBelongsTo: () => true,

--- a/src/dev/tests/identity/migrated/InvitesConversationList.test.tsx
+++ b/src/dev/tests/identity/migrated/InvitesConversationList.test.tsx
@@ -33,6 +33,21 @@ vi.mock('@/api/baseTypes', () => ({
   isHandledFetchError: () => false,
 }));
 
+// This test pins WIRING — that the name the identity module resolves is the one
+// this surface renders. It is not a test of QNS ownership, which lives in
+// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
+// both mutation-proven.
+//
+// The claim still travels the real path (profile -> claimedNamesIn ->
+// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
+// provider stops populating the verified map. Only the final comparison is
+// stubbed, because the address fixtures here are arbitrary and no real key
+// derives to them.
+vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
+  claimedNameBelongsTo: () => true,
+}));
+
 import { ConversationList } from '@/components/modals/SpaceSettingsModal/Invites';
 import { IdentityScopeProvider, useIdentityContext } from '@/identity/identityProvider';
 

--- a/src/dev/tests/identity/migrated/InvitesConversationList.test.tsx
+++ b/src/dev/tests/identity/migrated/InvitesConversationList.test.tsx
@@ -33,16 +33,12 @@ vi.mock('@/api/baseTypes', () => ({
   isHandledFetchError: () => false,
 }));
 
-// This test pins WIRING — that the name the identity module resolves is the one
-// this surface renders. It is not a test of QNS ownership, which lives in
-// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
-// both mutation-proven.
-//
-// The claim still travels the real path (profile -> claimedNamesIn ->
-// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
-// provider stops populating the verified map. Only the final comparison is
-// stubbed, because the address fixtures here are arbitrary and no real key
-// derives to them.
+// Pins WIRING, not QNS ownership. Only the final ownership comparison is
+// stubbed, because the address fixtures here are arbitrary and no real ed448
+// key derives to them. The claim still travels the whole real path, so this
+// still fails if the provider stops populating the verified map. Ownership
+// itself is pinned in `identity/verifiedQnsNames.test.ts` and shared's
+// `verifyQnsClaim.test.ts`, both mutation-proven.
 vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
   claimedNameBelongsTo: () => true,

--- a/src/dev/tests/identity/migrated/KickUserModal.test.tsx
+++ b/src/dev/tests/identity/migrated/KickUserModal.test.tsx
@@ -47,6 +47,21 @@ vi.mock('@quilibrium/quilibrium-js-sdk-channels', () => ({
   usePasskeysContext: () => ({ currentPasskeyInfo: { address: 'QmSelf000000000000000000000000000000000000' } }),
 }));
 
+// This test pins WIRING — that the name the identity module resolves is the one
+// this surface renders. It is not a test of QNS ownership, which lives in
+// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
+// both mutation-proven.
+//
+// The claim still travels the real path (profile -> claimedNamesIn ->
+// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
+// provider stops populating the verified map. Only the final comparison is
+// stubbed, because the address fixtures here are arbitrary and no real key
+// derives to them.
+vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
+  claimedNameBelongsTo: () => true,
+}));
+
 // Bypasses the kick action's own machinery (registration/actionQueue) — this
 // test is about NAME resolution, not the kick action itself.
 vi.mock('@/hooks', async (importOriginal) => {

--- a/src/dev/tests/identity/migrated/KickUserModal.test.tsx
+++ b/src/dev/tests/identity/migrated/KickUserModal.test.tsx
@@ -47,16 +47,12 @@ vi.mock('@quilibrium/quilibrium-js-sdk-channels', () => ({
   usePasskeysContext: () => ({ currentPasskeyInfo: { address: 'QmSelf000000000000000000000000000000000000' } }),
 }));
 
-// This test pins WIRING — that the name the identity module resolves is the one
-// this surface renders. It is not a test of QNS ownership, which lives in
-// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
-// both mutation-proven.
-//
-// The claim still travels the real path (profile -> claimedNamesIn ->
-// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
-// provider stops populating the verified map. Only the final comparison is
-// stubbed, because the address fixtures here are arbitrary and no real key
-// derives to them.
+// Pins WIRING, not QNS ownership. Only the final ownership comparison is
+// stubbed, because the address fixtures here are arbitrary and no real ed448
+// key derives to them. The claim still travels the whole real path, so this
+// still fails if the provider stops populating the verified map. Ownership
+// itself is pinned in `identity/verifiedQnsNames.test.ts` and shared's
+// `verifyQnsClaim.test.ts`, both mutation-proven.
 vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
   claimedNameBelongsTo: () => true,

--- a/src/dev/tests/identity/migrated/MentionDropdown.test.tsx
+++ b/src/dev/tests/identity/migrated/MentionDropdown.test.tsx
@@ -50,6 +50,21 @@ vi.mock('@/api/baseTypes', () => ({
   isHandledFetchError: () => false,
 }));
 
+// This test pins WIRING — that the name the identity module resolves is the one
+// this surface renders. It is not a test of QNS ownership, which lives in
+// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
+// both mutation-proven.
+//
+// The claim still travels the real path (profile -> claimedNamesIn ->
+// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
+// provider stops populating the verified map. Only the final comparison is
+// stubbed, because the address fixtures here are arbitrary and no real key
+// derives to them.
+vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
+  claimedNameBelongsTo: () => true,
+}));
+
 import { MentionDropdown } from '@/components/message/MentionDropdown';
 import { useMentionInput } from '@/hooks/business/mentions/useMentionInput';
 import { IdentityScopeProvider } from '@/identity/identityProvider';

--- a/src/dev/tests/identity/migrated/MentionDropdown.test.tsx
+++ b/src/dev/tests/identity/migrated/MentionDropdown.test.tsx
@@ -50,16 +50,12 @@ vi.mock('@/api/baseTypes', () => ({
   isHandledFetchError: () => false,
 }));
 
-// This test pins WIRING — that the name the identity module resolves is the one
-// this surface renders. It is not a test of QNS ownership, which lives in
-// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
-// both mutation-proven.
-//
-// The claim still travels the real path (profile -> claimedNamesIn ->
-// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
-// provider stops populating the verified map. Only the final comparison is
-// stubbed, because the address fixtures here are arbitrary and no real key
-// derives to them.
+// Pins WIRING, not QNS ownership. Only the final ownership comparison is
+// stubbed, because the address fixtures here are arbitrary and no real ed448
+// key derives to them. The claim still travels the whole real path, so this
+// still fails if the provider stops populating the verified map. Ownership
+// itself is pinned in `identity/verifiedQnsNames.test.ts` and shared's
+// `verifyQnsClaim.test.ts`, both mutation-proven.
 vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
   claimedNameBelongsTo: () => true,

--- a/src/dev/tests/identity/migrated/Message.test.tsx
+++ b/src/dev/tests/identity/migrated/Message.test.tsx
@@ -146,16 +146,12 @@ vi.mock('@/hooks/business/messages/useReadReceipt', () => ({
   useReadReceipt: () => ({ current: null }),
 }));
 
-// This test pins WIRING — that the name the identity module resolves is the one
-// this surface renders. It is not a test of QNS ownership, which lives in
-// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
-// both mutation-proven.
-//
-// The claim still travels the real path (profile -> claimedNamesIn ->
-// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
-// provider stops populating the verified map. Only the final comparison is
-// stubbed, because the address fixtures here are arbitrary and no real key
-// derives to them.
+// Pins WIRING, not QNS ownership. Only the final ownership comparison is
+// stubbed, because the address fixtures here are arbitrary and no real ed448
+// key derives to them. The claim still travels the whole real path, so this
+// still fails if the provider stops populating the verified map. Ownership
+// itself is pinned in `identity/verifiedQnsNames.test.ts` and shared's
+// `verifyQnsClaim.test.ts`, both mutation-proven.
 vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
   claimedNameBelongsTo: () => true,

--- a/src/dev/tests/identity/migrated/Message.test.tsx
+++ b/src/dev/tests/identity/migrated/Message.test.tsx
@@ -146,6 +146,21 @@ vi.mock('@/hooks/business/messages/useReadReceipt', () => ({
   useReadReceipt: () => ({ current: null }),
 }));
 
+// This test pins WIRING — that the name the identity module resolves is the one
+// this surface renders. It is not a test of QNS ownership, which lives in
+// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
+// both mutation-proven.
+//
+// The claim still travels the real path (profile -> claimedNamesIn ->
+// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
+// provider stops populating the verified map. Only the final comparison is
+// stubbed, because the address fixtures here are arbitrary and no real key
+// derives to them.
+vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
+  claimedNameBelongsTo: () => true,
+}));
+
 import { Message } from '@/components/message/Message';
 import { IdentityScopeProvider } from '@/identity/identityProvider';
 

--- a/src/dev/tests/identity/migrated/MessageComposer.test.tsx
+++ b/src/dev/tests/identity/migrated/MessageComposer.test.tsx
@@ -115,16 +115,12 @@ vi.mock('@/components/message/MentionDropdown', () => ({
   },
 }));
 
-// This test pins WIRING — that the name the identity module resolves is the one
-// this surface renders. It is not a test of QNS ownership, which lives in
-// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
-// both mutation-proven.
-//
-// The claim still travels the real path (profile -> claimedNamesIn ->
-// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
-// provider stops populating the verified map. Only the final comparison is
-// stubbed, because the address fixtures here are arbitrary and no real key
-// derives to them.
+// Pins WIRING, not QNS ownership. Only the final ownership comparison is
+// stubbed, because the address fixtures here are arbitrary and no real ed448
+// key derives to them. The claim still travels the whole real path, so this
+// still fails if the provider stops populating the verified map. Ownership
+// itself is pinned in `identity/verifiedQnsNames.test.ts` and shared's
+// `verifyQnsClaim.test.ts`, both mutation-proven.
 vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
   claimedNameBelongsTo: () => true,

--- a/src/dev/tests/identity/migrated/MessageComposer.test.tsx
+++ b/src/dev/tests/identity/migrated/MessageComposer.test.tsx
@@ -115,6 +115,21 @@ vi.mock('@/components/message/MentionDropdown', () => ({
   },
 }));
 
+// This test pins WIRING — that the name the identity module resolves is the one
+// this surface renders. It is not a test of QNS ownership, which lives in
+// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
+// both mutation-proven.
+//
+// The claim still travels the real path (profile -> claimedNamesIn ->
+// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
+// provider stops populating the verified map. Only the final comparison is
+// stubbed, because the address fixtures here are arbitrary and no real key
+// derives to them.
+vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
+  claimedNameBelongsTo: () => true,
+}));
+
 import { MessageComposer } from '@/components/message/MessageComposer';
 import { IdentityScopeProvider, useIdentityContext } from '@/identity/identityProvider';
 import { publicProfileQueryKey } from '@/hooks/business/user/useUserPublicProfile';

--- a/src/dev/tests/identity/migrated/MessageEditTextarea.test.tsx
+++ b/src/dev/tests/identity/migrated/MessageEditTextarea.test.tsx
@@ -57,16 +57,12 @@ vi.mock('@/components/context/useMessageDB', () => ({
   }),
 }));
 
-// This test pins WIRING — that the name the identity module resolves is the one
-// this surface renders. It is not a test of QNS ownership, which lives in
-// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
-// both mutation-proven.
-//
-// The claim still travels the real path (profile -> claimedNamesIn ->
-// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
-// provider stops populating the verified map. Only the final comparison is
-// stubbed, because the address fixtures here are arbitrary and no real key
-// derives to them.
+// Pins WIRING, not QNS ownership. Only the final ownership comparison is
+// stubbed, because the address fixtures here are arbitrary and no real ed448
+// key derives to them. The claim still travels the whole real path, so this
+// still fails if the provider stops populating the verified map. Ownership
+// itself is pinned in `identity/verifiedQnsNames.test.ts` and shared's
+// `verifyQnsClaim.test.ts`, both mutation-proven.
 vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
   claimedNameBelongsTo: () => true,

--- a/src/dev/tests/identity/migrated/MessageEditTextarea.test.tsx
+++ b/src/dev/tests/identity/migrated/MessageEditTextarea.test.tsx
@@ -57,6 +57,21 @@ vi.mock('@/components/context/useMessageDB', () => ({
   }),
 }));
 
+// This test pins WIRING — that the name the identity module resolves is the one
+// this surface renders. It is not a test of QNS ownership, which lives in
+// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
+// both mutation-proven.
+//
+// The claim still travels the real path (profile -> claimedNamesIn ->
+// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
+// provider stops populating the verified map. Only the final comparison is
+// stubbed, because the address fixtures here are arbitrary and no real key
+// derives to them.
+vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
+  claimedNameBelongsTo: () => true,
+}));
+
 // Toolbar/dropdown chrome — irrelevant to pill name resolution.
 vi.mock('@/components/message/MarkdownToolbar', () => ({ MarkdownToolbar: () => null }));
 vi.mock('@/components/message/MentionDropdown', () => ({ MentionDropdown: () => null }));

--- a/src/dev/tests/identity/migrated/MessageMarkdownRenderer.test.tsx
+++ b/src/dev/tests/identity/migrated/MessageMarkdownRenderer.test.tsx
@@ -41,16 +41,12 @@ vi.mock('@/api/baseTypes', () => ({
   isHandledFetchError: () => false,
 }));
 
-// This test pins WIRING — that the name the identity module resolves is the one
-// this surface renders. It is not a test of QNS ownership, which lives in
-// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
-// both mutation-proven.
-//
-// The claim still travels the real path (profile -> claimedNamesIn ->
-// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
-// provider stops populating the verified map. Only the final comparison is
-// stubbed, because the address fixtures here are arbitrary and no real key
-// derives to them.
+// Pins WIRING, not QNS ownership. Only the final ownership comparison is
+// stubbed, because the address fixtures here are arbitrary and no real ed448
+// key derives to them. The claim still travels the whole real path, so this
+// still fails if the provider stops populating the verified map. Ownership
+// itself is pinned in `identity/verifiedQnsNames.test.ts` and shared's
+// `verifyQnsClaim.test.ts`, both mutation-proven.
 vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
   claimedNameBelongsTo: () => true,

--- a/src/dev/tests/identity/migrated/MessageMarkdownRenderer.test.tsx
+++ b/src/dev/tests/identity/migrated/MessageMarkdownRenderer.test.tsx
@@ -41,6 +41,21 @@ vi.mock('@/api/baseTypes', () => ({
   isHandledFetchError: () => false,
 }));
 
+// This test pins WIRING — that the name the identity module resolves is the one
+// this surface renders. It is not a test of QNS ownership, which lives in
+// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
+// both mutation-proven.
+//
+// The claim still travels the real path (profile -> claimedNamesIn ->
+// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
+// provider stops populating the verified map. Only the final comparison is
+// stubbed, because the address fixtures here are arbitrary and no real key
+// derives to them.
+vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
+  claimedNameBelongsTo: () => true,
+}));
+
 import { MessageMarkdownRenderer } from '@/components/message/MessageMarkdownRenderer';
 import { IdentityScopeProvider, MemberName } from '@/identity';
 

--- a/src/dev/tests/identity/migrated/MessagePreview.test.tsx
+++ b/src/dev/tests/identity/migrated/MessagePreview.test.tsx
@@ -39,6 +39,21 @@ vi.mock('@/api/baseTypes', () => ({
   isHandledFetchError: () => false,
 }));
 
+// This test pins WIRING — that the name the identity module resolves is the one
+// this surface renders. It is not a test of QNS ownership, which lives in
+// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
+// both mutation-proven.
+//
+// The claim still travels the real path (profile -> claimedNamesIn ->
+// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
+// provider stops populating the verified map. Only the final comparison is
+// stubbed, because the address fixtures here are arbitrary and no real key
+// derives to them.
+vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
+  claimedNameBelongsTo: () => true,
+}));
+
 import { MessagePreview } from '@/components/message/MessagePreview';
 import { IdentityScopeProvider, MemberName } from '@/identity';
 import { buildSpaceMembersKey } from '@/hooks/queries/spaceMembers/buildSpaceMembersKey';

--- a/src/dev/tests/identity/migrated/MessagePreview.test.tsx
+++ b/src/dev/tests/identity/migrated/MessagePreview.test.tsx
@@ -39,16 +39,12 @@ vi.mock('@/api/baseTypes', () => ({
   isHandledFetchError: () => false,
 }));
 
-// This test pins WIRING — that the name the identity module resolves is the one
-// this surface renders. It is not a test of QNS ownership, which lives in
-// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
-// both mutation-proven.
-//
-// The claim still travels the real path (profile -> claimedNamesIn ->
-// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
-// provider stops populating the verified map. Only the final comparison is
-// stubbed, because the address fixtures here are arbitrary and no real key
-// derives to them.
+// Pins WIRING, not QNS ownership. Only the final ownership comparison is
+// stubbed, because the address fixtures here are arbitrary and no real ed448
+// key derives to them. The claim still travels the whole real path, so this
+// still fails if the provider stops populating the verified map. Ownership
+// itself is pinned in `identity/verifiedQnsNames.test.ts` and shared's
+// `verifyQnsClaim.test.ts`, both mutation-proven.
 vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
   claimedNameBelongsTo: () => true,

--- a/src/dev/tests/identity/migrated/MuteUserModal.test.tsx
+++ b/src/dev/tests/identity/migrated/MuteUserModal.test.tsx
@@ -40,16 +40,12 @@ vi.mock('@quilibrium/quilibrium-js-sdk-channels', () => ({
   usePasskeysContext: () => ({ currentPasskeyInfo: { address: 'QmSelf000000000000000000000000000000000000' } }),
 }));
 
-// This test pins WIRING — that the name the identity module resolves is the one
-// this surface renders. It is not a test of QNS ownership, which lives in
-// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
-// both mutation-proven.
-//
-// The claim still travels the real path (profile -> claimedNamesIn ->
-// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
-// provider stops populating the verified map. Only the final comparison is
-// stubbed, because the address fixtures here are arbitrary and no real key
-// derives to them.
+// Pins WIRING, not QNS ownership. Only the final ownership comparison is
+// stubbed, because the address fixtures here are arbitrary and no real ed448
+// key derives to them. The claim still travels the whole real path, so this
+// still fails if the provider stops populating the verified map. Ownership
+// itself is pinned in `identity/verifiedQnsNames.test.ts` and shared's
+// `verifyQnsClaim.test.ts`, both mutation-proven.
 vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
   claimedNameBelongsTo: () => true,

--- a/src/dev/tests/identity/migrated/MuteUserModal.test.tsx
+++ b/src/dev/tests/identity/migrated/MuteUserModal.test.tsx
@@ -40,6 +40,21 @@ vi.mock('@quilibrium/quilibrium-js-sdk-channels', () => ({
   usePasskeysContext: () => ({ currentPasskeyInfo: { address: 'QmSelf000000000000000000000000000000000000' } }),
 }));
 
+// This test pins WIRING — that the name the identity module resolves is the one
+// this surface renders. It is not a test of QNS ownership, which lives in
+// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
+// both mutation-proven.
+//
+// The claim still travels the real path (profile -> claimedNamesIn ->
+// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
+// provider stops populating the verified map. Only the final comparison is
+// stubbed, because the address fixtures here are arbitrary and no real key
+// derives to them.
+vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
+  claimedNameBelongsTo: () => true,
+}));
+
 import MuteUserModal from '@/components/modals/MuteUserModal';
 import { IdentityScopeProvider, type RosterNameRow } from '@/identity';
 

--- a/src/dev/tests/identity/migrated/NavRail.test.tsx
+++ b/src/dev/tests/identity/migrated/NavRail.test.tsx
@@ -49,16 +49,12 @@ vi.mock('@/components/context/ModalProvider', () => ({
   useModalContext: () => ({ openUserSettings: vi.fn(), openNotifications: vi.fn() }),
 }));
 
-// This test pins WIRING — that the name the identity module resolves is the one
-// this surface renders. It is not a test of QNS ownership, which lives in
-// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
-// both mutation-proven.
-//
-// The claim still travels the real path (profile -> claimedNamesIn ->
-// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
-// provider stops populating the verified map. Only the final comparison is
-// stubbed, because the address fixtures here are arbitrary and no real key
-// derives to them.
+// Pins WIRING, not QNS ownership. Only the final ownership comparison is
+// stubbed, because the address fixtures here are arbitrary and no real ed448
+// key derives to them. The claim still travels the whole real path, so this
+// still fails if the provider stops populating the verified map. Ownership
+// itself is pinned in `identity/verifiedQnsNames.test.ts` and shared's
+// `verifyQnsClaim.test.ts`, both mutation-proven.
 vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
   claimedNameBelongsTo: () => true,

--- a/src/dev/tests/identity/migrated/NavRail.test.tsx
+++ b/src/dev/tests/identity/migrated/NavRail.test.tsx
@@ -49,6 +49,21 @@ vi.mock('@/components/context/ModalProvider', () => ({
   useModalContext: () => ({ openUserSettings: vi.fn(), openNotifications: vi.fn() }),
 }));
 
+// This test pins WIRING — that the name the identity module resolves is the one
+// this surface renders. It is not a test of QNS ownership, which lives in
+// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
+// both mutation-proven.
+//
+// The claim still travels the real path (profile -> claimedNamesIn ->
+// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
+// provider stops populating the verified map. Only the final comparison is
+// stubbed, because the address fixtures here are arbitrary and no real key
+// derives to them.
+vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
+  claimedNameBelongsTo: () => true,
+}));
+
 vi.mock('@/hooks/queries/spaces', () => ({ useSpaces: () => ({ data: [] }) }));
 vi.mock('@/hooks/business/mentions', () => ({ useSpaceMentionCounts: () => ({}) }));
 vi.mock('@/hooks/business/replies', () => ({ useSpaceReplyCounts: () => ({}) }));

--- a/src/dev/tests/identity/migrated/NotificationItemMention.test.tsx
+++ b/src/dev/tests/identity/migrated/NotificationItemMention.test.tsx
@@ -46,6 +46,21 @@ vi.mock('@/api/baseTypes', () => ({
   isHandledFetchError: () => false,
 }));
 
+// This test pins WIRING — that the name the identity module resolves is the one
+// this surface renders. It is not a test of QNS ownership, which lives in
+// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
+// both mutation-proven.
+//
+// The claim still travels the real path (profile -> claimedNamesIn ->
+// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
+// provider stops populating the verified map. Only the final comparison is
+// stubbed, because the address fixtures here are arbitrary and no real key
+// derives to them.
+vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
+  claimedNameBelongsTo: () => true,
+}));
+
 import { NotificationItem } from '@/components/notifications/NotificationItem';
 import { IdentityScopeProvider } from '@/identity/identityProvider';
 import type { MentionNotification } from '@/hooks/business/mentions';

--- a/src/dev/tests/identity/migrated/NotificationItemMention.test.tsx
+++ b/src/dev/tests/identity/migrated/NotificationItemMention.test.tsx
@@ -46,16 +46,12 @@ vi.mock('@/api/baseTypes', () => ({
   isHandledFetchError: () => false,
 }));
 
-// This test pins WIRING — that the name the identity module resolves is the one
-// this surface renders. It is not a test of QNS ownership, which lives in
-// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
-// both mutation-proven.
-//
-// The claim still travels the real path (profile -> claimedNamesIn ->
-// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
-// provider stops populating the verified map. Only the final comparison is
-// stubbed, because the address fixtures here are arbitrary and no real key
-// derives to them.
+// Pins WIRING, not QNS ownership. Only the final ownership comparison is
+// stubbed, because the address fixtures here are arbitrary and no real ed448
+// key derives to them. The claim still travels the whole real path, so this
+// still fails if the provider stops populating the verified map. Ownership
+// itself is pinned in `identity/verifiedQnsNames.test.ts` and shared's
+// `verifyQnsClaim.test.ts`, both mutation-proven.
 vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
   claimedNameBelongsTo: () => true,

--- a/src/dev/tests/identity/migrated/NotificationPanel.test.tsx
+++ b/src/dev/tests/identity/migrated/NotificationPanel.test.tsx
@@ -105,16 +105,12 @@ vi.mock('@/components/modals/ConfirmationModal', () => ({
   default: () => null,
 }));
 
-// This test pins WIRING — that the name the identity module resolves is the one
-// this surface renders. It is not a test of QNS ownership, which lives in
-// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
-// both mutation-proven.
-//
-// The claim still travels the real path (profile -> claimedNamesIn ->
-// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
-// provider stops populating the verified map. Only the final comparison is
-// stubbed, because the address fixtures here are arbitrary and no real key
-// derives to them.
+// Pins WIRING, not QNS ownership. Only the final ownership comparison is
+// stubbed, because the address fixtures here are arbitrary and no real ed448
+// key derives to them. The claim still travels the whole real path, so this
+// still fails if the provider stops populating the verified map. Ownership
+// itself is pinned in `identity/verifiedQnsNames.test.ts` and shared's
+// `verifyQnsClaim.test.ts`, both mutation-proven.
 vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
   claimedNameBelongsTo: () => true,

--- a/src/dev/tests/identity/migrated/NotificationPanel.test.tsx
+++ b/src/dev/tests/identity/migrated/NotificationPanel.test.tsx
@@ -105,6 +105,21 @@ vi.mock('@/components/modals/ConfirmationModal', () => ({
   default: () => null,
 }));
 
+// This test pins WIRING — that the name the identity module resolves is the one
+// this surface renders. It is not a test of QNS ownership, which lives in
+// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
+// both mutation-proven.
+//
+// The claim still travels the real path (profile -> claimedNamesIn ->
+// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
+// provider stops populating the verified map. Only the final comparison is
+// stubbed, because the address fixtures here are arbitrary and no real key
+// derives to them.
+vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
+  claimedNameBelongsTo: () => true,
+}));
+
 import { NotificationPanel } from '@/components/notifications/NotificationPanel';
 import { IdentityScopeProvider } from '@/identity/identityProvider';
 

--- a/src/dev/tests/identity/migrated/PinnedMessagesPanel.test.tsx
+++ b/src/dev/tests/identity/migrated/PinnedMessagesPanel.test.tsx
@@ -95,6 +95,21 @@ vi.mock('@/components/message/MessagePreview', () => ({
   MessagePreview: () => null,
 }));
 
+// This test pins WIRING — that the name the identity module resolves is the one
+// this surface renders. It is not a test of QNS ownership, which lives in
+// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
+// both mutation-proven.
+//
+// The claim still travels the real path (profile -> claimedNamesIn ->
+// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
+// provider stops populating the verified map. Only the final comparison is
+// stubbed, because the address fixtures here are arbitrary and no real key
+// derives to them.
+vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
+  claimedNameBelongsTo: () => true,
+}));
+
 import { PinnedMessagesPanel } from '@/components/message/PinnedMessagesPanel';
 import { IdentityScopeProvider } from '@/identity/identityProvider';
 

--- a/src/dev/tests/identity/migrated/PinnedMessagesPanel.test.tsx
+++ b/src/dev/tests/identity/migrated/PinnedMessagesPanel.test.tsx
@@ -95,16 +95,12 @@ vi.mock('@/components/message/MessagePreview', () => ({
   MessagePreview: () => null,
 }));
 
-// This test pins WIRING — that the name the identity module resolves is the one
-// this surface renders. It is not a test of QNS ownership, which lives in
-// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
-// both mutation-proven.
-//
-// The claim still travels the real path (profile -> claimedNamesIn ->
-// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
-// provider stops populating the verified map. Only the final comparison is
-// stubbed, because the address fixtures here are arbitrary and no real key
-// derives to them.
+// Pins WIRING, not QNS ownership. Only the final ownership comparison is
+// stubbed, because the address fixtures here are arbitrary and no real ed448
+// key derives to them. The claim still travels the whole real path, so this
+// still fails if the provider stops populating the verified map. Ownership
+// itself is pinned in `identity/verifiedQnsNames.test.ts` and shared's
+// `verifyQnsClaim.test.ts`, both mutation-proven.
 vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
   claimedNameBelongsTo: () => true,

--- a/src/dev/tests/identity/migrated/PinnedMessagesPanelBodyMentions.test.tsx
+++ b/src/dev/tests/identity/migrated/PinnedMessagesPanelBodyMentions.test.tsx
@@ -106,6 +106,21 @@ vi.mock('react-virtuoso', () => ({
   },
 }));
 
+// This test pins WIRING — that the name the identity module resolves is the one
+// this surface renders. It is not a test of QNS ownership, which lives in
+// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
+// both mutation-proven.
+//
+// The claim still travels the real path (profile -> claimedNamesIn ->
+// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
+// provider stops populating the verified map. Only the final comparison is
+// stubbed, because the address fixtures here are arbitrary and no real key
+// derives to them.
+vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
+  claimedNameBelongsTo: () => true,
+}));
+
 import { PinnedMessagesPanel } from '@/components/message/PinnedMessagesPanel';
 import { MessagePreview } from '@/components/message/MessagePreview';
 import { IdentityScopeProvider } from '@/identity/identityProvider';

--- a/src/dev/tests/identity/migrated/PinnedMessagesPanelBodyMentions.test.tsx
+++ b/src/dev/tests/identity/migrated/PinnedMessagesPanelBodyMentions.test.tsx
@@ -106,16 +106,12 @@ vi.mock('react-virtuoso', () => ({
   },
 }));
 
-// This test pins WIRING — that the name the identity module resolves is the one
-// this surface renders. It is not a test of QNS ownership, which lives in
-// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
-// both mutation-proven.
-//
-// The claim still travels the real path (profile -> claimedNamesIn ->
-// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
-// provider stops populating the verified map. Only the final comparison is
-// stubbed, because the address fixtures here are arbitrary and no real key
-// derives to them.
+// Pins WIRING, not QNS ownership. Only the final ownership comparison is
+// stubbed, because the address fixtures here are arbitrary and no real ed448
+// key derives to them. The claim still travels the whole real path, so this
+// still fails if the provider stops populating the verified map. Ownership
+// itself is pinned in `identity/verifiedQnsNames.test.ts` and shared's
+// `verifyQnsClaim.test.ts`, both mutation-proven.
 vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
   claimedNameBelongsTo: () => true,

--- a/src/dev/tests/identity/migrated/ReactionsList.test.tsx
+++ b/src/dev/tests/identity/migrated/ReactionsList.test.tsx
@@ -48,6 +48,21 @@ vi.mock('@/components/context/ReactionsModalProvider', () => ({
   useReactionsModal: () => ({ showReactionsModal: vi.fn() }),
 }));
 
+// This test pins WIRING — that the name the identity module resolves is the one
+// this surface renders. It is not a test of QNS ownership, which lives in
+// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
+// both mutation-proven.
+//
+// The claim still travels the real path (profile -> claimedNamesIn ->
+// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
+// provider stops populating the verified map. Only the final comparison is
+// stubbed, because the address fixtures here are arbitrary and no real key
+// derives to them.
+vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
+  claimedNameBelongsTo: () => true,
+}));
+
 // The real Tooltip defers its content to a hover/floating-ui portal that
 // doesn't render in jsdom without simulated interaction — dump `content`
 // into a plain, always-present element instead so the resolved names can be

--- a/src/dev/tests/identity/migrated/ReactionsList.test.tsx
+++ b/src/dev/tests/identity/migrated/ReactionsList.test.tsx
@@ -48,16 +48,12 @@ vi.mock('@/components/context/ReactionsModalProvider', () => ({
   useReactionsModal: () => ({ showReactionsModal: vi.fn() }),
 }));
 
-// This test pins WIRING — that the name the identity module resolves is the one
-// this surface renders. It is not a test of QNS ownership, which lives in
-// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
-// both mutation-proven.
-//
-// The claim still travels the real path (profile -> claimedNamesIn ->
-// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
-// provider stops populating the verified map. Only the final comparison is
-// stubbed, because the address fixtures here are arbitrary and no real key
-// derives to them.
+// Pins WIRING, not QNS ownership. Only the final ownership comparison is
+// stubbed, because the address fixtures here are arbitrary and no real ed448
+// key derives to them. The claim still travels the whole real path, so this
+// still fails if the provider stops populating the verified map. Ownership
+// itself is pinned in `identity/verifiedQnsNames.test.ts` and shared's
+// `verifyQnsClaim.test.ts`, both mutation-proven.
 vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
   claimedNameBelongsTo: () => true,

--- a/src/dev/tests/identity/migrated/ThreadPanel.test.tsx
+++ b/src/dev/tests/identity/migrated/ThreadPanel.test.tsx
@@ -117,16 +117,12 @@ vi.mock('@/components/context/ThreadContext', () => ({
   }),
 }));
 
-// This test pins WIRING — that the name the identity module resolves is the one
-// this surface renders. It is not a test of QNS ownership, which lives in
-// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
-// both mutation-proven.
-//
-// The claim still travels the real path (profile -> claimedNamesIn ->
-// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
-// provider stops populating the verified map. Only the final comparison is
-// stubbed, because the address fixtures here are arbitrary and no real key
-// derives to them.
+// Pins WIRING, not QNS ownership. Only the final ownership comparison is
+// stubbed, because the address fixtures here are arbitrary and no real ed448
+// key derives to them. The claim still travels the whole real path, so this
+// still fails if the provider stops populating the verified map. Ownership
+// itself is pinned in `identity/verifiedQnsNames.test.ts` and shared's
+// `verifyQnsClaim.test.ts`, both mutation-proven.
 vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
   claimedNameBelongsTo: () => true,

--- a/src/dev/tests/identity/migrated/ThreadPanel.test.tsx
+++ b/src/dev/tests/identity/migrated/ThreadPanel.test.tsx
@@ -117,6 +117,21 @@ vi.mock('@/components/context/ThreadContext', () => ({
   }),
 }));
 
+// This test pins WIRING — that the name the identity module resolves is the one
+// this surface renders. It is not a test of QNS ownership, which lives in
+// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
+// both mutation-proven.
+//
+// The claim still travels the real path (profile -> claimedNamesIn ->
+// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
+// provider stops populating the verified map. Only the final comparison is
+// stubbed, because the address fixtures here are arbitrary and no real key
+// derives to them.
+vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
+  claimedNameBelongsTo: () => true,
+}));
+
 function makeFixture(rosterRow: Record<string, unknown>) {
   return {
     isOpen: true,

--- a/src/dev/tests/identity/migrated/ThreadsListPanel.test.tsx
+++ b/src/dev/tests/identity/migrated/ThreadsListPanel.test.tsx
@@ -79,6 +79,21 @@ vi.mock('@/utils/platform', () => ({
   isTouchDevice: () => false,
 }));
 
+// This test pins WIRING — that the name the identity module resolves is the one
+// this surface renders. It is not a test of QNS ownership, which lives in
+// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
+// both mutation-proven.
+//
+// The claim still travels the real path (profile -> claimedNamesIn ->
+// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
+// provider stops populating the verified map. Only the final comparison is
+// stubbed, because the address fixtures here are arbitrary and no real key
+// derives to them.
+vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
+  claimedNameBelongsTo: () => true,
+}));
+
 // Deliberately WRONG name — see file header. This is the panel's OLD data
 // source; if it still gets read, this is what renders instead of the
 // identity module's resolved name.

--- a/src/dev/tests/identity/migrated/ThreadsListPanel.test.tsx
+++ b/src/dev/tests/identity/migrated/ThreadsListPanel.test.tsx
@@ -79,16 +79,12 @@ vi.mock('@/utils/platform', () => ({
   isTouchDevice: () => false,
 }));
 
-// This test pins WIRING — that the name the identity module resolves is the one
-// this surface renders. It is not a test of QNS ownership, which lives in
-// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
-// both mutation-proven.
-//
-// The claim still travels the real path (profile -> claimedNamesIn ->
-// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
-// provider stops populating the verified map. Only the final comparison is
-// stubbed, because the address fixtures here are arbitrary and no real key
-// derives to them.
+// Pins WIRING, not QNS ownership. Only the final ownership comparison is
+// stubbed, because the address fixtures here are arbitrary and no real ed448
+// key derives to them. The claim still travels the whole real path, so this
+// still fails if the provider stops populating the verified map. Ownership
+// itself is pinned in `identity/verifiedQnsNames.test.ts` and shared's
+// `verifyQnsClaim.test.ts`, both mutation-proven.
 vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
   claimedNameBelongsTo: () => true,

--- a/src/dev/tests/identity/migrated/UserProfile.test.tsx
+++ b/src/dev/tests/identity/migrated/UserProfile.test.tsx
@@ -91,6 +91,21 @@ vi.mock('@/hooks/business/user/useBlockUser', () => ({
   useBlockUser: () => ({ isBlocked: () => false, blockUser: vi.fn(), unblockUser: vi.fn() }),
 }));
 
+// This test pins WIRING — that the name the identity module resolves is the one
+// this surface renders. It is not a test of QNS ownership, which lives in
+// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
+// both mutation-proven.
+//
+// The claim still travels the real path (profile -> claimedNamesIn ->
+// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
+// provider stops populating the verified map. Only the final comparison is
+// stubbed, because the address fixtures here are arbitrary and no real key
+// derives to them.
+vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
+  claimedNameBelongsTo: () => true,
+}));
+
 // Barrel — UserProfile imports three hooks from it directly, but the barrel
 // is also used transitively (e.g. ClickToCopyContent's useCopyToClipboard),
 // so keep everything else real and override only what this file needs to

--- a/src/dev/tests/identity/migrated/UserProfile.test.tsx
+++ b/src/dev/tests/identity/migrated/UserProfile.test.tsx
@@ -91,16 +91,12 @@ vi.mock('@/hooks/business/user/useBlockUser', () => ({
   useBlockUser: () => ({ isBlocked: () => false, blockUser: vi.fn(), unblockUser: vi.fn() }),
 }));
 
-// This test pins WIRING — that the name the identity module resolves is the one
-// this surface renders. It is not a test of QNS ownership, which lives in
-// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
-// both mutation-proven.
-//
-// The claim still travels the real path (profile -> claimedNamesIn ->
-// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
-// provider stops populating the verified map. Only the final comparison is
-// stubbed, because the address fixtures here are arbitrary and no real key
-// derives to them.
+// Pins WIRING, not QNS ownership. Only the final ownership comparison is
+// stubbed, because the address fixtures here are arbitrary and no real ed448
+// key derives to them. The claim still travels the whole real path, so this
+// still fails if the provider stops populating the verified map. Ownership
+// itself is pinned in `identity/verifiedQnsNames.test.ts` and shared's
+// `verifyQnsClaim.test.ts`, both mutation-proven.
 vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
   claimedNameBelongsTo: () => true,

--- a/src/dev/tests/identity/migrated/typingIndicatorParity.test.tsx
+++ b/src/dev/tests/identity/migrated/typingIndicatorParity.test.tsx
@@ -49,16 +49,12 @@ vi.mock('@/hooks/business/messages/useTypingIndicator', () => ({
   useTypingIndicator: (_scope: TypingScope | null) => typists,
 }));
 
-// This test pins WIRING — that the name the identity module resolves is the one
-// this surface renders. It is not a test of QNS ownership, which lives in
-// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
-// both mutation-proven.
-//
-// The claim still travels the real path (profile -> claimedNamesIn ->
-// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
-// provider stops populating the verified map. Only the final comparison is
-// stubbed, because the address fixtures here are arbitrary and no real key
-// derives to them.
+// Pins WIRING, not QNS ownership. Only the final ownership comparison is
+// stubbed, because the address fixtures here are arbitrary and no real ed448
+// key derives to them. The claim still travels the whole real path, so this
+// still fails if the provider stops populating the verified map. Ownership
+// itself is pinned in `identity/verifiedQnsNames.test.ts` and shared's
+// `verifyQnsClaim.test.ts`, both mutation-proven.
 vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
   claimedNameBelongsTo: () => true,

--- a/src/dev/tests/identity/migrated/typingIndicatorParity.test.tsx
+++ b/src/dev/tests/identity/migrated/typingIndicatorParity.test.tsx
@@ -49,6 +49,21 @@ vi.mock('@/hooks/business/messages/useTypingIndicator', () => ({
   useTypingIndicator: (_scope: TypingScope | null) => typists,
 }));
 
+// This test pins WIRING — that the name the identity module resolves is the one
+// this surface renders. It is not a test of QNS ownership, which lives in
+// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
+// both mutation-proven.
+//
+// The claim still travels the real path (profile -> claimedNamesIn ->
+// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
+// provider stops populating the verified map. Only the final comparison is
+// stubbed, because the address fixtures here are arbitrary and no real key
+// derives to them.
+vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
+  claimedNameBelongsTo: () => true,
+}));
+
 import { ChannelTypingIndicator } from '@/components/space/Channel';
 import { ThreadTypingIndicator } from '@/components/thread/ThreadPanel';
 

--- a/src/dev/tests/identity/migrated/useBatchSearchResultsDisplay.test.tsx
+++ b/src/dev/tests/identity/migrated/useBatchSearchResultsDisplay.test.tsx
@@ -52,16 +52,12 @@ vi.mock('@/components/context/useMessageDB', () => ({
   }),
 }));
 
-// This test pins WIRING — that the name the identity module resolves is the one
-// this surface renders. It is not a test of QNS ownership, which lives in
-// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
-// both mutation-proven.
-//
-// The claim still travels the real path (profile -> claimedNamesIn ->
-// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
-// provider stops populating the verified map. Only the final comparison is
-// stubbed, because the address fixtures here are arbitrary and no real key
-// derives to them.
+// Pins WIRING, not QNS ownership. Only the final ownership comparison is
+// stubbed, because the address fixtures here are arbitrary and no real ed448
+// key derives to them. The claim still travels the whole real path, so this
+// still fails if the provider stops populating the verified map. Ownership
+// itself is pinned in `identity/verifiedQnsNames.test.ts` and shared's
+// `verifyQnsClaim.test.ts`, both mutation-proven.
 vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
   claimedNameBelongsTo: () => true,

--- a/src/dev/tests/identity/migrated/useBatchSearchResultsDisplay.test.tsx
+++ b/src/dev/tests/identity/migrated/useBatchSearchResultsDisplay.test.tsx
@@ -52,6 +52,21 @@ vi.mock('@/components/context/useMessageDB', () => ({
   }),
 }));
 
+// This test pins WIRING — that the name the identity module resolves is the one
+// this surface renders. It is not a test of QNS ownership, which lives in
+// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
+// both mutation-proven.
+//
+// The claim still travels the real path (profile -> claimedNamesIn ->
+// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
+// provider stops populating the verified map. Only the final comparison is
+// stubbed, because the address fixtures here are arbitrary and no real key
+// derives to them.
+vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
+  claimedNameBelongsTo: () => true,
+}));
+
 import { useBatchSearchResultsDisplay } from '@/hooks/business/search/useBatchSearchResultsDisplay';
 import { IdentityScopeProvider, type RosterNameRow } from '@/identity';
 import type { SearchResult } from '@/db/messages';

--- a/src/dev/tests/identity/migrated/useInviteManagement.test.tsx
+++ b/src/dev/tests/identity/migrated/useInviteManagement.test.tsx
@@ -98,6 +98,21 @@ vi.mock('react-router', () => ({
   useNavigate: () => vi.fn(),
 }));
 
+// This test pins WIRING — that the name the identity module resolves is the one
+// this surface renders. It is not a test of QNS ownership, which lives in
+// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
+// both mutation-proven.
+//
+// The claim still travels the real path (profile -> claimedNamesIn ->
+// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
+// provider stops populating the verified map. Only the final comparison is
+// stubbed, because the address fixtures here are arbitrary and no real key
+// derives to them.
+vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
+  claimedNameBelongsTo: () => true,
+}));
+
 import { useInviteManagement } from '@/hooks/business/spaces/useInviteManagement';
 
 const SPACE_ID = 'space-1';

--- a/src/dev/tests/identity/migrated/useInviteManagement.test.tsx
+++ b/src/dev/tests/identity/migrated/useInviteManagement.test.tsx
@@ -98,16 +98,12 @@ vi.mock('react-router', () => ({
   useNavigate: () => vi.fn(),
 }));
 
-// This test pins WIRING — that the name the identity module resolves is the one
-// this surface renders. It is not a test of QNS ownership, which lives in
-// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
-// both mutation-proven.
-//
-// The claim still travels the real path (profile -> claimedNamesIn ->
-// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
-// provider stops populating the verified map. Only the final comparison is
-// stubbed, because the address fixtures here are arbitrary and no real key
-// derives to them.
+// Pins WIRING, not QNS ownership. Only the final ownership comparison is
+// stubbed, because the address fixtures here are arbitrary and no real ed448
+// key derives to them. The claim still travels the whole real path, so this
+// still fails if the provider stops populating the verified map. Ownership
+// itself is pinned in `identity/verifiedQnsNames.test.ts` and shared's
+// `verifyQnsClaim.test.ts`, both mutation-proven.
 vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
   claimedNameBelongsTo: () => true,

--- a/src/dev/tests/identity/migrated/useMentionInput.test.tsx
+++ b/src/dev/tests/identity/migrated/useMentionInput.test.tsx
@@ -57,16 +57,12 @@ vi.mock('@/api/baseTypes', () => ({
   isHandledFetchError: () => false,
 }));
 
-// This test pins WIRING — that the name the identity module resolves is the one
-// this surface renders. It is not a test of QNS ownership, which lives in
-// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
-// both mutation-proven.
-//
-// The claim still travels the real path (profile -> claimedNamesIn ->
-// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
-// provider stops populating the verified map. Only the final comparison is
-// stubbed, because the address fixtures here are arbitrary and no real key
-// derives to them.
+// Pins WIRING, not QNS ownership. Only the final ownership comparison is
+// stubbed, because the address fixtures here are arbitrary and no real ed448
+// key derives to them. The claim still travels the whole real path, so this
+// still fails if the provider stops populating the verified map. Ownership
+// itself is pinned in `identity/verifiedQnsNames.test.ts` and shared's
+// `verifyQnsClaim.test.ts`, both mutation-proven.
 vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
   claimedNameBelongsTo: () => true,

--- a/src/dev/tests/identity/migrated/useMentionInput.test.tsx
+++ b/src/dev/tests/identity/migrated/useMentionInput.test.tsx
@@ -57,6 +57,21 @@ vi.mock('@/api/baseTypes', () => ({
   isHandledFetchError: () => false,
 }));
 
+// This test pins WIRING — that the name the identity module resolves is the one
+// this surface renders. It is not a test of QNS ownership, which lives in
+// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
+// both mutation-proven.
+//
+// The claim still travels the real path (profile -> claimedNamesIn ->
+// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
+// provider stops populating the verified map. Only the final comparison is
+// stubbed, because the address fixtures here are arbitrary and no real key
+// derives to them.
+vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
+  claimedNameBelongsTo: () => true,
+}));
+
 /** Stands in for "some other already-rendered surface enriched this
  *  candidate" (a message header, the dropdown's own previous open, etc.) —
  *  `useMentionInput` itself never calls `request`. */

--- a/src/dev/tests/identity/migrated/useNameResolver.test.tsx
+++ b/src/dev/tests/identity/migrated/useNameResolver.test.tsx
@@ -26,16 +26,12 @@ vi.mock('@/api/baseTypes', () => ({
   isHandledFetchError: () => false,
 }));
 
-// This test pins WIRING — that the name the identity module resolves is the one
-// this surface renders. It is not a test of QNS ownership, which lives in
-// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
-// both mutation-proven.
-//
-// The claim still travels the real path (profile -> claimedNamesIn ->
-// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
-// provider stops populating the verified map. Only the final comparison is
-// stubbed, because the address fixtures here are arbitrary and no real key
-// derives to them.
+// Pins WIRING, not QNS ownership. Only the final ownership comparison is
+// stubbed, because the address fixtures here are arbitrary and no real ed448
+// key derives to them. The claim still travels the whole real path, so this
+// still fails if the provider stops populating the verified map. Ownership
+// itself is pinned in `identity/verifiedQnsNames.test.ts` and shared's
+// `verifyQnsClaim.test.ts`, both mutation-proven.
 vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
   claimedNameBelongsTo: () => true,

--- a/src/dev/tests/identity/migrated/useNameResolver.test.tsx
+++ b/src/dev/tests/identity/migrated/useNameResolver.test.tsx
@@ -26,6 +26,21 @@ vi.mock('@/api/baseTypes', () => ({
   isHandledFetchError: () => false,
 }));
 
+// This test pins WIRING — that the name the identity module resolves is the one
+// this surface renders. It is not a test of QNS ownership, which lives in
+// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
+// both mutation-proven.
+//
+// The claim still travels the real path (profile -> claimedNamesIn ->
+// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
+// provider stops populating the verified map. Only the final comparison is
+// stubbed, because the address fixtures here are arbitrary and no real key
+// derives to them.
+vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
+  claimedNameBelongsTo: () => true,
+}));
+
 import { useNameResolver } from '@/identity';
 import { IdentityScopeProvider } from '@/identity/identityProvider';
 

--- a/src/dev/tests/identity/migrated/useSearchResultDisplay.test.tsx
+++ b/src/dev/tests/identity/migrated/useSearchResultDisplay.test.tsx
@@ -53,16 +53,12 @@ vi.mock('@/components/context/useMessageDB', () => ({
   }),
 }));
 
-// This test pins WIRING — that the name the identity module resolves is the one
-// this surface renders. It is not a test of QNS ownership, which lives in
-// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
-// both mutation-proven.
-//
-// The claim still travels the real path (profile -> claimedNamesIn ->
-// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
-// provider stops populating the verified map. Only the final comparison is
-// stubbed, because the address fixtures here are arbitrary and no real key
-// derives to them.
+// Pins WIRING, not QNS ownership. Only the final ownership comparison is
+// stubbed, because the address fixtures here are arbitrary and no real ed448
+// key derives to them. The claim still travels the whole real path, so this
+// still fails if the provider stops populating the verified map. Ownership
+// itself is pinned in `identity/verifiedQnsNames.test.ts` and shared's
+// `verifyQnsClaim.test.ts`, both mutation-proven.
 vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
   claimedNameBelongsTo: () => true,

--- a/src/dev/tests/identity/migrated/useSearchResultDisplay.test.tsx
+++ b/src/dev/tests/identity/migrated/useSearchResultDisplay.test.tsx
@@ -53,6 +53,21 @@ vi.mock('@/components/context/useMessageDB', () => ({
   }),
 }));
 
+// This test pins WIRING — that the name the identity module resolves is the one
+// this surface renders. It is not a test of QNS ownership, which lives in
+// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
+// both mutation-proven.
+//
+// The claim still travels the real path (profile -> claimedNamesIn ->
+// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
+// provider stops populating the verified map. Only the final comparison is
+// stubbed, because the address fixtures here are arbitrary and no real key
+// derives to them.
+vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
+  claimedNameBelongsTo: () => true,
+}));
+
 import { useSearchResultDisplay } from '@/hooks/business/search/useSearchResultDisplay';
 import { IdentityScopeProvider, type RosterNameRow } from '@/identity';
 import type { SearchResult } from '@/db/messages';

--- a/src/dev/tests/identity/qnsClaimExemption.test.ts
+++ b/src/dev/tests/identity/qnsClaimExemption.test.ts
@@ -1,0 +1,119 @@
+/**
+ * The one sanctioned bypass of the QNS ownership check, and the gate that keeps
+ * it out of production.
+ *
+ * The dev overlay synthesizes `primary_username` values so the whole family of
+ * `.q` surfaces can be swept without registering real names. Those names are
+ * registered nowhere, so genuine verification strips all of them and the
+ * instrument goes inert — injecting names, having them removed, and rendering
+ * exactly as it did before it existed. The exemption is what stops that.
+ *
+ * Which makes the exemption itself a live "render this unverified `.q`" path,
+ * so the tests below care about two separate things:
+ *
+ *  1. it is unreachable outside a development build, and
+ *  2. even inside one it is narrow — it exempts only names the overlay itself
+ *     would produce for that exact address, never a real registration.
+ *
+ * ## What is asserted where
+ *
+ * These assert the RUNTIME gate. The complementary fact — that
+ * `fakeQnsCore` is absent from a release bundle entirely, because the folded
+ * condition leaves it with no importer — is a build-time property, MEASURED by
+ * grepping `dist/` after `yarn build` (0 occurrences of `deriveFakeQName`,
+ * `isFakeClaimFor`, `applyFakeQns` or the storage key, across 71 bundle files,
+ * on 2026-08-16). A unit test cannot see that, so do not add one that pretends
+ * to; re-run the grep if the gate's shape ever changes.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { isExemptClaim } from '@/identity/qnsClaimExemption';
+import { isFakeClaimFor, deriveFakeQName } from '@/dev/fake-qns/fakeQnsCore';
+
+const STORAGE_KEY = 'dev.fakeQns.state';
+const ADDR = 'QmPeerAEgVKpYZKYuFu2J49zHXnA8vZtEqHMtpB4imzzzz';
+const OTHER = 'QmThemThemThemThemThemThemThemThemThemThemThem';
+
+const setOverlay = (state: Record<string, unknown>) =>
+  globalThis.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+
+const ORIGINAL_ENV = process.env.NODE_ENV;
+
+beforeEach(() => globalThis.localStorage.clear());
+afterEach(() => {
+  process.env.NODE_ENV = ORIGINAL_ENV;
+  globalThis.localStorage.clear();
+});
+
+describe('isExemptClaim — the production gate', () => {
+  it('never exempts anything outside a development build', () => {
+    // The overlay is fully enabled and WOULD say yes. The gate still says no.
+    // This is the assertion that matters: everything else here is about
+    // keeping a dev tool usable, this one is about not shipping a bypass.
+    setOverlay({ enabled: true, giveEveryoneAName: true, entries: {} });
+    const claim = deriveFakeQName(ADDR);
+
+    expect(isFakeClaimFor(claim, ADDR)).toBe(true); // the overlay agrees...
+    for (const env of ['production', 'test', undefined]) {
+      process.env.NODE_ENV = env as string;
+      expect(isExemptClaim(claim, ADDR)).toBe(false); // ...the gate refuses
+    }
+  });
+
+  it('delegates to the overlay in a development build', () => {
+    process.env.NODE_ENV = 'development';
+    setOverlay({ enabled: true, giveEveryoneAName: true, entries: {} });
+    expect(isExemptClaim(deriveFakeQName(ADDR), ADDR)).toBe(true);
+  });
+});
+
+describe('isFakeClaimFor — narrowness', () => {
+  it('exempts a derived name only for the address it was derived from', () => {
+    setOverlay({ enabled: true, giveEveryoneAName: true, entries: {} });
+    const claim = deriveFakeQName(ADDR);
+    expect(isFakeClaimFor(claim, ADDR)).toBe(true);
+    expect(isFakeClaimFor(claim, OTHER)).toBe(false);
+  });
+
+  it('exempts nothing while the overlay is off', () => {
+    setOverlay({ enabled: false, giveEveryoneAName: true, entries: {} });
+    expect(isFakeClaimFor(deriveFakeQName(ADDR), ADDR)).toBe(false);
+  });
+
+  it('exempts nothing derived while giveEveryoneAName is off', () => {
+    setOverlay({ enabled: true, giveEveryoneAName: false, entries: {} });
+    expect(isFakeClaimFor(deriveFakeQName(ADDR), ADDR)).toBe(false);
+  });
+
+  it('exempts an explicit entry, and only its exact name', () => {
+    setOverlay({
+      enabled: true,
+      giveEveryoneAName: false,
+      entries: { [ADDR.toLowerCase()]: { primaryUsername: 'deliberate' } },
+    });
+    expect(isFakeClaimFor('deliberate', ADDR)).toBe(true);
+    expect(isFakeClaimFor('something-else', ADDR)).toBe(false);
+  });
+
+  it('does NOT exempt a real registration that merely passed through the overlay', () => {
+    // The case that would hide the regression the instrument exists to catch.
+    // An address with an explicit entry claiming a DIFFERENT name — a real one
+    // the overlay left alone — must still face the genuine check.
+    setOverlay({
+      enabled: true,
+      giveEveryoneAName: true,
+      entries: { [ADDR.toLowerCase()]: { displayName: 'Someone' } },
+    });
+    expect(isFakeClaimFor('a-real-registered-name', ADDR)).toBe(false);
+    // An explicit entry with no primaryUsername also suppresses the derived
+    // name, so the overlay cannot exempt by two routes at once.
+    expect(isFakeClaimFor(deriveFakeQName(ADDR), ADDR)).toBe(false);
+  });
+
+  it('exempts nothing for a blank name or address', () => {
+    setOverlay({ enabled: true, giveEveryoneAName: true, entries: {} });
+    expect(isFakeClaimFor('', ADDR)).toBe(false);
+    expect(isFakeClaimFor('   ', ADDR)).toBe(false);
+    expect(isFakeClaimFor(deriveFakeQName(ADDR), '')).toBe(false);
+  });
+});

--- a/src/dev/tests/identity/rawNameFieldAudit.test.ts
+++ b/src/dev/tests/identity/rawNameFieldAudit.test.ts
@@ -151,10 +151,17 @@ const EXCEPTIONS: Record<string, string> = {
     'onboarding flow state — same reasoning.',
   'src/hooks/business/user/useAuthenticationFlow.ts':
     'builds the initial self user record straight from the passkey response during sign-in/sign-up, before any provider or public profile exists — the legitimate bootstrap source, not a render.',
+  // ⚠️ These two reasons were TOO BROAD and hid a real defect. "Editing your own
+  // profile" is true of the input fields, and it silently also covered a
+  // READ-ONLY render of the verified-QNS marker: General rendered
+  // `{primaryUsername}.q` from a claim nobody had checked, and UserSettingsModal
+  // sourced it straight from `public_profile.primary_username`. Narrowed to name
+  // what is actually allowed, so the next reviewer can check the claim against
+  // the file instead of reading "settings form" and moving on.
   'src/components/modals/UserSettingsModal/General.tsx':
-    "settings form editing YOUR OWN profile (display name + primary username fields) — the operator's explicit exception category.",
+    'settings form editing YOUR OWN profile (display name / bio INPUTS — nothing to resolve, it is what the user is typing). Its one READ of `primaryUsername` renders the `.q` notice, and that value arrives ALREADY VERIFIED from UserSettingsModal — a presentational pass-through, same category as UserAvatar.tsx. It must never resolve or verify a claim itself.',
   'src/components/modals/UserSettingsModal/UserSettingsModal.tsx':
-    'same settings-form category as General.tsx (the tab container/save logic).',
+    'same settings-form category as General.tsx (tab container / save logic). It derives the `.q` notice value through `useResolvedMemberName` (verified), NOT from `public_profile.primary_username` — pinned by `userSettingsSelfQnsNotice.test.ts`. Reverting that read to the raw profile is the regression this entry exists to make visible.',
   'src/hooks/business/user/useUserSettings.ts':
     'business logic behind the self-settings form (General.tsx/UserSettingsModal.tsx) — editing your own profile.',
   'src/hooks/business/spaces/useSpaceProfile.ts':

--- a/src/dev/tests/identity/rootScopeDmLocalNames.test.tsx
+++ b/src/dev/tests/identity/rootScopeDmLocalNames.test.tsx
@@ -52,6 +52,21 @@ vi.mock('@/components/context/useMessageDB', () => ({
   }),
 }));
 
+// This test pins WIRING — that the name the identity module resolves is the one
+// this surface renders. It is not a test of QNS ownership, which lives in
+// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
+// both mutation-proven.
+//
+// The claim still travels the real path (profile -> claimedNamesIn ->
+// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
+// provider stops populating the verified map. Only the final comparison is
+// stubbed, because the address fixtures here are arbitrary and no real key
+// derives to them.
+vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
+  claimedNameBelongsTo: () => true,
+}));
+
 import { IdentityScopeProvider, useResolvedMemberName } from '@/identity';
 import { useRootIdentityScope } from '@/hooks/business/identity';
 

--- a/src/dev/tests/identity/rootScopeDmLocalNames.test.tsx
+++ b/src/dev/tests/identity/rootScopeDmLocalNames.test.tsx
@@ -52,16 +52,12 @@ vi.mock('@/components/context/useMessageDB', () => ({
   }),
 }));
 
-// This test pins WIRING — that the name the identity module resolves is the one
-// this surface renders. It is not a test of QNS ownership, which lives in
-// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
-// both mutation-proven.
-//
-// The claim still travels the real path (profile -> claimedNamesIn ->
-// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
-// provider stops populating the verified map. Only the final comparison is
-// stubbed, because the address fixtures here are arbitrary and no real key
-// derives to them.
+// Pins WIRING, not QNS ownership. Only the final ownership comparison is
+// stubbed, because the address fixtures here are arbitrary and no real ed448
+// key derives to them. The claim still travels the whole real path, so this
+// still fails if the provider stops populating the verified map. Ownership
+// itself is pinned in `identity/verifiedQnsNames.test.ts` and shared's
+// `verifyQnsClaim.test.ts`, both mutation-proven.
 vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
   claimedNameBelongsTo: () => true,

--- a/src/dev/tests/identity/rootScopeSelfName.test.tsx
+++ b/src/dev/tests/identity/rootScopeSelfName.test.tsx
@@ -26,6 +26,21 @@ import * as React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
+// This test pins WIRING — that the name the identity module resolves is the one
+// this surface renders. It is not a test of QNS ownership, which lives in
+// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
+// both mutation-proven.
+//
+// The claim still travels the real path (profile -> claimedNamesIn ->
+// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
+// provider stops populating the verified map. Only the final comparison is
+// stubbed, because the address fixtures here are arbitrary and no real key
+// derives to them.
+vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
+  claimedNameBelongsTo: () => true,
+}));
+
 const SELF = 'QmSelfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
 
 const getPublicProfile = vi.fn();

--- a/src/dev/tests/identity/rootScopeSelfName.test.tsx
+++ b/src/dev/tests/identity/rootScopeSelfName.test.tsx
@@ -26,16 +26,12 @@ import * as React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
-// This test pins WIRING — that the name the identity module resolves is the one
-// this surface renders. It is not a test of QNS ownership, which lives in
-// `identity/verifiedQnsNames.test.ts` and shared's `verifyQnsClaim.test.ts`,
-// both mutation-proven.
-//
-// The claim still travels the real path (profile -> claimedNamesIn ->
-// verifiedQnsNames -> IdentitySources -> the ladder), so this still fails if the
-// provider stops populating the verified map. Only the final comparison is
-// stubbed, because the address fixtures here are arbitrary and no real key
-// derives to them.
+// Pins WIRING, not QNS ownership. Only the final ownership comparison is
+// stubbed, because the address fixtures here are arbitrary and no real ed448
+// key derives to them. The claim still travels the whole real path, so this
+// still fails if the provider stops populating the verified map. Ownership
+// itself is pinned in `identity/verifiedQnsNames.test.ts` and shared's
+// `verifyQnsClaim.test.ts`, both mutation-proven.
 vi.mock('@quilibrium/quorum-shared', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@quilibrium/quorum-shared')>()),
   claimedNameBelongsTo: () => true,

--- a/src/dev/tests/identity/userSettingsSelfQnsNotice.test.tsx
+++ b/src/dev/tests/identity/userSettingsSelfQnsNotice.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * Your own `.q` notice in Settings must not be the one surface that still
+ * trusts an unchecked claim.
+ *
+ * `UserSettingsModal` used to read `public_profile.primary_username` straight
+ * from the fetch and hand it to `General`, which renders
+ * `<strong>{primaryUsername}.q</strong>`. That bypassed the identity module
+ * entirely. It survived the `rawNameFieldAudit` because both files sit in that
+ * audit's "settings form editing YOUR OWN profile" exception — a reason that is
+ * true of the edit fields and quietly covered a READ-ONLY render of the trust
+ * marker as well. (Both exception reasons have since been corrected to say what
+ * is actually allowed.)
+ *
+ * The practical harm was sharper than the rule it broke. Once verification
+ * shipped, an unverified name renders NOWHERE — so this panel would have kept
+ * insisting "your QNS name alice.q is shown as your name" while the user's own
+ * name in the nav rail showed something else, with no way to tell which was
+ * lying.
+ *
+ * ## What this pins, and what it does not
+ *
+ * It pins the DECISION the modal now makes: ask the identity module, and treat
+ * an unverified self-claim as absent. It deliberately does NOT render `General`
+ * — that component owns an image dropzone and a dozen unrelated props, so
+ * mounting it would test react-dropzone rather than this. The rendering half is
+ * a one-line `{primaryUsername && ...}` guard in `General.tsx`, and the audit
+ * above is what keeps the modal from going back to a raw read.
+ *
+ * ⚠️ Unlike the ~41 wiring tests, this one does NOT stub `claimedNameBelongsTo`.
+ * The real verdict is the entire point, so it uses a real ed448-shaped key and
+ * the address it genuinely derives to.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { deriveAddress } from '@quilibrium/quorum-shared';
+
+/** Invented ed448-shaped public key (57 bytes). Not a real account's. */
+const KEY =
+  '030a11181f262d343b424950575e656c737a81888f969da4abb2b9c0c7ced5dce3eaf1f8ff060d141b222930373e454c535a61686f767d848b';
+
+/** The address KEY really derives to — the rightful owner of `alice`. */
+const OWNER = deriveAddress(KEY);
+/** Owns nothing. */
+const IMPOSTOR = 'QmThemThemThemThemThemThemThemThemThemThemThem';
+
+const getPublicProfile = vi.fn();
+vi.mock('@/api/baseTypes', () => ({
+  QuorumApiClient: class {
+    getPublicProfile(address: string) {
+      return getPublicProfile(address);
+    }
+  },
+  isHandledFetchError: () => false,
+}));
+
+import { IdentityScopeProvider, useResolvedMemberName } from '@/identity';
+
+/**
+ * The exact derivation `UserSettingsModal` performs to decide whether the
+ * notice appears. Kept identical to the source, so a change there that this
+ * no longer mirrors is a signal to revisit both.
+ */
+function SelfQnsProbe({ address }: { address: string }) {
+  const resolved = useResolvedMemberName(address, { enrich: true, global: true });
+  const primaryUsername = resolved.isQnsVerified ? resolved.name : undefined;
+  return <div data-testid="notice">{primaryUsername ? `${primaryUsername}.q` : 'NO NOTICE'}</div>;
+}
+
+function renderProbe(address: string) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <IdentityScopeProvider rostersBySpace={{}} selfAddress={address}>
+        <SelfQnsProbe address={address} />
+      </IdentityScopeProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe('UserSettingsModal — your own QNS notice respects verification', () => {
+  beforeEach(() => {
+    getPublicProfile.mockReset();
+    getPublicProfile.mockResolvedValue({
+      data: { primary_username: 'alice', display_name: 'A' },
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        // `alice` really belongs to OWNER, and to nobody else.
+        json: async () => ({ records: [{ address: '0xwhatever', resolveKey: KEY }] }),
+      })),
+    );
+  });
+
+  it('shows the notice when the name genuinely belongs to you', async () => {
+    renderProbe(OWNER);
+    await waitFor(() =>
+      expect(screen.getByTestId('notice')).toHaveTextContent('alice.q'),
+    );
+  });
+
+  it('shows NOTHING when the claim is not yours', async () => {
+    // The regression case. Same claim, same resolver answer, different account.
+    // Before the fix this panel rendered "alice.q" for the impostor while every
+    // other surface in the app correctly withheld it.
+    renderProbe(IMPOSTOR);
+
+    // Wait for the profile fetch AND give the verification lookup time to land,
+    // so this asserts a SETTLED negative rather than "the render hasn't caught
+    // up yet" — which would pass even on a build that never verifies at all.
+    await waitFor(() => expect(getPublicProfile).toHaveBeenCalled());
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(screen.getByTestId('notice')).toHaveTextContent('NO NOTICE');
+  });
+});

--- a/src/dev/tests/identity/verifiedQnsNames.test.ts
+++ b/src/dev/tests/identity/verifiedQnsNames.test.ts
@@ -1,0 +1,223 @@
+/**
+ * The desktop half of claim verification: turn a map of fetched public profiles
+ * into a map of names that have actually been PROVEN to belong to the address
+ * claiming them.
+ *
+ * These are the pure functions behind `useVerifiedQnsNames`. The ownership
+ * predicate itself lives in `@quilibrium/quorum-shared` and has its own tests;
+ * what is pinned here is the part desktop owns — which claims get looked up,
+ * which addresses end up in the verified map, and what happens in the states
+ * that are neither "verified" nor "rejected".
+ *
+ * ## The fixture
+ *
+ * `KEY` is invented — an arithmetic pattern, nobody's real key — and `ADDRESS`
+ * is what `deriveAddress(KEY)` produces. Both are shared with quorum-mobile's
+ * equivalent test and with shared's `verifyQnsClaim.test.ts`, so a divergence
+ * shows up in all three rather than silently in one client.
+ *
+ * The verify predicate is deliberately NOT mocked in this file. Mocking it
+ * would leave the impostor case asserting only that a stub was called, and the
+ * impostor case is the entire point of the feature.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { deriveAddress } from '@quilibrium/quorum-shared';
+import {
+  claimedNamesIn,
+  verifiedNamesFrom,
+  profileGlobalNamesFrom,
+  QNS_CLAIM_LIMIT,
+} from '@/identity/useVerifiedQnsNames';
+import type { PublicProfileResponse } from '@/api/baseTypes';
+
+/** Invented ed448-shaped public key (57 bytes). Not a real account's. */
+const KEY =
+  '030a11181f262d343b424950575e656c737a81888f969da4abb2b9c0c7ced5dce3eaf1f8ff060d141b222930373e454c535a61686f767d848b';
+
+/** The address KEY really derives to — i.e. the rightful owner of `alice`. */
+const OWNER = deriveAddress(KEY);
+
+/** Somebody else entirely. Owns nothing. */
+const IMPOSTOR = 'QmThemThemThemThemThemThemThemThemThemThemThem';
+
+const profile = (over: Partial<PublicProfileResponse> = {}): PublicProfileResponse =>
+  ({
+    display_name: '',
+    profile_image: '',
+    bio: '',
+    timestamp: 0,
+    signature: '',
+    ...over,
+  }) as PublicProfileResponse;
+
+/** A resolver answer proving `alice` belongs to OWNER. */
+const ALICE_RESOLVES = { alice: { address: '0xwhatever', resolveKey: KEY } };
+
+describe('claimedNamesIn', () => {
+  it('collects the distinct names being claimed', () => {
+    expect(
+      claimedNamesIn({
+        [OWNER]: profile({ primary_username: 'alice' }),
+        [IMPOSTOR]: profile({ primary_username: 'bob' }),
+      }).sort(),
+    ).toEqual(['alice', 'bob']);
+  });
+
+  it('collapses two accounts claiming the same name into one lookup', () => {
+    // Cost property AND security property: both claimants are then judged
+    // against the same single answer, so the collision is settled by the very
+    // request that verifies whoever genuinely owns it.
+    expect(
+      claimedNamesIn({
+        [OWNER]: profile({ primary_username: 'alice' }),
+        [IMPOSTOR]: profile({ primary_username: 'alice' }),
+      }),
+    ).toEqual(['alice']);
+  });
+
+  it('ignores profiles that claim nothing', () => {
+    expect(
+      claimedNamesIn({
+        [OWNER]: profile({ display_name: 'Just A Name' }),
+        [IMPOSTOR]: null,
+      }),
+    ).toEqual([]);
+  });
+
+  it('trims, so a padded claim cannot dodge the dedupe', () => {
+    expect(
+      claimedNamesIn({
+        [OWNER]: profile({ primary_username: '  alice  ' }),
+        [IMPOSTOR]: profile({ primary_username: 'alice' }),
+      }),
+    ).toEqual(['alice']);
+  });
+
+  it('does not fold case, because the resolver is the authority on matching', () => {
+    // Normalising here would mean verifying a name the user never claimed.
+    expect(
+      claimedNamesIn({
+        [OWNER]: profile({ primary_username: 'Alice' }),
+        [IMPOSTOR]: profile({ primary_username: 'alice' }),
+      }).sort(),
+    ).toEqual(['Alice', 'alice']);
+  });
+
+  it('caps the set at one batch', () => {
+    // Past the cap a claim is simply never looked up, so it stays unverified
+    // and renders as the global name. The overflow degrades in the safe
+    // direction: it can under-show a real `.q`, never promote a forged one.
+    const many: Record<string, PublicProfileResponse> = {};
+    for (let i = 0; i < QNS_CLAIM_LIMIT + 25; i++) {
+      many[`Qm${i}`] = profile({ primary_username: `name${i}` });
+    }
+    expect(claimedNamesIn(many)).toHaveLength(QNS_CLAIM_LIMIT);
+  });
+});
+
+describe('verifiedNamesFrom', () => {
+  it('keeps a claim that resolves back to the claiming address', () => {
+    const out = verifiedNamesFrom(
+      { [OWNER]: profile({ primary_username: 'alice' }) },
+      ALICE_RESOLVES,
+    );
+    expect(out).toEqual({ [OWNER]: 'alice' });
+  });
+
+  it('drops the same claim made by somebody else', () => {
+    // THE case. `alice` is a real, registered, resolvable name — it just is not
+    // theirs. A real user cannot stage this, which is exactly why it needs a
+    // test rather than a device check.
+    const out = verifiedNamesFrom(
+      { [IMPOSTOR]: profile({ primary_username: 'alice' }) },
+      ALICE_RESOLVES,
+    );
+    expect(out).toEqual({});
+  });
+
+  it('settles a collision in favour of the real owner only', () => {
+    const out = verifiedNamesFrom(
+      {
+        [OWNER]: profile({ primary_username: 'alice' }),
+        [IMPOSTOR]: profile({ primary_username: 'alice' }),
+      },
+      ALICE_RESOLVES,
+    );
+    expect(out).toEqual({ [OWNER]: 'alice' });
+  });
+
+  it('treats a lookup still in flight as unproven', () => {
+    // Unproven includes NOT-YET-KNOWN. A `.q` shown for even the instant before
+    // a lookup lands is the whole attack, because a screenshot does not expire.
+    const out = verifiedNamesFrom({ [OWNER]: profile({ primary_username: 'alice' }) }, {});
+    expect(out).toEqual({});
+  });
+
+  it('treats an unregistered name as unproven', () => {
+    // A miss arrives as a null slot, not an error.
+    const out = verifiedNamesFrom(
+      { [OWNER]: profile({ primary_username: 'ghost' }) },
+      { ghost: null },
+    );
+    expect(out).toEqual({});
+  });
+
+  it('treats a name with no Quorum binding as unproven', () => {
+    // MEASURED: most registered names carry no `resolveKey` at all. They are
+    // unverifiable by construction, not broken.
+    const out = verifiedNamesFrom(
+      { [OWNER]: profile({ primary_username: 'alice' }) },
+      { alice: { address: '0xabc' } },
+    );
+    expect(out).toEqual({});
+  });
+
+  it('honours a dev exemption, and only for the exact pair', () => {
+    const isExempt = (name: string, address: string) =>
+      name === 'qa1234' && address === IMPOSTOR;
+    const out = verifiedNamesFrom(
+      {
+        [IMPOSTOR]: profile({ primary_username: 'qa1234' }),
+        [OWNER]: profile({ primary_username: 'qa1234' }),
+      },
+      {},
+      isExempt,
+    );
+    expect(out).toEqual({ [IMPOSTOR]: 'qa1234' });
+  });
+
+  it('returns a stable reference when nothing verifies', () => {
+    // These maps feed IdentitySources, which feeds memos down to a virtualised
+    // list. A fresh {} per render would invalidate all of them every tick.
+    const a = verifiedNamesFrom({ [OWNER]: profile({ primary_username: 'alice' }) }, {});
+    const b = verifiedNamesFrom({ [IMPOSTOR]: profile({ primary_username: 'bob' }) }, {});
+    expect(a).toBe(b);
+  });
+});
+
+describe('profileGlobalNamesFrom', () => {
+  it('maps addresses to their profile display name', () => {
+    expect(
+      profileGlobalNamesFrom({
+        [OWNER]: profile({ display_name: 'Alice' }),
+        [IMPOSTOR]: profile({ display_name: 'Bob' }),
+      }),
+    ).toEqual({ [OWNER]: 'Alice', [IMPOSTOR]: 'Bob' });
+  });
+
+  it('carries no trust claim, so it is never verified', () => {
+    // A display name is not a name anyone can own, so it needs no check. This
+    // is why the two maps are separate rather than one profile object.
+    expect(
+      profileGlobalNamesFrom({ [IMPOSTOR]: profile({ display_name: 'Alice' }) }),
+    ).toEqual({ [IMPOSTOR]: 'Alice' });
+  });
+
+  it('omits blank and missing names, and returns a stable empty reference', () => {
+    const a = profileGlobalNamesFrom({ [OWNER]: profile({ display_name: '   ' }) });
+    const b = profileGlobalNamesFrom({ [IMPOSTOR]: null });
+    expect(a).toEqual({});
+    expect(a).toBe(b);
+  });
+});

--- a/src/hooks/business/conversations/useConversationsWithProfileBackfill.ts
+++ b/src/hooks/business/conversations/useConversationsWithProfileBackfill.ts
@@ -50,7 +50,18 @@ const isPlaceholderName = isPlaceholderDisplayName;
  * A conversation row augmented with the partner's QNS primary username, sourced
  * from the same public-profile fetch this hook already performs. Additive and
  * desktop-only — the shared `Conversation` type is untouched, so mobile is
- * unaffected. The DM sidebar resolves `name.q` (Model B) from this field.
+ * unaffected.
+ *
+ * ⚠️ **Do not render this field, and do not append `.q` to it.** It is the RAW,
+ * self-reported claim exactly as the server returned it — nobody has checked
+ * that the account owns the name. Name resolution moved to the identity module
+ * and no longer reads it (see `DirectMessageContactsList.tsx`, which says the
+ * same from the consuming side); the one place allowed to decide a claim is
+ * genuine is `identity/useVerifiedQnsNames.ts`.
+ *
+ * This comment previously said the DM sidebar resolved `name.q` from this
+ * field. That stopped being true, and a reader who believed it would wire a new
+ * consumer straight to an unverified claim.
  */
 export type ConversationWithQns = Conversation & { primaryUsername?: string };
 

--- a/src/identity/identityProvider.tsx
+++ b/src/identity/identityProvider.tsx
@@ -4,6 +4,7 @@ import type { MemberIdentity } from '@quilibrium/quorum-shared';
 import { QuorumApiClient, isHandledFetchError } from '../api/baseTypes';
 import type { PublicProfileResponse } from '../api/baseTypes';
 import { publicProfileQueryKey } from '../hooks/business/user/useUserPublicProfile';
+import { profileGlobalNamesFrom, useVerifiedQnsNames } from './useVerifiedQnsNames';
 
 // Stable reference for callers that pass no `locallyKnownNames` (every Space
 // surface) — a fresh `{}` literal on every render would invalidate the
@@ -28,10 +29,37 @@ export const EMPTY_ROSTERS_BY_SPACE: Record<string, Record<string, RosterNameRow
 export interface IdentitySources {
   /** spaceId -> address -> roster row. Local, from messageDB.getSpaceMembers. */
   rostersBySpace: Record<string, Record<string, RosterNameRow>>;
-  /** address -> public profile. The ONLY source of primary_username. */
-  profiles: Record<string, PublicProfileResponse | null>;
+  /**
+   * address -> a QNS name PROVEN to belong to that address.
+   *
+   * ⚠️ There is deliberately NO profile object in here, and that is a security
+   * property rather than a tidiness one. `primary_username` is a self-reported
+   * CLAIM: it arrives inside someone else's profile and nothing upstream checks
+   * it. While this interface carried the raw profile, every surface could read
+   * the claim and render a `.q` for it, and desktop's single read did exactly
+   * that — no check of any kind.
+   *
+   * Now an unverified claim has nowhere to live. Only `useVerifiedQnsNames` can
+   * write this map, and only after resolving the name and deriving the claimed
+   * owner's address back to the address the claim arrived with. A surface
+   * cannot render a forged `.q` even by mistake, because there is nothing to
+   * render it FROM — which is what makes "no surface forgot" provable rather
+   * than hopeful.
+   *
+   * An address absent from this map is UNPROVEN, and that deliberately includes
+   * not-yet-known: a lookup in flight yields no entry, so the global name
+   * renders and only ever upgrades INTO a `.q`.
+   */
+  verifiedQnsNames: Record<string, string>;
+  /**
+   * address -> the display name from that address's public profile.
+   *
+   * Split out from the verified map because a display name carries no
+   * ownership claim — nobody can own "Alice" — so it needs no lookup and must
+   * not be delayed behind one.
+   */
+  profileGlobalNames: Record<string, string>;
   selfAddress: string | null;
-  selfProfile: PublicProfileResponse | null;
   /**
    * address -> a name known LOCALLY, with no network round-trip. Fed by a
    * caller that already has this in memory — today that's a DM's
@@ -96,22 +124,28 @@ export function identityFromMaps(
   sources: IdentitySources,
 ): MemberIdentity {
   const row = spaceId ? sources.rostersBySpace[spaceId]?.[address] : undefined;
-  const isSelf = !!sources.selfAddress && sources.selfAddress === address;
-  // Self's identity comes from its own public profile. `currentPasskeyInfo` is
-  // the device-local auth record and carries no QNS name.
-  const profile = isSelf ? sources.selfProfile : (sources.profiles[address] ?? null);
 
   return {
     address,
     // Only a real space context can have a per-space nickname.
     spaceName: nn(row?.display_name),
-    qnsName: nn(profile?.primary_username),
+    // Already verified, or absent. This read used to be
+    // `nn(profile?.primary_username)` — the raw claim, with no check of any
+    // kind. The check now happens once, upstream, in `useVerifiedQnsNames`;
+    // see `IdentitySources.verifiedQnsNames` for why it cannot live here.
+    //
+    // Self is not a special case. Its identity comes from its own public
+    // profile like anyone else's (`currentPasskeyInfo` is the device-local auth
+    // record and carries no QNS name), and self's own claim is verified on the
+    // same path — a name you have not registered does not become yours because
+    // you are the one looking.
+    qnsName: nn(sources.verifiedQnsNames[address]),
     // Prefer the live roster global slot, then the published profile, then a
     // name known only locally (no fetch) — never a second, parallel lookup
     // path; this is the one place the tiers merge.
     globalName:
       nn(row?.global_display_name) ??
-      nn(profile?.display_name) ??
+      nn(sources.profileGlobalNames[address]) ??
       nn(sources.locallyKnownNames[address]),
   };
 }
@@ -262,6 +296,12 @@ export const IdentityScopeProvider: React.FunctionComponent<{
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [addresses, updatedAtKey]);
 
+  // The two maps that replace the raw profile object. Derived HERE, at the one
+  // point every profile this provider fetched passes through, so there is
+  // exactly one place that can write a verified name.
+  const profileGlobalNames = React.useMemo(() => profileGlobalNamesFrom(profiles), [profiles]);
+  const verifiedQnsNames = useVerifiedQnsNames(profiles);
+
   React.useEffect(() => {
     if (selfAddress) request(selfAddress);
   }, [selfAddress, request]);
@@ -293,30 +333,40 @@ export const IdentityScopeProvider: React.FunctionComponent<{
     () => (parent ? mergeRostersBySpace(parent.sources.rostersBySpace, rostersBySpace) : rostersBySpace),
     [parent, rostersBySpace],
   );
-  const mergedProfiles = React.useMemo(
-    () => (parent ? mergeFlat(parent.sources.profiles, profiles) : profiles),
-    [parent, profiles],
+  const mergedVerifiedQnsNames = React.useMemo(
+    () => (parent ? mergeFlat(parent.sources.verifiedQnsNames, verifiedQnsNames) : verifiedQnsNames),
+    [parent, verifiedQnsNames],
+  );
+  const mergedProfileGlobalNames = React.useMemo(
+    () => (parent ? mergeFlat(parent.sources.profileGlobalNames, profileGlobalNames) : profileGlobalNames),
+    [parent, profileGlobalNames],
   );
   const mergedLocallyKnownNames = React.useMemo(
     () => (parent ? mergeFlat(parent.sources.locallyKnownNames, locallyKnownNames) : locallyKnownNames),
     [parent, locallyKnownNames],
   );
 
-  const selfProfile = selfAddress ? (mergedProfiles[selfAddress] ?? null) : null;
-
   const value = React.useMemo<IdentityContextValue>(
     () => ({
       sources: {
         rostersBySpace: mergedRostersBySpace,
-        profiles: mergedProfiles,
+        verifiedQnsNames: mergedVerifiedQnsNames,
+        profileGlobalNames: mergedProfileGlobalNames,
         selfAddress,
-        selfProfile,
         locallyKnownNames: mergedLocallyKnownNames,
       },
       defaultSpaceId: spaceId,
       request,
     }),
-    [mergedRostersBySpace, mergedProfiles, selfAddress, selfProfile, mergedLocallyKnownNames, spaceId, request],
+    [
+      mergedRostersBySpace,
+      mergedVerifiedQnsNames,
+      mergedProfileGlobalNames,
+      selfAddress,
+      mergedLocallyKnownNames,
+      spaceId,
+      request,
+    ],
   );
 
   return <IdentityContext.Provider value={value}>{children}</IdentityContext.Provider>;

--- a/src/identity/qnsClaimExemption.ts
+++ b/src/identity/qnsClaimExemption.ts
@@ -1,0 +1,38 @@
+/**
+ * The one sanctioned way a `.q` renders without passing the ownership check,
+ * and it exists only in dev builds.
+ *
+ * The dev QNS overlay (`src/dev/fake-qns/`) synthesizes `primary_username`
+ * values so the whole family of `.q` surfaces can be swept without registering
+ * real names. Those synthetic names are registered nowhere, so genuine
+ * verification strips every one of them — the overlay would inject names, the
+ * verifier would remove them, and every surface would render exactly as it did
+ * before the overlay existed. The panel would report success while showing
+ * nothing, which is indistinguishable from the feature being broken.
+ *
+ * ## Why a `NODE_ENV` gate and not a runtime flag
+ *
+ * `process.env.NODE_ENV` is replaced with a literal at build time, so in a
+ * release build the condition below folds to `false`, the call is dead code,
+ * and `fakeQnsCore` has no remaining importer and drops out of the bundle. That
+ * is asserted, not assumed — see `qnsClaimExemption.test.ts`.
+ *
+ * A runtime flag would leave a live code path in production that returns "this
+ * claim is fine, skip the check", which is precisely the thing verification
+ * exists to make impossible.
+ */
+
+import { isFakeClaimFor } from '../dev/fake-qns/fakeQnsCore';
+
+/**
+ * True when `name` is a claim the dev overlay itself synthesized for `address`.
+ *
+ * Always false in production. Callers treat a true result as "verified", so
+ * this must stay narrower than the overlay's own output: a REAL registration
+ * passing through the overlay untouched is not exempt, because verifying real
+ * names is the behaviour the overlay exists to observe.
+ */
+export function isExemptClaim(name: string, address: string): boolean {
+  if (process.env.NODE_ENV !== 'development') return false;
+  return isFakeClaimFor(name, address);
+}

--- a/src/identity/useVerifiedQnsNames.ts
+++ b/src/identity/useVerifiedQnsNames.ts
@@ -1,0 +1,207 @@
+/**
+ * Drop a claimed `.q` unless it really belongs to the account claiming it.
+ *
+ * ## Where this sits
+ *
+ * ```
+ * public profile          carries primary_username — a CLAIM, not a fact
+ *        ▼
+ * useVerifiedQnsNames     ← the only place that resolves claims (one batch)
+ *        ▼                  an unproven claim never enters the map
+ * IdentitySources         ← carries verified names, and NO profile object
+ *        ▼
+ * identityFromMaps        ← unchanged, still pure and synchronous
+ *        ▼
+ * every display surface   ← unchanged, all ~20 of them
+ * ```
+ *
+ * Verification happens UPSTREAM of the ladder, by changing the DATA rather than
+ * teaching every surface about the network. Two things fall out of that:
+ *
+ * - Every surface inherits the check without any of them changing, which is the
+ *   whole reason this repo has one resolver.
+ * - An unverified claim has nowhere to live. `IdentitySources` carries no
+ *   profile object at all, so a surface cannot render an unproven `.q` even by
+ *   mistake — there is nothing to render it FROM. Doing this per-surface would
+ *   be the wrong shape: one surface that forgot would render a forgery, and
+ *   there would be no way to prove none forgot.
+ *
+ * ## Fail closed, on the name only
+ *
+ * A failed check changes which NAME renders. It never drops, hides, delays or
+ * flags a message. Anything else would be a censorship weapon: forge a profile
+ * as somebody, fail its verification, and watch their messages vanish. Delivery
+ * and display stay separate concerns; a message has passed signature and
+ * decryption long before any of this runs.
+ *
+ * ## Cost
+ *
+ * Bounded by distinct claimed NAMES on screen, not by members and not by
+ * messages. Two accounts claiming the same name share one lookup. Mobile
+ * measured a 100-name batch at ~190ms against ~167ms for one name, so a
+ * screenful costs about what a single name costs — that measurement is what
+ * makes verifying affordable rather than merely defensible.
+ *
+ * Claims only exist where a public profile was already fetched, and that fetch
+ * is demand-driven (`enrich`), so this adds NO new per-address request: it adds
+ * one batched request per screen, on top of fetches that were already happening.
+ */
+
+import * as React from 'react';
+import { useQuery } from '@tanstack/react-query';
+import {
+  claimedNameBelongsTo,
+  resolveNamesBatch,
+  QNS_BATCH_LIMIT,
+  type QnsBatchResult,
+} from '@quilibrium/quorum-shared';
+import type { PublicProfileResponse } from '../api/baseTypes';
+import { isExemptClaim } from './qnsClaimExemption';
+
+/**
+ * Most claims verified for one screen.
+ *
+ * Equal to the server's batch maximum, so "one screen" is always "one request".
+ * A claim past the cap is never looked up, so it stays unverified and the member
+ * renders under their global name — the same thing a member with no cached
+ * profile does today. The overflow can only ever under-show a real `.q`; it
+ * cannot promote a forged one.
+ */
+export const QNS_CLAIM_LIMIT = QNS_BATCH_LIMIT;
+
+/** A profile map as the provider holds it. */
+export type ProfileMap = Record<string, PublicProfileResponse | null>;
+
+/** Stable empties. These maps feed `IdentitySources`, which feeds memos all the
+ *  way down to a virtualised list, so a fresh `{}` per render would invalidate
+ *  every one of them on every tick. */
+const NO_NAMES: Record<string, string> = {};
+const NO_RECORDS: QnsBatchResult = {};
+
+/** The name a profile is claiming, trimmed. Empty string when it claims none. */
+const claimOf = (p: PublicProfileResponse | null | undefined): string =>
+  (p?.primary_username ?? '').trim();
+
+/**
+ * The distinct names actually being claimed, capped at one batch.
+ *
+ * Distinct does real work in both directions. It is the cost property — one
+ * lookup however many accounts claim the same name — and it is a security
+ * property, because every claimant of a name is then judged against the same
+ * single answer, so a collision is settled by the very request that verifies
+ * whoever genuinely owns it.
+ *
+ * Whitespace is trimmed so a padded claim cannot dodge the dedupe. Case is NOT
+ * folded: the resolver is the authority on what a name matches, and quietly
+ * normalising here would mean verifying a name the user never claimed.
+ */
+export function claimedNamesIn(profiles: ProfileMap, limit: number = QNS_CLAIM_LIMIT): string[] {
+  const seen = new Set<string>();
+  for (const address of Object.keys(profiles)) {
+    const name = claimOf(profiles[address]);
+    if (name) seen.add(name);
+    if (seen.size >= limit) break;
+  }
+  return Array.from(seen);
+}
+
+/**
+ * `address -> the profile's display name`. No trust claim, so no check.
+ *
+ * Separate from the verified map on purpose: a display name is not something
+ * anyone can own, so gating it behind a network lookup would delay every name
+ * on screen to protect a value that needs no protecting.
+ */
+export function profileGlobalNamesFrom(profiles: ProfileMap): Record<string, string> {
+  const out: Record<string, string> = {};
+  let any = false;
+  for (const address of Object.keys(profiles)) {
+    const name = (profiles[address]?.display_name ?? '').trim();
+    if (name) {
+      out[address] = name;
+      any = true;
+    }
+  }
+  return any ? out : NO_NAMES;
+}
+
+/**
+ * `address -> a name PROVEN to belong to it`. Everything else is simply absent.
+ *
+ * **Unproven includes not-yet-known.** A lookup still in flight leaves the
+ * address out, exactly as a rejected one does, so the global name renders. That
+ * is the difference between this being a defence and being decoration: a `.q`
+ * shown for even the instant before a lookup lands is the whole attack, because
+ * a screenshot of that instant does not expire. Only ever upgrade INTO a `.q`,
+ * never render one optimistically and correct it.
+ */
+export function verifiedNamesFrom(
+  profiles: ProfileMap,
+  records: QnsBatchResult,
+  isExempt: (name: string, address: string) => boolean = isExemptClaim,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  let any = false;
+
+  for (const address of Object.keys(profiles)) {
+    const claim = claimOf(profiles[address]);
+    if (!claim) continue;
+
+    // The claimant address is the key of the map the claim arrived in — never a
+    // value read out of the claim's own payload, which would let a forger
+    // supply both sides of the comparison.
+    if (isExempt(claim, address) || claimedNameBelongsTo(records[claim], address)) {
+      out[address] = claim;
+      any = true;
+    }
+  }
+
+  return any ? out : NO_NAMES;
+}
+
+/**
+ * Resolve every claimed name in one request, and return the verified map.
+ *
+ * `staleTime` is a SECURITY parameter here, not a performance one: it is the
+ * window in which a name that has been transferred away keeps verifying under
+ * its previous owner. One hour, matching the public-profile cache so a member's
+ * identity does not half-refresh. Do not shorten it for freshness or lengthen
+ * it for cost without saying so here — and note the interactive lookup in
+ * `useResolveQnsName.ts` deliberately uses a DIFFERENT, shorter value for a
+ * different question. The two are not meant to agree.
+ */
+export function useVerifiedQnsNames(profiles: ProfileMap): Record<string, string> {
+  const names = React.useMemo(() => claimedNamesIn(profiles), [profiles]);
+  // Sorted, so two surfaces holding the same claimants in a different insertion
+  // order share one cache entry instead of issuing the same request twice.
+  const namesKey = React.useMemo(() => [...names].sort().join('|'), [names]);
+
+  const { data } = useQuery({
+    queryKey: ['qns-verify-claims', namesKey],
+    queryFn: () => resolveNamesBatch(names),
+    enabled: names.length > 0,
+    staleTime: 60 * 60 * 1000,
+    gcTime: 24 * 60 * 60 * 1000,
+    // A retry only extends the window in which real claims render unverified.
+    // They degrade to the global name meanwhile, which is correct but invisible,
+    // so prefer settling fast and refreshing on the next natural cache miss.
+    //
+    // Note the transport THROWS on failure rather than reporting every name
+    // unresolved (see `resolveNamesBatch`). That matters with a one-hour
+    // staleTime: a swallowed error would cache "nobody owns anything" for an
+    // hour after a single blip. An error caches nothing, so the next mount
+    // retries.
+    retry: false,
+    // Carry the previous answer while a wider set resolves, or every name on
+    // screen flickers whenever a new claimant appears. Safe in the fail-closed
+    // direction, which is why it is allowed: the carried map is keyed by name
+    // and holds the same records this key would fetch, so no verdict changes. A
+    // name that is NEW in the wider set is simply absent from it, and absent
+    // means unverified — carrying it forward can only under-show, never promote
+    // something unchecked.
+    placeholderData: (previous) => previous,
+  });
+
+  const records = data ?? NO_RECORDS;
+  return React.useMemo(() => verifiedNamesFrom(profiles, records), [profiles, records]);
+}

--- a/src/identity/useVerifiedQnsNames.ts
+++ b/src/identity/useVerifiedQnsNames.ts
@@ -106,6 +106,32 @@ export function claimedNamesIn(profiles: ProfileMap, limit: number = QNS_CLAIM_L
 }
 
 /**
+ * Build an `address -> name` map, returning the stable empty object when `pick`
+ * found nothing for anyone.
+ *
+ * The stable-empty part is the reason this is a helper rather than two loops:
+ * these maps feed `IdentitySources`, which feeds memos all the way down to a
+ * virtualised list, so a fresh `{}` per render would invalidate every one of
+ * them on every tick. Keeping that trick in ONE place means the two callers
+ * cannot drift into doing it differently.
+ */
+function namesBy(
+  profiles: ProfileMap,
+  pick: (address: string) => string | null,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  let found = false;
+  for (const address of Object.keys(profiles)) {
+    const name = pick(address);
+    if (name) {
+      out[address] = name;
+      found = true;
+    }
+  }
+  return found ? out : NO_NAMES;
+}
+
+/**
  * `address -> the profile's display name`. No trust claim, so no check.
  *
  * Separate from the verified map on purpose: a display name is not something
@@ -113,16 +139,7 @@ export function claimedNamesIn(profiles: ProfileMap, limit: number = QNS_CLAIM_L
  * on screen to protect a value that needs no protecting.
  */
 export function profileGlobalNamesFrom(profiles: ProfileMap): Record<string, string> {
-  const out: Record<string, string> = {};
-  let any = false;
-  for (const address of Object.keys(profiles)) {
-    const name = (profiles[address]?.display_name ?? '').trim();
-    if (name) {
-      out[address] = name;
-      any = true;
-    }
-  }
-  return any ? out : NO_NAMES;
+  return namesBy(profiles, (address) => (profiles[address]?.display_name ?? '').trim() || null);
 }
 
 /**
@@ -140,23 +157,16 @@ export function verifiedNamesFrom(
   records: QnsBatchResult,
   isExempt: (name: string, address: string) => boolean = isExemptClaim,
 ): Record<string, string> {
-  const out: Record<string, string> = {};
-  let any = false;
-
-  for (const address of Object.keys(profiles)) {
+  return namesBy(profiles, (address) => {
     const claim = claimOf(profiles[address]);
-    if (!claim) continue;
+    if (!claim) return null;
 
     // The claimant address is the key of the map the claim arrived in — never a
     // value read out of the claim's own payload, which would let a forger
     // supply both sides of the comparison.
-    if (isExempt(claim, address) || claimedNameBelongsTo(records[claim], address)) {
-      out[address] = claim;
-      any = true;
-    }
-  }
-
-  return any ? out : NO_NAMES;
+    const proven = isExempt(claim, address) || claimedNameBelongsTo(records[claim], address);
+    return proven ? claim : null;
+  });
 }
 
 /**
@@ -169,6 +179,25 @@ export function verifiedNamesFrom(
  * it for cost without saying so here — and note the interactive lookup in
  * `useResolveQnsName.ts` deliberately uses a DIFFERENT, shorter value for a
  * different question. The two are not meant to agree.
+ *
+ * ## Known cost: the key is the name SET, so a growing set re-resolves all of it
+ *
+ * Scrolling a channel adds claimants one at a time. Each addition changes
+ * `namesKey`, which React Query treats as a new query, so the WHOLE accumulated
+ * set is fetched again rather than just the new name. Nested providers whose
+ * sets differ by even one address likewise do not share a cache entry.
+ *
+ * This is a deliberate trade, and quorum-mobile made the same one for the same
+ * reason: a 100-name batch was measured at ~190ms against ~167ms for a single
+ * name, so re-resolving everything costs barely more than resolving the delta,
+ * and it avoids a per-name bookkeeping layer. The abort signal above keeps the
+ * superseded requests from finishing.
+ *
+ * **If it ever does show up as a real cost, the fix is per-name cache entries**
+ * (one query key per name, coalesced into a batch by a dataloader-style layer),
+ * which makes additions incremental and shares every resolved name across all
+ * providers automatically. Do NOT reach for a shorter `staleTime` instead — the
+ * batch is what buys headroom here, and the TTL is a security parameter.
  */
 export function useVerifiedQnsNames(profiles: ProfileMap): Record<string, string> {
   const names = React.useMemo(() => claimedNamesIn(profiles), [profiles]);
@@ -178,7 +207,10 @@ export function useVerifiedQnsNames(profiles: ProfileMap): Record<string, string
 
   const { data } = useQuery({
     queryKey: ['qns-verify-claims', namesKey],
-    queryFn: () => resolveNamesBatch(names),
+    // `signal` so a request superseded by a widening set is abandoned rather
+    // than left to finish and have its answer discarded — see the note on
+    // re-resolution below, which is what makes that happen at all.
+    queryFn: ({ signal }) => resolveNamesBatch(names, signal),
     enabled: names.length > 0,
     staleTime: 60 * 60 * 1000,
     gcTime: 24 * 60 * 60 * 1000,


### PR DESCRIPTION
Desktop read `primary_username` straight out of a fetched public profile and
rendered it with a `.q` suffix, with no ownership check of any kind. That field
is self-reported: it arrives inside someone else's profile, and a signature
proves who sent a payload rather than that its contents are true. So anyone who
could get a `primary_username` into a profile desktop fetches rendered as
verified, whether or not they owned the name.

The suffix is the only signal a viewer gets that a name is genuinely owned, so
this is an impersonation the recipient cannot detect by looking.

### The check happens once, upstream

`IdentitySources` no longer carries a profile object at all. It carries
`verifiedQnsNames` (address to a name already proven to belong to it) and
`profileGlobalNames` (a display name, which carries no ownership claim and needs
no check). An unverified claim now has nowhere to live, so no surface can render
one even by mistake — which is what makes "no surface forgot" provable rather
than hopeful. Doing it per-surface would have been the wrong shape: one surface
that forgot would render a forgery and there would be no way to prove none did.

All ~20 `.q` render sites became truthful with no edits, because `isQnsVerified`
was already just "is there a qnsName".

**Absent means unproven, and that deliberately includes not-yet-known.** A lookup
in flight leaves the address out and the global name renders, so a name only ever
upgrades *into* a `.q`. Self is not a special case: a name you have not
registered does not become yours because you are the one looking at it.

### Cost

Claims resolve in one batched request per screen, capped at the server's limit of
100, on top of profile fetches that were already happening — so no new
per-address request. `staleTime` is one hour and is a security parameter: it is
the window in which a transferred name keeps verifying under its previous owner.

### Notes

- The dev QNS overlay gets a narrow, `NODE_ENV`-gated exemption, without which its
  synthesized names would be stripped and the instrument would silently go inert.
  The post-build guard now fails if that bypass ever reaches a production bundle —
  confirmed it catches the regression by moving the gate behind a runtime value
  and watching the build fail.
- A second defect found in review: the user-settings panel rendered your own
  unverified claim directly, bypassing the identity module. It survived the
  existing `rawNameFieldAudit` because both files sat under a "settings form
  editing your own profile" exception that quietly also covered a read-only render
  of the trust marker. Both exception reasons have been narrowed.
- Surface tests stub the final comparison: their address fixtures are arbitrary
  and no real key derives to them. The claim still travels the whole real path in
  those tests, so they still fail if the provider stops populating the verified
  map. Ownership itself is pinned separately and is mutation-proven.

158 test files, 1468 tests passing. Typecheck clean. Requires quorum-shared
2.1.0-43.

### Commits

- fix(identity): verify a QNS claim before rendering it as a .q
- refactor(identity): fold the duplicated map builder, wire the abort signal
- fix(identity): the settings .q notice was the last unverified render
