### PR TITLE
fix(identity): moderation confirmations use the resolved avatar, not the caller payload

### DIFF
--- a/.agents/INDEX.md
+++ b/.agents/INDEX.md
@@ -114,6 +114,7 @@ This is the main index for all documentation, bug reports, and task management.
 - 🐛 [Eight name surfaces never reached the resolver](issues/2026-08-10-name-surfaces-that-never-reached-the-resolver.md)
 - 🐛 [Notification switches freeze the UI for ~1.8s](issues/2026-08-13-notification-toggle-freeze-is-the-config-encode-chain.md)
 - 🐛 [Desktop has no `.q` broadcast, and trusts a `.q` it never checks](issues/2026-08-16-desktop-has-no-q-broadcast-and-renders-claims-unverified.md)
+- 🐛 [Mute/Block/Kick confirmations show no avatar when the profile card was opened from a mention pill](issues/2026-08-16-moderation-confirmations-show-no-avatar-from-a-mention-pill.md)
 - 📋 [Durable multi-device: per-device signing keys via master-signed device statements](issues/2026-07-19-per-device-signing-keys-registration-anchored.md)
 - 📋 [DM partner identity never recovers on an established session](issues/2026-08-01-dm-partner-identity-lost-on-established-sessions.md)
 - 📋 [Spaces: desktop never re-announces identity on connect](issues/2026-08-01-space-member-identity-announce-on-connect.md)
@@ -793,4 +794,4 @@ This is the main index for all documentation, bug reports, and task management.
 
 ---
 
-**Last Updated**: 2026-08-16 14:49:59
+**Last Updated**: 2026-08-16 15:03:42

--- a/.agents/issues/2026-08-16-moderation-confirmations-show-no-avatar-from-a-mention-pill.md
+++ b/.agents/issues/2026-08-16-moderation-confirmations-show-no-avatar-from-a-mention-pill.md
@@ -1,0 +1,150 @@
+---
+type: bug
+title: "Mute/Block/Kick confirmations show no avatar when the profile card was opened from a mention pill"
+status: in-progress
+priority: low
+created: 2026-08-16
+updated: 2026-08-16
+area: identity resolution / moderation modals
+related:
+  - ".agents/issues/.done/2026-08-11-profile-card-from-a-mention-pill-shows-a-stale-bio-and-no-avatar.md"
+---
+
+# Mute/Block/Kick confirmations show no avatar when the profile card was opened from a mention pill
+
+## Status
+
+**2026-08-16 — fixed on branch `fix/moderation-modal-avatar-resolved-icon`, not yet
+merged.** Three one-word swaps in `UserProfile.tsx` plus a new test file. Tests
+written first and observed failing with `userIcon: undefined` — the reported
+symptom — then green after the fix. Identity suite 234/234, adjacent component
+and hook suites 184/184, typecheck clean, lint clean on both changed files.
+
+Not yet visually confirmed in a running build.
+
+## The report
+
+> Channel A (the target user has never posted here, I simply mentioned their
+> username and clicked it to open the UserProfileModal). When I open the
+> UserProfileModal by clicking a mention in channel A, and then click mute,
+> block, kick, the second modal that opens doesn't show the user pfp.
+>
+> Channel B (the target user has posted one msg here). I tried opening the
+> UserProfileModal by clicking the user avatar in channel B, and in that way
+> the confirmation modals for mute, block, kick, do show the user pfp
+> correctly.
+
+Reported as "only reproduced this once, not sure if it's a bug". It is a bug,
+and it is deterministic.
+
+**The channel is incidental.** What varies is the ENTRY POINT, and the two
+happen to correlate: you can only click someone's message avatar in a channel
+where they have posted. Open the card from a mention pill in channel B and the
+same three confirmations lose the avatar there too.
+
+## The mechanism
+
+This is
+`2026-08-11-profile-card-from-a-mention-pill-shows-a-stale-bio-and-no-avatar`
+(PR #328) one hop further down the same chain.
+
+That fix gave the card `useProfileCardIdentityFields`, an avatar/bio ladder
+keyed on the address: caller pre-fill → per-space override → roster global slot
+→ published public profile. So the CARD renders the right avatar from either
+entry point, which is why the card itself looked fine in both channels.
+
+The three moderation buttons kept handing the modals the RAW caller payload:
+
+```ts
+// src/components/user/UserProfile.tsx — before
+openBlockUser({ address: props.user.address, userIcon: props.user.userIcon, … });
+openMuteUser ({ address: props.user.address, userIcon: props.user.userIcon, … });
+openKickUser ({ address: props.user.address, userIcon: props.user.userIcon });
+```
+
+`props.user.userIcon` is whatever the click event carried:
+
+| Entry point | Payload | Source |
+|---|---|---|
+| Message avatar | fully-merged member record, icon included | `Message.tsx`'s `onUserClick` |
+| Mention pill | `{ address }` and nothing else | `MessageMarkdownRenderer.tsx:877` |
+
+The address-only payload is deliberate (the NAME resolves from `src/identity`
+either way, so carrying a snapshot would just be a second thing that can
+drift). So from a mention pill the modals received `userIcon: undefined`.
+
+`ModalProvider` passes it straight through
+(`ModalProvider.tsx:106/205/220`), and the confirmation modals render it as a
+plain prop with no ladder of their own — `KickUserModal.tsx:85`, and the same
+shape in `MuteUserModal` and `BlockUserModal`. Result: initials where the photo
+belongs, in the dialog whose whole job is "confirm this is the right person".
+The NAME in those modals was always correct, because they resolve it from the
+address themselves via `useResolvedMemberName`.
+
+## The fix
+
+Pass the icon the card already resolved, since the modals can only be opened
+from the card:
+
+```ts
+userIcon: resolvedUserIcon,   // ×3
+```
+
+`resolvedUserIcon` is the output of `useProfileCardIdentityFields`, already
+computed at `UserProfile.tsx:162` and already rendered by the card's own
+`<UserAvatar>` two elements above the buttons.
+
+**Alternative considered and rejected as heavier:** have each modal run the
+ladder itself from `userAddress` + the route's `spaceId`, the way they already
+resolve the name. Correct, and more robust if a fourth caller ever opens these
+modals without going through the card, but it duplicates a roster read per
+modal to fix a bug with exactly one caller. Worth revisiting only if such a
+caller appears.
+
+## The test
+
+`src/dev/tests/identity/moderationModalHandoffIcon.test.tsx` — 4 tests.
+
+Asserts on the HAND-OFF payload (`openBlockUser`/`openMuteUser`/`openKickUser`
+call args) rather than on the rendered confirmation, because the hand-off is
+the value that changed and the modals downstream of it are a bare prop render.
+
+Fixture shape matters: the roster row carries the avatar only in
+`global_user_icon` (no per-space override, its normal state) and the public
+profile has an empty `profile_image` (what anyone who never opted into a public
+photo has). So the roster is the only source of that avatar, exactly as in the
+reported case.
+
+Carries a **control arm**: the message-avatar payload is asserted to produce an
+identical hand-off. That path already worked before the fix, so if the control
+is the assertion that fails, the ladder broke rather than the hand-off, and the
+sibling `profileCardRosterFields.test.tsx` is the file to read.
+
+Red-before-green was observed in the correct order: all 4 failed with
+`userIcon: undefined` against the expected roster icon, including the control
+arm showing the two entry points diverging, before any production change.
+
+## Found but NOT fixed — `isKicked` has the same shape
+
+`UserProfile.tsx:529/532/540` reads `props.user.isKicked`, also from the raw
+caller payload. From a mention pill it is `undefined`, so for an
+already-kicked member the Kick button does not grey out and still reads "Kick"
+instead of "Kicked!".
+
+Left alone deliberately: it is a different field with a different source (not
+part of the avatar/bio ladder), fixing it means deciding where kicked-state
+should resolve from, and widening a three-line UI fix to carry it would have
+made this change harder to review. Worth its own issue if it bothers anyone.
+
+## Definition of done
+
+- [x] Mechanism traced to `file:line`, both payloads compared
+- [x] Test written first, observed red for the reported reason
+- [x] Fix applied, test green
+- [x] Identity suite (234), adjacent suites (184), typecheck, lint
+- [ ] Visually confirmed in a running build, from both entry points
+- [ ] Merged
+
+---
+
+*Last updated: 2026-08-16*

--- a/src/components/user/UserProfile.tsx
+++ b/src/components/user/UserProfile.tsx
@@ -173,6 +173,14 @@ const UserProfile: React.FunctionComponent<{
   // `openBlockUser`/`openMuteUser`/`openKickUser` anymore (was
   // `displayName: resolvedNameText`, the exact field-threading this refactor
   // removes; see KickUserModal/MuteUserModal/BlockUserModal).
+  //
+  // The AVATAR is the exception, and the reason those three call sites below
+  // must pass `resolvedUserIcon` rather than `props.user.userIcon`: the icon
+  // is not a name, so the identity module does not carry it, and the modals
+  // take `userIcon` as a plain prop with no ladder of their own. Handing them
+  // the raw caller payload reproduced the mention-pill bug one hop further
+  // down — the card showed the photo, and the confirmation it opened showed
+  // initials. See `moderationModalHandoffIcon.test.tsx`.
   const [noteValue, setNoteValue] = React.useState('');
   const [noteCharCount, setNoteCharCount] = React.useState(0);
   const [isNoteFocused, setIsNoteFocused] = React.useState(false);
@@ -488,7 +496,7 @@ const UserProfile: React.FunctionComponent<{
                     onClick={() => {
                       openBlockUser({
                         address: props.user.address,
-                        userIcon: props.user.userIcon,
+                        userIcon: resolvedUserIcon,
                         spaceId: props.spaceId!,
                         isUnblocking: isUserBlocked,
                       });
@@ -511,7 +519,7 @@ const UserProfile: React.FunctionComponent<{
                     onClick={() => {
                       openMuteUser({
                         address: props.user.address,
-                        userIcon: props.user.userIcon,
+                        userIcon: resolvedUserIcon,
                         isUnmuting: isUserMuted,
                       });
                       props.dismiss?.();
@@ -532,7 +540,7 @@ const UserProfile: React.FunctionComponent<{
                       if (props.user.isKicked) return;
                       openKickUser({
                         address: props.user.address,
-                        userIcon: props.user.userIcon,
+                        userIcon: resolvedUserIcon,
                       });
                       props.dismiss?.();
                     }}

--- a/src/dev/tests/identity/moderationModalHandoffIcon.test.tsx
+++ b/src/dev/tests/identity/moderationModalHandoffIcon.test.tsx
@@ -1,0 +1,266 @@
+/**
+ * The Block/Mute/Kick confirmations must show the avatar the CARD resolved,
+ * not the one the card was handed.
+ *
+ * This is `2026-08-11-profile-card-from-a-mention-pill-shows-a-stale-bio-and-no-avatar`
+ * one hop further down the chain. That fix gave the card
+ * `useProfileCardIdentityFields`, so the card itself renders the right avatar
+ * from either entry point. But the three moderation buttons kept handing
+ * `props.user.userIcon` — the RAW caller payload — to
+ * `openBlockUser`/`openMuteUser`/`openKickUser`. From a mention pill that
+ * payload is `{ address }` and nothing else, so the confirmation dialog showed
+ * initials while the card two pixels above it showed the photo.
+ *
+ * The confirmation modals have no ladder of their own (they take `userIcon` as
+ * a plain prop and render it — see KickUserModal.tsx), so the hand-off IS the
+ * defect. These tests assert on the hand-off payload for that reason: it is
+ * the exact value that changed, and it fails for the reported reason when the
+ * fix is reverted.
+ *
+ * Reported symptom: open a profile card by clicking a mention, then click
+ * Mute/Block/Kick — the confirmation has no profile picture. Open the same
+ * person's card from their message avatar and the same three confirmations
+ * show it. The channel is incidental: you can only click an avatar in a
+ * channel where they posted, which is what made this look channel-dependent.
+ */
+import * as React from 'react';
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { i18n } from '@lingui/core';
+import { messages } from '@/i18n/en/messages';
+import { IdentityScopeProvider } from '@/identity';
+
+beforeAll(() => {
+  i18n.load('en', messages);
+  i18n.activate('en');
+});
+
+const getPublicProfile = vi.fn();
+vi.mock('@/api/baseTypes', () => ({
+  QuorumApiClient: class {
+    getPublicProfile(address: string) {
+      return getPublicProfile(address);
+    }
+  },
+  isHandledFetchError: () => false,
+}));
+
+const SELF_ADDR = 'QmSelf00000000000000000000000000000000';
+vi.mock('@quilibrium/quilibrium-js-sdk-channels', () => ({
+  channel: {},
+  usePasskeysContext: () => ({ currentPasskeyInfo: { address: SELF_ADDR } }),
+}));
+
+const getSpaceMembers = vi.fn();
+const getSpace = vi.fn();
+vi.mock('@/components/context/useMessageDB', () => ({
+  useMessageDB: () => ({
+    messageDB: {
+      getSpace: (spaceId: string) => getSpace(spaceId),
+      getSpaceMembers: (spaceId: string) => getSpaceMembers(spaceId),
+      getUserConfig: vi.fn().mockResolvedValue(null),
+      saveUserConfig: vi.fn(),
+      deleteUserNote: vi.fn(),
+      saveUserNote: vi.fn(),
+    },
+  }),
+}));
+
+// The whole point of the file: capture what the card hands the modals.
+const openMuteUser = vi.fn();
+const openKickUser = vi.fn();
+const openBlockUser = vi.fn();
+vi.mock('@/components/context/ModalProvider', () => ({
+  useModals: () => ({ openMuteUser, openKickUser, openBlockUser }),
+}));
+
+// See UserProfile.test.tsx: ClickToCopyContent pulls in react-tooltip, which
+// crashes under vitest with a duplicate-React "Invalid hook call".
+vi.mock('@/components/ui', () => ({
+  ClickToCopyContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+// Owner, so the Kick button renders at all (kick has no role path — it needs
+// the owner's ED448 key, so `useSpaceOwner` is the only gate).
+vi.mock('@/hooks/queries/spaceOwner', () => ({
+  useSpaceOwner: () => ({ data: true }),
+}));
+vi.mock('@/hooks/queries/mutedUsers', () => ({
+  useMutedUsers: () => ({ data: [] }),
+}));
+vi.mock('@/hooks/queries/userNotes', () => ({
+  useUserNote: () => ({ data: null }),
+  buildUserNoteKey: ({ targetAddress }: { targetAddress: string }) => ['user-note', targetAddress],
+}));
+vi.mock('@/hooks/business/user/useBlockUser', () => ({
+  useBlockUser: () => ({ isBlocked: () => false, blockUser: vi.fn(), unblockUser: vi.fn() }),
+}));
+
+vi.mock('@/hooks', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/hooks')>();
+  return {
+    ...actual,
+    useUserRoleManagement: () => ({ addRole: vi.fn(), removeRole: vi.fn(), loadingRoles: new Set() }),
+    useUserProfileActions: () => ({ sendMessage: vi.fn() }),
+    useUserRoleDisplay: () => ({ userRoles: [], availableRoles: [] }),
+  };
+});
+
+const ADDR = 'QmPeerUEgVKpYZKYuFu2J49zHXnA8vZtEqHMtpB4imzzzz';
+const SPACE_ID = 'space-1';
+
+const ROSTER_ICON = 'https://example.com/live-roster-avatar.png';
+
+/**
+ * The member row as the identity announce leaves it: no per-space override
+ * (its normal state), the avatar living in the live-pushed global slot. The
+ * published public profile has no photo, which is what anyone who never opted
+ * in has — so the roster is the ONLY source of this avatar, exactly as in the
+ * reported case.
+ */
+const ROSTER_ROW = {
+  address: ADDR,
+  user_address: ADDR,
+  display_name: '',
+  global_display_name: 'Alice',
+  user_icon: '',
+  bio: '',
+  global_user_icon: ROSTER_ICON,
+  global_bio: 'A bio.',
+};
+
+const PUBLIC_PROFILE = {
+  primary_username: 'alice',
+  display_name: 'Alice',
+  bio: 'A bio.',
+  profile_image: '',
+};
+
+/** Grants SELF the `user:mute` permission, so the Mute button renders.
+ *  Mute has no owner bypass by design — the receiving side cannot verify
+ *  ownership, so owners must hold a role like every other moderator. */
+const SPACE = {
+  spaceId: SPACE_ID,
+  roles: [
+    {
+      roleId: 'mod',
+      roleTag: 'mod',
+      displayName: 'Mod',
+      color: 'blue',
+      members: [SELF_ADDR],
+      permissions: ['user:mute'],
+    },
+  ],
+};
+
+import UserProfile from '@/components/user/UserProfile';
+
+function renderCard(user: Record<string, unknown>) {
+  getPublicProfile.mockResolvedValue({ data: PUBLIC_PROFILE });
+  getSpaceMembers.mockResolvedValue([ROSTER_ROW]);
+  getSpace.mockResolvedValue(SPACE);
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <IdentityScopeProvider
+        spaceId={SPACE_ID}
+        rostersBySpace={{
+          [SPACE_ID]: {
+            [ADDR]: {
+              display_name: ROSTER_ROW.display_name,
+              global_display_name: ROSTER_ROW.global_display_name,
+            },
+          },
+        }}
+        selfAddress={SELF_ADDR}
+      >
+        <UserProfile spaceId={SPACE_ID} user={user} dismiss={() => {}} />
+      </IdentityScopeProvider>
+    </QueryClientProvider>,
+  );
+}
+
+/** What `MessageMarkdownRenderer`'s mention-pill click passes: address only. */
+const MENTION_PAYLOAD = { address: ADDR };
+
+/** What `Message.tsx`'s avatar click passes: the merged member record. */
+const AVATAR_PAYLOAD = {
+  address: ADDR,
+  displayName: 'Alice',
+  userIcon: ROSTER_ICON,
+  bio: 'A bio.',
+};
+
+/** Wait until the ladder has settled, i.e. the card is showing the roster
+ *  avatar. Clicking before this would test the pre-fill flash, not the fix. */
+async function waitForCardAvatar() {
+  await waitFor(() => {
+    const img = document.querySelector<HTMLImageElement>('.user-profile-icon img');
+    expect(img?.src).toBe(ROSTER_ICON);
+  });
+}
+
+describe('moderation confirmations get the RESOLVED avatar, not the caller payload', () => {
+  beforeEach(() => {
+    getPublicProfile.mockReset();
+    getSpaceMembers.mockReset();
+    getSpace.mockReset();
+    openMuteUser.mockReset();
+    openKickUser.mockReset();
+    openBlockUser.mockReset();
+  });
+
+  it('passes the roster avatar to Block, from an address-only payload', async () => {
+    renderCard(MENTION_PAYLOAD);
+    await waitForCardAvatar();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Block' }));
+
+    expect(openBlockUser).toHaveBeenCalledWith(
+      expect.objectContaining({ address: ADDR, userIcon: ROSTER_ICON }),
+    );
+  });
+
+  it('passes the roster avatar to Mute, from an address-only payload', async () => {
+    renderCard(MENTION_PAYLOAD);
+    await waitForCardAvatar();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Mute' }));
+
+    expect(openMuteUser).toHaveBeenCalledWith(
+      expect.objectContaining({ address: ADDR, userIcon: ROSTER_ICON }),
+    );
+  });
+
+  it('passes the roster avatar to Kick, from an address-only payload', async () => {
+    renderCard(MENTION_PAYLOAD);
+    await waitForCardAvatar();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Kick' }));
+
+    expect(openKickUser).toHaveBeenCalledWith(
+      expect.objectContaining({ address: ADDR, userIcon: ROSTER_ICON }),
+    );
+  });
+
+  it('hands the message-avatar entry point the identical payload', async () => {
+    // Control arm. This path already worked before the fix — its payload
+    // carried the icon. If THIS one ever fails, the ladder itself broke, not
+    // the hand-off, and the sibling profileCardRosterFields test is the one to
+    // read.
+    const mention = renderCard(MENTION_PAYLOAD);
+    await waitForCardAvatar();
+    fireEvent.click(screen.getByRole('button', { name: 'Kick' }));
+    const fromMention = openKickUser.mock.calls[0][0];
+    mention.unmount();
+
+    openKickUser.mockReset();
+    renderCard(AVATAR_PAYLOAD);
+    await waitForCardAvatar();
+    fireEvent.click(screen.getByRole('button', { name: 'Kick' }));
+    const fromAvatar = openKickUser.mock.calls[0][0];
+
+    expect(fromMention).toEqual(fromAvatar);
+  });
+});


### PR DESCRIPTION
The Block/Mute/Kick confirmation dialogs showed initials instead of the member's
profile picture whenever the profile card had been opened from a **mention pill**.
Opening the same person's card from their message avatar, one click away, showed
the picture correctly.

This is #328 one hop further down the same chain. That fix gave the card
`useProfileCardIdentityFields`, an avatar/bio ladder keyed on the address, so the
card itself renders correctly from either entry point. The three moderation
buttons kept handing the modals the raw click payload instead:

| Entry point | Payload | Result |
|---|---|---|
| Message avatar | fully-merged member record, icon included | picture shown |
| Mention pill | `{ address }` and nothing else | `userIcon: undefined` |

The confirmation modals take `userIcon` as a plain prop with no ladder of their
own, so the hand-off is the defect. The name in those dialogs was always right,
because they resolve it from the address themselves.

Fix: pass `resolvedUserIcon`, which the card has already resolved and is already
rendering two elements above the buttons. The modals can only be opened from the
card, so there is no caller that would miss it.

The reported channel dependency was incidental — you can only click a message
avatar in a channel where the member has posted, which is what made an
entry-point bug look channel-scoped.

### Verification

- New test `moderationModalHandoffIcon.test.tsx`, 4 tests, asserting the hand-off
  payload from an address-only click, with a control arm proving the
  message-avatar entry point produces an identical payload.
- All four were observed **red before the fix**, failing with
  `userIcon: undefined` against the expected roster icon — the reported symptom.
- Identity suite 234/234, adjacent component and hook suites 184/184, typecheck
  clean, lint clean on both changed files.
- Visually confirmed in a running build from both entry points.

### Known, not fixed here

`props.user.isKicked` reads from the same raw payload, so from a mention pill an
already-kicked member's Kick button does not grey out. Different field, different
source; written up in the issue rather than widened into this change.
