### PR TITLE
fix(identity): resolve the profile card's kicked state from the roster, and assert entry-point parity

### DIFF
--- a/.agents/INDEX.md
+++ b/.agents/INDEX.md
@@ -114,6 +114,7 @@ This is the main index for all documentation, bug reports, and task management.
 - 🐛 [Eight name surfaces never reached the resolver](issues/2026-08-10-name-surfaces-that-never-reached-the-resolver.md)
 - 🐛 [Notification switches freeze the UI for ~1.8s](issues/2026-08-13-notification-toggle-freeze-is-the-config-encode-chain.md)
 - 🐛 [Desktop has no `.q` broadcast, and trusts a `.q` it never checks](issues/2026-08-16-desktop-has-no-q-broadcast-and-renders-claims-unverified.md)
+- 🐛 [The profile card's Kick button state came from the click payload](issues/2026-08-16-profile-card-entry-point-parity.md)
 - 📋 [Durable multi-device: per-device signing keys via master-signed device statements](issues/2026-07-19-per-device-signing-keys-registration-anchored.md)
 - 📋 [DM partner identity never recovers on an established session](issues/2026-08-01-dm-partner-identity-lost-on-established-sessions.md)
 - 📋 [Spaces: desktop never re-announces identity on connect](issues/2026-08-01-space-member-identity-announce-on-connect.md)
@@ -794,4 +795,4 @@ This is the main index for all documentation, bug reports, and task management.
 
 ---
 
-**Last Updated**: 2026-08-16 15:08:29
+**Last Updated**: 2026-08-16 15:26:47

--- a/.agents/issues/.done/2026-08-16-moderation-confirmations-show-no-avatar-from-a-mention-pill.md
+++ b/.agents/issues/.done/2026-08-16-moderation-confirmations-show-no-avatar-from-a-mention-pill.md
@@ -130,7 +130,13 @@ Red-before-green was observed in the correct order: all 4 failed with
 `userIcon: undefined` against the expected roster icon, including the control
 arm showing the two entry points diverging, before any production change.
 
-## Found but NOT fixed — `isKicked` has the same shape
+## Found but NOT fixed here — `isKicked` has the same shape
+
+> **Superseded 2026-08-16.** Fixed in the follow-up, together with a parity test
+> that asserts the whole card renders identically from both entry points rather
+> than chasing one field at a time. See
+> `2026-08-16-profile-card-entry-point-parity.md`. The section below is kept as
+> the original finding.
 
 `UserProfile.tsx:529/532/540` reads `props.user.isKicked`, also from the raw
 caller payload. From a mention pill it is `undefined`, so for an

--- a/.agents/issues/2026-08-16-profile-card-entry-point-parity.md
+++ b/.agents/issues/2026-08-16-profile-card-entry-point-parity.md
@@ -1,0 +1,129 @@
+---
+type: bug
+title: "The profile card's Kick button state came from the click payload, so it was wrong from a mention pill"
+status: in-progress
+priority: low
+created: 2026-08-16
+updated: 2026-08-16
+area: identity resolution / profile card
+related:
+  - ".agents/issues/.done/2026-08-16-moderation-confirmations-show-no-avatar-from-a-mention-pill.md"
+  - ".agents/issues/.done/2026-08-11-profile-card-from-a-mention-pill-shows-a-stale-bio-and-no-avatar.md"
+---
+
+# The profile card's Kick button state came from the click payload
+
+## Status
+
+**2026-08-16 — fixed on branch `fix/profile-card-entry-point-parity`, not yet
+merged.** `isKicked` now resolves from the roster row, and a new parity test
+asserts the whole card renders identically from both entry points.
+
+Verified: parity test written first and observed **red**, naming the Kick button
+as the only divergence in both the card and drawer variants; green after the fix.
+Identity suite 238/238, typecheck clean, lint clean on all three changed files.
+
+Not yet visually confirmed in a running build.
+
+## Why this exists: the same bug had been fixed twice, one field at a time
+
+| Fix | Field | Date |
+|---|---|---|
+| #328 | the card's own bio and avatar | 2026-08-11 |
+| #344 | the avatar handed to Block/Mute/Kick | 2026-08-16 |
+| this | the Kick button's `isKicked` state | 2026-08-16 |
+
+All three are one defect wearing different hats. A mention-pill click passes
+`{ address }` and nothing else; a message-avatar click passes a fully-merged
+member record. **Any field the card reads off that payload rather than resolving
+from the address renders differently depending on which pill you clicked.**
+
+Fixing them one at a time does not converge. Each fix leaves the next unfound
+field in place, and nothing tells you how many remain. #344's write-up closed
+with a "Found but NOT fixed" section naming `isKicked` — which is exactly how
+the third instance was about to become the fourth.
+
+So the instrument came first this time, and the fix second.
+
+## The instrument
+
+`src/dev/tests/identity/profileCardEntryPointParity.test.tsx` renders the card
+from both payloads against **identical sources** and asserts the entire rendered
+output matches. Not one field: the whole DOM.
+
+The fixture is deliberately hostile — the member is kicked, and their avatar and
+bio exist only in the roster's live-pushed global slots while the public profile
+is empty. That is the state where the caller payload and the address-keyed
+sources disagree most, so a field read from the wrong source cannot pass by
+coincidence.
+
+Three assertions, in increasing strictness:
+
+1. **Button summary** (label + disabled state per control). Runs first because
+   it names the offending control in one readable line.
+2. **Byte-identical normalised markup**, card variant.
+3. **Byte-identical normalised markup**, drawer variant — a different render
+   path through the same component, so it can diverge independently.
+
+Plus a control arm asserting the two payloads really are different objects, so
+the file cannot pass trivially by comparing two identical inputs.
+
+Only `button-<random>` ids are normalised away (`Button.web.tsx:12` generates
+them per render). Nothing else is masked; masking is how a parity test quietly
+stops testing.
+
+## What it found
+
+Exactly one divergence, in both variants — about 5KB of markup identical, then:
+
+```
+btn-danger-outline  "Kick"      ← mention pill  (isKicked undefined)
+btn-disabled        "Kicked!"   ← message avatar (isKicked true)  + disabled=""
+```
+
+Meaning: for a member you have **already kicked**, opening their card from a
+mention pill showed an enabled "Kick" button instead of a greyed-out "Kicked!".
+
+It also confirms the useful negative: after #328 and #344, nothing else on this
+card is read raw. That was previously an assumption.
+
+## The fix
+
+`isKicked` is a real persisted roster field — written by `MessageService.ts:5914`,
+mapped at `indexedDbAdapter.ts:159`, read off the same row by
+`useChannelData.ts:106`. `useProfileCardIdentityFields` already reads that exact
+row for this address, so resolving it there costs nothing extra (same react-query
+key, a cache read).
+
+```ts
+isKicked: member ? Boolean(member.isKicked) : callerIsKicked,
+```
+
+**The precedence is deliberately the reverse of the avatar's.** The avatar puts
+the caller pre-fill first to avoid a flash while the roster read settles, which
+is safe because the two agree. `isKicked` can genuinely disagree: a caller
+snapshot taken before the kick says `false` while the roster says `true`, and
+letting a stale `false` win would re-enable a destructive moderation action
+against someone already removed. Freshness beats flicker for that control. The
+caller value survives only as the fallback when there is no roster row at all
+(a DM).
+
+## Scope note
+
+The parity test covers `UserProfile` only, which is what the report was about.
+Other surfaces that render a member from a caller-supplied payload are not in
+scope here and have not been checked for the same class of defect.
+
+## Definition of done
+
+- [x] Instrument written first, observed red, naming the divergence
+- [x] Divergence traced to a real persisted field with an address-keyed source
+- [x] Fix applied, parity green in both variants
+- [x] Identity suite (238), typecheck, lint
+- [x] Supersedes the "Found but NOT fixed" note in the #344 write-up
+- [ ] Visually confirmed in a running build
+- [ ] Merged
+
+---
+
+*Last updated: 2026-08-16*

--- a/src/components/user/UserProfile.tsx
+++ b/src/components/user/UserProfile.tsx
@@ -159,11 +159,16 @@ const UserProfile: React.FunctionComponent<{
   // what feeds the initials fallback below, so it always agrees with the name
   // actually rendered beside it (design constraint 4 of the identity
   // migration: the avatar and the name must not disagree).
-  const { userIcon: resolvedUserIcon, bio: resolvedBio } = useProfileCardIdentityFields({
+  const {
+    userIcon: resolvedUserIcon,
+    bio: resolvedBio,
+    isKicked: resolvedIsKicked,
+  } = useProfileCardIdentityFields({
     address: props.user.address,
     spaceId: props.spaceId,
     callerIcon: props.user.userIcon as string | undefined,
     callerBio: props.user.bio as string | undefined,
+    callerIsKicked: props.user.isKicked as boolean | undefined,
     publicProfileIcon: openedUserPublicProfile?.profile_image,
     publicProfileBio: openedUserPublicProfile?.bio,
     ownConfigBio: ownConfig?.bio,
@@ -534,10 +539,10 @@ const UserProfile: React.FunctionComponent<{
                     type="danger-outline"
                     size="compact"
                     fullWidth
-                    disabled={props.user.isKicked}
+                    disabled={resolvedIsKicked}
                     iconName="ban"
                     onClick={() => {
-                      if (props.user.isKicked) return;
+                      if (resolvedIsKicked) return;
                       openKickUser({
                         address: props.user.address,
                         userIcon: resolvedUserIcon,
@@ -545,7 +550,7 @@ const UserProfile: React.FunctionComponent<{
                       props.dismiss?.();
                     }}
                   >
-                    {props.user.isKicked ? t`Kicked!` : t`Kick`}
+                    {resolvedIsKicked ? t`Kicked!` : t`Kick`}
                   </Button>
                 )}
               </div>

--- a/src/dev/tests/identity/profileCardEntryPointParity.test.tsx
+++ b/src/dev/tests/identity/profileCardEntryPointParity.test.tsx
@@ -1,0 +1,290 @@
+/**
+ * The profile card must render IDENTICALLY from both entry points.
+ *
+ * This is the general form of two bugs already fixed one field at a time:
+ *
+ *   #328  the card's own bio and avatar    (2026-08-11)
+ *   #344  the avatar handed to Block/Mute/Kick (2026-08-16)
+ *
+ * Both had the same shape. A mention-pill click passes `{ address }` and
+ * nothing else (`MessageMarkdownRenderer.tsx`, deliberate — the name resolves
+ * from `src/identity` either way); a message-avatar click passes a fully-merged
+ * member record (`Message.tsx`). Any field the card reads off that payload
+ * instead of resolving from the address therefore renders differently
+ * depending on which pill you happened to click.
+ *
+ * Fixing those fields one at a time does not converge — each fix leaves the
+ * next unfound field in place, and nothing says how many are left. So this file
+ * asserts the WHOLE rendered card is identical between the two payloads,
+ * against identical sources. Any divergence is a bug of this class, including
+ * ones nobody has thought of yet.
+ *
+ * The fixture is deliberately hostile: the member is KICKED and their avatar
+ * exists only in the roster's live-pushed global slot, with an empty public
+ * profile. That is the state in which the caller payload and the address-keyed
+ * sources disagree the most, so a field read from the wrong one cannot pass by
+ * coincidence.
+ *
+ * READING A FAILURE: the button-summary assertion runs first and names the
+ * offending control in plain text. The full-DOM assertion below it is the
+ * exhaustive net and produces a long diff — check the summary first.
+ *
+ * WHAT THIS DOES NOT COVER: the loading window. The caller payload is
+ * deliberately the top rung of the avatar/bio ladder so the avatar path does
+ * not flash while the roster read settles, which means the two entry points
+ * legitimately differ for a few milliseconds. Both renders are awaited to a
+ * settled state before comparison.
+ */
+import * as React from 'react';
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { i18n } from '@lingui/core';
+import { messages } from '@/i18n/en/messages';
+import { IdentityScopeProvider } from '@/identity';
+
+beforeAll(() => {
+  i18n.load('en', messages);
+  i18n.activate('en');
+});
+
+const getPublicProfile = vi.fn();
+vi.mock('@/api/baseTypes', () => ({
+  QuorumApiClient: class {
+    getPublicProfile(address: string) {
+      return getPublicProfile(address);
+    }
+  },
+  isHandledFetchError: () => false,
+}));
+
+const SELF_ADDR = 'QmSelf00000000000000000000000000000000';
+vi.mock('@quilibrium/quilibrium-js-sdk-channels', () => ({
+  channel: {},
+  usePasskeysContext: () => ({ currentPasskeyInfo: { address: SELF_ADDR } }),
+}));
+
+const getSpaceMembers = vi.fn();
+const getSpace = vi.fn();
+vi.mock('@/components/context/useMessageDB', () => ({
+  useMessageDB: () => ({
+    messageDB: {
+      getSpace: (spaceId: string) => getSpace(spaceId),
+      getSpaceMembers: (spaceId: string) => getSpaceMembers(spaceId),
+      getUserConfig: vi.fn().mockResolvedValue(null),
+      saveUserConfig: vi.fn(),
+      deleteUserNote: vi.fn(),
+      saveUserNote: vi.fn(),
+    },
+  }),
+}));
+
+vi.mock('@/components/context/ModalProvider', () => ({
+  useModals: () => ({ openMuteUser: vi.fn(), openKickUser: vi.fn(), openBlockUser: vi.fn() }),
+}));
+
+// See UserProfile.test.tsx: ClickToCopyContent pulls in react-tooltip, which
+// crashes under vitest with a duplicate-React "Invalid hook call".
+vi.mock('@/components/ui', () => ({
+  ClickToCopyContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+// Owner, so every moderation control is on screen and therefore in scope for
+// the comparison. A card missing the buttons would pass this file trivially.
+vi.mock('@/hooks/queries/spaceOwner', () => ({
+  useSpaceOwner: () => ({ data: true }),
+}));
+vi.mock('@/hooks/queries/mutedUsers', () => ({
+  useMutedUsers: () => ({ data: [] }),
+}));
+vi.mock('@/hooks/queries/userNotes', () => ({
+  useUserNote: () => ({ data: null }),
+  buildUserNoteKey: ({ targetAddress }: { targetAddress: string }) => ['user-note', targetAddress],
+}));
+vi.mock('@/hooks/business/user/useBlockUser', () => ({
+  useBlockUser: () => ({ isBlocked: () => false, blockUser: vi.fn(), unblockUser: vi.fn() }),
+}));
+
+vi.mock('@/hooks', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/hooks')>();
+  return {
+    ...actual,
+    useUserRoleManagement: () => ({ addRole: vi.fn(), removeRole: vi.fn(), loadingRoles: new Set() }),
+    useUserProfileActions: () => ({ sendMessage: vi.fn() }),
+    useUserRoleDisplay: () => ({ userRoles: [], availableRoles: [] }),
+  };
+});
+
+const ADDR = 'QmPeerUEgVKpYZKYuFu2J49zHXnA8vZtEqHMtpB4imzzzz';
+const SPACE_ID = 'space-1';
+const ROSTER_ICON = 'https://example.com/live-roster-avatar.png';
+const ROSTER_BIO = 'The bio I just edited on my other device.';
+
+/**
+ * Kicked, avatar and bio only in the live-pushed global slots, no per-space
+ * override. `isKicked` is a real persisted roster field (written by
+ * `MessageService.ts:5914`, mapped at `indexedDbAdapter.ts:159`), so it is
+ * resolvable from the address like everything else here.
+ */
+const ROSTER_ROW = {
+  address: ADDR,
+  user_address: ADDR,
+  display_name: '',
+  global_display_name: 'Alice',
+  user_icon: '',
+  bio: '',
+  global_user_icon: ROSTER_ICON,
+  global_bio: ROSTER_BIO,
+  isKicked: true,
+};
+
+/** Opt-in and empty, which is its normal state — so the roster is the only
+ *  source of the avatar and the caller payload cannot be covered for. */
+const PUBLIC_PROFILE = {
+  primary_username: 'alice',
+  display_name: 'Alice',
+  bio: ROSTER_BIO,
+  profile_image: '',
+};
+
+/** Grants SELF `user:mute`, so the Mute button renders. Mute has no owner
+ *  bypass by design; owners hold a role like any other moderator. */
+const SPACE = {
+  spaceId: SPACE_ID,
+  roles: [
+    {
+      roleId: 'mod',
+      roleTag: 'mod',
+      displayName: 'Mod',
+      color: 'blue',
+      members: [SELF_ADDR],
+      permissions: ['user:mute'],
+    },
+  ],
+};
+
+import UserProfile from '@/components/user/UserProfile';
+
+/** What `MessageMarkdownRenderer`'s mention-pill click passes. */
+const MENTION_PAYLOAD = { address: ADDR };
+
+/** What `Message.tsx`'s avatar click passes: the merged member record, whose
+ *  fields `useChannelData` has already resolved off the same roster row. */
+const AVATAR_PAYLOAD = {
+  address: ADDR,
+  displayName: 'Alice',
+  userIcon: ROSTER_ICON,
+  bio: ROSTER_BIO,
+  isKicked: true,
+};
+
+function renderCard(user: Record<string, unknown>, variant?: 'card' | 'drawer') {
+  getPublicProfile.mockResolvedValue({ data: PUBLIC_PROFILE });
+  getSpaceMembers.mockResolvedValue([ROSTER_ROW]);
+  getSpace.mockResolvedValue(SPACE);
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <IdentityScopeProvider
+        spaceId={SPACE_ID}
+        rostersBySpace={{
+          [SPACE_ID]: {
+            [ADDR]: {
+              display_name: ROSTER_ROW.display_name,
+              global_display_name: ROSTER_ROW.global_display_name,
+            },
+          },
+        }}
+        selfAddress={SELF_ADDR}
+      >
+        <UserProfile spaceId={SPACE_ID} user={user} dismiss={() => {}} variant={variant} />
+      </IdentityScopeProvider>
+    </QueryClientProvider>,
+  );
+}
+
+/**
+ * `Button.web.tsx` generates `button-<random>` when given no explicit id, and
+ * feeds it to the tooltip's `id`/`data-tooltip-id`. That is genuine
+ * per-render noise, not a divergence, so it is normalised away. Nothing else
+ * about the markup is touched — the point of this file is to compare
+ * everything that is NOT noise.
+ */
+function normalize(html: string): string {
+  return html.replace(/button-[a-z0-9]+/g, 'button-NORMALIZED');
+}
+
+/** The legible half of the comparison: every control, its label, and whether
+ *  it is disabled. A failure here names the broken button in one line. */
+function buttonSummary(root: HTMLElement) {
+  return Array.from(root.querySelectorAll('button')).map((b) => ({
+    label: b.textContent?.trim(),
+    disabled: b.disabled,
+  }));
+}
+
+/** Settled = the roster read has landed and the card is showing the roster
+ *  avatar. Comparing before this would compare the deliberate pre-fill flash. */
+async function renderSettled(user: Record<string, unknown>, variant?: 'card' | 'drawer') {
+  const view = renderCard(user, variant);
+  const iconSelector = variant === 'drawer' ? '.user-profile-header img' : '.user-profile-icon img';
+  await waitFor(() => {
+    const img = view.container.querySelector<HTMLImageElement>(iconSelector);
+    expect(img?.src).toBe(ROSTER_ICON);
+  });
+  return view;
+}
+
+async function captureBothEntryPoints(variant?: 'card' | 'drawer') {
+  const mentionView = await renderSettled(MENTION_PAYLOAD, variant);
+  const fromMention = {
+    buttons: buttonSummary(mentionView.container),
+    html: normalize(mentionView.container.innerHTML),
+  };
+  mentionView.unmount();
+
+  const avatarView = await renderSettled(AVATAR_PAYLOAD, variant);
+  const fromAvatar = {
+    buttons: buttonSummary(avatarView.container),
+    html: normalize(avatarView.container.innerHTML),
+  };
+  avatarView.unmount();
+
+  return { fromMention, fromAvatar };
+}
+
+describe('the profile card renders identically from both entry points', () => {
+  beforeEach(() => {
+    getPublicProfile.mockReset();
+    getSpaceMembers.mockReset();
+    getSpace.mockReset();
+  });
+
+  it('shows the same controls, with the same labels and disabled states', async () => {
+    const { fromMention, fromAvatar } = await captureBothEntryPoints();
+    expect(fromMention.buttons).toEqual(fromAvatar.buttons);
+  });
+
+  it('produces byte-identical markup', async () => {
+    const { fromMention, fromAvatar } = await captureBothEntryPoints();
+    expect(fromMention.html).toBe(fromAvatar.html);
+  });
+
+  it('produces byte-identical markup in the drawer variant too', async () => {
+    // The below-1024px presentation is a different render path through the
+    // same component, so it can diverge independently of the card variant.
+    const { fromMention, fromAvatar } = await captureBothEntryPoints('drawer');
+    expect(fromMention.html).toBe(fromAvatar.html);
+  });
+
+  it('sanity: the fixture actually distinguishes the two payloads', async () => {
+    // Control arm. If the sources were so complete that the caller payload
+    // could not matter, every assertion above would pass no matter how many
+    // fields were read raw, and this file would be worthless. Prove the
+    // payloads really are different objects carrying different information.
+    expect(Object.keys(MENTION_PAYLOAD)).toEqual(['address']);
+    expect(Object.keys(AVATAR_PAYLOAD).length).toBeGreaterThan(1);
+    expect(AVATAR_PAYLOAD.isKicked).toBe(true);
+    expect((MENTION_PAYLOAD as Record<string, unknown>).isKicked).toBeUndefined();
+  });
+});

--- a/src/hooks/business/user/useProfileCardIdentityFields.ts
+++ b/src/hooks/business/user/useProfileCardIdentityFields.ts
@@ -117,6 +117,8 @@ export interface UseProfileCardIdentityFieldsArgs {
   spaceId?: string;
   callerIcon?: string;
   callerBio?: string;
+  /** Pre-fill only, and the LOWEST rung for this one — see the return value. */
+  callerIsKicked?: boolean;
   publicProfileIcon?: string;
   publicProfileBio?: string;
   ownConfigBio?: string;
@@ -127,10 +129,15 @@ export function useProfileCardIdentityFields({
   spaceId,
   callerIcon,
   callerBio,
+  callerIsKicked,
   publicProfileIcon,
   publicProfileBio,
   ownConfigBio,
-}: UseProfileCardIdentityFieldsArgs): { userIcon?: string; bio?: string } {
+}: UseProfileCardIdentityFieldsArgs): {
+  userIcon?: string;
+  bio?: string;
+  isKicked?: boolean;
+} {
   const { messageDB } = useMessageDB();
 
   const { data: members } = useQuery({
@@ -165,11 +172,25 @@ export function useProfileCardIdentityFields({
     return {
       userIcon: pickProfileCardIcon(sources),
       bio: pickProfileCardBio(sources),
+      // Membership state, not an identity field, so it is not a ladder: the
+      // roster row is the ONLY real source (`MessageService` writes it there,
+      // `useChannelData` reads it from there). The caller value is a stale
+      // snapshot of that same row, so it serves only until the roster read
+      // lands — and only when there is no row at all, e.g. a DM.
+      //
+      // NOTE the precedence is the REVERSE of the avatar's above, deliberately.
+      // The avatar puts the caller first to avoid a flash, which is safe
+      // because the two agree. Here they can disagree: a caller snapshot taken
+      // before the kick says `false` while the roster says `true`, and letting
+      // a stale `false` win would re-enable a moderation action against someone
+      // already removed. Freshness beats flicker for a destructive control.
+      isKicked: member ? Boolean(member.isKicked) : callerIsKicked,
     };
   }, [
     member,
     callerIcon,
     callerBio,
+    callerIsKicked,
     publicProfileIcon,
     publicProfileBio,
     ownConfigBio,


### PR DESCRIPTION
Third instance of a single defect, so this one fixes the class rather than the field.

The profile card has two entry points carrying different payloads: a mention-pill
click passes `{ address }` and nothing else (deliberate, since the name resolves
from `src/identity` either way), while a message-avatar click passes a
fully-merged member record. **Any field the card reads off that payload instead
of resolving from the address renders differently depending on which pill was
clicked.**

| Fix | Field |
|---|---|
| #328 | the card's own bio and avatar |
| #344 | the avatar handed to Block/Mute/Kick |
| this | the Kick button's `isKicked` state |

Fixing them one at a time does not converge — each fix leaves the next unfound
field in place, and nothing says how many remain. #344 closed with a
"found but not fixed" note naming `isKicked`, which is exactly how the third
instance was about to become the fourth.

### The instrument, written first

`profileCardEntryPointParity.test.tsx` renders the card from both payloads
against **identical sources** and asserts the entire rendered output matches —
not one field, the whole DOM, in both the card and drawer variants.

The fixture is deliberately hostile: the member is kicked, and their avatar and
bio exist only in the roster's live-pushed global slots while the public profile
is empty. That is the state where the caller payload and the address-keyed
sources disagree most, so a field read from the wrong source cannot pass by
coincidence. A control arm asserts the two payloads really are different objects,
so the file cannot pass trivially.

Only per-render random button ids are normalised (`Button.web.tsx:12` generates
them). Nothing else is masked — masking is how a parity test quietly stops
testing.

### What it found

Exactly one divergence. Around 5KB of markup identical, then:

```
btn-danger-outline  "Kick"      <- mention pill   (isKicked undefined)
btn-disabled        "Kicked!"   <- message avatar (isKicked true) + disabled=""
```

For a member who has **already been kicked**, opening their card from a mention
pill showed an enabled "Kick" button instead of a greyed-out "Kicked!".

It also establishes the useful negative: after #328 and #344, nothing else on
this card is read raw. That was previously an assumption.

### The fix

`isKicked` is a real persisted roster field (written by `MessageService.ts:5914`,
mapped at `indexedDbAdapter.ts:159`, read off the same row by
`useChannelData.ts:106`). `useProfileCardIdentityFields` already reads that exact
row for this address, so resolving it there is a cache read, not extra IO.

Precedence is deliberately **the reverse of the avatar's**. The avatar puts the
caller pre-fill first to avoid a flash, which is safe because the two sources
agree. These can genuinely disagree: a caller snapshot taken before the kick says
`false` while the roster says `true`, and letting a stale `false` win would
re-enable a destructive moderation action against someone already removed.
Freshness beats flicker for that control. The caller value survives only as the
fallback when there is no roster row at all (a DM).

### Verification

- Parity test written first and observed **red**, naming the Kick button as the
  only divergence in both variants; green after the fix.
- Identity suite 238/238, typecheck clean, lint clean on all three changed files.
- Not yet exercised by hand in a running build.

### Scope

Covers `UserProfile` only. Other surfaces that render a member from a
caller-supplied payload have not been checked for the same class of defect.
