### PR TITLE
fix(db): recover MessageDB from a browser-forced connection close

### DIFF
--- a/.agents/INDEX.md
+++ b/.agents/INDEX.md
@@ -111,6 +111,7 @@ This is the main index for all documentation, bug reports, and task management.
 - 🐛 ["Delete Space" is Leave with a destructive-sounding label, and the owner must never click it](issues/2026-08-02-delete-space-is-leave-and-can-permanently-brick-a-space.md)
 - 🐛 [The roster pull: what it actually does](issues/2026-08-02-roster-pull-delivers-nothing-to-a-new-joiner.md)
 - 🐛 [Sync requests expire unread, behind a reconnect backlog](issues/2026-08-02-sync-requests-arrive-four-minutes-late-and-every-peer-rejects-them.md)
+- 🐛 [MessageDB never recovers from an abnormally closed IndexedDB connection](issues/2026-08-06-messagedb-never-recovers-from-an-abnormally-closed-connection.md)
 - 🐛 [Eight name surfaces never reached the resolver](issues/2026-08-10-name-surfaces-that-never-reached-the-resolver.md)
 - 🐛 [Notification switches freeze the UI for ~1.8s](issues/2026-08-13-notification-toggle-freeze-is-the-config-encode-chain.md)
 - 🐛 [Desktop has no `.q` broadcast, and trusts a `.q` it never checks](issues/2026-08-16-desktop-has-no-q-broadcast-and-renders-claims-unverified.md)
@@ -268,7 +269,6 @@ This is the main index for all documentation, bug reports, and task management.
 - 🐛 [The roster diff treats your own row like a stranger's](issues/.open/2026-08-05-roster-sync-has-no-self-exclusion-a-peer-can-overwrite-your-own-row.md)
 - 🐛 [Safari wipes all IndexedDB after 7 idle days — DM ratchet state and history are unrecoverable](issues/.open/2026-08-05-safari-itp-wipes-indexeddb-after-7-idle-days.md)
 - 🐛 [Every shared primitive reaches consumers as `any`](issues/.open/2026-08-06-invalid-icon-names-render-nothing-and-no-type-error-catches-them.md)
-- 🐛 [MessageDB never recovers from an abnormally closed IndexedDB connection](issues/.open/2026-08-06-messagedb-never-recovers-from-an-abnormally-closed-connection.md)
 - 🐛 [The two default user configs disagree on which fields exist](issues/.open/2026-08-07-the-two-default-user-configs-disagree-on-which-fields-exist.md)
 - 🐛 [Generating a public invite link never reaches existing members](issues/.open/2026-08-11-public-invite-link-never-reaches-existing-members.md)
 - 🐛 [The Account Key warning names the smallest loss, not the largest](issues/.open/2026-08-14-security-tab-key-warning-understates-wallet-access.md)
@@ -317,6 +317,7 @@ This is the main index for all documentation, bug reports, and task management.
 - 📋 [Unshipped security branches (local, not pushed)](issues/.open/2026-08-12-unshipped-security-branches.md)
 - 📋 [Move the config-save encode chain to a Web Worker](issues/.open/2026-08-13-config-encode-worker-plan.md)
 - 📋 [Rebuild the sync indicator on a per-space "behind by N" signal](issues/.open/2026-08-13-sync-indicator-needs-a-per-space-behind-by-signal.md)
+- 📋 [A DB call landing mid-close still fails once](issues/.open/2026-08-17-a-db-call-landing-mid-close-still-fails-once.md)
 
 ### Deferred
 
@@ -796,4 +797,4 @@ This is the main index for all documentation, bug reports, and task management.
 
 ---
 
-**Last Updated**: 2026-08-16 15:59:09
+**Last Updated**: 2026-08-17 10:52:48

--- a/.agents/issues/.open/2026-08-17-a-db-call-landing-mid-close-still-fails-once.md
+++ b/.agents/issues/.open/2026-08-17-a-db-call-landing-mid-close-still-fails-once.md
@@ -1,0 +1,70 @@
+---
+type: task
+title: "Retry once on InvalidStateError so a DB call landing mid-close recovers instead of failing"
+status: open
+priority: medium
+created: 2026-08-17
+updated: 2026-08-17
+severity: one failed read or write per forced close, presented to the user as a server outage
+area: IndexedDB connection lifecycle
+repos: quorum-desktop
+related:
+  - ".agents/issues/2026-08-06-messagedb-never-recovers-from-an-abnormally-closed-connection.md"
+  - ".agents/issues/.open/2026-08-06-a-message-read-failure-is-presented-as-a-server-outage-or-a-redirect-home.md"
+---
+
+# A DB call landing mid-close still fails once
+
+Found while fixing the `onclose` bug, and deliberately left out of that change to
+keep it reviewable. That fix is a prerequisite for this one.
+
+## The remaining gap
+
+The closing of an IndexedDB connection is not atomic. The connection is marked
+as closing **synchronously**, but the `close` event fires only once in-flight
+transactions have finished aborting. Both the spec and `fake-indexeddb`'s
+`closeConnection` behave this way.
+
+`MessageDB` now clears its handle in `onclose`, so it reopens transparently on
+the next call. But a call that lands *inside* that window sees a handle that is
+still non-null and a connection that already refuses transactions, so
+`this.db!.transaction(...)` throws `InvalidStateError` and that one call fails.
+
+Impact is one failed read or write per forced close, not a wedged session. It
+still reaches the user as the misleading "server outage" or redirect-home
+presentation tracked in the related issue.
+
+## Suggested fix
+
+Funnel transaction creation through a private helper that retries once:
+
+```ts
+private async tx(stores: string | string[], mode: IDBTransactionMode) {
+  await this.init();
+  try {
+    return this.db!.transaction(stores, mode);
+  } catch (err) {
+    if ((err as DOMException)?.name !== 'InvalidStateError') throw err;
+    this.db = null;      // the handle is closing or closed
+    await this.init();   // reopen, then let this attempt stand or fail honestly
+    return this.db!.transaction(stores, mode);
+  }
+}
+```
+
+There are **104** `this.db!.transaction(...)` call sites, which is why this wants
+a helper and its own review pass rather than being folded into the `onclose`
+change.
+
+## Testing notes
+
+`fake-indexeddb`'s `forceCloseDatabase()` makes this reproducible — see
+`src/dev/tests/db/messageDbForcedClose.test.ts` for the working pattern.
+
+Hitting the window deterministically is the hard part: it only exists while a
+transaction is unfinished, so the test needs a write in flight at the moment of
+the forced close. Do not reach for a fixed `setTimeout` to arrange it; that is
+exactly what made the first version of the sibling test flaky under load.
+
+---
+*Last updated: 2026-08-17*

--- a/.agents/issues/.open/2026-08-17-a-db-call-landing-mid-close-still-fails-once.md
+++ b/.agents/issues/.open/2026-08-17-a-db-call-landing-mid-close-still-fails-once.md
@@ -44,7 +44,7 @@ private async tx(stores: string | string[], mode: IDBTransactionMode) {
   try {
     return this.db!.transaction(stores, mode);
   } catch (err) {
-    if ((err as DOMException)?.name !== 'InvalidStateError') throw err;
+    if (!this.isClosedConnectionError(err)) throw err;
     this.db = null;      // the handle is closing or closed
     await this.init();   // reopen, then let this attempt stand or fail honestly
     return this.db!.transaction(stores, mode);
@@ -55,6 +55,33 @@ private async tx(stores: string | string[], mode: IDBTransactionMode) {
 There are **104** `this.db!.transaction(...)` call sites, which is why this wants
 a helper and its own review pass rather than being folded into the `onclose`
 change.
+
+## ⚠️ Do not match on `InvalidStateError` alone
+
+The obvious guard — `if (err.name !== 'InvalidStateError') throw err` — is
+wrong, and this is the main reason the `onclose` fix was kept as a separate,
+independently useful change rather than being replaced by this one.
+
+`IDBDatabase.transaction()` throws `InvalidStateError` for **two unrelated
+reasons**, and the error carries nothing that distinguishes them
+(READ: `node_modules/fake-indexeddb/build/esm/FDBDatabase.js:129-137`, two
+separate throw sites, same error type):
+
+1. the connection is closing or closed — retrying after a reopen is correct;
+2. **a versionchange transaction is currently running** — retrying is actively
+   harmful. The helper would discard a perfectly healthy connection and reopen
+   mid-upgrade, turning a transient wait into a wedged database.
+
+So the retry needs a positive test that the connection is actually gone, not
+just that this error name appeared. Options, in preference order:
+
+- track a flag set by the `onclose` handler (which by spec fires *only* on an
+  abnormal close, never on our own `close()`) and retry only when it is set;
+- track whether an upgrade is in flight and refuse to retry during one.
+
+The first reuses machinery that already exists after the `onclose` change and is
+the reason these two fixes are complementary rather than redundant: `onclose`
+answers "did the connection really die?" precisely, where the error name cannot.
 
 ## Testing notes
 

--- a/.agents/issues/2026-08-06-messagedb-never-recovers-from-an-abnormally-closed-connection.md
+++ b/.agents/issues/2026-08-06-messagedb-never-recovers-from-an-abnormally-closed-connection.md
@@ -84,6 +84,45 @@ Verification (MEASURED, `src/dev/tests/db/messageDbForcedClose.test.ts`):
 - The suite includes a **control arm** (a read with no close at all) that passes
   in both directions, so the red is attributable to the forced close.
 
+### Three further defects found in review, all fixed on the same branch
+
+An independent review pass (correctness, silent-failure and test-coverage
+reviewers, fresh context) found three problems. Two were in the `onclose` fix as
+first written, one was pre-existing in the same method. All are fixed here, each
+with a test verified to fail without its guard.
+
+**1. Handlers bound to the field, not to their own connection.** Found
+independently by two reviewers. `onversionchange` and the new `onclose` both did
+a bare `this.db = null`, with no check that the connection firing the event was
+still the current one. They now capture `const connection = request.result` and
+clear only on identity match. Without this, a stale connection's close event
+wipes the reference to a healthy one.
+
+**2. `init()` had no in-flight guard, so concurrent callers each opened their own
+connection.** The last `onsuccess` won the field and the rest were orphaned:
+still open, never closed, and able to block a later `onupgradeneeded`
+indefinitely — the exact state the neighbouring `onblocked` handler warns about.
+Dozens of React Query fetchers hit the DB in parallel on mount, so this was
+routine at cold start rather than exotic. `init()` now shares one in-flight
+promise, cleared on both settle paths so a failed open can still be retried.
+
+**3. The recovery was completely silent.** A forced close fires *only* on an
+abnormal close (never on our own `close()`), so every occurrence means the
+browser destroyed or invalidated the store. Recovering without a trace meant the
+app would reopen onto a possibly-wiped database, look empty-but-healthy, and
+leave no evidence the user's history had just been lost. This directly concerns
+the unmeasured population in
+`.agents/issues/.open/2026-08-05-safari-itp-wipes-indexeddb-after-7-idle-days.md`.
+Now logged via `logger.warn`, matching the `onblocked` pattern in the same
+method. **Caveat:** `logger` is a no-op in production builds
+(`.agents/issues/.open/2026-08-01-every-logger-call-is-a-no-op-in-production-builds.md`),
+so this buys local diagnosability only. Real field visibility needs that issue
+fixed, or a durable breadcrumb outside IndexedDB.
+
+Final verification: 7/7 in this file, **1483/1483** full suite across 161 files,
+`tsc --noEmit` clean, no new lint. Reverting the guards turns the three new tests
+red for their own specific reasons.
+
 ### Known limit: a call landing mid-close still fails once
 
 Not anticipated in the original write-up, found while fixing. `closeConnection`

--- a/.agents/issues/2026-08-06-messagedb-never-recovers-from-an-abnormally-closed-connection.md
+++ b/.agents/issues/2026-08-06-messagedb-never-recovers-from-an-abnormally-closed-connection.md
@@ -1,10 +1,10 @@
 ---
 type: bug
 title: "MessageDB never recovers from an abnormally closed IndexedDB connection, breaking all persistence for the rest of the session"
-status: open
+status: in-progress
 priority: high
 created: 2026-08-06
-updated: 2026-08-06
+updated: 2026-08-17
 severity: session-wide — one closed connection breaks every read and write in the app (messages, config, space members) until a full page reload
 area: IndexedDB connection lifecycle
 repos: quorum-desktop
@@ -64,6 +64,50 @@ Feature-detect if older Safari is a target. Worth pairing with a test that
 force-closes the connection and asserts the next read succeeds — `fake-indexeddb`
 may not simulate an abnormal close, so this might need a real-browser check.
 
+## Status
+
+Fixed on branch `fix/messagedb-recover-from-forced-close` (2026-08-17), exactly
+the `onclose` handler suggested above, in `MessageDB.init()`.
+
+**`fake-indexeddb` CAN simulate an abnormal close** — the doubt recorded above is
+resolved. It ships `forceCloseDatabase()` (exported from the package root and
+from `fake-indexeddb/lib/forceCloseDatabase`), which runs the spec's
+closing-connection steps with the forced flag set and dispatches a real `close`
+event. No real-browser harness was needed to get a regression test.
+
+Verification (MEASURED, `src/dev/tests/db/messageDbForcedClose.test.ts`):
+
+- Without the fix, 2 of 3 tests fail — reproducing `InvalidStateError` thrown
+  from `FDBDatabase.transaction`, which is the exact symptom described above.
+- With the fix, 3 of 3 pass. Full suite 1479/1479 across 161 files, `tsc
+  --noEmit` clean, no new lint (the one warning in `messages.ts` predates this).
+- The suite includes a **control arm** (a read with no close at all) that passes
+  in both directions, so the red is attributable to the forced close.
+
+### Known limit: a call landing mid-close still fails once
+
+Not anticipated in the original write-up, found while fixing. `closeConnection`
+marks the connection closing **synchronously** but defers the `close` event
+whenever a transaction is still unfinished. During that window
+`db.transaction()` already throws while `this.db` is still non-null, because the
+handler has not run yet. Real browsers have the same window: the spec fires
+`close` only after in-flight transactions finish aborting.
+
+So the fix downgrades the fault from *permanent* (every call for the rest of the
+session) to *one failed call, then transparent recovery*. That is the intended
+scope, and it is a large improvement, but it is not "no user-visible error". A
+caller unlucky enough to land in the window still gets the misleading
+presentation described in the related issue.
+
+Closing that window fully means retrying once on `InvalidStateError` at the point
+transactions are created. There are 104 `this.db!.transaction(...)` call sites,
+so it wants a private helper rather than 104 edits — **worth its own issue, not
+this one**.
+
+This race is also why the first version of the regression test was flaky: it
+waited a fixed `setTimeout(0)`, which passed in isolation and failed under
+full-suite CPU load. It now polls for the handler's actual effect.
+
 ## Why it was not fixed in the same change
 
 The "channel is empty" fix was scoped to the message read path and its cache
@@ -71,4 +115,4 @@ keys. This one changes when the database reopens, which touches every consumer
 in the app. It should land on its own, with its own verification.
 
 ---
-*Last updated: 2026-08-06*
+*Last updated: 2026-08-17*

--- a/src/db/messages.ts
+++ b/src/db/messages.ts
@@ -257,6 +257,16 @@ export class MessageDB {
           this.db?.close();
           this.db = null;
         };
+        // The browser can close the connection without us asking: storage
+        // eviction, corruption, Safari's ITP wipe, or the user clearing site
+        // data with the tab open. The handle stays non-null but every
+        // transaction on it throws InvalidStateError, and since init() returns
+        // early on `if (this.db)` it would never reopen — wedging every read and
+        // write for the rest of the tab's session (one MessageDB instance is
+        // shared app-wide). Dropping the reference lets the next init() reopen.
+        this.db.onclose = () => {
+          this.db = null;
+        };
         resolve();
       };
 

--- a/src/db/messages.ts
+++ b/src/db/messages.ts
@@ -214,6 +214,18 @@ interface StoredSearchIndex {
 
 export class MessageDB {
   private db: IDBDatabase | null = null;
+  /**
+   * In-flight `indexedDB.open`, shared by concurrent init() callers.
+   *
+   * Without this, every caller that arrives while `db` is still null starts its
+   * own open request, and the last `onsuccess` to land wins the field. The
+   * earlier connections are orphaned: still open, never closed, and still
+   * holding the lifecycle handlers set below. That leaks a connection which can
+   * block a later `onupgradeneeded` indefinitely (the case `onblocked` warns
+   * about). Dozens of React Query fetchers hit the DB in parallel on mount, so
+   * this race is routine at cold start, not exotic.
+   */
+  private initPromise: Promise<void> | null = null;
   private readonly DB_NAME = QUORUM_DB_NAME;
   private readonly DB_VERSION = QUORUM_DB_VERSION;
   private searchIndices: Map<string, MiniSearch<SearchableMessage>> = new Map();
@@ -235,8 +247,9 @@ export class MessageDB {
 
   async init() {
     if (this.db) return;
+    if (this.initPromise) return this.initPromise;
 
-    return new Promise<void>((resolve, reject) => {
+    this.initPromise = new Promise<void>((resolve, reject) => {
       const request = indexedDB.open(this.DB_NAME, this.DB_VERSION);
 
       request.onerror = () => reject(request.error);
@@ -249,13 +262,18 @@ export class MessageDB {
         );
       };
       request.onsuccess = () => {
-        this.db = request.result;
+        // Bind the handlers below to THIS connection rather than to `this.db`.
+        // A handler that reads the field would, when fired by a connection that
+        // is no longer current, clear the reference to a different and healthy
+        // one. Comparing identity before clearing makes a stale event a no-op.
+        const connection = request.result;
+        this.db = connection;
         // If another tab later requests a higher version, yield: close this
         // connection so its upgrade isn't blocked (prevents a wedged DB across
         // version bumps). The next DB call reopens via init().
-        this.db.onversionchange = () => {
-          this.db?.close();
-          this.db = null;
+        connection.onversionchange = () => {
+          connection.close();
+          if (this.db === connection) this.db = null;
         };
         // The browser can close the connection without us asking: storage
         // eviction, corruption, Safari's ITP wipe, or the user clearing site
@@ -264,8 +282,19 @@ export class MessageDB {
         // early on `if (this.db)` it would never reopen — wedging every read and
         // write for the rest of the tab's session (one MessageDB instance is
         // shared app-wide). Dropping the reference lets the next init() reopen.
-        this.db.onclose = () => {
-          this.db = null;
+        connection.onclose = () => {
+          // Per spec this event fires ONLY on an abnormal close, never on our
+          // own close(). So every occurrence means the browser destroyed or
+          // invalidated the store underneath us, and the reopen below may well
+          // land on an empty database with the user's history gone. Recovering
+          // silently would erase the only evidence that happened.
+          // NOTE: logger is a no-op in production builds, so this currently buys
+          // local diagnosability only — see
+          // .agents/issues/.open/2026-08-01-every-logger-call-is-a-no-op-in-production-builds.md
+          logger.warn(
+            '[MessageDB] connection force-closed by the browser (eviction, corruption, ITP wipe, or cleared site data); reopening on next access — local data may have been lost'
+          );
+          if (this.db === connection) this.db = null;
         };
         resolve();
       };
@@ -459,6 +488,15 @@ export class MessageDB {
         }
       };
     });
+
+    try {
+      await this.initPromise;
+    } finally {
+      // Clear on both paths. On success `db` is set, so the check above
+      // short-circuits anyway; on failure this is what lets the next caller
+      // retry the open instead of re-awaiting a permanently rejected promise.
+      this.initPromise = null;
+    }
   }
 
   async getMessage({

--- a/src/dev/tests/db/messageDbForcedClose.test.ts
+++ b/src/dev/tests/db/messageDbForcedClose.test.ts
@@ -1,0 +1,98 @@
+import 'fake-indexeddb/auto';
+import { describe, it, expect, beforeEach } from 'vitest';
+import forceCloseDatabase from 'fake-indexeddb/lib/forceCloseDatabase';
+import { MessageDB } from '../../../db/messages';
+import type { ChannelThread } from '@quilibrium/quorum-shared';
+
+/**
+ * The browser can force-close an IndexedDB connection without the app asking:
+ * storage eviction, corruption, Safari's ITP wipe, or the user clearing site
+ * data with the tab open. When that happens the connection object is still
+ * non-null but every transaction on it throws InvalidStateError.
+ *
+ * `MessageDB.init()` short-circuits on `if (this.db) return`, so unless the
+ * closed connection is cleared the instance never reopens — and since
+ * MessageDBProvider builds one instance for the whole app lifetime, that
+ * wedges every read and write for the rest of the tab's session.
+ *
+ * `forceCloseDatabase` is fake-indexeddb's spec-accurate simulation of exactly
+ * that event (closing-connection steps with the forced flag set), which is what
+ * makes this reproducible without a real browser.
+ */
+/**
+ * Wait for the forced close to actually land rather than guessing a delay.
+ *
+ * `closeConnection` sets `_closePending` synchronously but defers the close
+ * event via queueTask whenever a transaction is not yet finished, so a fixed
+ * `setTimeout(0)` is a race: it passed in isolation and failed under full-suite
+ * CPU load. Polling the condition the fix is responsible for makes the test
+ * deterministic regardless of machine load.
+ */
+const waitForConnectionDrop = async (db: MessageDB): Promise<void> => {
+  for (let i = 0; i < 100; i++) {
+    if ((db as unknown as { db: IDBDatabase | null }).db === null) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error(
+    'onclose never cleared the connection handle after a forced close'
+  );
+};
+
+describe('MessageDB - recovery from a forced connection close', () => {
+  let db: MessageDB;
+
+  const thread: ChannelThread = {
+    threadId: 'thread-forced-close',
+    spaceId: 'space-1',
+    channelId: 'channel-1',
+    rootMessageId: 'msg-1',
+    createdBy: 'user-1',
+    createdAt: 1000,
+    lastActivityAt: 2000,
+    replyCount: 0,
+    isClosed: false,
+    hasParticipated: false,
+  };
+
+  beforeEach(async () => {
+    const FDBFactory = (await import('fake-indexeddb/lib/FDBFactory')).default;
+    globalThis.indexedDB = new FDBFactory();
+
+    db = new MessageDB();
+    await db.init();
+  });
+
+  // Control arm: proves the harness itself can read back a write, so a failure
+  // in the test below is attributable to the forced close and nothing else.
+  it('reads back a saved thread when the connection is never closed', async () => {
+    await db.saveChannelThread(thread);
+    await expect(db.getChannelThread(thread.threadId)).resolves.toMatchObject({
+      threadId: thread.threadId,
+    });
+  });
+
+  it('reopens and serves reads after the browser force-closes the connection', async () => {
+    await db.saveChannelThread(thread);
+
+    const rawConnection = (db as unknown as { db: IDBDatabase | null }).db;
+    expect(rawConnection).not.toBeNull();
+
+    forceCloseDatabase(rawConnection);
+    await waitForConnectionDrop(db);
+
+    await expect(db.getChannelThread(thread.threadId)).resolves.toMatchObject({
+      threadId: thread.threadId,
+    });
+  });
+
+  it('serves writes after the browser force-closes the connection', async () => {
+    const rawConnection = (db as unknown as { db: IDBDatabase | null }).db;
+    forceCloseDatabase(rawConnection);
+    await waitForConnectionDrop(db);
+
+    await expect(db.saveChannelThread(thread)).resolves.toBeUndefined();
+    await expect(db.getChannelThread(thread.threadId)).resolves.toMatchObject({
+      threadId: thread.threadId,
+    });
+  });
+});

--- a/src/dev/tests/db/messageDbForcedClose.test.ts
+++ b/src/dev/tests/db/messageDbForcedClose.test.ts
@@ -1,8 +1,17 @@
 import 'fake-indexeddb/auto';
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import forceCloseDatabase from 'fake-indexeddb/lib/forceCloseDatabase';
 import { MessageDB } from '../../../db/messages';
+import { logger } from '@quilibrium/quorum-shared';
 import type { ChannelThread } from '@quilibrium/quorum-shared';
+
+/** Read the private connection handle the lifecycle handlers manage. */
+const connectionOf = (db: MessageDB): IDBDatabase | null =>
+  (db as unknown as { db: IDBDatabase | null }).db;
+
+const setConnection = (db: MessageDB, connection: IDBDatabase | null): void => {
+  (db as unknown as { db: IDBDatabase | null }).db = connection;
+};
 
 /**
  * The browser can force-close an IndexedDB connection without the app asking:
@@ -30,7 +39,7 @@ import type { ChannelThread } from '@quilibrium/quorum-shared';
  */
 const waitForConnectionDrop = async (db: MessageDB): Promise<void> => {
   for (let i = 0; i < 100; i++) {
-    if ((db as unknown as { db: IDBDatabase | null }).db === null) return;
+    if (connectionOf(db) === null) return;
     await new Promise((resolve) => setTimeout(resolve, 5));
   }
   throw new Error(
@@ -74,19 +83,21 @@ describe('MessageDB - recovery from a forced connection close', () => {
   it('reopens and serves reads after the browser force-closes the connection', async () => {
     await db.saveChannelThread(thread);
 
-    const rawConnection = (db as unknown as { db: IDBDatabase | null }).db;
+    const rawConnection = connectionOf(db);
     expect(rawConnection).not.toBeNull();
 
     forceCloseDatabase(rawConnection);
     await waitForConnectionDrop(db);
 
+    // Asserting on the saved row, not merely on "a read succeeded", also proves
+    // the reopen landed on the SAME database rather than a fresh empty one.
     await expect(db.getChannelThread(thread.threadId)).resolves.toMatchObject({
       threadId: thread.threadId,
     });
   });
 
   it('serves writes after the browser force-closes the connection', async () => {
-    const rawConnection = (db as unknown as { db: IDBDatabase | null }).db;
+    const rawConnection = connectionOf(db);
     forceCloseDatabase(rawConnection);
     await waitForConnectionDrop(db);
 
@@ -94,5 +105,78 @@ describe('MessageDB - recovery from a forced connection close', () => {
     await expect(db.getChannelThread(thread.threadId)).resolves.toMatchObject({
       threadId: thread.threadId,
     });
+  });
+
+  it('recovers from repeated forced closes, not just the first', async () => {
+    for (let cycle = 0; cycle < 3; cycle++) {
+      forceCloseDatabase(connectionOf(db));
+      await waitForConnectionDrop(db);
+
+      const cycleThread = { ...thread, threadId: `thread-cycle-${cycle}` };
+      await expect(db.saveChannelThread(cycleThread)).resolves.toBeUndefined();
+      await expect(
+        db.getChannelThread(cycleThread.threadId)
+      ).resolves.toMatchObject({ threadId: cycleThread.threadId });
+    }
+  });
+
+  it('logs a warning when the browser force-closes the connection', async () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+    forceCloseDatabase(connectionOf(db));
+    await waitForConnectionDrop(db);
+
+    // A forced close only ever happens for reasons that destroy or invalidate
+    // the store, so recovering without a trace would erase the only evidence
+    // the user's local data may have just been wiped.
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('force-closed by the browser')
+    );
+  });
+});
+
+describe('MessageDB - connection lifecycle guards', () => {
+  beforeEach(async () => {
+    const FDBFactory = (await import('fake-indexeddb/lib/FDBFactory')).default;
+    globalThis.indexedDB = new FDBFactory();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('opens exactly one connection when init() is called concurrently', async () => {
+    const openSpy = vi.spyOn(globalThis.indexedDB, 'open');
+    const db = new MessageDB();
+
+    await Promise.all(Array.from({ length: 8 }, () => db.init()));
+
+    // Without the in-flight guard each caller starts its own open and the last
+    // onsuccess wins the field, orphaning the rest: still open, never closed,
+    // and able to block a later onupgradeneeded forever.
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    expect(connectionOf(db)).not.toBeNull();
+  });
+
+  it('ignores a close event from a connection that is no longer current', async () => {
+    const db = new MessageDB();
+    await db.init();
+    const stale = connectionOf(db);
+    expect(stale).not.toBeNull();
+
+    // Stand in for the losing side of an init() race: another connection has
+    // since become the current one, while `stale` still carries the handlers.
+    const replacement = await new Promise<IDBDatabase>((resolve, reject) => {
+      const request = globalThis.indexedDB.open('quorum-db-replacement', 1);
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+    setConnection(db, replacement);
+
+    forceCloseDatabase(stale);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // The stale connection's handler must not clear a healthy current one.
+    expect(connectionOf(db)).toBe(replacement);
   });
 });


### PR DESCRIPTION
## What this fixes

`MessageDB.init()` returned early on `if (this.db)`, and only `onversionchange` ever cleared that field. When the browser force-closed the connection (storage eviction, corruption, Safari's ITP wipe, or the user clearing site data with the tab open), the handle was left non-null but dead, so every transaction on it threw `InvalidStateError`.

One `MessageDB` instance is shared app-wide, so a single forced close wedged messages, config, space members and encryption state for the rest of that tab's session, recoverable only by a full page reload.

## What landed

- An `onclose` handler that drops the dead reference, letting the next `init()` reopen transparently.
- Lifecycle handlers now bind to their own connection instead of the mutable field, so a stale connection's event can no longer clear a healthy one.
- `init()` shares one in-flight open. Concurrent callers each started their own before; the last `onsuccess` won the field and the rest were orphaned, still open, never closed, and able to block a later `onupgradeneeded` indefinitely. Dozens of React Query fetchers hit the DB in parallel on mount, so this was routine at cold start.
- A forced close is now logged. Per spec that event fires only on an abnormal close, never on our own `close()`, so every occurrence means the browser destroyed or invalidated the store. Recovering silently left no trace that a user's local history may have just been lost.

## Verification

`fake-indexeddb` simulates this precisely via `forceCloseDatabase()`, which runs the spec's closing-connection steps with the forced flag set, so no real-browser harness was needed.

7 tests in `src/dev/tests/db/messageDbForcedClose.test.ts`, each verified to fail without its own guard, plus a control arm that passes in both directions. Full suite 1483/1483 across 161 files, `tsc --noEmit` clean, no new lint.

## Known limit

The `close` event fires only after in-flight transactions finish aborting, so a call landing inside that window still fails once before recovery kicks in. That is a large improvement on the previous permanent wedge, but not zero. Filed separately: closing it fully would touch 104 transaction call sites and needs its own review.

## Commits

- fix: reopen MessageDB after the browser force-closes its connection
- fix: harden MessageDB connection lifecycle after review
- docs: index the MessageDB forced-close issues
