### PR TITLE
test(config): measure config sync across clients, desktop to mobile

### DIFF
--- a/.agents/issues/.open/2026-08-07-config-sync-overhaul-design.md
+++ b/.agents/issues/.open/2026-08-07-config-sync-overhaul-design.md
@@ -753,7 +753,11 @@ below reads as "what is left", not "what was planned".
    catching that error, and catching it without persisting would be choosing to
    keep losing the edit. The fix comes along.
    **✅ DESKTOP SHIPPED 2026-08-09** in PRs #321 (data-loss half) and #322
-   (recording + UI), plus shared 2.1.0-41. **Mobile blocked on that publish.**
+   (recording + UI), plus shared 2.1.0-41. **✅ MOBILE 2026-08-17** on branch
+   `feat/config-sync-slice1-2`, once shared published and mobile's pin reached
+   2.1.0-43. Mobile needed no control-flow change, as scoped — but it is the only
+   client that can reach `no-keys`, so all six outcomes are live there. Release-build
+   verification still outstanding, which is the one thing this slice was for.
    *Design change made during implementation:* the line is **failures-only**.
    "Last synced N ago" reported the last time the device had something to
    *publish*, not the last time it reached the server, so a healthy device that
@@ -761,8 +765,11 @@ below reads as "what is left", not "what was planned".
    normal use, which is also why §5.3 tiering will not crowd the panel.
 2. **Slice 2 — "Off stays off."** §5.1 device-local `allowSync`. *Observable:*
    turn sync off on device A, use device B, restart A, it is still off.
-   **✅ DESKTOP SHIPPED 2026-08-09** in PR #322. Mobile still to do, and not
-   blocked by anything — it needs no new shared type.
+   **✅ DESKTOP SHIPPED 2026-08-09** in PR #322. **✅ MOBILE 2026-08-17**, in the
+   same branch as slice 1 rather than its own, because a gap here is confusing in
+   a new way (a patched client keeps publishing `allowSync: true` to an unpatched
+   one) and both halves are a handful of lines. Two-device runs on real hardware
+   still outstanding.
 3. **Slice 3 — "Choose what leaves."** §5.3 tiering, with Traps 1-3 resolved.
    *Observable:* switching the keys tier off keeps settings syncing and shrinks
    the blob by ~98%.

--- a/.agents/issues/.open/2026-08-08-make-allowsync-a-per-device-setting.md
+++ b/.agents/issues/.open/2026-08-08-make-allowsync-a-per-device-setting.md
@@ -25,9 +25,33 @@ Fully unblocked. Small. Best done soon after the timestamp-authority fix
 
 ## Status
 
+**2026-08-17 — mobile implemented** on branch `feat/config-sync-slice1-2`, in the
+same branch as Slice 1, per this file's own "prefer one release" guidance. Both
+halves now exist; this issue stays open until the mobile branch merges and the
+two-device runs below are done on real hardware.
+
+The mobile change is at the `...decryptedConfig` adopt site in
+`services/config/configService.ts`, sourcing `allowSync` from
+`getLocalUserConfig(address)?.allowSync ?? false` — re-read at the adopt site,
+not taken from the earlier `localConfig` snapshot, per the ⚠️ below.
+
+Four unit tests, including the control arm for the device that had sync **on**.
+The control arm earned its place twice over:
+
+1. As designed — hardcoding `allowSync = false` turns **only** the control arm
+   red, while the other three pass. MEASURED by mutation, not assumed.
+2. Unexpectedly — the first draft of the control arm **passed on the unfixed
+   tree for the wrong reason**. `getConfig` verifies the blob's signature through
+   `await import(...)`, which throws under jest, and the `catch` returns `false`,
+   so the test returned the local config without ever reaching the adopt site. It
+   would have passed against any implementation. Fixed by asserting the path was
+   *entered* (`expect(mockVerifyEd448).toHaveBeenCalled()`) and by repairing the
+   underlying transform — filed as
+   [a mobile issue](../../../../quorum-mobile/.agents/issues/.open/2026-08-17-dynamic-imports-silently-took-their-error-branch-under-jest.md),
+   because 64 call sites share that shape.
+
 **2026-08-09 — desktop shipped in PR #322** (`feat(config): report sync failures,
-and make turning sync off stick`). **Mobile remains**, and this issue stays open
-until it lands.
+and make turning sync off stick`).
 
 What landed: the local `allowSync` is now authoritative at the adopt site in
 `getConfig`, set on the config object itself so the DB row, the React Query cache
@@ -165,11 +189,25 @@ Confirm no other read path resolves `allowSync` from a remote object.
 ## Definition of Done
 
 - [x] Desktop preserves the local `allowSync` on adopt, in DB and cache — PR #322
-- [ ] Mobile preserves it, re-reading the local value at the adopt site
-- [ ] Both verification runs pass, and both go red on revert
+- [x] Mobile preserves it, re-reading the local value at the adopt site —
+      branch `feat/config-sync-slice1-2`, 2026-08-17
+- [x] Unit-level equivalents pass on mobile, and each goes red on revert.
+      Three mutations MEASURED: dropping the line turns 3 red with the control
+      arm still green; hardcoding `false` turns **only** the control arm red;
+      reading the stale pre-verification snapshot turns only the re-read test red
+- [x] **Verified end to end against the real relay** (mobile), 2026-08-17 —
+      `yarn harness:config-sync`, a new headless scenario. A setting published by
+      one device is adopted by another; a fresh device starts OFF whatever the
+      blob says; a blob saying `true` does not switch a switched-off device back
+      on; and the control arm (a device that had sync ON keeps it ON) passes.
+      Reverting the fix turns the scenario red. Real encryption, real POST/GET,
+      real signature verification — not mocks. Also produced the first real
+      payload reading from a mobile publish: **594 bytes** for a 0-Space config.
+- [ ] Two-device runs on real hardware (the harness models a reinstall — same
+      account, empty local store — not two devices publishing concurrently)
 - [ ] Cross-client run done in both directions
-- [ ] **Both clients done** — prefer one release here; a long gap is confusing
+- [x] **Both clients done** — landed in one wave, as this file recommended
 
 ---
 
-*Last updated: 2026-08-09*
+*Last updated: 2026-08-17*

--- a/.agents/issues/.open/2026-08-08-record-and-show-what-the-last-config-publish-actually-did.md
+++ b/.agents/issues/.open/2026-08-08-record-and-show-what-the-last-config-publish-actually-did.md
@@ -53,8 +53,72 @@ threshold follow once §4.1 is answered or the data explains itself.
 
 ## Status
 
-**2026-08-09 — the whole desktop side has shipped. Only mobile remains, and it
-is blocked on a package publish.**
+**2026-08-17 — mobile implemented, unblocked and done.** `@quilibrium/quorum-shared`
+published past 2.1.0-41 and mobile's pin is now **2.1.0-43**, which carries
+`PublishOutcome` and `LastPublish`. Branch `feat/config-sync-slice1-2`, together
+with Slice 2.
+
+What landed on mobile:
+
+- `services/config/lastPublish.ts` — MMKV-backed, same store id as the config
+  (`quorum-config`) so an account reset clears it, key `quorum:sync:lastPublish`
+  matching desktop. `classifyPublishError` is duplicated from desktop
+  **verbatim and deliberately** — see the drift note below.
+- All six outcomes recorded in `saveConfig`. As predicted, no control-flow change
+  was needed: every branch already existed and four already logged.
+- `components/SyncStatusLine.tsx`, failures-only, rendered under "Enable Sync" in
+  `ProfileModal`'s Privacy & Sync section. Copy is **word-for-word identical to
+  desktop's**, minus the lingui `t` macro, since mobile has no i18n library.
+- The record is written **before** each `logger.*` call, so it does not inherit
+  the release-build no-op that made this branch silent on mobile in the first
+  place.
+
+19 tests (8 recording + 11 render). Every one confirmed able to fail: 11
+individual mutations were applied and each turned its specific test red.
+Notably, recording the failure unconditionally in the `catch` — rather than
+guarding on `published` — turns red, which pins the case where the server
+accepted the upload and only the local bookkeeping after it threw.
+
+**Two UI strings deliberately DIVERGE from desktop's, found by review.** Both
+because the same outcome value does not mean the same thing on the two clients.
+Recorded here so a future parity sweep does not "fix" them back:
+
+- **`timeout`.** Desktop says *"It will keep retrying"*, which is true here —
+  the action queue retries transient failures with backoff. **Mobile has no
+  queue and never did**; `saveConfig`'s catch swallows the error and returns, so
+  nothing retries until the user next changes a setting. The line was copied
+  verbatim and was therefore a lie on mobile — the exact false reassurance this
+  slice exists to remove. Mobile now says the change is saved and goes out with
+  the next change.
+- **`rejected`.** Desktop wraps only the POST in its `try`, so `rejected`
+  genuinely means the server refused it. **Mobile's `try` also covers key
+  collection, encryption and signing**, so a local crypto fault lands in the
+  same bucket. Naming the server would send someone debugging a device-local
+  fault to the wrong system, so mobile's line no longer does.
+
+**Follow-up this exposes:** `PublishOutcome` has no member for "failed before
+the request was sent". Mobile compensates by prefixing the record's `detail`
+with `before send:`, which is a workaround, not a fix — the UI still cannot
+tell the two apart. A `local-error` member in shared would close it properly,
+and would let mobile's copy be specific again. **Also worth its own issue:
+mobile does not retry a failed config publish at all**, which is what forced the
+copy change above.
+
+**Drift risk worth naming:** `classifyPublishError` now exists twice, in
+`src/utils/lastPublish.ts` here and `services/config/lastPublish.ts` on mobile.
+If they diverge, the same failure reads as different states on a phone and a
+laptop, which is exactly the confusion this slice exists to remove. §7 of the
+design already lists the publish-outcome work as a shared-declaration candidate;
+the classifier belongs there too — and it classifies on the error MESSAGE, so it
+cannot see where the failure happened, which is the root of the `rejected`
+ambiguity above.
+
+**Still open here:** verification in a mobile **release** build (the whole point
+is that the existing signal compiles out there), and the by-hand runs that force
+each outcome on a device.
+
+**2026-08-09 — the whole desktop side had shipped; mobile was blocked on a
+package publish.**
 
 **PR #322** (`feat(config): report sync failures, and make turning sync off
 stick`) landed the recording and the UI:
@@ -377,22 +441,26 @@ One line of text, no new controls:
 
 ## Definition of Done
 
-- [x] Shared type added (2.1.0-41, shared PR #78) — **publish pending**, lead dev
+- [x] Shared type added (2.1.0-41, shared PR #78) — **published**; mobile pinned
+      to 2.1.0-43, which carries it
 - [x] All outcomes desktop can reach are recorded — PR #322. `no-keys` is
       unreachable here: the action queue throws on a missing keyset before
       `saveConfig` runs
-- [ ] All six outcomes recorded on mobile
+- [x] All six outcomes recorded on mobile — branch `feat/config-sync-slice1-2`,
+      2026-08-17. Mobile **can** reach `no-keys`, so all six are live on one
+      client
 - [x] Desktop failure path persists locally, restores the timestamp, and re-throws
       — PR #321
-- [ ] Status line in both clients' privacy settings — desktop done (PR #322,
-      failures-only), mobile pending
+- [x] Status line in both clients' privacy settings — desktop PR #322, mobile
+      2026-08-17. Both failures-only, identical copy
 - [ ] Verified in a mobile release build
-- [ ] Revert tests confirmed red
-- [ ] **Both clients done** — order is a scheduling call, but mobile is not optional
+- [x] Revert tests confirmed red — 11 mutations on mobile, each turning its own
+      test red, against a baseline verified before mutating
+- [x] **Both clients done**
 
 ---
 
-*Last updated: 2026-08-09*
+*Last updated: 2026-08-17*
 
 ## Updates
 - **2026-08-08 08:32**: Instrument built before the fix: added ConfigService.unit.test.tsx section 8 (4 tests) on branch test/config-publish-failure-persistence. MEASURED — a rejected publish never calls saveUserConfig at all, so the user's edit is discarded. Control arm (accepted publish persists) passes, so the harness is sound. 32 passed / 2 failed; the 2 failures are the acceptance criteria.

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "test:run": "vitest --run",
     "harness": "vitest --run --config vitest.harness.config.ts",
     "bench": "vitest --run --config vitest.perf.config.ts",
-    "harness:cross": "node src/dev/tests/harness/run-cross.mjs"
+    "harness:cross": "node src/dev/tests/harness/run-cross.mjs",
+    "harness:config-cross": "node src/dev/tests/harness/run-config-cross.mjs"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/src/dev/tests/harness/config-cross.scenario.test.ts
+++ b/src/dev/tests/harness/config-cross.scenario.test.ts
@@ -1,0 +1,108 @@
+// CROSS-CLIENT. Desktop publishes a user config; MOBILE reads it back.
+//
+//   yarn harness:config-cross          (runs both halves, in order)
+//   yarn harness config-cross          (this half alone — publish only)
+//
+// This is the desktop half. It answers a question neither repo could answer
+// alone: does a config written by DESKTOP decrypt and land correctly on MOBILE?
+//
+// Everything before this was same-client. Mobile's own scenario proves mobile
+// round-trips its own blob, which is real evidence about the wire format but
+// says nothing about the other client — and the two ConfigService
+// implementations are independent code that share only a type. The known
+// merge-asymmetry issue exists precisely because they drifted.
+//
+// ─── How the two halves share an account ────────────────────────────────────
+//
+// Config sync is per-ACCOUNT, so both clients must be the same account. Mobile
+// owns the identity: its harness already persists a throwaway account key at
+// dev/harness/.state/config-sync-bot.json (gitignored, generated, never a real
+// account — see mobile's identity.ts for why a persisted key means "throwaway
+// by construction"). This half loads that key and publishes as that account,
+// which is exactly what a second device does.
+//
+// It then writes the values it published to a handoff file in mobile's
+// rendezvous directory, so mobile asserts against what was ACTUALLY sent rather
+// than against a constant duplicated in two repos that can drift apart.
+//
+// ⚠️ Writes a REAL settings row on production for that throwaway account.
+import { test, expect } from 'vitest';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { createSpaceBot } from './spaceBot';
+import type { UserConfig } from '../../../db/messages';
+
+const DESKTOP_REPO = resolve(__dirname, '../../../..');
+const MOBILE_REPO = resolve(DESKTOP_REPO, '..', 'quorum-mobile');
+const MOBILE_BOT_STATE = resolve(MOBILE_REPO, 'dev/harness/.state/config-sync-bot.json');
+const HANDOFF = resolve(MOBILE_REPO, 'dev/harness/.state/rendezvous/config-cross.json');
+
+test('config-cross: desktop publishes a config for the shared account', async () => {
+  if (!existsSync(MOBILE_BOT_STATE)) {
+    throw new Error(
+      `No mobile bot state at ${MOBILE_BOT_STATE}.\n` +
+        'Run mobile\'s own scenario first to mint the shared throwaway account:\n' +
+        '  cd ../quorum-mobile && yarn harness:config-sync'
+    );
+  }
+  const { privateKeyHex } = JSON.parse(readFileSync(MOBILE_BOT_STATE, 'utf8')) as {
+    privateKeyHex?: string;
+  };
+  // A state file WITHOUT privateKeyHex means mobile was pointed at a real
+  // account through its env var, and this scenario must not publish over it.
+  expect(
+    privateKeyHex,
+    'mobile bot state has no privateKeyHex — that means it is NOT a throwaway account'
+  ).toBeTruthy();
+
+  const bot = await createSpaceBot('config-cross-desktop', { privateKeyHex });
+  await bot.start();
+
+  try {
+    const stamp = String(Date.now());
+    // Distinctive enough that mobile adopting a stale row cannot pass by
+    // coincidence, and covering both a short string and a bulk field.
+    const published = {
+      name: `desktop-cross-${stamp}`,
+      profile_image: `data:image/png;base64,DESKTOP${stamp}`,
+    };
+
+    const existing = await bot.graph.configService.getConfig({
+      address: bot.identity.address,
+      userKey: bot.identity.keyset.userKeyset,
+    });
+
+    const config: UserConfig = {
+      ...existing,
+      allowSync: true,
+      name: published.name,
+      profile_image: published.profile_image,
+    } as UserConfig;
+
+    await bot.graph.configService.saveConfig({ config, keyset: bot.identity.keyset });
+
+    // The publish must be real before mobile is asked to read it. Reading the
+    // row straight back off the relay is the only check that distinguishes
+    // "accepted" from "stored" — mobile's half would otherwise fail with a
+    // misleading verdict about the OTHER client.
+    const stored = await bot.graph.configService.getConfig({
+      address: bot.identity.address,
+      userKey: bot.identity.keyset.userKeyset,
+    });
+    expect(stored.name).toBe(published.name);
+
+    console.log(`[config-cross] desktop published as ${bot.identity.address.slice(0, 12)}…`);
+    console.log(`[config-cross] name=${published.name}`);
+
+    mkdirSync(dirname(HANDOFF), { recursive: true });
+    writeFileSync(
+      HANDOFF,
+      JSON.stringify({ publishedBy: 'desktop', at: Date.now(), ...published }, null, 2)
+    );
+    console.log(`[config-cross] handoff written for mobile: ${HANDOFF}`);
+  } finally {
+    // Synchronous, and in a finally so a failed assertion still clears the
+    // ActionQueue interval and closes the socket — otherwise the run hangs.
+    bot.stop();
+  }
+}, 300_000);

--- a/src/dev/tests/harness/run-config-cross.mjs
+++ b/src/dev/tests/harness/run-config-cross.mjs
@@ -1,0 +1,67 @@
+// Orchestrator for the desktop→mobile CONFIG measurement.
+//
+//   yarn harness:config-cross
+//
+// Runs the two halves in order, in two repos: desktop publishes a user config
+// for a shared throwaway account, then mobile pulls it and asserts what arrived.
+//
+// Unlike run-cross.mjs (the DM measurement) the halves are SEQUENTIAL, not
+// concurrent, and that is a property of what is being measured rather than a
+// simplification. DMs need both peers live at once because delivery is the
+// thing under test. A config is a row on a server: one client writes it, the
+// other reads it later, and they never need to be running at the same time.
+//
+// ⚠️ quorum-mobile is NOT modified. This drives its existing scenario, the same
+// way run-cross.mjs does.
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const DESKTOP_REPO = resolve(HERE, '../../../..');
+const MOBILE_REPO = resolve(DESKTOP_REPO, '..', 'quorum-mobile');
+
+if (!existsSync(MOBILE_REPO)) {
+  console.error(`[config-cross] quorum-mobile not found at ${MOBILE_REPO}`);
+  console.error('[config-cross] both repos must be checked out side by side.');
+  process.exit(1);
+}
+
+const run = (label, cmd, args, cwd) =>
+  new Promise((resolveRun) => {
+    console.log(`\n[config-cross] ── ${label} ──`);
+    const child = spawn(cmd, args, { cwd, shell: true, stdio: 'inherit' });
+    child.on('exit', (code) => resolveRun(code ?? 1));
+  });
+
+const publish = await run(
+  'desktop publishes',
+  'yarn',
+  ['harness', 'config-cross'],
+  DESKTOP_REPO
+);
+
+// Stop here rather than running mobile against a row that was never written.
+// Mobile would fail on a stale handoff, or worse pass against one, and either
+// way the verdict would point at the wrong client.
+if (publish !== 0) {
+  console.error('\n[config-cross] desktop half failed — not running mobile.');
+  console.error('[config-cross] nothing was proved about the other client.');
+  process.exit(publish);
+}
+
+const read = await run(
+  'mobile reads it back',
+  'yarn',
+  ['harness', 'config-cross'],
+  MOBILE_REPO
+);
+
+console.log('');
+if (read === 0) {
+  console.log('[config-cross] desktop → mobile: config crossed clients intact.');
+} else {
+  console.error('[config-cross] desktop → mobile: FAILED. See the mobile half above.');
+}
+process.exit(read);


### PR DESCRIPTION
Answers a question neither repo could answer alone: does a config written by **desktop** decrypt and land correctly on **mobile**?

Both clients had only ever been checked against themselves. The two `ConfigService` implementations are independent code sharing a type, and the known merge-asymmetry issue exists precisely because they drifted apart — so same-client tests were blind to cross-client drift by construction.

```
yarn harness:config-cross

[config-cross] ── desktop publishes ──
[config-cross] ── mobile reads it back ──
[config-cross] mobile adopted desktop's config: name=true image=true
[config-cross] desktop → mobile: config crossed clients intact.
```

## What it does

This half publishes a real config for a shared throwaway account, using the key mobile's harness already persists, then hands off what it published. Mobile pulls on an empty local store and asserts both a short field and a bulk field — the name alone would pass with the image dropped.

It also asserts mobile does **not** inherit the `allowSync: true` published here, so the device-local rule is proven across clients rather than only against mobile's own blob. Reverting that fix turns the scenario red.

## Design notes

**The halves are sequential, not concurrent.** That follows from what is being measured: a config is a row on a server, written by one client and read later by another. DMs need both peers live because delivery itself is under test.

**Mobile asserts against the handoff file, not a shared constant.** Two repos holding the same literal can drift into agreeing about a value neither actually sent, and the assertion would still pass.

**The orchestrator stops if this half fails**, rather than running mobile against a row that was never written — mobile would otherwise fail on a stale handoff and point the verdict at the wrong client.

`quorum-mobile` is not modified by the orchestrator; it drives that repo's existing scenario, as `run-cross.mjs` already does.

## Also in this PR

Records the mobile half of both config-sync slices, now shipped in quorum-mobile #252, and documents two UI strings that deliberately diverge from this repo's copy:

- mobile has no retry queue, so "It will keep retrying" was false there
- mobile's `try` block is wider, so `rejected` cannot claim the server refused it

Both divergences are recorded in the issue files so a future parity sweep does not "fix" them back.

Typecheck clean.
