### PR TITLE
fix: production build rendered a blank page

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "dev": "vite --config web/vite.config.ts",
     "dev:clean": "rimraf node_modules/.vite && vite --config web/vite.config.ts",
     "build": "vite build --config web/vite.config.ts && yarn check:bundle",
-    "check:bundle": "node scripts/check-bundle-globals.mjs",
+    "check:bundle": "node scripts/check-bundle-globals.mjs && node scripts/check-bundle-dev-imports.mjs",
     "build:preview": "yarn build && yarn preview --config web/vite.config.ts",
     "electron:dev": "cross-env NODE_ENV=development electron web/electron/main.cjs",
     "electron:build": "yarn build && electron-builder",

--- a/scripts/check-bundle-dev-imports.mjs
+++ b/scripts/check-bundle-dev-imports.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+/**
+ * Fail the build if the production bundle still IMPORTS a module under
+ * `src/dev/`.
+ *
+ * Sibling of `check-bundle-globals.mjs`, and it exists because that check has a
+ * blind spot that shipped a blank app.
+ *
+ * ## The bug this would have caught
+ *
+ * `web/vite.config.ts` marks everything under `src/dev/` as `external` in a
+ * production build. Externalisation is a RESOLUTION-time decision, so it
+ * happens long before tree-shaking, and an external module is deliberately
+ * preserved as a runtime import rather than inlined.
+ *
+ * So when `src/identity/qnsClaimExemption.ts` statically imported
+ * `../dev/fake-qns/fakeQnsCore`, the result was the worst of both worlds:
+ *
+ *     import"../src/dev/fake-qns/fakeQnsCore"   // in the bundle
+ *     dist/src/dev/fake-qns/fakeQnsCore         // never emitted
+ *
+ * The browser 404'd it, the module graph failed, and React never mounted. The
+ * whole app was a blank page.
+ *
+ * `check-bundle-globals.mjs` did not catch it, and was not wrong to miss it: it
+ * forbids dev IDENTIFIERS (`isFakeClaimFor`, `dev.fakeQns.state`) and those were
+ * genuinely absent — precisely BECAUSE the module was external, so none of its
+ * code was inlined. It answers "did dev code ship?". This answers the different
+ * question "did a reference to dev code survive?".
+ *
+ * Both failure modes are real and neither implies the other:
+ *   - code inlined, no import   -> globals check catches it
+ *   - import dangling, no code  -> this check catches it
+ *
+ * Usage: node scripts/check-bundle-dev-imports.mjs [bundleDir]
+ * Runs automatically after `yarn build`.
+ */
+
+import { readdirSync, readFileSync, statSync, existsSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = fileURLToPath(new URL('..', import.meta.url));
+const bundleDir = process.argv[2]
+  ? join(repoRoot, process.argv[2])
+  : join(repoRoot, 'dist');
+
+const SCANNED_EXTENSIONS = ['.js', '.mjs', '.cjs', '.html'];
+
+/**
+ * Matches a module specifier containing a `dev/` path segment in any import
+ * form the bundler emits:
+ *
+ *   import"../src/dev/x"            side-effect only (the form that broke)
+ *   import x from"../src/dev/x"     default / named
+ *   from"../src/dev/x"              re-export
+ *   import("../src/dev/x")          dynamic
+ *
+ * Deliberately matches the SPECIFIER STRING, which survives minification.
+ * Identifier names do not, which is why the sibling check cannot be relied on
+ * alone for a minified build.
+ */
+const DEV_SPECIFIER = /(?:\bimport\s*\(?|\bfrom\s*)["']([^"']*\/dev\/[^"']*)["']/g;
+
+function walk(dir) {
+  if (!existsSync(dir)) return [];
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry === '.git') continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...walk(full));
+    else if (SCANNED_EXTENSIONS.some((e) => entry.endsWith(e))) out.push(full);
+  }
+  return out;
+}
+
+if (!existsSync(bundleDir)) {
+  console.error(
+    `[check-bundle-dev-imports] bundle directory not found: ${bundleDir}`
+  );
+  process.exit(1);
+}
+
+const files = walk(bundleDir);
+const findings = [];
+
+for (const file of files) {
+  const text = readFileSync(file, 'utf8');
+  for (const match of text.matchAll(DEV_SPECIFIER)) {
+    const specifier = match[1];
+    // node_modules packages legitimately have `dev` in a path; only our own
+    // source tree is the concern.
+    if (!/(^|\/)src\/dev\//.test(specifier) && !/^\.{1,2}\/dev\//.test(specifier))
+      continue;
+    findings.push({ file: relative(repoRoot, file), specifier });
+  }
+}
+
+if (findings.length > 0) {
+  console.error(
+    '\n[check-bundle-dev-imports] FAIL — the production bundle imports dev-only modules.\n'
+  );
+  for (const { file, specifier } of findings) {
+    console.error(`  ${file}\n    imports  ${specifier}`);
+  }
+  console.error(
+    [
+      '',
+      'These modules are excluded from the output by vite.config.ts, so the',
+      'import resolves to nothing at runtime: the browser 404s it, the module',
+      'graph fails, and the app renders a blank page.',
+      '',
+      'A static import cannot be made conditional, and a NODE_ENV gate around',
+      'the CALL does not help — externalisation happens before tree-shaking.',
+      'Invert the dependency instead: let the dev module register itself with',
+      'the production module, so production never names src/dev/ at all. See',
+      'src/identity/qnsClaimExemption.ts for the worked example.',
+      '',
+    ].join('\n')
+  );
+  process.exit(1);
+}
+
+console.log(
+  `[check-bundle-dev-imports] OK — ${files.length} bundle file(s) scanned, no dev-module imports.`
+);

--- a/src/dev/fake-qns/fakeQnsCore.ts
+++ b/src/dev/fake-qns/fakeQnsCore.ts
@@ -40,6 +40,8 @@
  * render. Publishing, the signature payload and the server are not exercised.
  */
 
+import { registerExemptionChecker } from '../../identity/qnsClaimExemption';
+
 const STORAGE_KEY = 'dev.fakeQns.state';
 
 /** The public-profile shape, kept structural so this never has to import from
@@ -273,3 +275,16 @@ export function applyFakeQns(
     signature: actual?.signature ?? '',
   };
 }
+
+// Hand the exemption checker to src/identity/qnsClaimExemption at module load.
+//
+// The dependency points THIS way on purpose. Production code must never name a
+// module under src/dev/: web/vite.config.ts externalises this directory in a
+// release build, and an external import is preserved as a runtime fetch for a
+// file that is not in the output. When qnsClaimExemption imported this module
+// directly, that dangling import 404'd and the whole app failed to mount.
+//
+// Registering here costs nothing: this module only loads in a dev build, and
+// the overlay cannot be enabled without it being loaded, so an unregistered
+// checker and a disabled overlay mean the same thing.
+registerExemptionChecker(isFakeClaimFor);

--- a/src/identity/qnsClaimExemption.ts
+++ b/src/identity/qnsClaimExemption.ts
@@ -13,16 +13,56 @@
  * ## Why a `NODE_ENV` gate and not a runtime flag
  *
  * `process.env.NODE_ENV` is replaced with a literal at build time, so in a
- * release build the condition below folds to `false`, the call is dead code,
- * and `fakeQnsCore` has no remaining importer and drops out of the bundle. That
- * is asserted, not assumed — see `qnsClaimExemption.test.ts`.
+ * release build the condition below folds to `false` and the call is dead code.
  *
  * A runtime flag would leave a live code path in production that returns "this
  * claim is fine, skip the check", which is precisely the thing verification
  * exists to make impossible.
+ *
+ * ## ⚠️ Why the overlay REGISTERS itself instead of being imported
+ *
+ * This module used to `import { isFakeClaimFor } from '../dev/fake-qns/…'`
+ * directly, on the reasoning that the dead branch below would leave it with no
+ * importer, so it would tree-shake away. That reasoning was wrong, and it
+ * shipped a blank app.
+ *
+ * `web/vite.config.ts` marks everything under `src/dev/` as `external` in a
+ * production build. Externalisation happens at RESOLUTION time, long before
+ * tree-shaking gets a chance, and an external module is deliberately preserved
+ * as a runtime import. So the "eliminated" import survived into the bundle as
+ * `import"../src/dev/fake-qns/fakeQnsCore"`, pointing at a file that the very
+ * same rule had excluded from the output. The browser 404'd it, the module
+ * graph failed, and React never mounted.
+ *
+ * A static import cannot be made conditional, so the dependency is inverted
+ * instead: production never names `src/dev/` at all, and the overlay hands its
+ * checker in when it loads. `scripts/check-bundle-dev-imports.mjs` fails the
+ * build if any `src/dev/` import reaches the bundle again.
+ *
+ * This is NOT a behaviour change. `isFakeClaimFor` reads `getFakeQnsState()`,
+ * which lives inside the overlay module, and returns false unless the overlay
+ * is enabled. "Checker not registered" and "overlay not loaded" are therefore
+ * the same state, and the overlay cannot be enabled without being loaded — so
+ * the unregistered answer (false) is the answer the old code gave too.
  */
 
-import { isFakeClaimFor } from '../dev/fake-qns/fakeQnsCore';
+type ExemptionChecker = (name: string, address: string) => boolean;
+
+let checker: ExemptionChecker | null = null;
+
+/**
+ * Called by `src/dev/fake-qns/fakeQnsCore` at module load. Nothing in a
+ * production build calls this, because nothing in a production build imports
+ * that module.
+ */
+export function registerExemptionChecker(next: ExemptionChecker): void {
+  checker = next;
+}
+
+/** Test seam. Production never reaches this. */
+export function __resetExemptionCheckerForTests(): void {
+  checker = null;
+}
 
 /**
  * True when `name` is a claim the dev overlay itself synthesized for `address`.
@@ -33,6 +73,8 @@ import { isFakeClaimFor } from '../dev/fake-qns/fakeQnsCore';
  * names is the behaviour the overlay exists to observe.
  */
 export function isExemptClaim(name: string, address: string): boolean {
+  // Folds to `return false` in a release build, so the line below is dead code
+  // and `checker` is unreachable regardless of what may have registered it.
   if (process.env.NODE_ENV !== 'development') return false;
-  return isFakeClaimFor(name, address);
+  return checker ? checker(name, address) : false;
 }


### PR DESCRIPTION
## The bug

A production build rendered a **blank page**. React never mounted.

```
in the bundle:   import"../src/dev/fake-qns/fakeQnsCore"
never emitted:   dist/src/dev/fake-qns/fakeQnsCore
```

The browser 404'd that import, the module graph failed, and nothing rendered.

`src/identity/qnsClaimExemption.ts` imported that dev module directly, on the reasoning that the `NODE_ENV` gate around the *call* would leave it with no importer, so it would tree-shake away. The reasoning is sound but something beats it to the punch: `web/vite.config.ts` marks `src/dev/` as `external`, and externalisation is a resolution-time decision that happens long before tree-shaking. An external module is deliberately **preserved** as a runtime import, so the "eliminated" import survived, pointing at a file the same rule had excluded.

**Only production builds are affected.** The external rule is itself gated on `NODE_ENV === 'production'`, so `yarn dev` resolves the module normally and works fine — which is why this went unnoticed.

Introduced by #343 (2026-08-16). Not deployed: the latest tag is `prod-2026-08-05`, which predates it. The next deploy would have shipped a blank app.

## The fix

A static import cannot be conditional, so the dependency is inverted. The dev overlay registers its checker with `qnsClaimExemption` at module load, and production never names `src/dev/` at all.

**Not a behaviour change.** `isFakeClaimFor` reads `getFakeQnsState()`, which lives inside the overlay module, and returns false unless the overlay is enabled. "Checker unregistered" and "overlay not loaded" are therefore the same state, and the overlay cannot be enabled without being loaded — so the unregistered answer (`false`) is the answer the old code gave. All 8 existing exemption tests pass untouched.

## New build guard

`scripts/check-bundle-globals.mjs` did not catch this, and was not wrong to miss it: it forbids dev *identifiers*, and those were genuinely absent — precisely **because** the module was external, so none of its code was inlined. It answers "did dev code ship?".

`scripts/check-bundle-dev-imports.mjs` answers the different question: "did a *reference* to dev code survive?". Neither failure mode implies the other, and both now run from `yarn check:bundle`. It matches module specifier strings, which survive minification, unlike identifiers.

## Verification

Real production build, served with `vite preview`, in a real browser:

| | root children | page |
|---|---|---|
| before | 0 | blank |
| after | 1 | sign-in screen renders |

The new guard was also run against the **pre-fix** bundle and confirmed to exit 1, rather than assuming it works.

Suite: 1483 tests pass, 0 type errors.
