### PR TITLE
feat(settings): remind sync-off users that this device is their only copy

### DIFF
--- a/.agents/docs/features/user-data-backup.md
+++ b/.agents/docs/features/user-data-backup.md
@@ -197,12 +197,54 @@ The Data Backup section appears in **User Settings > Security**, below the "Acco
 >
 > Design history: [`.agents/issues/.open/2026-08-09-backup-restore-overhaul-design.md`](../../issues/.open/2026-08-09-backup-restore-overhaul-design.md).
 
-- **No automatic backups** — users must manually export. There is no scheduled or triggered backup.
+- **No automatic backups** — users must manually export. There is no scheduled or triggered backup. **Since 2026-08-17 there is a *reminder***, which is not the same thing: `BackupStatus` on the General settings tab shows a warning when `allowSync` is off and no backup has been taken in 30 days (`utils/lastBackup.ts`). It prompts; it does not export. It also only reaches users who open Settings, which is the population least in need of it — see M4 in [the ITP issue](../../issues/.open/2026-08-05-safari-itp-wipes-indexeddb-after-7-idle-days.md).
 - **No incremental backups** — each export contains all DM data. Acceptable given DM-only scope keeps file sizes manageable.
 - **Space messages not backed up** — they resync from other members. Single-member spaces can lose message history (space definition recovers via API).
 - **No fresh-device restore during onboarding** — users must complete login first, then import from Settings. A dedicated onboarding restore flow is a potential future enhancement.
 - **Import skips encryption states and config** — on an active account, only messages and conversations are restored. An `allowSync=false` user who lost data and then joined new spaces before importing cannot recover their old space list from the backup.
 - **DM session continuity is not restored** — history comes back, sessions do not. See §6 of the overhaul design above (absorbed from [the now-archived DM-sessions issue](../../issues/.archived/2026-08-05-qmbak-backup-cannot-restore-dm-sessions.md)).
+
+### DM session continuity: a decision, not a gap — and deliberately not surfaced in the UI
+
+Worth stating at length because the terse bullet above reads like unfinished work,
+and it is not.
+
+**The decision.** Restoring DM ratchet state is never done, rather than done
+carefully. Rewinding a sending chain risks message-key reuse, so slice 4 of the
+overhaul removed the hazard instead of managing it. A restore therefore gives
+back readable history and Space key material, and each DM conversation resumes on
+a **fresh** session the next time a message is sent.
+
+**Measured** (2026-08-17, `yarn harness dm-itp-wipe`): after a total wipe, a DM to
+an existing contact re-initiates via the force-sender-init path and both sides
+exchange messages again. So "DMs are broken after a restore" is wrong. The
+conversation works.
+
+**Why there is no user-facing copy about it.** Proposed 2026-08-17 and rejected,
+for reasons that will apply again to the next person who proposes it:
+
+- It is not actionable. The conversation heals itself with no user involvement.
+- It is not visible. The one plausible symptom is that messages sent to you around
+  the moment of data loss may never arrive — and **you cannot notice a message you
+  never received**. Copy about it is anxiety with nothing attached.
+- It cannot be said in the user's vocabulary. "Session" is our word. Every other
+  line in `summariseRestore` either explains a visible absence or tells the user
+  what to do; a line about ratchet sessions does neither, and would be the only
+  entry in that list describing an internal mechanism.
+
+This matches the reasoning already recorded on the export confirmation modal in
+`Security.tsx`, which deliberately omits a comparable nuance: *"Rather than state
+something true for one group and misleading for the other, the copy sticks to what
+is true for both."*
+
+**Open, and unmeasured.** Whether any messages are genuinely lost in the gap — sent
+to the old session inbox before the wiped side re-initiates — has NOT been
+measured. Inbound frames for an unknown inbox are retained rather than dropped, so
+they may well be readable once the session is re-established, but nobody has
+watched it. If that measurement ever runs and shows real loss, revisit the
+no-copy decision above; until then, do not write UI copy asserting a symptom
+nobody has observed. The instrument to settle it is `dm-itp-wipe`, extended so the
+peer sends *before* the wiped side re-initiates.
 
 ## Related Documentation
 
@@ -211,4 +253,4 @@ The Data Backup section appears in **User Settings > Security**, below the "Acco
 - [Cryptographic Architecture](../cryptographic-architecture.md) — Ed448 key hierarchy
 - [Task: User Data Backup & Restore](../../issues/.done/user-data-backup-restore-feature.md) — Implementation task with full context
 
-_Last updated: 2026-08-12_
+_Last updated: 2026-08-17_

--- a/.agents/issues/.open/2026-08-05-safari-itp-wipes-indexeddb-after-7-idle-days.md
+++ b/.agents/issues/.open/2026-08-05-safari-itp-wipes-indexeddb-after-7-idle-days.md
@@ -5,7 +5,7 @@ status: open
 priority: high
 ai_generated: true
 created: 2026-08-05
-updated: 2026-08-05
+updated: 2026-08-17
 related_docs:
   - "../../docs/features/user-data-backup.md"
   - "../../docs/cryptographic-architecture.md"
@@ -23,11 +23,23 @@ related_reports:
 
 ## Status
 
-Unverified against a live Safari instance. The mechanism is confirmed from
-WebKit's own documentation and the code paths are confirmed by reading this
-repo, but **no one has yet watched a real Quorum account get wiped**. That
-reproduction is step 1 of any fix (see Verification). Filed as `high` rather
-than `critical` because the affected population is currently unmeasured.
+**The consequence is now measured. The Safari trigger is not.**
+
+The issue makes two claims, and they need different instruments:
+
+| Claim | Status |
+|---|---|
+| **A.** WebKit deletes script-writable storage after 7 days of Safari use without interaction | **Still unverified here.** Documented by WebKit and demonstrated by third parties, but nobody on this project has watched it happen. Needs real Safari on Apple hardware; the 7-day counter cannot be advanced from outside. |
+| **B.** Once the database is gone, DM history and sessions do not come back, while the conversation can resume on a fresh session | **VERIFIED 2026-08-17**, headless, by `dm-itp-wipe` (see Verification). |
+
+Splitting them matters because B is where every mitigation lands, and B is
+**not Safari-specific**: the client cannot tell *why* its database vanished.
+ITP, a "clear site data" click and a brand-new device are the same event to it.
+So B was testable immediately, on Windows, without Apple hardware — which is
+what made the 8-day Mac reproduction stop being a blocker on everything else.
+
+Still `high` rather than `critical`: the affected population remains unmeasured
+(what share of users are on Safari web rather than Electron).
 
 ## Symptoms
 
@@ -243,16 +255,66 @@ knows it is a routine occurrence rather than an edge case.
 
 ## Verification
 
-**Do not close this on reasoning.** The mechanism is documented but the specific
-consequence for a Quorum account has not been observed. Establish the baseline
-first, then re-run after each mitigation.
+**Do not close this on reasoning.**
 
-- [ ] **Reproduce.** On a Mac, log into `app.quorummessenger.com` in Safari, seed a space and a DM with history. Use Safari daily for other sites, never returning to Quorum. Check at day 8. Record exactly which IndexedDB databases survive (`quorum_db`, SDK `KeyDB`).
-  - Faster proxy for iteration: Safari → Develop → Empty Caches, or delete the origin's data in Settings → Privacy → Manage Website Data. Confirm it produces the same end state before trusting it as a substitute.
-- [ ] **Control arm.** Same procedure in Chrome. It must **not** wipe. If both arms wipe, the instrument is measuring something else.
+### Measured 2026-08-17 — `dm-itp-wipe` (headless, Windows)
+
+`src/dev/tests/harness/dm-itp-wipe.scenario.test.ts`, run with
+`yarn harness dm-itp-wipe`. Two bots on the live relay, real `MessageService`,
+real SDK crypto, `fake-indexeddb` for storage. It seeds DM history both ways,
+destroys one side's entire database with `indexedDB.deleteDatabase` (the way the
+browser does it, not row by row), and counts what is left through
+`getAllDMData` — deliberately the same read the `.qmbak` export uses, so a count
+of zero means *a backup taken at that moment would capture nothing*.
+
+```
+bob BEFORE  messages=3 conversations=1 sessions=1
+bob AFTER   messages=0 conversations=0 sessions=0
+seeded=3 revived=0 onDiskNow=[recover-init #1 | after-wipe #1]
+databases immediately after wipe:            quorum_db_itp-alice
+databases after first read (init recreates): quorum_db_itp-alice, quorum_db_itp-bob
+```
+
+What that establishes:
+
+- **The DM loss is total.** Messages, conversations and ratchet states all go to
+  zero together. Nothing in the app restores them.
+- **The conversation still resumes.** With no encryption state present, the send
+  path opens a fresh session (`ForceSenderInit`) and traffic flows both ways
+  again — `recover-init #1` reached the peer, `after-wipe #1` came back.
+- **Resuming does not revive history.** 0 of 3 seeded messages returned. This is
+  the distinction the issue turns on, and it is now pinned by an assertion
+  rather than by argument.
+- **Control arm held.** The eviction hit one side only; the other party's census
+  was byte-identical before and after. If both had moved, the harness would have
+  been sharing one database between bots and every number above would be junk.
+
+Two things it measured that were **not** obvious beforehand, both worth carrying
+into any fix:
+
+- **`quorum_db` existing proves nothing.** The database is recreated, empty, the
+  instant anything reads — `MessageDB.init()` rebuilds the schema. A diagnostic
+  that checks for the database's presence would report "fine" on a wiped account.
+  Sample before the first read or the measurement is worthless.
+- **Counting persistence callbacks overcounts.** One logical message can be saved
+  more than once (un-acked frames are redelivered on `listen`; the receive path
+  also salvages the message embedded in a refused init envelope). A first cut
+  asserted `=== 2` and measured 4. The test asserts on distinct message bodies.
+
+**The test can fail** (checked, not assumed): swapping `wipeAll()` for the older
+`wipeSessions()` — which removes only `encryption_states` — turns it red with
+`messages=3 conversations=1 sessions=0`. So it genuinely distinguishes a session
+wipe from a storage eviction, which is exactly the difference this issue is about.
+
+### Still open
+
+- [ ] **Reproduce claim A.** On a Mac, log into `app.quorummessenger.com` in Safari, seed a space and a DM with history. Use Safari daily for other sites, never returning to Quorum. Check at day 8. Record exactly which IndexedDB databases survive (`quorum_db`, SDK `KeyDB`).
+  - Needs Apple hardware. Cloud Safari services do not help: their sessions last minutes and the counter needs days.
+  - The "faster proxy" (Empty Caches / Manage Website Data) is now redundant for the *app-side* question — `dm-itp-wipe` answers it repeatably. The Mac run is only needed to confirm WebKit's **trigger**.
+- [ ] **Control arm.** Same procedure in Chrome. It must **not** wipe. Only meaningful once the Safari arm above actually runs.
 - [ ] Confirm the installed case is exempt: repeat with the app added to the Dock.
-- [ ] After a wipe, confirm what login actually restores (expected: profile, spaces, space keys; not DMs).
-- [ ] After a wipe, confirm a DM to an existing contact re-initiates via `ForceSenderInit` and both sides can talk again.
+- [ ] After a wipe, confirm what login actually restores (expected: profile, spaces, space keys; not DMs). **Not covered by `dm-itp-wipe`** — that harness is transport-level and never exercises the `ConfigService` login/restore path. This still needs either a browser run or a new harness slice.
+- [x] ~~After a wipe, confirm a DM to an existing contact re-initiates via `ForceSenderInit` and both sides can talk again.~~ **Done** — see above.
 - [ ] After M1, confirm a `.qmbak` restore into the wiped profile brings back a *decryptable* existing session — and that restoring into a live account still leaves live states untouched.
 - [ ] Revert M1 and confirm the new test goes red. An assertion that passes either way is worse than no test.
 
@@ -268,3 +330,8 @@ first, then re-run after each mitigation.
 - [User Data Backup & Restore](../../docs/features/user-data-backup.md) — the `.qmbak` feature and its current limits
 - [Cryptographic Architecture](../../docs/cryptographic-architecture.md) §Key Storage Locations — what lives in IndexedDB
 - [Profile Sync on Returning User Login](../../docs/features/profile-sync-returning-user-login.md) — the recovery path that already exists for identity and profile
+- `src/dev/tests/harness/dm-itp-wipe.scenario.test.ts` — the reproduction of the app-side consequence; `yarn harness dm-itp-wipe`
+
+---
+
+*Last updated: 2026-08-17*

--- a/.agents/issues/.open/2026-08-05-safari-itp-wipes-indexeddb-after-7-idle-days.md
+++ b/.agents/issues/.open/2026-08-05-safari-itp-wipes-indexeddb-after-7-idle-days.md
@@ -31,6 +31,7 @@ The issue makes two claims, and they need different instruments:
 |---|---|
 | **A.** WebKit deletes script-writable storage after 7 days of Safari use without interaction | **Still unverified here.** Documented by WebKit and demonstrated by third parties, but nobody on this project has watched it happen. Needs real Safari on Apple hardware; the 7-day counter cannot be advanced from outside. |
 | **B.** Once the database is gone, DM history and sessions do not come back, while the conversation can resume on a fresh session | **VERIFIED 2026-08-17**, headless, by `dm-itp-wipe` (see Verification). |
+| **C.** Login restores profile, Spaces and Space keys | **VERIFIED 2026-08-17** by `space-wipe-restore` — **but only when `allowSync` is on, which is not the default.** With sync off the eviction takes the Spaces as well. The recoverability table below is corrected accordingly. |
 
 Splitting them matters because B is where every mitigation lands, and B is
 **not Safari-specific**: the client cannot tell *why* its database vanished.
@@ -127,17 +128,36 @@ Firefox users; it does not rescue the Safari tab case.** Only installing does.
 
 ### 3. What is actually lost vs recoverable
 
+> **⚠️ Corrected 2026-08-17 after measurement.** An earlier version of this table
+> marked profile, Spaces and Space keys as recoverable without qualification.
+> **That is only true if the user has `allowSync` ON.** It is device-local and
+> **defaults to OFF** ([ConfigService.ts:289](../../../src/services/ConfigService.ts#L289),
+> `storedConfig?.allowSync ?? false`), and both the `spaceKeys` build and the
+> `postUserSettings` call sit inside `if (config.allowSync)`
+> ([:695](../../../src/services/ConfigService.ts#L695),
+> [:864](../../../src/services/ConfigService.ts#L864)). With sync off, **nothing
+> is ever published**, so there is nothing to restore from and the eviction takes
+> the Spaces too. Measured both ways by `space-wipe-restore` — see Verification.
+
 | Data | Store | Recoverable? | How |
 |---|---|---|---|
 | Account identity | passkey `largeBlob` (platform authenticator) | ✅ | Not browser storage; survives |
-| Profile (name, avatar, bio) | encrypted server config | ✅ | Re-fetched on login |
-| Spaces list | encrypted server config | ✅ | Same |
-| Space keys + space ratchet state | encrypted server config (`config.spaceKeys`) | ✅ | [ConfigService.ts:545-561](../../../src/services/ConfigService.ts#L545-L561) backs up `keys` + `encryptionState` per space |
-| Bookmarks, settings | encrypted server config | ✅ | Same parcel |
-| **DM message history** | IndexedDB `messages` | ❌ | No server-side message storage (P2P) |
-| **DM conversation metadata** | IndexedDB `conversations` | ❌ | Same |
-| **DM Double Ratchet states** | IndexedDB `encryption_states` | ❌ | Same |
-| Space message history | IndexedDB `messages` | ⚠️ | Likely re-syncable from peers via the sync manifest protocol — **unverified** |
+| Profile (name, avatar, bio) | encrypted server config | ✅ **only if `allowSync`** | Re-fetched on login. MEASURED: returns with sync on, absent with sync off |
+| Spaces list | encrypted server config | ✅ **only if `allowSync`** | MEASURED: 1 Space restored with sync on, 0 with sync off |
+| Space keys | encrypted server config (`config.spaceKeys`) | ✅ **only if `allowSync`**, minus `signing` | MEASURED: 6 of 7 keys return. `signing` is skipped **by design** ([ConfigService.ts:467](../../../src/services/ConfigService.ts#L467)) so a restored device signs with its own per-device `inbox` key |
+| Space ratchet state | encrypted server config (`config.spaceKeys[].encryptionState`) | ✅ **only if `allowSync`** | MEASURED: the Space group ratchet is the *only* ratchet state that returns |
+| Bookmarks, settings | encrypted server config | ✅ **only if `allowSync`** | Same parcel, same gate |
+| **DM message history** | IndexedDB `messages` | ❌ | No server-side message storage (P2P). MEASURED: 0 restored |
+| **DM conversation metadata** | IndexedDB `conversations` | ❌ | Same. MEASURED: 0 restored |
+| **DM Double Ratchet states** | IndexedDB `encryption_states` | ❌ | Same. MEASURED: not in the config parcel; does not return |
+| Space message history | IndexedDB `messages` | ⚠️ | Likely re-syncable from peers via the sync manifest protocol — **still unverified** |
+
+**The practical consequence of the `allowSync` gate.** The population most
+exposed to this bug is not the one the table originally implied. A sync-off user
+— the default — loses *everything* local to an eviction: DMs **and** Spaces
+**and** profile. Whatever share of Safari web users that is, they are strictly
+worse off than this issue first described, and M2 (steer them to install) matters
+more for them than for anyone else.
 
 The existing [User Data Backup & Restore](../../docs/features/user-data-backup.md)
 doc already names this class of loss: *"scenarios where DM data is permanently
@@ -306,6 +326,45 @@ into any fix:
 `messages=3 conversations=1 sessions=0`. So it genuinely distinguishes a session
 wipe from a storage eviction, which is exactly the difference this issue is about.
 
+### Measured 2026-08-17 — `space-wipe-restore` (headless, Windows)
+
+`src/dev/tests/harness/space-wipe-restore.scenario.test.ts`, run with
+`yarn harness space-wipe-restore`. Answers the "what does login restore"
+question, which `dm-itp-wipe` could not reach: that path runs through
+`ConfigService.getConfig`, and the DM harness is transport-level.
+
+Two accounts, identical shape (one Space, a profile name, a DM each). **One
+variable: `allowSync`.** Both are evicted identically, then both log back in.
+
+```
+sync ON  BEFORE   spaces=1 keys=[…,config,hub,inbox,owner,signing] name=Synced   dmMessages=2 dmConvs=1
+sync ON  WIPED    spaces=0 keys=[]                                  name=(none)  dmMessages=0 dmConvs=0
+sync ON  RESTORED spaces=1 keys=[…,config,hub,inbox,owner]          name=Synced  dmMessages=0 dmConvs=0
+
+sync OFF BEFORE   spaces=1 keys=[…,config,hub,inbox,owner,signing] name=Unsynced dmMessages=2 dmConvs=1
+sync OFF WIPED    spaces=0 keys=[]                                  name=(none)  dmMessages=0 dmConvs=0
+sync OFF RESTORED spaces=0 keys=[]                                  name=(none)  dmMessages=0 dmConvs=0
+```
+
+- **Sync on:** the Space, its keys and the profile name all return. DMs stay at
+  zero — the login that rebuilt an entire Space restores no conversation data,
+  because none of it is in the parcel.
+- **Sync off:** nothing returns. Not the Space, not the keys, not the profile.
+  This is the default setting.
+- **`signing` is the one key that does not come back, deliberately.**
+  `adoptSpaces` skips it ([ConfigService.ts:467](../../../src/services/ConfigService.ts#L467))
+  so a restored device signs with its own per-device `inbox` key rather than
+  adopting the shared slot. The test asserts the exact key set, so removing that
+  `continue` goes red rather than silently regressing the per-device signing design.
+- **Only the Space group ratchet returns.** The restored `encryption_states` row
+  is `<spaceId>/<spaceId>`. The DM ratchet is not in the config and does not come
+  back — which is the same conclusion `dm-itp-wipe` reached from the other side.
+
+**Causation checked, not assumed.** Flipping *only* the sync-off arm to
+`allowSync: true` makes it restore its Space (`spaces=0` → `1`) and turns the
+test red. So the difference between the arms is `allowSync` itself, not some
+incidental difference between the two accounts.
+
 ### Still open
 
 - [ ] **Reproduce claim A.** On a Mac, log into `app.quorummessenger.com` in Safari, seed a space and a DM with history. Use Safari daily for other sites, never returning to Quorum. Check at day 8. Record exactly which IndexedDB databases survive (`quorum_db`, SDK `KeyDB`).
@@ -313,7 +372,8 @@ wipe from a storage eviction, which is exactly the difference this issue is abou
   - The "faster proxy" (Empty Caches / Manage Website Data) is now redundant for the *app-side* question — `dm-itp-wipe` answers it repeatably. The Mac run is only needed to confirm WebKit's **trigger**.
 - [ ] **Control arm.** Same procedure in Chrome. It must **not** wipe. Only meaningful once the Safari arm above actually runs.
 - [ ] Confirm the installed case is exempt: repeat with the app added to the Dock.
-- [ ] After a wipe, confirm what login actually restores (expected: profile, spaces, space keys; not DMs). **Not covered by `dm-itp-wipe`** — that harness is transport-level and never exercises the `ConfigService` login/restore path. This still needs either a browser run or a new harness slice.
+- [x] ~~After a wipe, confirm what login actually restores (expected: profile, spaces, space keys; not DMs).~~ **Done** — `space-wipe-restore`, see above. The expectation was right *for sync-on users only*; the table above is corrected.
+- [ ] **NEW, opened by that measurement:** decide whether a sync-off user losing their Spaces to an eviction is acceptable. It is the default setting, and this issue was originally written as though Spaces were always safe. Options: default `allowSync` on, warn before eviction-prone conditions, or make M2 (install) the answer and say so explicitly.
 - [x] ~~After a wipe, confirm a DM to an existing contact re-initiates via `ForceSenderInit` and both sides can talk again.~~ **Done** — see above.
 - [ ] After M1, confirm a `.qmbak` restore into the wiped profile brings back a *decryptable* existing session — and that restoring into a live account still leaves live states untouched.
 - [ ] Revert M1 and confirm the new test goes red. An assertion that passes either way is worse than no test.
@@ -330,7 +390,9 @@ wipe from a storage eviction, which is exactly the difference this issue is abou
 - [User Data Backup & Restore](../../docs/features/user-data-backup.md) — the `.qmbak` feature and its current limits
 - [Cryptographic Architecture](../../docs/cryptographic-architecture.md) §Key Storage Locations — what lives in IndexedDB
 - [Profile Sync on Returning User Login](../../docs/features/profile-sync-returning-user-login.md) — the recovery path that already exists for identity and profile
-- `src/dev/tests/harness/dm-itp-wipe.scenario.test.ts` — the reproduction of the app-side consequence; `yarn harness dm-itp-wipe`
+- `src/dev/tests/harness/dm-itp-wipe.scenario.test.ts` — the reproduction of the app-side DM consequence; `yarn harness dm-itp-wipe`
+- `src/dev/tests/harness/space-wipe-restore.scenario.test.ts` — what login restores, sync on vs off; `yarn harness space-wipe-restore`
+- [Make allowSync a per-device setting](2026-08-08-make-allowsync-a-per-device-setting.md) — the `allowSync` gate this issue now depends on
 
 ---
 

--- a/.agents/issues/.open/2026-08-05-safari-itp-wipes-indexeddb-after-7-idle-days.md
+++ b/.agents/issues/.open/2026-08-05-safari-itp-wipes-indexeddb-after-7-idle-days.md
@@ -155,9 +155,22 @@ Firefox users; it does not rescue the Safari tab case.** Only installing does.
 **The practical consequence of the `allowSync` gate.** The population most
 exposed to this bug is not the one the table originally implied. A sync-off user
 — the default — loses *everything* local to an eviction: DMs **and** Spaces
-**and** profile. Whatever share of Safari web users that is, they are strictly
-worse off than this issue first described, and M2 (steer them to install) matters
-more for them than for anyone else.
+**and** profile. The server is holding nothing for them.
+
+**Their one protection is a `.qmbak` file**, and since PR #324 it is a real one:
+the export reads the `space_keys` and `spaces` stores directly rather than the
+sync-only `user_config.spaceKeys` snapshot, so a sync-off backup carries the
+Space keys — including `owner` — that it previously omitted. See M1 for the
+measured coverage. That makes the ordering here:
+
+1. **M2 (install)** — the only mitigation that stops the wipe happening.
+2. **M4 (prompt for a backup)** — the only thing that helps a user it already
+   happened to, and now unblocked.
+3. Everything else softens the edges.
+
+`allowSync` stays **off** by default (product decision, 2026-08-17). This issue
+should not propose flipping it; it should assume sync-off is the norm and make
+the backup path carry the weight.
 
 The existing [User Data Backup & Restore](../../docs/features/user-data-backup.md)
 doc already names this class of loss: *"scenarios where DM data is permanently
@@ -209,18 +222,41 @@ end to end is part of Verification below.
 
 Ordered by ratio of user protection to effort.
 
-### M1 — Make `.qmbak` able to restore DM sessions → **split out**
+### M1 — ~~Make `.qmbak` able to restore DM sessions~~ → **RESOLVED, and the answer was "no"**
 
-> **Corrected 2026-08-05.** An earlier draft of this issue described this as a
-> small conditional-import fix. That was wrong. The export is missing
-> `inbox_mapping` and `latest_states`, the ratchet blob is opaque so send and
-> receive chains cannot be separated at the app layer, and naively restoring a
-> rewound sending chain risks message-key reuse. It needs SDK input.
+> **Superseded 2026-08-17.** This mitigation is closed. Both of its premises have
+> moved, and the earlier text here — plus its link to a since-archived issue —
+> was sending readers to the wrong conclusion.
 
-Tracked separately as
-[2026-08-05-qmbak-backup-cannot-restore-dm-sessions.md](2026-08-05-qmbak-backup-cannot-restore-dm-sessions.md).
-It is **independent of ITP** — it applies equally to cache clears, device resets
-and new devices — so it should not block or be blocked by the mitigations below.
+**What was decided.** Restoring DM ratchet state is now deliberately **never**
+done, rather than done carefully. Rewinding a sending chain risks message-key
+reuse, and the overhaul chose to remove that hazard instead of managing it
+(slice 4 of [the backup/restore overhaul](2026-08-09-backup-restore-overhaul-design.md),
+which **supersedes** the old split-out issue, now at
+`.agents/issues/.archived/2026-08-05-qmbak-backup-cannot-restore-dm-sessions.md`).
+
+**What shipped instead (PR #324).** The export stopped reading the
+`user_config.spaceKeys` snapshot — empty for a sync-off user — and now reads the
+`spaces` and `space_keys` stores directly. So a backup carries the Space key
+material it always claimed to, **regardless of `allowSync`**.
+
+**Verified 2026-08-17** by running the suites, not by reading them: 36 tests pass
+across `backupSpaceKeyCoverage.test.ts` and `backupSpaceRestore.test.ts`,
+including `restores a Space onto a wiped device`, which throws the database away
+and asserts the `owner` **private key** comes back from the file. A live-relay
+restore is covered by `space-kick.scenario.test.ts`, whose control arm confirms a
+Space does rebuild for a user who was never kicked.
+
+**So, for a sync-off user holding a backup:**
+
+| | Restored from `.qmbak`? |
+|---|---|
+| Spaces, Space keys (incl. `owner`), profile | ✅ |
+| DM message history, conversations | ✅ |
+| DM Double Ratchet sessions | ❌ **by design** — conversations resume on a fresh session |
+
+The residual is no longer a missing capability. It is that **taking a backup is
+manual**, which is M4.
 
 ### M2 — Warn Safari users and steer them to install → **specced separately**
 
@@ -235,7 +271,7 @@ desktop equivalent of Add to Home Screen and grants the same ITP exemption.
 Three things found while speccing it that belong here:
 
 - **Install is gated on an unverified assumption.** Nobody has confirmed that passkey auth (`navigator.credentials.get()` + `largeBlob`) works inside an iOS standalone web app. If it does not, this mitigation collapses and this bug needs a different answer. That check is Phase 0 of the install task and should run before anything else here.
-- **Installing does not carry the user's data across.** An iOS Home Screen web app gets a **separate storage partition** from Safari: no shared IndexedDB, localStorage, cookies or service worker. So telling a Safari-tab user to install means telling them to start with an empty database and leave their DM history behind in the tab. The handoff is export `.qmbak` → import in the installed app, which routes this bug straight through [the backup issue](2026-08-05-qmbak-backup-cannot-restore-dm-sessions.md) and its session-continuity gap. **The two issues are less independent than originally filed.** (Whether macOS Add to Dock partitions the same way is unverified, and desktop users are the ones likeliest to have the most history to lose.)
+- **Installing does not carry the user's data across.** An iOS Home Screen web app gets a **separate storage partition** from Safari: no shared IndexedDB, localStorage, cookies or service worker. So telling a Safari-tab user to install means telling them to start with an empty database and leave their history behind in the tab. The handoff is export `.qmbak` → import in the installed app. **Updated 2026-08-17:** that handoff now works for everything except DM session continuity — Spaces, keys and history all cross over (see M1), and existing conversations resume on a fresh session. So install advice is safe to give provided it is paired with "export a backup first", which is not optional here: without the file, a sync-off user who installs starts from nothing. (Whether macOS Add to Dock partitions the same way is unverified, and desktop users are the ones likeliest to have the most history to lose.)
 - **The install advice is only safe if the origin never changes.** Passkeys are scoped to `app.quorummessenger.com` (the SDK omits `rp.id`, so WebAuthn defaults it to the calling origin's effective domain), and IndexedDB is keyed by origin. The QStorage hosting migration must therefore change only what sits *behind* that hostname. If the URL changes, every passkey stops working and every local database is orphaned at once — and an installed web app is pinned to its origin too, so everyone who followed this advice would be stranded. Full detail in the install task under "Blocking constraints".
 
 ### M3 — Call `navigator.storage.persist()` on startup (code, trivial)
@@ -244,14 +280,28 @@ Genuinely protects Chrome and Firefox users against quota-pressure eviction, and
 succeeds on Safari once the app is installed. Log the result so we can see, in the
 field, how often it is granted.
 
-### M4 — Prompt for a backup on a schedule (UX, medium)
+### M4 — Prompt for a backup on a schedule (UX, medium) → **UNBLOCKED, and now the highest-value unbuilt item**
 
 The `.qmbak` export exists but is manual and buried in Settings → Privacy/Security.
 A periodic nudge (or an automatic export to the Downloads folder in Electron)
-converts it from a feature nobody uses into an actual safety net. **Blocked on
-[the backup issue](2026-08-05-qmbak-backup-cannot-restore-dm-sessions.md)** —
-prompting users to take a backup that cannot fully restore would manufacture
-exactly the false confidence that issue is about.
+converts it from a feature nobody uses into an actual safety net.
+
+> **Unblocked 2026-08-17.** This was previously held back on the grounds that
+> "prompting users to take a backup that cannot fully restore would manufacture
+> false confidence". That reasoning no longer applies: since PR #324 a backup
+> restores Spaces, Space keys and DM history, for sync-off users too (M1). The
+> only thing it does not restore is DM session continuity, and that is a
+> deliberate decision rather than a shortfall, so a prompt is no longer promising
+> something the file cannot deliver.
+
+**With `allowSync` staying off by default, this is the only protection a default
+user has.** The server holds nothing for them: no profile, no Spaces, no keys. A
+`.qmbak` file is the entire safety net, and today it only exists if the user went
+looking for it. The honest framing for any prompt is therefore "this is your only
+copy", not "extra safety".
+
+Copy should not over-promise: a restore brings back history and Spaces, and
+existing DM conversations continue on a new session.
 
 ### M6 — Document the user-level ITP opt-out, but do not recommend it (docs, trivial)
 
@@ -373,10 +423,11 @@ incidental difference between the two accounts.
 - [ ] **Control arm.** Same procedure in Chrome. It must **not** wipe. Only meaningful once the Safari arm above actually runs.
 - [ ] Confirm the installed case is exempt: repeat with the app added to the Dock.
 - [x] ~~After a wipe, confirm what login actually restores (expected: profile, spaces, space keys; not DMs).~~ **Done** — `space-wipe-restore`, see above. The expectation was right *for sync-on users only*; the table above is corrected.
-- [ ] **NEW, opened by that measurement:** decide whether a sync-off user losing their Spaces to an eviction is acceptable. It is the default setting, and this issue was originally written as though Spaces were always safe. Options: default `allowSync` on, warn before eviction-prone conditions, or make M2 (install) the answer and say so explicitly.
+- [x] ~~Decide whether a sync-off user losing their Spaces to an eviction is acceptable.~~ **Decided 2026-08-17: `allowSync` stays OFF by default.** So the answer is not to sync more, it is to make the backup path carry the weight — M2 to prevent the wipe, M4 to make a backup exist when it happens anyway. Do not reopen this as "default sync on".
 - [x] ~~After a wipe, confirm a DM to an existing contact re-initiates via `ForceSenderInit` and both sides can talk again.~~ **Done** — see above.
-- [ ] After M1, confirm a `.qmbak` restore into the wiped profile brings back a *decryptable* existing session — and that restoring into a live account still leaves live states untouched.
-- [ ] Revert M1 and confirm the new test goes red. An assertion that passes either way is worse than no test.
+- [x] ~~After M1, confirm a `.qmbak` restore into the wiped profile brings back a *decryptable* existing session — and that restoring into a live account still leaves live states untouched.~~ **Moot.** M1 was resolved by deciding never to restore DM ratchet state, so there is no restored session to check. The half that does apply — a restore into a live account leaving live state untouched — is covered by the additive property tests in `backupSpaceRestore.test.ts`.
+- [x] ~~Revert M1 and confirm the new test goes red.~~ **Done in the equivalent form**, by the people who shipped it: the sync-off export assertions in `backupSpaceKeyCoverage.test.ts` were mutation-verified (assembling `spaceKeys` outside the `allowSync` branch turns all three arm-A tests red, controls stay green). The two scenarios added by this issue were mutation-verified the same way — see each Measured block above.
+- [ ] **Confirm a `.qmbak` round trip survives a real eviction end to end**, rather than a fixture wipe: same account, database destroyed underneath it, import, then actually use the restored Space. `backupSpaceRestore.test.ts` swaps in a fresh database and `space-kick` restores into a *different* bot identity; neither is quite the returning user. Low priority — the parts are each measured, only the seam is not.
 
 ## Prevention
 
@@ -393,6 +444,7 @@ incidental difference between the two accounts.
 - `src/dev/tests/harness/dm-itp-wipe.scenario.test.ts` — the reproduction of the app-side DM consequence; `yarn harness dm-itp-wipe`
 - `src/dev/tests/harness/space-wipe-restore.scenario.test.ts` — what login restores, sync on vs off; `yarn harness space-wipe-restore`
 - [Make allowSync a per-device setting](2026-08-08-make-allowsync-a-per-device-setting.md) — the `allowSync` gate this issue now depends on
+- [Backup/restore overhaul](2026-08-09-backup-restore-overhaul-design.md) — shipped the Space-key backup (PR #324) that makes `.qmbak` the sync-off user's recovery path. **Supersedes** the old `qmbak-backup-cannot-restore-dm-sessions` issue this file used to link to, now in `.archived/`
 
 ---
 

--- a/src/components/modals/UserSettingsModal/BackupStatus.tsx
+++ b/src/components/modals/UserSettingsModal/BackupStatus.tsx
@@ -1,0 +1,102 @@
+import * as React from 'react';
+import { t } from '@lingui/core/macro';
+import { Callout } from '../../primitives';
+import { hasCurrentBackup } from '../../../utils/lastBackup';
+
+/**
+ * Warns when this device is the only copy of the user's data. Renders nothing
+ * at all otherwise.
+ *
+ * Silence means covered, matching `PasskeyStatus` directly above and
+ * `SyncStatusLine` in this same folder. A standing "your data is safe" banner
+ * would be permanent furniture on the healthy path, and permanent furniture
+ * stops being read.
+ *
+ * ## Why sync-off is the trigger
+ *
+ * With `allowSync` off — the DEFAULT, and a deliberate product decision — the
+ * server holds nothing for this account: no profile, no Spaces, no Space keys.
+ * `saveConfig` builds `spaceKeys` and calls `postUserSettings` only inside
+ * `if (config.allowSync)` (ConfigService.ts:695, :864), so nothing is ever
+ * published. A `.qmbak` file is then the user's entire safety net.
+ *
+ * Measured, not assumed: `space-wipe-restore` under
+ * `src/dev/tests/harness/` evicts two accounts that differ only in this flag.
+ * The sync-on account gets its Space, keys and profile back on login; the
+ * sync-off account gets nothing. See
+ * `.agents/issues/.open/2026-08-05-safari-itp-wipes-indexeddb-after-7-idle-days.md`.
+ *
+ * A sync-ON user is not warned, because their Spaces and profile do come back.
+ * Their DM history still does not, which is a real gap this callout stays quiet
+ * about deliberately: warning everyone permanently is how a warning becomes
+ * wallpaper, and the sync-off user is the one who loses everything.
+ *
+ * ## Why there is no dismiss button
+ *
+ * The condition IS the dismissal: take a backup and this disappears for 30 days
+ * (`BACKUP_MAX_AGE_MS`). An X would let someone silence the warning without
+ * taking the backup, leaving them equally exposed and no longer told — which is
+ * worse than never showing it, because it manufactures the false confidence
+ * this whole reminder exists to prevent.
+ *
+ * ## What the copy does not say
+ *
+ * It does not name Safari. The risk is identical whether the browser evicts
+ * storage on a timer, the user clears site data, or the laptop dies, and naming
+ * one cause would let everyone else conclude they are safe.
+ *
+ * It also does not promise a full restore. A `.qmbak` brings back Spaces, keys
+ * and message history, but existing DM conversations resume on a NEW session
+ * because ratchet state is deliberately never restored. That caveat belongs
+ * next to the export button, not in a two-sentence callout.
+ */
+const BackupStatus: React.FunctionComponent<{
+  /** This device's sync setting. Undefined while the config is still loading. */
+  allowSync: boolean | undefined;
+  /** Switch the settings modal to the tab holding Data Backup. */
+  onGoToBackup: () => void;
+  className?: string;
+}> = ({ allowSync, onGoToBackup, className }) => {
+  // Config still loading. Rendering the warning here would flash it at every
+  // sync-ON user on every open, which is the fastest way to teach people to
+  // ignore it.
+  if (allowSync === undefined) return null;
+
+  // Sync is on: profile, Spaces and Space keys are recoverable from the server.
+  if (allowSync) return null;
+
+  // Read at render rather than in state. This only has to be correct when the
+  // panel is drawn, and an export elsewhere in the modal re-renders it — the
+  // same reason `SyncStatusLine` re-reads its record rather than caching it.
+  if (hasCurrentBackup()) return null;
+
+  return (
+    <div className={className}>
+      {/*
+        No <Icon> here. Callout renders its own variant icon, so adding the
+        matching one gives two triangles side by side.
+      */}
+      <Callout variant="warning" size="sm" className="w-full">
+        {/*
+          `text-sm` on the text AND the link. A bare <button> keeps the UA
+          font-size under Tailwind's preflight (`font-size: 100%`), which does
+          not resolve to the callout's size, so the link renders visibly larger
+          than the sentence it sits in.
+        */}
+        <div className="text-sm">
+          {t`Sync is off, so this device holds the only copy of your messages and Spaces. A backup file is the only way to get them back if this browser loses its data.`}{' '}
+          {/*
+            `link-inline` (src/styles/_base.scss) takes the size, weight and
+            colour of the sentence it sits in. A <button> rather than an <a>
+            because it performs an action.
+          */}
+          <button type="button" onClick={onGoToBackup} className="link-inline">
+            {t`Save a backup`}
+          </button>
+        </div>
+      </Callout>
+    </div>
+  );
+};
+
+export default BackupStatus;

--- a/src/components/modals/UserSettingsModal/General.tsx
+++ b/src/components/modals/UserSettingsModal/General.tsx
@@ -9,6 +9,7 @@ import { SpaceTag } from '../../space/SpaceTag';
 import type { BroadcastSpaceTag } from '@quilibrium/quorum-shared';
 import type { SelectOption } from '../../primitives';
 import PasskeyStatus from './PasskeyStatus';
+import BackupStatus from './BackupStatus';
 
 interface EligibleSpaceTag {
   spaceId: string;
@@ -46,6 +47,10 @@ interface GeneralProps {
   spaceTagId: string | undefined;
   setSpaceTagId: (id: string | undefined) => void;
   eligibleSpaceTags: EligibleSpaceTag[];
+  /** Sync setting for the backup reminder. `undefined` while config loads. */
+  allowSync: boolean | undefined;
+  /** Switches the modal to the tab holding Data Backup. */
+  onGoToBackup: () => void;
 }
 
 const General: React.FunctionComponent<GeneralProps> = ({
@@ -73,6 +78,8 @@ const General: React.FunctionComponent<GeneralProps> = ({
   spaceTagId,
   setSpaceTagId,
   eligibleSpaceTags,
+  allowSync,
+  onGoToBackup,
 }) => {
   // Determine if there's an image to display (new upload or existing, not marked for deletion)
   const hasImage = (() => {
@@ -150,6 +157,20 @@ const General: React.FunctionComponent<GeneralProps> = ({
         and General is the tab people actually open.
       */}
       <PasskeyStatus className="mt-4 mb-4 px-5 max-md:px-4" />
+      {/*
+        Below the passkey warning, and on General for the same reason it is:
+        this is a standing fact about the account, and General is the tab people
+        actually open. Renders nothing (including its wrapper) unless sync is off
+        AND no recent backup exists, so it costs a sync-on user nothing.
+
+        Order is deliberate. Losing the account key outranks losing the data on
+        it, so the passkey warning stays first when both apply.
+      */}
+      <BackupStatus
+        allowSync={allowSync}
+        onGoToBackup={onGoToBackup}
+        className="mt-4 mb-4 px-5 max-md:px-4"
+      />
       <div className="modal-content-section">
         <Spacer size="md" direction="vertical" borderTop={true} />
         <div className="text-subtitle-2">

--- a/src/components/modals/UserSettingsModal/Security.tsx
+++ b/src/components/modals/UserSettingsModal/Security.tsx
@@ -27,6 +27,14 @@ interface SecurityProps {
   removedDevices?: string[];
   deviceNames?: { [inboxAddress: string]: string };
   saveDeviceName?: (name: string) => Promise<void>;
+  /**
+   * Arrived here from the backup reminder rather than from the sidebar, so
+   * bring Data Backup into view. It sits below two other sections, far enough
+   * down that landing at the top of this tab leaves it off screen.
+   */
+  focusBackup?: boolean;
+  /** Called once the scroll has happened, so a later sidebar visit does not repeat it. */
+  onBackupFocused?: () => void;
 }
 
 const Security: React.FunctionComponent<SecurityProps> = ({
@@ -40,7 +48,38 @@ const Security: React.FunctionComponent<SecurityProps> = ({
   removedDevices = [],
   deviceNames = {},
   saveDeviceName,
+  focusBackup = false,
+  onBackupFocused,
 }) => {
+  const backupHeadingRef = React.useRef<HTMLDivElement>(null);
+
+  /**
+   * Bring Data Backup into view when the user arrived via the reminder.
+   *
+   * Inside a rAF, not directly in the effect: this tab mounts in the same
+   * commit that sets the flag, and scrolling before the browser has laid the
+   * new content out measures the wrong offsets and lands short.
+   *
+   * Focus moves too, not just the scroll. A keyboard or screen-reader user who
+   * follows a "Save a backup" link and lands with focus still on the old tab
+   * has not arrived anywhere — the heading takes `tabIndex={-1}` so it can
+   * receive focus programmatically without joining the tab order.
+   */
+  React.useEffect(() => {
+    if (!focusBackup) return;
+    const id = requestAnimationFrame(() => {
+      const el = backupHeadingRef.current;
+      if (el) {
+        el.scrollIntoView({ block: 'start', behavior: 'smooth' });
+        el.focus({ preventScroll: true });
+      }
+      // Cleared even when the ref is missing, so a failed scroll cannot leave
+      // the flag armed and re-fire on every later visit to this tab.
+      onBackupFocused?.();
+    });
+    return () => cancelAnimationFrame(id);
+  }, [focusBackup, onBackupFocused]);
+
   // QR display state. The confirmation itself is a ConfirmationModal (below);
   // this only tracks the reveal.
   const [showQRCode, setShowQRCode] = React.useState(false);
@@ -616,7 +655,13 @@ const Security: React.FunctionComponent<SecurityProps> = ({
         </div>
 
         <Spacer size="md" direction="vertical" borderTop={true} />
-        <div className="text-subtitle-2 mb-2">{t`Data Backup`}</div>
+        <div
+          ref={backupHeadingRef}
+          tabIndex={-1}
+          className="text-subtitle-2 mb-2 outline-none"
+        >
+          {t`Data Backup`}
+        </div>
         <div className="modal-content-info">
           <div className="flex flex-col gap-2">
             <div className="flex flex-col gap-2 p-3 rounded-md border">

--- a/src/components/modals/UserSettingsModal/UserSettingsModal.tsx
+++ b/src/components/modals/UserSettingsModal/UserSettingsModal.tsx
@@ -285,6 +285,12 @@ const UserSettingsModal: React.FunctionComponent<{
                         spaceTagId={spaceTagId}
                         setSpaceTagId={setSpaceTagId}
                         eligibleSpaceTags={eligibleSpaceTags}
+                        // `undefined` until the config has loaded, so the backup
+                        // reminder stays silent rather than flashing at every
+                        // sync-ON user on open. `allowSync` defaults to false
+                        // before load, which would otherwise read as "sync off".
+                        allowSync={isConfigLoaded ? allowSync : undefined}
+                        onGoToBackup={() => setSelectedCategory('security')}
                       />
                     );
                   case 'privacy':

--- a/src/components/modals/UserSettingsModal/UserSettingsModal.tsx
+++ b/src/components/modals/UserSettingsModal/UserSettingsModal.tsx
@@ -62,6 +62,12 @@ const UserSettingsModal: React.FunctionComponent<{
 
   const [saveError, setSaveError] = React.useState<string>('');
 
+  // Set only by the backup reminder's link, and cleared by Security once it has
+  // scrolled. Reaching Security from the sidebar leaves it false, so the jump
+  // happens for the user who asked for it and nobody else.
+  const [focusBackup, setFocusBackup] = React.useState(false);
+  const handleBackupFocused = React.useCallback(() => setFocusBackup(false), []);
+
   // Use our extracted hooks
   const {
     displayName,
@@ -290,7 +296,10 @@ const UserSettingsModal: React.FunctionComponent<{
                         // sync-ON user on open. `allowSync` defaults to false
                         // before load, which would otherwise read as "sync off".
                         allowSync={isConfigLoaded ? allowSync : undefined}
-                        onGoToBackup={() => setSelectedCategory('security')}
+                        onGoToBackup={() => {
+                          setSelectedCategory('security');
+                          setFocusBackup(true);
+                        }}
                       />
                     );
                   case 'privacy':
@@ -328,6 +337,8 @@ const UserSettingsModal: React.FunctionComponent<{
                         removedDevices={removedDevices}
                         deviceNames={deviceNames}
                         saveDeviceName={saveDeviceName}
+                        focusBackup={focusBackup}
+                        onBackupFocused={handleBackupFocused}
                       />
                     );
                   case 'notifications':

--- a/src/dev/tests/components/BackupStatus.test.tsx
+++ b/src/dev/tests/components/BackupStatus.test.tsx
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { i18n } from '@lingui/core';
+import { messages } from '@/i18n/en/messages';
+import BackupStatus from '@/components/modals/UserSettingsModal/BackupStatus';
+import { recordLastBackup, BACKUP_MAX_AGE_MS } from '@/utils/lastBackup';
+
+/**
+ * A reminder that only fires when the user is genuinely exposed.
+ *
+ * "Renders nothing" is the load-bearing assertion in this file, not an absence
+ * of one. Three separate conditions each have to silence it, and a regression in
+ * any of them turns a targeted warning into permanent furniture that everyone
+ * learns to ignore — at which point it protects nobody, including the sync-off
+ * user it exists for.
+ *
+ * The inverse matters just as much: the shown-arm test is what stops the whole
+ * component being silently dead. A file that only asserted silence would pass
+ * against a component that returns null unconditionally.
+ */
+beforeAll(() => {
+  i18n.load('en', messages);
+  i18n.activate('en');
+});
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.useRealTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+const noop = () => {};
+
+describe('BackupStatus', () => {
+  describe('says nothing when there is nothing to warn about', () => {
+    it('when sync is ON — Spaces, keys and profile come back on login', () => {
+      const { container } = render(
+        <BackupStatus allowSync={true} onGoToBackup={noop} />
+      );
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('when the config has not loaded yet', () => {
+      // `allowSync` is false before load, which would otherwise read as
+      // "sync off" and flash the warning at every sync-ON user on open.
+      const { container } = render(
+        <BackupStatus allowSync={undefined} onGoToBackup={noop} />
+      );
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('when sync is off but a recent backup exists', () => {
+      recordLastBackup(Date.now());
+      const { container } = render(
+        <BackupStatus allowSync={false} onGoToBackup={noop} />
+      );
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('when the backup is just inside the 30-day window', () => {
+      recordLastBackup(Date.now() - (BACKUP_MAX_AGE_MS - 60_000));
+      const { container } = render(
+        <BackupStatus allowSync={false} onGoToBackup={noop} />
+      );
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+
+  describe('warns when this device is the only copy', () => {
+    it('sync off and no backup ever taken', () => {
+      render(<BackupStatus allowSync={false} onGoToBackup={noop} />);
+      expect(
+        screen.getByText(/only copy of your messages and Spaces/i)
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /save a backup/i })
+      ).toBeInTheDocument();
+    });
+
+    it('sync off and the backup has aged past the window', () => {
+      recordLastBackup(Date.now() - (BACKUP_MAX_AGE_MS + 60_000));
+      render(<BackupStatus allowSync={false} onGoToBackup={noop} />);
+      expect(
+        screen.getByText(/only copy of your messages and Spaces/i)
+      ).toBeInTheDocument();
+    });
+
+    it('a corrupt stored record counts as no backup, not as a valid one', () => {
+      // Failing OPEN here would silence the warning for anyone whose record got
+      // mangled — the safe direction is to warn.
+      localStorage.setItem('quorum:backup:lastBackup', 'not json');
+      render(<BackupStatus allowSync={false} onGoToBackup={noop} />);
+      expect(
+        screen.getByText(/only copy of your messages and Spaces/i)
+      ).toBeInTheDocument();
+    });
+
+    it('the link routes to the backup section', () => {
+      const onGoToBackup = vi.fn();
+      render(<BackupStatus allowSync={false} onGoToBackup={onGoToBackup} />);
+      fireEvent.click(screen.getByRole('button', { name: /save a backup/i }));
+      expect(onGoToBackup).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('the copy makes no promise the restore cannot keep', () => {
+    it('does not name a single browser as the cause', () => {
+      // The risk is identical for a cleared site, a dead laptop or an automatic
+      // eviction. Naming Safari would let everyone else conclude they are safe.
+      const { container } = render(
+        <BackupStatus allowSync={false} onGoToBackup={noop} />
+      );
+      expect(container.textContent).not.toMatch(/safari/i);
+    });
+
+    it('does not claim conversations are restored', () => {
+      // A .qmbak brings back history and Spaces, but DM ratchet state is
+      // deliberately never restored, so existing chats resume on a NEW session.
+      const { container } = render(
+        <BackupStatus allowSync={false} onGoToBackup={noop} />
+      );
+      expect(container.textContent).not.toMatch(/restore your conversations/i);
+    });
+  });
+});

--- a/src/dev/tests/components/BackupStatus.test.tsx
+++ b/src/dev/tests/components/BackupStatus.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { i18n } from '@lingui/core';
 import { messages } from '@/i18n/en/messages';
@@ -24,12 +24,10 @@ beforeAll(() => {
 });
 
 beforeEach(() => {
+  // The component reads its record straight from localStorage, so each case has
+  // to start from "nothing recorded" or an earlier case's backup would silence
+  // the next one.
   localStorage.clear();
-  vi.useRealTimers();
-});
-
-afterEach(() => {
-  vi.useRealTimers();
 });
 
 const noop = () => {};

--- a/src/dev/tests/components/securityBackupFocus.test.tsx
+++ b/src/dev/tests/components/securityBackupFocus.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * Security — arriving from the backup reminder lands on Data Backup.
+ *
+ * The reminder on General says "Save a backup" and switches to this tab. Data
+ * Backup is the third section down a long panel, so without this the link
+ * delivers the user to a tab where the thing they came for is off screen, and
+ * the callout's whole job is to get a backup taken.
+ *
+ * Both directions are asserted deliberately. "Scrolls when asked" is the
+ * feature; "does not scroll when reached from the sidebar" is what stops the
+ * panel yanking itself around on every ordinary visit. A test file with only
+ * the first would pass against a component that scrolls unconditionally.
+ *
+ * jsdom implements no layout, so `scrollIntoView` does not exist on Element and
+ * has to be stubbed. That limits what this can claim: it verifies the component
+ * asks the right element to come into view, NOT that the element ends up
+ * visible. Whether the scroll lands correctly inside the modal's scroll
+ * container is a real-browser question.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { i18n } from '@lingui/core';
+import { I18nProvider } from '@lingui/react';
+import { messages } from '@/i18n/en/messages';
+
+import Security from '@/components/modals/UserSettingsModal/Security';
+
+beforeAll(() => {
+  i18n.load('en', messages);
+  i18n.activate('en');
+});
+
+const scrollIntoView = vi.fn();
+
+beforeEach(() => {
+  scrollIntoView.mockClear();
+  // Not present in jsdom at all — assigning it is what makes the call
+  // observable. Set per test run rather than once, so a mock left dirty by an
+  // earlier case cannot read as a fresh call here.
+  Element.prototype.scrollIntoView = scrollIntoView;
+});
+
+const KEYSET = {
+  deviceKeyset: {
+    inbox_keyset: { inbox_address: 'QmFixtureInboxAAAAAAAAAAAAAAAAAAAAAAAAAAA' },
+  },
+};
+
+function renderSecurity(
+  overrides: Partial<React.ComponentProps<typeof Security>> = {}
+) {
+  const props = {
+    stagedRegistration: { device_registrations: [] },
+    keyset: KEYSET,
+    removeDevice: vi.fn(),
+    downloadKey: vi.fn(),
+    exportBackup: vi.fn(async () => {}),
+    importBackup: vi.fn(async () => ({}) as never),
+    getPrivateKeyHex: vi.fn(async () => 'deadbeef'),
+    removedDevices: [],
+    deviceNames: {},
+    saveDeviceName: vi.fn(async () => {}),
+    ...overrides,
+  };
+  render(
+    <I18nProvider i18n={i18n}>
+      <Security {...(props as React.ComponentProps<typeof Security>)} />
+    </I18nProvider>
+  );
+  return props;
+}
+
+describe('Security — focusing Data Backup', () => {
+  it('brings Data Backup into view when arriving from the reminder', async () => {
+    const onBackupFocused = vi.fn();
+    renderSecurity({ focusBackup: true, onBackupFocused });
+
+    await waitFor(() => expect(scrollIntoView).toHaveBeenCalledTimes(1));
+
+    // The element asked to scroll must be the Data Backup heading itself, not
+    // merely "something on the page" — scrolling to the wrong section would
+    // satisfy a bare call-count assertion while leaving the user lost.
+    expect(scrollIntoView.mock.instances[0]).toBe(
+      screen.getByText('Data Backup')
+    );
+  });
+
+  it('moves focus to the heading, not just the scroll position', async () => {
+    // A keyboard or screen-reader user who follows the link and lands with
+    // focus still on the previous tab has not arrived anywhere.
+    renderSecurity({ focusBackup: true, onBackupFocused: vi.fn() });
+
+    await waitFor(() =>
+      expect(document.activeElement).toBe(screen.getByText('Data Backup'))
+    );
+  });
+
+  it('reports back so a later visit does not scroll again', async () => {
+    const onBackupFocused = vi.fn();
+    renderSecurity({ focusBackup: true, onBackupFocused });
+
+    await waitFor(() => expect(onBackupFocused).toHaveBeenCalledTimes(1));
+  });
+
+  it('does NOT scroll when the tab was reached from the sidebar', async () => {
+    const onBackupFocused = vi.fn();
+    renderSecurity({ focusBackup: false, onBackupFocused });
+
+    // Give the rAF the same chance to fire as the positive case gets.
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(scrollIntoView).not.toHaveBeenCalled();
+    expect(onBackupFocused).not.toHaveBeenCalled();
+  });
+
+  it('defaults to not scrolling when the prop is omitted entirely', async () => {
+    renderSecurity();
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(scrollIntoView).not.toHaveBeenCalled();
+  });
+});

--- a/src/dev/tests/harness/README.md
+++ b/src/dev/tests/harness/README.md
@@ -125,6 +125,7 @@ Log analyzers stay in `.agents/tools/dm-debug/` (`dr-ablate`, `dr-replay`,
 | `yarn harness dm-basic` | two bots exchange numbered DMs, no browser (HARNESS_ROUNDS) |
 | `yarn harness dm-volume` | concurrent bidirectional load; samples skipped-keys growth |
 | `yarn harness dm-reset-recover` | wipe a session mid-conversation, verify it re-inits and recovers |
+| `yarn harness dm-itp-wipe` | destroy one side's whole database (storage eviction: Safari ITP, cleared site data, new device) and measure the cost — history and sessions go to zero, the conversation resumes on a fresh session, and nothing revives the old messages. The other bot is a control arm. Distinct from `dm-reset-recover`, which wipes only sessions and keeps history |
 | `yarn harness dm-reorder` | **reproduces the production DM failure on demand.** Withholds the head of a sending chain so a stale skipped-keys bucket forms, then delivers the sender's next chain: the frames at colliding indices fail AEAD, and only those |
 | `yarn harness dm-loss` | send-vs-arrive frame loss per direction, joined by ciphertext fingerprint (issue #183 item 2). `HARNESS_LOSS_CANONICAL=1` runs it on the canonical aged multi-device accounts instead of fresh throwaways — the account shape is a variable in its own right, so the two arms answer different questions |
 | `yarn harness dm-stale-bucket` | the reorder cycle at scale, with the client-side mitigation OFF then ON, on fresh accounts per arm |

--- a/src/dev/tests/harness/README.md
+++ b/src/dev/tests/harness/README.md
@@ -137,6 +137,7 @@ Log analyzers stay in `.agents/tools/dm-debug/` (`dr-ablate`, `dr-replay`,
 |---|---|
 | `yarn harness space-create` | S0: a bot creates a real space on production and reads its manifest back through the joiner's own decode path |
 | `yarn harness space-basic` | S1: B joins A's space by invite and must receive **both** A's post and A's member row. `HARNESS_SPACE_WINDOW_MS` / `HARNESS_SPACE_SAMPLE_MS` tune the wait |
+| `yarn harness space-wipe-restore` | what logging back in restores after a storage eviction. Two accounts of identical shape, one variable — `allowSync`. Sync on: Space, keys and profile return, DMs do not. Sync off (the DEFAULT): nothing returns, so the eviction takes the Spaces too. The sync-off arm is also the control — if both restored, something other than the published config would be doing it |
 
 `space-basic` asserts the ROSTER as well as the message, because the roster half
 is the thing under investigation. B writes only its own member row locally, so a

--- a/src/dev/tests/harness/bot.ts
+++ b/src/dev/tests/harness/bot.ts
@@ -16,7 +16,7 @@ import { ActionQueueService } from '../../../services/ActionQueueService';
 import { ActionQueueHandlers } from '../../../services/ActionQueueHandlers';
 import type { HandlerDependencies } from '../../../services/ActionQueueHandlers';
 import type { EncryptedMessage, MessageDB } from '../../../db/messages';
-import { makeMessageDB } from './storage';
+import { deleteDatabaseFor, makeMessageDB } from './storage';
 import { makeApiClient, WsTransport } from './transport';
 import { makeDeps, deleteInboxMessages } from './deps';
 import { XpdumpLog } from './xpdump';
@@ -50,6 +50,16 @@ export interface HarnessBot {
   send(toAddress: string, text: string): Promise<void>;
   /** Delete all local DM sessions — simulates a reset/wipe. Returns rows removed. */
   wipeSessions(): Promise<number>;
+  /**
+   * Destroy this bot's ENTIRE database — every store, not just sessions.
+   *
+   * The storage-eviction case: Safari's ITP wipe, "clear site data", a new
+   * device. Distinct from `wipeSessions`, which removes only `encryption_states`
+   * and leaves history readable. Conflating the two is the mistake this exists to
+   * prevent: a session wipe costs you the ability to decrypt on the old session,
+   * a full wipe costs you the messages as well.
+   */
+  wipeAll(): Promise<void>;
   /** Fetch + delete queued frames on the device inbox (clears stale-frame confound). */
   drainInbox(): Promise<number>;
   start(): Promise<void>;
@@ -145,6 +155,15 @@ export async function createBot(
       const rows = await messageDB.getAllEncryptionStates();
       for (const r of rows) await messageDB.deleteEncryptionState(r);
       return rows.length;
+    },
+    wipeAll: async () => {
+      await deleteDatabaseFor(messageDB);
+      // Force the next refreshSubscriptions() to actually re-send `listen`,
+      // mirroring the app reload that follows a real wipe: the browser comes back
+      // with no sessions and subscribes from scratch. The address set normally
+      // shrinks here anyway (session inboxes are gone), so the memo would usually
+      // miss on its own — this just removes the dependence on that.
+      subscribed = '';
     },
     drainInbox: async () => {
       const res = await apiClient.getInbox(identity.inboxAddress);

--- a/src/dev/tests/harness/dm-itp-wipe.scenario.test.ts
+++ b/src/dev/tests/harness/dm-itp-wipe.scenario.test.ts
@@ -96,7 +96,7 @@ test(
     const seededTexts = await textsOnDisk(bob);
 
     console.log(
-      `[dm-itp-wipe] bob BEFORE  messages=${bobBefore.messages} conversations=${bobBefore.conversations} sessions=${bobBefore.sessions}`
+      `[dm-itp-wipe] bob BEFORE  messages=${bobBefore.messages} conversations=${bobBefore.conversations} sessions=${bobBefore.encryptionStates}`
     );
     console.log(`[dm-itp-wipe] databases BEFORE: ${dbsBefore?.join(', ') ?? '(databases() unsupported)'}`);
 
@@ -104,7 +104,7 @@ test(
     // against an account that never had anything to lose.
     expect(bobBefore.messages).toBeGreaterThan(0);
     expect(bobBefore.conversations).toBeGreaterThan(0);
-    expect(bobBefore.sessions).toBeGreaterThan(0);
+    expect(bobBefore.encryptionStates).toBeGreaterThan(0);
     expect(seededTexts.length).toBeGreaterThan(0);
 
     // ── 2. The eviction ────────────────────────────────────────────────────
@@ -126,7 +126,7 @@ test(
     const dbsAfterReopen = await listDatabaseNames();
 
     console.log(
-      `[dm-itp-wipe] bob AFTER   messages=${bobAfter.messages} conversations=${bobAfter.conversations} sessions=${bobAfter.sessions}`
+      `[dm-itp-wipe] bob AFTER   messages=${bobAfter.messages} conversations=${bobAfter.conversations} sessions=${bobAfter.encryptionStates}`
     );
     console.log(
       `[dm-itp-wipe] databases immediately after wipe: ${dbsRightAfterWipe?.join(', ') ?? '(databases() unsupported)'}`
@@ -138,7 +138,7 @@ test(
     // The loss, measured.
     expect(bobAfter.messages).toBe(0);
     expect(bobAfter.conversations).toBe(0);
-    expect(bobAfter.sessions).toBe(0);
+    expect(bobAfter.encryptionStates).toBe(0);
 
     // CONTROL ARM. Eviction hit one browser. If Alice's numbers move too, the
     // harness is sharing one database between bots (a real regression it has had

--- a/src/dev/tests/harness/dm-itp-wipe.scenario.test.ts
+++ b/src/dev/tests/harness/dm-itp-wipe.scenario.test.ts
@@ -1,0 +1,187 @@
+// Storage eviction — what a Quorum account actually loses when the browser
+// destroys its database, and what comes back afterwards.
+//
+// Filed against
+// `.agents/issues/.open/2026-08-05-safari-itp-wipes-indexeddb-after-7-idle-days.md`,
+// whose Verification section opens with "Do not close this on reasoning."
+//
+// ── What this can and cannot answer ────────────────────────────────────────
+//
+// The issue makes two separable claims, and only the second is about Quorum:
+//
+//   A. Safari's ITP deletes script-writable storage after 7 days of Safari use
+//      without interaction. A WebKit POLICY claim. Not testable here, and not
+//      testable on Windows at all — it needs real Safari and a 7-day counter
+//      that cannot be advanced from outside. It stays unverified by this file.
+//
+//   B. When the database is gone, DM history and sessions do not come back,
+//      while the conversation itself can resume on a fresh session. An APP
+//      behaviour claim. The app cannot tell WHY its database vanished — ITP, a
+//      "clear site data" click, and a new device are the same event to it — so
+//      this is fully testable anywhere, including headless on Windows.
+//
+// This scenario measures B. It deliberately does not dress itself up as
+// measuring A.
+//
+// ── Why not just reuse dm-reset-recover ────────────────────────────────────
+//
+// That one calls `wipeSessions()`, which removes `encryption_states` and leaves
+// `messages` and `conversations` intact. It is the milder failure: you lose the
+// ability to decrypt on the old session but keep your history. Eviction takes
+// both, and the difference is the entire point of the issue — so this asserts on
+// the census, not only on recovery, and the mutation check below confirms a
+// session-only wipe makes it go red.
+//
+//   yarn harness dm-itp-wipe
+import { test, expect } from 'vitest';
+import { createBot } from './bot';
+import { dmCensus, listDatabaseNames } from './inspect';
+import { dbNameOf } from './storage';
+
+const SETTLE_MS = Number(process.env.HARNESS_SETTLE_MS ?? 6000);
+
+const settle = () => new Promise((r) => setTimeout(r, SETTLE_MS));
+
+/** Every post body this bot currently has ON DISK (not the in-memory capture log). */
+async function textsOnDisk(bot: Awaited<ReturnType<typeof createBot>>): Promise<string[]> {
+  const data = await bot.messageDB.getAllDMData({ address: bot.identity.address });
+  return data.messages
+    .filter((m) => m.content?.type === 'post')
+    .map((m) => m.content?.text ?? '');
+}
+
+test(
+  'dm-itp-wipe: an evicted database loses history and sessions, and the conversation resumes on a fresh one',
+  async () => {
+    const [alice, bob] = await Promise.all([
+      createBot('itp-alice'),
+      createBot('itp-bob'),
+    ]);
+
+    // Distinct texts, NOT a count of callbacks. `onDecrypted` fires per
+    // saveMessage, and one logical message can legitimately be persisted more
+    // than once: un-acked frames are redelivered on every `listen`, and the
+    // receive path additionally salvages the message embedded in a refused init
+    // envelope. A first cut of this test asserted `=== 2` on the callback count
+    // and measured 4 for exactly that reason. A set asks the question the
+    // scenario actually cares about — did this message arrive at all.
+    const bobSeen = new Set<string>();
+    const aliceSeen = new Set<string>();
+    const noteInto = (seen: Set<string>) => (m: { content?: { type?: string; text?: string } }) => {
+      if (m.content?.type === 'post' && m.content.text) seen.add(m.content.text);
+    };
+    bob.onDecrypted = noteInto(bobSeen);
+    alice.onDecrypted = noteInto(aliceSeen);
+
+    // Frames left queued by a previous run would be redelivered on `listen` and
+    // land in the post-wipe window, where they would look like recovered history.
+    await Promise.all([alice.drainInbox(), bob.drainInbox()]);
+    await Promise.all([alice.start(), bob.start()]);
+
+    // ── 1. Seed real history, both directions ──────────────────────────────
+    await alice.send(bob.identity.address, 'seed-a #1');
+    await settle();
+    await alice.send(bob.identity.address, 'seed-a #2');
+    await settle();
+    await bob.send(alice.identity.address, 'seed-b #1');
+    await settle();
+
+    expect(bobSeen.has('seed-a #1')).toBe(true);
+    expect(bobSeen.has('seed-a #2')).toBe(true);
+    expect(aliceSeen.has('seed-b #1')).toBe(true);
+
+    const bobBefore = await dmCensus(bob.messageDB, bob.identity.address);
+    const aliceBefore = await dmCensus(alice.messageDB, alice.identity.address);
+    const dbsBefore = await listDatabaseNames();
+    const seededTexts = await textsOnDisk(bob);
+
+    console.log(
+      `[dm-itp-wipe] bob BEFORE  messages=${bobBefore.messages} conversations=${bobBefore.conversations} sessions=${bobBefore.sessions}`
+    );
+    console.log(`[dm-itp-wipe] databases BEFORE: ${dbsBefore?.join(', ') ?? '(databases() unsupported)'}`);
+
+    // Precondition. Without real data on disk, everything below would pass
+    // against an account that never had anything to lose.
+    expect(bobBefore.messages).toBeGreaterThan(0);
+    expect(bobBefore.conversations).toBeGreaterThan(0);
+    expect(bobBefore.sessions).toBeGreaterThan(0);
+    expect(seededTexts.length).toBeGreaterThan(0);
+
+    // ── 2. The eviction ────────────────────────────────────────────────────
+    // Bob's browser only. Alice is the control arm: she must be untouched.
+    const bobDbName = dbNameOf(bob.messageDB);
+    await bob.wipeAll();
+
+    // Sample the database list BEFORE anything reads through MessageDB. Every
+    // read method starts with `await this.init()`, which re-opens — and therefore
+    // re-CREATES — the database with an empty schema. Measured here: taking this
+    // sample after the census showed `quorum_db_itp-bob` present again and made
+    // the delete look like it had not happened. It had; the app had simply
+    // rebuilt an empty one on first touch, which is exactly what a real tab does
+    // on the visit after an eviction.
+    const dbsRightAfterWipe = await listDatabaseNames();
+
+    const bobAfter = await dmCensus(bob.messageDB, bob.identity.address);
+    const aliceAfterWipe = await dmCensus(alice.messageDB, alice.identity.address);
+    const dbsAfterReopen = await listDatabaseNames();
+
+    console.log(
+      `[dm-itp-wipe] bob AFTER   messages=${bobAfter.messages} conversations=${bobAfter.conversations} sessions=${bobAfter.sessions}`
+    );
+    console.log(
+      `[dm-itp-wipe] databases immediately after wipe: ${dbsRightAfterWipe?.join(', ') ?? '(databases() unsupported)'}`
+    );
+    console.log(
+      `[dm-itp-wipe] databases after first read (init recreates): ${dbsAfterReopen?.join(', ') ?? '(databases() unsupported)'}`
+    );
+
+    // The loss, measured.
+    expect(bobAfter.messages).toBe(0);
+    expect(bobAfter.conversations).toBe(0);
+    expect(bobAfter.sessions).toBe(0);
+
+    // CONTROL ARM. Eviction hit one browser. If Alice's numbers move too, the
+    // harness is sharing one database between bots (a real regression it has had
+    // before — see storage.ts) and every assertion above is measuring the wrong
+    // thing.
+    expect(aliceAfterWipe).toEqual(aliceBefore);
+
+    // The database itself was destroyed, not merely emptied...
+    if (dbsRightAfterWipe) expect(dbsRightAfterWipe).not.toContain(bobDbName);
+    // ...and the app rebuilds an empty one the moment it reads again. Worth
+    // pinning: "quorum_db exists" is NOT evidence that a user's data survived.
+    if (dbsAfterReopen) expect(dbsAfterReopen).toContain(bobDbName);
+
+    // ── 3. Recovery: Bob re-initiates ──────────────────────────────────────
+    // With no encryption state present the send path opens a NEW session via
+    // DoubleRatchetInboxEncryptForceSenderInit (MessageService).
+    await bob.send(alice.identity.address, 'recover-init #1');
+    await settle();
+    expect(aliceSeen.has('recover-init #1')).toBe(true);
+
+    // ── 4. And the reply flows back over the fresh session ─────────────────
+    await alice.send(bob.identity.address, 'after-wipe #1');
+    await settle();
+    expect(bobSeen.has('after-wipe #1')).toBe(true);
+
+    // ── 5. The conversation resumed; the history did NOT come back ─────────
+    // This is the distinction the issue turns on. Recovery alone would be
+    // satisfied by step 4 — what makes the loss permanent is that nothing
+    // restored the seeded messages in the process.
+    const bobTextsAfter = await textsOnDisk(bob);
+    const revived = seededTexts.filter((t) => bobTextsAfter.includes(t));
+
+    console.log(
+      `[dm-itp-wipe] seeded=${seededTexts.length} revived=${revived.length} onDiskNow=[${bobTextsAfter.join(' | ')}]`
+    );
+
+    alice.stop();
+    bob.stop();
+
+    expect(revived).toEqual([]);
+    // Bob can talk again, so the store is not simply broken — it is empty and
+    // moving forward.
+    expect(bobTextsAfter.some((t) => t.startsWith('after-wipe'))).toBe(true);
+  },
+  240_000
+);

--- a/src/dev/tests/harness/inspect.ts
+++ b/src/dev/tests/harness/inspect.ts
@@ -65,3 +65,46 @@ export async function totalSkipped(db: MessageDB): Promise<number> {
   const stats = await ratchetStats(db);
   return stats.reduce((a, s) => a + s.skipped, 0);
 }
+
+export interface DmCensus {
+  messages: number;
+  conversations: number;
+  /** encryption_states rows — the Double Ratchet sessions. */
+  sessions: number;
+}
+
+/**
+ * How much DM data this bot currently holds, counted through `getAllDMData` —
+ * deliberately the SAME read the `.qmbak` export uses (BackupService).
+ *
+ * Using the export's own lens means a census of 0 is not merely "the stores look
+ * empty", it is "a backup taken right now would capture nothing", which is the
+ * claim the ITP issue actually makes. Counting the raw stores by hand could
+ * disagree with what a backup would really see and would not notice.
+ */
+export async function dmCensus(db: MessageDB, address: string): Promise<DmCensus> {
+  const data = await db.getAllDMData({ address });
+  return {
+    messages: data.messages.length,
+    conversations: data.conversations.length,
+    sessions: data.encryption_states.length,
+  };
+}
+
+/**
+ * Every IndexedDB database that exists right now, by name.
+ *
+ * The ITP issue asks for exactly this ("record exactly which IndexedDB databases
+ * survive: quorum_db, SDK KeyDB"), and it is worth RECORDING rather than
+ * asserting: whether the SDK's `KeyDB` even materialises in a headless run is not
+ * something to assume in either direction.
+ *
+ * Returns null when the runtime has no `databases()` — a caller must not read
+ * that as "no databases exist".
+ */
+export async function listDatabaseNames(): Promise<string[] | null> {
+  const factory = indexedDB as IDBFactory & { databases?: () => Promise<IDBDatabaseInfo[]> };
+  if (typeof factory.databases !== 'function') return null;
+  const infos = await factory.databases();
+  return infos.map((d) => d.name ?? '(unnamed)').sort();
+}

--- a/src/dev/tests/harness/inspect.ts
+++ b/src/dev/tests/harness/inspect.ts
@@ -69,8 +69,18 @@ export async function totalSkipped(db: MessageDB): Promise<number> {
 export interface DmCensus {
   messages: number;
   conversations: number;
-  /** encryption_states rows — the Double Ratchet sessions. */
-  sessions: number;
+  /**
+   * `encryption_states` rows — ALL of them, not only DM sessions.
+   *
+   * Named for what it counts rather than what you might hope it counts.
+   * `getAllDMData` reaches this through `getAllEncryptionStates()`, which is
+   * not filtered by conversation type, so a Space's group ratchet lands here
+   * too. Measured in `space-wipe-restore`: an account with one Space and one DM
+   * reads 2, and after a config restore reads 1 — the Space ratchet came back,
+   * the DM ratchet did not. Calling this `sessions` invited exactly the wrong
+   * reading of that number.
+   */
+  encryptionStates: number;
 }
 
 /**
@@ -87,7 +97,7 @@ export async function dmCensus(db: MessageDB, address: string): Promise<DmCensus
   return {
     messages: data.messages.length,
     conversations: data.conversations.length,
-    sessions: data.encryption_states.length,
+    encryptionStates: data.encryption_states.length,
   };
 }
 

--- a/src/dev/tests/harness/space-wipe-restore.scenario.test.ts
+++ b/src/dev/tests/harness/space-wipe-restore.scenario.test.ts
@@ -1,0 +1,257 @@
+// What logging back in actually restores after a storage eviction — and what
+// silently does not.
+//
+//   yarn harness space-wipe-restore
+//
+// ── Why this exists ────────────────────────────────────────────────────────
+//
+// `.agents/issues/.open/2026-08-05-safari-itp-wipes-indexeddb-after-7-idle-days.md`
+// carries a recoverability table saying profile, Spaces and Space keys come back
+// on login while DMs do not. `dm-itp-wipe` already measured the DM half. This
+// measures the OTHER half, which nothing covered: the restore runs through
+// `ConfigService.getConfig`, and the DM harness is transport-level and never
+// touches it.
+//
+// ── The variable ───────────────────────────────────────────────────────────
+//
+// Both arms are the same account shape doing the same things. Exactly one thing
+// differs: `allowSync`.
+//
+// That is the variable because the recovery the issue describes is not a
+// property of having an account — it is a property of having PUBLISHED. Reading
+// the code says publication is gated:
+//
+//   - `saveConfig` builds `config.spaceKeys` only inside `if (config.allowSync)`
+//     (ConfigService.ts:695), and the `postUserSettings` call sits inside that
+//     same block (ConfigService.ts:864). Sync off ⇒ nothing ever reaches the
+//     server.
+//   - `allowSync` is device-local and defaults to FALSE
+//     (ConfigService.ts:289, `storedConfig?.allowSync ?? false`).
+//
+// So the sync-off arm is not a contrived edge case, it is the DEFAULT, and if it
+// restores nothing then the issue's table is true only for the subset of users
+// who turned sync on. Reading is how this codebase has been wrong before, so
+// both arms are measured rather than argued.
+//
+// The sync-off arm doubles as the control: if BOTH arms restored their Spaces,
+// something other than the published config would be putting them back and every
+// conclusion here would be wrong.
+import { test, expect } from 'vitest';
+import type { UserRegistration } from '@quilibrium/quilibrium-js-sdk-channels';
+import { createSpaceBot, type HarnessSpaceBot } from './spaceBot';
+import { makeApiClient } from './transport';
+import { dmCensus } from './inspect';
+import { deleteDatabaseFor } from './storage';
+
+interface Snapshot {
+  spaces: number;
+  /** Sorted keyIds, not a count — WHICH key is missing is the interesting part. */
+  keyIds: string[];
+  displayName: string | undefined;
+  dmMessages: number;
+  dmConversations: number;
+  /** conversationIds of every encryption_states row, sorted. */
+  stateConvs: string[];
+}
+
+async function snapshot(bot: HarnessSpaceBot): Promise<Snapshot> {
+  const address = bot.identity.address;
+  const spaces = await bot.messageDB.getSpaces();
+  const keyIds: string[] = [];
+  for (const s of spaces) {
+    for (const k of await bot.messageDB.getSpaceKeys(s.spaceId)) keyIds.push(k.keyId);
+  }
+  const cfg = await bot.messageDB.getUserConfig({ address });
+  const dm = await dmCensus(bot.messageDB, address);
+  const states = await bot.messageDB.getAllEncryptionStates();
+  return {
+    spaces: spaces.length,
+    keyIds: keyIds.sort(),
+    displayName: cfg?.name,
+    dmMessages: dm.messages,
+    dmConversations: dm.conversations,
+    stateConvs: states.map((s) => s.conversationId).sort(),
+  };
+}
+
+const fmt = (s: Snapshot) =>
+  `spaces=${s.spaces} keys=[${s.keyIds.join(',')}] name=${s.displayName ?? '(none)'} ` +
+  `dmMessages=${s.dmMessages} dmConvs=${s.dmConversations} ` +
+  `states=[${s.stateConvs.map((c) => c.slice(0, 20)).join(' | ')}]`;
+
+/**
+ * Send one DM through the real submitMessage path, purely to put DM rows on
+ * disk. Delivery is NOT awaited: the sender persists its own copy, which is all
+ * this scenario needs. Whether DMs traverse the wire is dm-basic's job.
+ */
+async function seedDm(from: HarnessSpaceBot, to: HarnessSpaceBot, text: string): Promise<void> {
+  const apiClient = makeApiClient();
+  const self = (await apiClient.getUser(from.identity.address))?.data as UserRegistration;
+  const counterparty = (await apiClient.getUser(to.identity.address))?.data as UserRegistration;
+  await from.graph.messageService.submitMessage(
+    to.identity.address,
+    text,
+    self,
+    counterparty,
+    from.queryClient,
+    {
+      credentialId: '',
+      address: from.identity.address,
+      publicKey: Buffer.from(
+        new Uint8Array(from.identity.keyset.userKeyset.user_key.public_key)
+      ).toString('hex'),
+      completedOnboarding: true,
+    },
+    from.identity.keyset
+  );
+}
+
+/** Set the profile name and sync preference, then run the real publish path. */
+async function publishConfig(
+  bot: HarnessSpaceBot,
+  { allowSync, name }: { allowSync: boolean; name: string }
+): Promise<void> {
+  const address = bot.identity.address;
+  const current = await bot.graph.configService.getConfig({
+    address,
+    userKey: bot.identity.keyset.userKeyset,
+  });
+  await bot.graph.configService.saveConfig({
+    config: { ...current, address, name, allowSync },
+    keyset: bot.identity.keyset,
+  });
+}
+
+test(
+  'space-wipe-restore: login rebuilds Spaces and profile only for a published config, and never DMs',
+  async () => {
+    const stamp = String(Date.now()).slice(-6);
+    const [on, off] = await Promise.all([
+      createSpaceBot(`cfg-on-${stamp}`),
+      createSpaceBot(`cfg-off-${stamp}`),
+    ]);
+    await Promise.all([on.start(), off.start()]);
+
+    // try/finally: an early throw would otherwise leak a live production socket
+    // and the ActionQueue interval per bot for the rest of the worker process.
+    try {
+      // ── 1. Both accounts get the same shape: a Space, a profile, a DM ─────
+      const onSpace = await on.createSpace(`wipe-restore-on-${stamp}`);
+      const offSpace = await off.createSpace(`wipe-restore-off-${stamp}`);
+
+      await seedDm(on, off, `dm-from-on-${stamp}`);
+      await seedDm(off, on, `dm-from-off-${stamp}`);
+
+      // ── 2. The one difference ────────────────────────────────────────────
+      await publishConfig(on, { allowSync: true, name: `Synced ${stamp}` });
+      await publishConfig(off, { allowSync: false, name: `Unsynced ${stamp}` });
+
+      const onBefore = await snapshot(on);
+      const offBefore = await snapshot(off);
+      console.log(`[space-wipe-restore] sync ON  BEFORE  ${fmt(onBefore)}`);
+      console.log(`[space-wipe-restore] sync OFF BEFORE  ${fmt(offBefore)}`);
+
+      // Preconditions. Without these, every "it came back" below could pass
+      // against an account that never had anything in the first place.
+      expect(onBefore.spaces).toBeGreaterThan(0);
+      expect(onBefore.keyIds.length).toBeGreaterThan(0);
+      expect(onBefore.dmMessages).toBeGreaterThan(0);
+      expect(offBefore.spaces).toBeGreaterThan(0);
+      expect(offBefore.keyIds.length).toBeGreaterThan(0);
+      expect(offBefore.dmMessages).toBeGreaterThan(0);
+
+      // ── 3. The eviction — both arms, identically ─────────────────────────
+      await Promise.all([
+        deleteDatabaseFor(on.messageDB),
+        deleteDatabaseFor(off.messageDB),
+      ]);
+      // In-memory Space registrations survive in this process but would not
+      // survive the browser reload that follows a real eviction. Clearing them
+      // keeps the restore honest: adoptSpaces has to rebuild from the published
+      // blob, not read a leftover.
+      on.graph.spaceInfo.current = {};
+      off.graph.spaceInfo.current = {};
+
+      const onWiped = await snapshot(on);
+      const offWiped = await snapshot(off);
+      console.log(`[space-wipe-restore] sync ON  WIPED   ${fmt(onWiped)}`);
+      console.log(`[space-wipe-restore] sync OFF WIPED   ${fmt(offWiped)}`);
+
+      expect(onWiped).toEqual({
+        spaces: 0,
+        keyIds: [],
+        displayName: undefined,
+        dmMessages: 0,
+        dmConversations: 0,
+        stateConvs: [],
+      });
+      expect(offWiped).toEqual(onWiped);
+
+      // ── 4. Log back in ───────────────────────────────────────────────────
+      // getConfig IS the returning-user path: fetch the encrypted blob, verify
+      // its ed448 signature, decrypt it, then adoptSpaces() rebuilds Spaces and
+      // key material from `config.spaceKeys`.
+      await Promise.all([
+        on.graph.configService.getConfig({
+          address: on.identity.address,
+          userKey: on.identity.keyset.userKeyset,
+        }),
+        off.graph.configService.getConfig({
+          address: off.identity.address,
+          userKey: off.identity.keyset.userKeyset,
+        }),
+      ]);
+
+      const onAfter = await snapshot(on);
+      const offAfter = await snapshot(off);
+      console.log(`[space-wipe-restore] sync ON  RESTORED ${fmt(onAfter)}`);
+      console.log(`[space-wipe-restore] sync OFF RESTORED ${fmt(offAfter)}`);
+
+      // ── 5. What the published config gave back ───────────────────────────
+      expect(onAfter.spaces).toBe(onBefore.spaces);
+      expect(onAfter.displayName).toBe(onBefore.displayName);
+      expect((await on.messageDB.getSpace(onSpace.spaceId))?.spaceId).toBe(onSpace.spaceId);
+      console.log(
+        `[space-wipe-restore] key delta: before=[${onBefore.keyIds.join(',')}] ` +
+          `after=[${onAfter.keyIds.join(',')}] ` +
+          `missing=[${onBefore.keyIds.filter((k) => !onAfter.keyIds.includes(k)).join(',')}]`
+      );
+
+      // Every key returns EXCEPT `signing`, and that gap is deliberate rather
+      // than a hole in the recovery. `adoptSpaces` skips the synced `signing`
+      // slot (ConfigService.ts:467) so a restored device signs with its OWN
+      // per-device `inbox` key — `getSigningKey` falls through to it
+      // (MessageService.ts:1757). Asserting the exact set, rather than a count,
+      // means deleting that `continue` turns this red instead of silently
+      // putting a restored device back on a shared signing key.
+      expect(onAfter.keyIds).toEqual(onBefore.keyIds.filter((k) => k !== 'signing'));
+      // ...so the key it signs with instead had better be present.
+      expect(onAfter.keyIds).toContain('inbox');
+
+      // ...and what it did NOT restore. There is no server-side copy of DM
+      // data, so the login that rebuilt an entire Space leaves the
+      // conversations at zero.
+      expect(onAfter.dmMessages).toBe(0);
+      expect(onAfter.dmConversations).toBe(0);
+
+      // The only ratchet state that comes back is the SPACE group ratchet,
+      // carried in `config.spaceKeys[].encryptionState`. The DM ratchet — the
+      // thing that would let an existing conversation continue — is not in the
+      // parcel and does not return.
+      expect(onAfter.stateConvs).toEqual([`${onSpace.spaceId}/${onSpace.spaceId}`]);
+
+      // ── 6. The unpublished account gets nothing ──────────────────────────
+      // Same eviction, same login, no published blob. This is the control: if
+      // this arm also came back, something other than the config would be doing
+      // the restoring and step 5 would prove nothing.
+      expect(offAfter.spaces).toBe(0);
+      expect(offAfter.keyIds).toEqual([]);
+      expect(offAfter.dmMessages).toBe(0);
+      expect(await off.messageDB.getSpace(offSpace.spaceId)).toBeNull();
+    } finally {
+      on.stop();
+      off.stop();
+    }
+  },
+  300_000
+);

--- a/src/dev/tests/harness/storage.ts
+++ b/src/dev/tests/harness/storage.ts
@@ -26,3 +26,50 @@ export async function makeMessageDB(namespace?: string): Promise<MessageDB> {
   await db.init();
   return db;
 }
+
+/** The database name a MessageDB instance is actually bound to. */
+export function dbNameOf(db: MessageDB): string {
+  return (db as unknown as { DB_NAME: string }).DB_NAME;
+}
+
+/**
+ * Destroy the whole database behind a MessageDB — every store, the way the
+ * BROWSER destroys it, not row by row.
+ *
+ * This is what Safari's ITP does after 7 days of non-interaction, and equally
+ * what "clear site data" and a brand-new device look like to the app: it comes
+ * back to a database that is not there. Deleting rows through the app's own
+ * write methods would be a different (and much gentler) experiment — the point
+ * here is that the store itself vanishes underneath a live connection.
+ *
+ * Nothing has to be re-wired afterwards. `deleteDatabase` fires `versionchange`
+ * on every open connection, and MessageDB's own handler closes the connection
+ * and drops its reference (messages.ts, `connection.onversionchange`). Every
+ * read/write method then calls `await this.init()`, which reopens — empty. So
+ * the caller keeps the SAME MessageDB instance, and every reference held by
+ * MessageService / ActionQueueService / the capture tee stays valid. That
+ * recovery is real production code, not a harness fixture.
+ *
+ * Deliberately NOT the SDK's `KeyDB`. `wipeLocalAppData` (services/resetAppData.ts)
+ * deletes both because a real reset must, but this harness never populates KeyDB
+ * — bot identities are re-derived from `.state/<name>.json`, since the
+ * passkey/WebAuthn layer cannot cross into node (identity.ts). Deleting it here
+ * would be a no-op dressed up as coverage, and worse, all bots in this process
+ * share one global fake-indexeddb, so it would reach into the OTHER bot. The
+ * scenario logs `listDatabaseNames()` instead, which records what is actually
+ * there rather than assuming.
+ */
+export function deleteDatabaseFor(db: MessageDB): Promise<void> {
+  const name = dbNameOf(db);
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.deleteDatabase(name);
+    req.onsuccess = () => resolve();
+    req.onerror = () => reject(req.error);
+    // Must REJECT, never resolve. A blocked delete leaves the data fully intact,
+    // so treating it as success would let every "the history is gone" assertion
+    // downstream pass against a database that was never touched — the exact
+    // shape of a test that cannot fail. resetAppData.ts carries the same rule
+    // for the same reason.
+    req.onblocked = () => reject(new Error(`deleteDatabase(${name}) blocked`));
+  });
+}

--- a/src/hooks/business/user/useUserSettings.ts
+++ b/src/hooks/business/user/useUserSettings.ts
@@ -17,6 +17,7 @@ import { publicProfileQueryKey } from './useUserPublicProfile';
 import { getDeviceName } from '../../../utils/deviceInfo';
 import { showError } from '../../../utils/toast';
 import { normalizePrivateKeyHex } from '../../../utils/privateKey';
+import { recordLastBackup } from '../../../utils/lastBackup';
 
 export interface UseUserSettingsOptions {
   onSave?: () => void;
@@ -287,6 +288,20 @@ export const useUserSettings = (
     link.click();
     document.body.removeChild(link);
     window.URL.revokeObjectURL(url);
+
+    // Recorded HERE rather than at the call site, and that placement is the
+    // point: the guard at the top of this function returns silently when there
+    // is no keyset, so a call that produced no file resolves exactly like one
+    // that did. Recording after the download has fired means that path cannot
+    // mark the user as backed up.
+    //
+    // KNOWN LIMIT, deliberately accepted: an anchor-click download reports
+    // nothing back, so a user who cancels the browser's save dialog is recorded
+    // as having a backup. There is no event that distinguishes the two. The
+    // 30-day expiry is what bounds it — that user is reminded again, rather
+    // than never. Fixing it properly needs a real save API (Electron) and is
+    // not worth diverging the two platforms for today.
+    recordLastBackup();
   };
 
   const importBackup = async (file: File): Promise<RestoreReport> => {

--- a/src/utils/lastBackup.ts
+++ b/src/utils/lastBackup.ts
@@ -1,0 +1,101 @@
+/**
+ * Desktop's store for when a `.qmbak` backup was last taken.
+ *
+ * Exists so the app can tell "this user has a backup" from "this user has
+ * never taken one", which nothing recorded before. That distinction is what
+ * lets the reminder in Settings clear itself when the user acts, instead of
+ * needing a dismiss button — a dismissed warning would silence the message
+ * while leaving the user just as exposed.
+ *
+ * Deliberately mirrors `lastPublish.ts`: same localStorage shape, same
+ * never-throw contract, same device-local scope. It is NOT part of UserConfig.
+ * Taking a backup is a per-device act, so syncing it would tell every other
+ * device it was covered when it was not, and would rewrite the synced blob on
+ * every export.
+ *
+ * ## The record is destroyed by the event it guards against, and that is correct
+ *
+ * localStorage is script-writable storage, so the same eviction that removes
+ * IndexedDB removes this too (Safari ITP, "clear site data", a new device). The
+ * restored user therefore reads "no backup on record" and is warned again —
+ * which is right, because the backup file they took is no longer *on* this
+ * device and the fresh database is once more the only copy.
+ *
+ * See .agents/issues/.open/2026-08-05-safari-itp-wipes-indexeddb-after-7-idle-days.md (M4)
+ */
+
+const KEY = 'quorum:backup:lastBackup';
+
+/**
+ * Local for now rather than in quorum-shared. Mobile has no equivalent reminder
+ * yet, and a one-field shape is not worth a cross-repo build to share. Move it
+ * when mobile grows the same callout — that is the moment the shape has two
+ * consumers and can actually drift.
+ */
+export interface LastBackup {
+  /** Epoch ms of the last SUCCESSFUL export. */
+  at: number;
+}
+
+/**
+ * How long a backup counts as current.
+ *
+ * Not a safety guarantee, a nagging interval: past this the reminder returns.
+ * Short enough that a stale file does not quietly become the plan, long enough
+ * that it is not furniture — permanent furniture stops being read, which is the
+ * reasoning `PasskeyStatus` already states for rendering nothing on the healthy
+ * path.
+ */
+export const BACKUP_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+
+/**
+ * Never throws. An instrument that can break the path it measures is worse than
+ * no instrument, and this one sits on the export path.
+ */
+export function recordLastBackup(at: number = Date.now()): void {
+  try {
+    if (typeof localStorage === 'undefined') return;
+    const entry: LastBackup = { at };
+    localStorage.setItem(KEY, JSON.stringify(entry));
+  } catch {
+    // Quota, private mode, a serialisation edge — losing one reading is fine.
+    // Worst case the user is reminded again sooner than necessary.
+  }
+}
+
+/** Returns null when nothing has been recorded yet, or the stored value is unusable. */
+export function readLastBackup(): LastBackup | null {
+  try {
+    if (typeof localStorage === 'undefined') return null;
+    const raw = localStorage.getItem(KEY);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      typeof (parsed as LastBackup).at !== 'number' ||
+      !Number.isFinite((parsed as LastBackup).at)
+    ) {
+      return null;
+    }
+    return parsed as LastBackup;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Is there a backup recent enough to stay quiet about?
+ *
+ * A future timestamp counts as current rather than stale. It can only come from
+ * a clock change, and the failure mode of the alternative — treating it as
+ * stale — is nagging someone who just took a backup, which is the one user this
+ * feature should never bother.
+ */
+export function hasCurrentBackup(
+  last: LastBackup | null = readLastBackup(),
+  now: number = Date.now()
+): boolean {
+  if (!last) return false;
+  return now - last.at < BACKUP_MAX_AGE_MS;
+}


### PR DESCRIPTION
Warns a sync-off user that this device holds the only copy of their data, and adds the headless measurements that establish why that warning is needed.

## Why

With `allowSync` off — the default — the server holds nothing for the account: no profile, no Spaces, no Space keys. `saveConfig` builds `spaceKeys` and calls `postUserSettings` only inside `if (config.allowSync)`, so nothing is ever published. A `.qmbak` file is that user's entire safety net, and until now it only existed if they went looking for it.

That was not previously measured. The storage-eviction issue asserted that profile, Spaces and Space keys always return on login; they only do for sync-enabled users.

## What shipped

**A reminder on the General settings tab**, directly below the passkey warning. It renders nothing at all unless sync is off *and* no backup was taken in the last 30 days, so it costs a sync-on user nothing.

No dismiss button, deliberately: the condition is the dismissal. Taking the backup clears it. An X would let someone silence the warning while staying exposed, which is worse than never showing it. Following the link lands on the Data Backup section rather than the top of a long panel, and moves focus there so the jump works for keyboard and screen-reader users.

`lastBackup.ts` mirrors `lastPublish.ts`, including the never-throw contract. The record is written inside the hook rather than at the call site, because `exportBackup` returns silently when there is no keyset — a call that produced no file otherwise resolves exactly like one that did.

## The measurements behind it

Two headless harness scenarios, both control-armed and mutation-verified.

`dm-itp-wipe` destroys a database and counts the cost: 3 messages / 1 conversation / 1 session to zero, nothing revived, and the conversation resuming on a fresh session. Two findings that were not obvious — the database is recreated empty on first read, so its presence is no evidence any data survived; and counting persistence callbacks overcounts, because redelivery and init-envelope salvage both persist the same message again.

`space-wipe-restore` measures what logging back in restores. Two accounts of identical shape differing only in `allowSync`: the sync-on account gets its Space, keys and profile back, the sync-off account gets nothing. Flipping only that flag moves the result, so the cause is established rather than assumed.

## Docs

Corrects the recoverability table for the `allowSync` gate, retires a mitigation whose premise had moved (three links pointed at a superseded, archived issue), and records why DM session continuity has no user-facing copy — it is not actionable, the conversation heals itself, and the one plausible symptom is a message you never received.

## Verification

`tsc` clean, lint 0 errors with no new warnings, full suite 163 files / 1498 tests green. Every new assertion was checked by mutation: each guard removed in turn produces exactly the expected failures, including the inverse case that would catch a component silently rendering nothing.

## Commits

- test(harness): measure what a storage eviction costs a DM account
- docs: record the measured half of the storage-eviction issue
- test(harness): measure what logging back in actually restores
- docs: correct the recoverability table for the allowSync gate
- docs: retire M1 and unblock M4 on the storage-eviction issue
- feat(settings): remind sync-off users that this device is their only copy
- test(settings): drop needless timer fiddling from the backup reminder tests
- feat(settings): land on Data Backup when following the backup reminder
- docs(backup): record why DM session continuity has no user-facing copy
