### PR TITLE
test(config): close the mobile to desktop direction of the cross-client measurement

### DIFF
--- a/src/dev/tests/harness/README.md
+++ b/src/dev/tests/harness/README.md
@@ -29,7 +29,40 @@ cp src/dev/tests/harness/.env.example src/dev/tests/harness/.env.local
 
 yarn harness ping        # slice 1: a bot registers, connects, subscribes
 yarn harness             # run every scenario
+
+yarn harness:config-cross   # cross-client config sync, BOTH directions — see below
 ```
+
+### Cross-client config sync (`yarn harness:config-cross`)
+
+Spans both repos. quorum-mobile must be checked out beside this one; nothing in
+it is modified, the orchestrator just drives its existing scenarios.
+
+```
+[config-cross] ── summary ──
+  ok   desktop → mobile
+  ok   mobile → desktop
+```
+
+Each direction is publish-then-read for one shared throwaway account: one client
+writes the settings row, the other pulls it and asserts against a handoff file
+recording what was actually sent. Asserting against the handoff rather than a
+constant is deliberate — two repos can drift into agreeing about a value neither
+of them ever transmitted.
+
+**Both directions, because one is not symmetric evidence.** The two
+`ConfigService` implementations are independent code sharing only a type;
+encryption, signing and field ordering are written twice. "Desktop's blob
+decrypts on mobile" says nothing about the reverse, and the known
+merge-asymmetry issue exists because the two drifted apart.
+
+`--only=to-mobile` / `--only=to-desktop` runs a single direction. The halves are
+sequential rather than concurrent, unlike `run-cross.mjs`: a config is a row on
+a server, so the two clients never need to be live at the same time. Both
+directions write the same row, which is also why they cannot overlap.
+
+Each reader refuses a handoff older than 30 minutes. Without that, a stale file
+lets a run pass against a row written days ago — a green that proves nothing.
 
 No `.env.local` is required — with no keys the harness generates its own throwaway
 accounts, which is all the transport scenarios need.
@@ -253,4 +286,4 @@ See `2026-07-27-headless-dm-harness.md` under .agents/issues/ for the DM slice p
 `.agents/issues/transport/2026-07-27-headless-space-harness.md` for the space one,
 and `.agents/issues/transport/2026-07-26-dm-desktop-to-desktop-resurfaced.md` §1 for the DM
 findings.
-*Last updated: 2026-08-02*
+*Last updated: 2026-08-17*

--- a/src/dev/tests/harness/config-from-mobile.scenario.test.ts
+++ b/src/dev/tests/harness/config-from-mobile.scenario.test.ts
@@ -1,0 +1,119 @@
+// CROSS-CLIENT, the direction that was missing. MOBILE publishes a user config;
+// this half reads it back on DESKTOP.
+//
+//   yarn harness:config-cross            (runs BOTH directions, in order)
+//   yarn harness config-from-mobile      (this half alone, after mobile published)
+//
+// `config-cross.scenario.test.ts` next to this file covers desktop → mobile.
+// One direction is not symmetric evidence: encryption, signing and field
+// ordering are written twice, once per client, so "desktop's blob decrypts on
+// mobile" says nothing about the reverse. The known merge-asymmetry issue
+// exists precisely because the two implementations drifted.
+//
+// Mobile's half (`dev/harness/config-to-desktop.scenario.ts` in quorum-mobile)
+// publishes for the shared throwaway account, proves the row landed by reading
+// it straight back off the relay, and writes what it sent to the handoff file
+// below. This half asserts against that file rather than a constant, so the two
+// repos cannot drift into agreeing about a value neither actually sent.
+//
+// ─── The file name avoids "config-cross" on purpose ─────────────────────────
+//
+// `yarn harness config-cross` passes its argument to vitest as a path filter,
+// so a file named `config-cross-from-mobile` would be pulled into the other
+// direction's run as well. Both would then read and write the same account's
+// row in an order vitest does not guarantee, and the resulting failure would
+// look like a protocol bug rather than a naming accident.
+//
+// ⚠️ Reads a REAL settings row on production for that throwaway account.
+import { test, expect } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { createSpaceBot } from './spaceBot';
+
+const DESKTOP_REPO = resolve(__dirname, '../../../..');
+const MOBILE_REPO = resolve(DESKTOP_REPO, '..', 'quorum-mobile');
+const MOBILE_BOT_STATE = resolve(MOBILE_REPO, 'dev/harness/.state/config-sync-bot.json');
+const HANDOFF = resolve(MOBILE_REPO, 'dev/harness/.state/rendezvous/config-from-mobile.json');
+
+/** How old a handoff may be before it is treated as a different run's leftovers. */
+const MAX_HANDOFF_AGE_MS = 30 * 60 * 1000;
+
+test('config-cross: desktop adopts a config that MOBILE published', async () => {
+  if (!existsSync(HANDOFF)) {
+    throw new Error(
+      `No handoff at ${HANDOFF}.\n` +
+        'The mobile half publishes first. From the mobile repo:\n' +
+        '  yarn harness:config-to-desktop'
+    );
+  }
+
+  const handoff = JSON.parse(readFileSync(HANDOFF, 'utf8')) as {
+    publishedBy: string;
+    at: number;
+    name: string;
+    profile_image: string;
+  };
+
+  // A stale handoff is the failure mode that would quietly turn this into a
+  // no-op: the assertions would still pass, against a row from an old run,
+  // while proving nothing about the code as it stands today.
+  expect(handoff.publishedBy).toBe('mobile');
+  const age = Date.now() - handoff.at;
+  if (age > MAX_HANDOFF_AGE_MS) {
+    throw new Error(
+      `Handoff is ${Math.round(age / 60_000)} minutes old, which is older than this ` +
+        'check trusts. Re-run the mobile half so the row on the relay matches it.'
+    );
+  }
+
+  if (!existsSync(MOBILE_BOT_STATE)) {
+    throw new Error(
+      `No mobile bot state at ${MOBILE_BOT_STATE}.\n` +
+        'Both halves must be the same account; mobile owns the key.'
+    );
+  }
+  const { privateKeyHex } = JSON.parse(readFileSync(MOBILE_BOT_STATE, 'utf8')) as {
+    privateKeyHex?: string;
+  };
+  // A state file WITHOUT privateKeyHex means mobile was pointed at a real
+  // account through its env var, and this scenario must not touch it.
+  expect(
+    privateKeyHex,
+    'mobile bot state has no privateKeyHex — that means it is NOT a throwaway account'
+  ).toBeTruthy();
+
+  const bot = await createSpaceBot('config-cross-read-desktop', { privateKeyHex });
+  await bot.start();
+
+  try {
+    const adopted = await bot.graph.configService.getConfig({
+      address: bot.identity.address,
+      userKey: bot.identity.keyset.userKeyset,
+    });
+
+    // THE cross-client assertion, and the one this whole direction existed to
+    // make. A short string and a bulk field, because the name alone would pass
+    // even if the image were being dropped in transit.
+    expect(adopted.name).toBe(handoff.name);
+    expect((adopted as unknown as { profile_image?: string }).profile_image).toBe(
+      handoff.profile_image
+    );
+
+    // Mobile published `allowSync: true`. Desktop must still refuse to inherit
+    // it — this bot has no stored config, which is exactly the fresh-install
+    // case the device-local rule was written for (#322). Now proven across
+    // clients rather than only against desktop's own blob.
+    expect(adopted.allowSync).toBe(false);
+
+    console.log(
+      `[config-cross] desktop adopted mobile's config: name=${adopted.name === handoff.name} image=${
+        (adopted as unknown as { profile_image?: string }).profile_image ===
+        handoff.profile_image
+      }`
+    );
+  } finally {
+    // Synchronous, and in a finally so a failed assertion still clears the
+    // ActionQueue interval and closes the socket — otherwise the run hangs.
+    bot.stop();
+  }
+}, 300_000);

--- a/src/dev/tests/harness/run-config-cross.mjs
+++ b/src/dev/tests/harness/run-config-cross.mjs
@@ -1,18 +1,29 @@
-// Orchestrator for the desktop→mobile CONFIG measurement.
+// Orchestrator for the cross-client CONFIG measurement, BOTH directions.
 //
-//   yarn harness:config-cross
+//   yarn harness:config-cross                    both directions
+//   yarn harness:config-cross --only=to-mobile   desktop publishes, mobile reads
+//   yarn harness:config-cross --only=to-desktop  mobile publishes, desktop reads
 //
-// Runs the two halves in order, in two repos: desktop publishes a user config
-// for a shared throwaway account, then mobile pulls it and asserts what arrived.
+// Each direction is publish-then-read for the same throwaway account: one
+// client writes the row, the other pulls it and asserts against a handoff file
+// describing what was actually sent.
 //
-// Unlike run-cross.mjs (the DM measurement) the halves are SEQUENTIAL, not
-// concurrent, and that is a property of what is being measured rather than a
-// simplification. DMs need both peers live at once because delivery is the
+// ─── Why both directions, and not just one ──────────────────────────────────
+//
+// The two `ConfigService` implementations are independent code sharing only a
+// type. Encryption, signing and field ordering are written twice, so "desktop's
+// blob decrypts on mobile" is not evidence about the reverse. The known
+// merge-asymmetry issue exists because the two drifted apart, which is exactly
+// the class of fault a one-directional check cannot see.
+//
+// ─── Why the halves are SEQUENTIAL, unlike run-cross.mjs ────────────────────
+//
+// The DM measurement needs both peers live at once because delivery is the
 // thing under test. A config is a row on a server: one client writes it, the
 // other reads it later, and they never need to be running at the same time.
 //
-// ⚠️ quorum-mobile is NOT modified. This drives its existing scenario, the same
-// way run-cross.mjs does.
+// ⚠️ quorum-mobile is NOT modified. This drives its existing scenarios, the
+// same way run-cross.mjs does.
 import { spawn } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
@@ -28,6 +39,13 @@ if (!existsSync(MOBILE_REPO)) {
   process.exit(1);
 }
 
+const onlyArg = process.argv.find((a) => a.startsWith('--only='));
+const only = onlyArg ? onlyArg.slice('--only='.length) : null;
+if (only && only !== 'to-mobile' && only !== 'to-desktop') {
+  console.error(`[config-cross] unknown --only=${only}; expected to-mobile or to-desktop.`);
+  process.exit(1);
+}
+
 const run = (label, cmd, args, cwd) =>
   new Promise((resolveRun) => {
     console.log(`\n[config-cross] ── ${label} ──`);
@@ -35,33 +53,81 @@ const run = (label, cmd, args, cwd) =>
     child.on('exit', (code) => resolveRun(code ?? 1));
   });
 
-const publish = await run(
-  'desktop publishes',
-  'yarn',
-  ['harness', 'config-cross'],
-  DESKTOP_REPO
-);
+/**
+ * One direction: the publisher runs, and the reader only runs if it succeeded.
+ *
+ * Stopping between the halves matters. Running the reader against a row that
+ * was never written makes it fail on a missing or stale handoff, or worse pass
+ * against an old one — and either way the verdict points at the wrong client.
+ */
+async function direction({ name, publish, read }) {
+  const published = await run(publish.label, publish.cmd, publish.args, publish.cwd);
+  if (published !== 0) {
+    console.error(`\n[config-cross] ${name}: the publishing half failed — not running the reader.`);
+    console.error('[config-cross] nothing was proved about the other client.');
+    return published;
+  }
 
-// Stop here rather than running mobile against a row that was never written.
-// Mobile would fail on a stale handoff, or worse pass against one, and either
-// way the verdict would point at the wrong client.
-if (publish !== 0) {
-  console.error('\n[config-cross] desktop half failed — not running mobile.');
-  console.error('[config-cross] nothing was proved about the other client.');
-  process.exit(publish);
+  const adopted = await run(read.label, read.cmd, read.args, read.cwd);
+  console.log('');
+  if (adopted === 0) {
+    console.log(`[config-cross] ${name}: config crossed clients intact.`);
+  } else {
+    console.error(`[config-cross] ${name}: FAILED. See the reading half above.`);
+  }
+  return adopted;
 }
 
-const read = await run(
-  'mobile reads it back',
-  'yarn',
-  ['harness', 'config-cross'],
-  MOBILE_REPO
-);
+const DIRECTIONS = {
+  'to-mobile': {
+    name: 'desktop → mobile',
+    publish: {
+      label: 'desktop publishes',
+      cmd: 'yarn',
+      args: ['harness', 'config-cross'],
+      cwd: DESKTOP_REPO,
+    },
+    read: {
+      label: 'mobile reads it back',
+      cmd: 'yarn',
+      args: ['harness', 'config-cross'],
+      cwd: MOBILE_REPO,
+    },
+  },
+  'to-desktop': {
+    name: 'mobile → desktop',
+    publish: {
+      label: 'mobile publishes',
+      cmd: 'yarn',
+      args: ['harness:config-to-desktop'],
+      cwd: MOBILE_REPO,
+    },
+    read: {
+      label: 'desktop reads it back',
+      cmd: 'yarn',
+      args: ['harness', 'config-from-mobile'],
+      cwd: DESKTOP_REPO,
+    },
+  },
+};
 
-console.log('');
-if (read === 0) {
-  console.log('[config-cross] desktop → mobile: config crossed clients intact.');
-} else {
-  console.error('[config-cross] desktop → mobile: FAILED. See the mobile half above.');
+// Both directions write the SAME account's row, so they must not overlap.
+// Running them in sequence is what keeps each reader looking at the row its own
+// publisher just wrote, rather than at whichever direction finished last.
+const order = only ? [only] : ['to-mobile', 'to-desktop'];
+const results = [];
+
+for (const key of order) {
+  const code = await direction(DIRECTIONS[key]);
+  results.push({ name: DIRECTIONS[key].name, code });
+  // Carry on to the other direction even after a failure. Knowing whether ONE
+  // direction is broken or BOTH are is most of the diagnosis, and the second
+  // run costs seconds.
 }
-process.exit(read);
+
+console.log('\n[config-cross] ── summary ──');
+for (const { name, code } of results) {
+  console.log(`  ${code === 0 ? 'ok  ' : 'FAIL'} ${name}`);
+}
+
+process.exit(results.some((r) => r.code !== 0) ? 1 : 0);


### PR DESCRIPTION
The cross-client harness only ran desktop-publishes / mobile-reads. One direction is not symmetric evidence: the two `ConfigService` implementations are independent code sharing only a type, and encryption, signing and field ordering are each written twice. "Desktop's blob decrypts on mobile" says nothing about the reverse, and the known merge-asymmetry issue exists because the two drifted apart.

quorum-mobile #254 added the publishing half there (`yarn harness:config-to-desktop`), which writes a handoff describing what it actually sent. This adds the reading half here and turns the orchestrator into both directions.

```bash
yarn harness:config-cross                    # both, in sequence
yarn harness:config-cross --only=to-mobile   # one direction
yarn harness:config-cross --only=to-desktop
```

Measured against production, both green in 34s:

```
[config-cross] ── summary ──
  ok   desktop → mobile
  ok   mobile → desktop
```

## Two mutations, so the new half is not a green that would survive anything

1. **Tampering with the handoff** so it disagrees with the published row turns it red: `expected 'mobile-cross-<ts>' to be 'mobile-cross-<ts>-TAMPERED'`. That is the check that the reader is really pulling the relay row rather than reflecting the file back at itself.
2. **Removing the device-local `allowSync` rule** at the adopt site (`ConfigService.ts:289`) turns it red: `expected true to be false`, because desktop then inherits mobile's `allowSync: true`. The per-device rule from #322 is now proven **across clients**, not only against desktop's own blob.

## Details worth knowing

The scenario filename avoids the substring `config-cross` deliberately: that argument is a vitest path filter, so a collision would pull this reader into the other direction's run, and both directions write the same account row in an order vitest does not guarantee.

The orchestrator now continues to the second direction after a failure rather than exiting. Knowing whether one direction is broken or both are is most of the diagnosis, and the second run costs seconds.

quorum-mobile is not modified. This drives its existing scenarios, as `run-cross.mjs` already does.

## Checks

1518 tests / 165 files green. Typecheck 0 errors.
