### PR TITLE
fix(invite): tell existing members when a public link is generated

### DIFF
--- a/.agents/docs/features/invite-system-analysis.md
+++ b/.agents/docs/features/invite-system-analysis.md
@@ -353,9 +353,15 @@ The isolation the original design bought is still there, and does not depend on
 the domain: a staging link carries staging keys and a staging Space id, so it
 cannot open a production Space whatever host it names.
 
-Note that message deep-links (`src/utils/messageLinkUtils.ts` via
-`environmentDomains.ts`) remain environment-aware. Only invite generation was
-made canonical.
+Note that **message deep-links were not changed and remain environment-derived**:
+`src/hooks/business/messages/useMessageActions.ts:288` builds them from
+`window.location.origin + pathname`. That is fine for the same reason it was not
+fine for invites — a message link is copied to the clipboard for immediate use,
+never persisted into a Space record and replicated to other people's devices.
+(Acceptance-side parsing for message links lives in shared's
+`src/utils/messageLinkUtils.ts`; there is no such file in this repo.)
+
+Only invite generation was made canonical.
 
 ### Files involved:
 - `@quilibrium/quorum-shared` `src/utils/inviteDomain.ts` - canonical generation, permissive acceptance

--- a/.agents/docs/features/invite-system-analysis.md
+++ b/.agents/docs/features/invite-system-analysis.md
@@ -4,7 +4,7 @@ title: Invite System Documentation
 status: done
 ai_generated: true
 created: 2026-01-09T00:00:00.000Z
-updated: 2026-06-08T00:00:00.000Z
+updated: 2026-08-19T00:00:00.000Z
 ---
 
 # Invite System Documentation
@@ -308,40 +308,61 @@ These are cryptographic validation failures, not time-based expirations. Common 
 
 ---
 
-## Environment-Specific Invite System (September 2025 Update)
+## Invite Domains
 
-### Dynamic Domain Resolution
+> **⚠️ SUPERSEDED 2026-08-19 by quorum-shared #84.** The environment-derived
+> generation described below is gone. It is kept here because the reasoning was
+> sound and knowing why it was dropped matters more than the fact that it was.
 
-The invite system now dynamically detects the environment and uses appropriate domains:
+### Current behaviour: generation canonical, acceptance permissive
 
 **Implementation:** `@quilibrium/quorum-shared` — `src/utils/inviteDomain.ts`
 
-1. **Production Environment** (`app.quorummessenger.com`):
-   - Generates invite links with `qm.one` (short domain)
-   - Accepts both `qm.one` and `app.quorummessenger.com` links
-   - Maintains backward compatibility with all existing invites
+- **Generation** — `getInviteBaseDomain()` returns `app.quorummessenger.com`
+  unconditionally, on every build. `getInviteUrlBase()` is therefore always
+  `https://app.quorummessenger.com/` (one-time) or `.../invite/` (public).
+- **Acceptance** — `getValidInvitePrefixes()` is unchanged and stays broad:
+  production, the legacy `qm.one` form, staging, and localhost ports. Links
+  already in circulation keep parsing.
+- **Mobile** does not import these helpers; its own generator was already
+  hardcoded to the production host. This change is what lets the two converge.
 
-2. **Staging Environment** (`test.quorummessenger.com`):
-   - Generates invite links with `test.quorummessenger.com`
-   - Only accepts staging domain links (isolation from production)
-   - Prevents cross-environment invite confusion
+Cost: on a non-production build, a generated link no longer deep-links back into
+that build. Pasting one into the join field still works, because the entire join
+payload lives in the hash fragment and the host is never contacted. Only
+click-through needs the domain edited by hand.
 
-3. **Local Development** (`localhost:port`):
-   - Generates invite links with `http://localhost:port`
-   - Accepts all domains for comprehensive testing
-   - Supports common development ports (3000, 5173, etc.)
+### Why the environment-derived design was dropped
 
-### Key Benefits:
-- **No hardcoded domains**: Automatically adapts to deployment environment
-- **Staging isolation**: Test environment works independently
-- **Local testing**: Developers can test invite flows without deployment
-- **Production safety**: No changes to existing production behavior
+The original design (September 2025) generated `test.quorummessenger.com` on
+staging and `localhost:port` in development, for **staging isolation** — so a
+test invite could not be mistaken for a production one. That was deliberate and
+it worked, *for as long as a Space's `inviteUrl` stayed on the device that
+generated it*.
 
-### Files Modified:
-- `@quilibrium/quorum-shared` `src/utils/inviteDomain.ts` - Utility for dynamic domain resolution
-- `src/components/context/MessageDB.tsx` - Provides access to `InvitationService` which uses dynamic domain for invite generation
-- `src/components/modals/JoinSpaceModal.tsx` - Uses dynamic domain for display
-- `src/hooks/business/spaces/useInviteValidation.ts` - Dynamic validation prefixes
+It does not stay there. The URL is persisted into `space.inviteUrl` and
+replicated to every member on every client, and receivers additionally
+reconstruct it locally from an incoming envelope using **their own** environment
+(`src/services/MessageService.ts:5511-5514`). So the environment of whoever last
+touched a link leaks to every member, and a link minted on a developer's machine
+reaches real users as a URL they cannot open. Worse on mobile, whose accept-list
+never included the staging host: such a link fails `isPublicInvite()` and hides
+the member-facing share affordance entirely.
+
+The isolation the original design bought is still there, and does not depend on
+the domain: a staging link carries staging keys and a staging Space id, so it
+cannot open a production Space whatever host it names.
+
+Note that message deep-links (`src/utils/messageLinkUtils.ts` via
+`environmentDomains.ts`) remain environment-aware. Only invite generation was
+made canonical.
+
+### Files involved:
+- `@quilibrium/quorum-shared` `src/utils/inviteDomain.ts` - canonical generation, permissive acceptance
+- `src/services/InvitationService.ts` - generates both link kinds
+- `src/services/SpaceService.ts`, `src/services/MessageService.ts` - also build invite URLs
+- `src/components/modals/JoinSpaceModal.tsx` - display only
+- `src/hooks/business/spaces/useInviteValidation.ts` - validation prefixes
 
 ## Duplicate Prevention (Fixed)
 
@@ -359,4 +380,4 @@ The invite system now dynamically detects the environment and uses appropriate d
 
 _Covers: SpaceSettingsModal/Invites.tsx, useInviteManagement.ts, useInviteValidation.ts, useSpaceJoining.ts, InvitationService.ts, MessageDB Context, InviteLink.tsx, inviteDomain.ts_
 
-_Last updated: 2026-06-08_
+_Last updated: 2026-08-19_

--- a/.agents/docs/quorum-shared-architecture.md
+++ b/.agents/docs/quorum-shared-architecture.md
@@ -3,7 +3,7 @@ type: doc
 title: Quorum Ecosystem Architecture
 status: done
 created: 2026-01-09T00:00:00.000Z
-updated: 2026-06-11T00:00:00.000Z
+updated: 2026-08-19T00:00:00.000Z
 ---
 
 # Quorum Ecosystem Architecture
@@ -568,14 +568,18 @@ import {
 
 ### Invite Domain Helpers
 
-Environment-aware URL/prefix generation for invite links. Replaces hardcoded `qm.one`/`app.quorummessenger.com` regex literals.
+URL/prefix helpers for invite links. **Generation is canonical, acceptance is
+permissive** (changed in shared #84, 2026-08-19): every generated link carries
+the production host, while the accept-list stays broad so links already in
+circulation keep parsing. Generation was previously environment-derived; see
+`features/invite-system-analysis.md` for why that was dropped.
 
 ```typescript
 import {
-  getInviteBaseDomain,       // env-aware: prod/staging/localhost
-  getInviteUrlBase,          // (isPublicInvite: boolean) => string
-  getInviteDisplayDomain,
-  getValidInvitePrefixes,    // env-aware: prefix list for link detection
+  getInviteBaseDomain,       // ALWAYS app.quorummessenger.com, on every build
+  getInviteUrlBase,          // (isPublicInvite: boolean) => string, always https
+  getInviteDisplayDomain,    // same value, for UI
+  getValidInvitePrefixes,    // still env-aware: broad accept-list for link detection
   parseInviteParams,         // parse an invite URL into structured parts
 } from '@quilibrium/quorum-shared';
 ```
@@ -810,4 +814,4 @@ function MyComponent() {
 
 ---
 
-*Last updated: 2026-06-11*
+*Last updated: 2026-08-19*

--- a/src/components/modals/SpaceSettingsModal/Invites.tsx
+++ b/src/components/modals/SpaceSettingsModal/Invites.tsx
@@ -381,11 +381,18 @@ const Invites: React.FunctionComponent<InvitesProps> = ({
     invite(address, sendArgs.mode);
   };
 
-  // Non-owners see a stripped-down read-only view: the public invite URL
-  // (replicated to every member's local Space record via the encrypted
-  // manifest) + Copy + Send via DM. The Send path uses mode='public' which
+  // Non-owners see a stripped-down read-only view: the public invite URL +
+  // Copy + Send via DM. The Send path uses mode='public' which
   // forwards space.inviteUrl as-is without consuming the eval pool. See
   // #29 in port-from-mobile/candidates.md for the capability investigation.
+  //
+  // How the URL gets here: the owner's client sends a `space-manifest` control
+  // message on the hub when it generates the link. NOT the manifest POSTed to
+  // the server — that one is only ever read by joiners and device restores, so
+  // it never reaches somebody already in the Space. This comment previously
+  // claimed the opposite, which was the visible symptom of that gap: members
+  // who were in the Space before the link existed saw no Invites section at
+  // all, because the field they read was never populated.
   if (!isSpaceOwner) {
     const sendDisabled =
       sendingInvite || !(selectedUser || resolvedUser);

--- a/src/dev/tests/services/InvitationService.unit.test.tsx
+++ b/src/dev/tests/services/InvitationService.unit.test.tsx
@@ -779,13 +779,22 @@ describe('InvitationService - Unit Tests', () => {
       expect(mockDeps.messageDB.getSpaceMembers).not.toHaveBeenCalled();
     });
 
-    it('should NOT enqueue outbound sync envelopes (no member rekey messages)', async () => {
+    it('should send exactly one envelope, not one per member (no rekey loop)', async () => {
       const spaceId = 'space-no-outbounds';
       setupForPublicGen(spaceId);
 
       await invitationService.generateNewInviteLink(spaceId, {} as any, {} as any, {} as any);
 
-      expect(mockDeps.enqueueOutbound).not.toHaveBeenCalled();
+      // This asserted `enqueueOutbound` was NEVER called. That became false the
+      // moment the manifest broadcast was added, and the assertion kept passing
+      // only because broadcastSpaceManifest is mocked in this file — so it was
+      // describing the mock, not the code.
+      //
+      // The invariant it was actually guarding is that the pre-consolidation
+      // rekey loop is gone: one broadcast goes out regardless of member count,
+      // and the member list is never read.
+      expect(broadcastSpaceManifest).toHaveBeenCalledTimes(1);
+      expect(mockDeps.messageDB.getSpaceMembers).not.toHaveBeenCalled();
     });
 
     it('should call postSpaceManifest to refresh the on-server snapshot', async () => {

--- a/src/dev/tests/services/InvitationService.unit.test.tsx
+++ b/src/dev/tests/services/InvitationService.unit.test.tsx
@@ -9,7 +9,16 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { InvitationService } from '@/services/InvitationService';
+import { broadcastSpaceManifest } from '@/services/spaceManifestBroadcast';
+import { channel_raw as chRaw } from '@quilibrium/quilibrium-js-sdk-channels';
 import { QueryClient } from '@tanstack/react-query';
+
+// Stubbed so a test can read the manifest OBJECT handed to the broadcast.
+// Sealing it for real would only let us assert on ciphertext, and the property
+// that matters here is object identity with what was POSTed.
+vi.mock('@/services/spaceManifestBroadcast', () => ({
+  broadcastSpaceManifest: vi.fn(),
+}));
 
 // Mock multiformats sha256 so Buffer-based digest works in jsdom — under this
 // environment `Buffer instanceof Uint8Array` is false and multiformats' coerce()
@@ -868,14 +877,18 @@ describe('InvitationService - Unit Tests', () => {
     });
   });
 
-  describe('8. URL host override (qm.one -> app.quorummessenger.com)', () => {
-    // The buildInviteBase helper substitutes qm.one with app.quorummessenger.com
-    // to match mobile's generation host. We assert against the public-gen URL
-    // because the test env runs under jsdom (localhost), so the prod qm.one
-    // branch in shared's getInviteUrlBase isn't hit at runtime — but the
-    // .replace() in buildInviteBase is a deterministic string op so any URL
-    // emitted from prod-shaped paths will be cleaned.
-    it('should never emit qm.one in any generated invite URL', async () => {
+  describe('8. Generated invite URLs always carry the production host', () => {
+    // This used to assert only the ABSENCE of qm.one, which the test
+    // environment made free: jsdom serves from localhost, so the old
+    // environment-derived getInviteUrlBase returned a localhost base and the
+    // qm.one branch was never reached. The assertion could not have failed.
+    //
+    // It now asserts the host positively, which is the property that actually
+    // matters: a link generated on ANY build — localhost included, as here —
+    // must be one a recipient can open. Links are persisted into
+    // space.inviteUrl and replicated to every member, so a dev-host URL reaches
+    // real users as something they cannot use.
+    it('should emit app.quorummessenger.com even though the test env is localhost', async () => {
       const spaceId = 'space-host-override';
 
       // Private path
@@ -896,6 +909,8 @@ describe('InvitationService - Unit Tests', () => {
 
       const privateLink = await invitationService.constructInviteLink(spaceId);
       expect(privateLink).not.toContain('qm.one');
+      expect(privateLink).not.toContain('localhost');
+      expect(privateLink.startsWith('https://app.quorummessenger.com/')).toBe(true);
 
       // Public path
       mockDeps.messageDB.getSpace = vi.fn().mockResolvedValue({ spaceId, inviteUrl: null });
@@ -920,6 +935,107 @@ describe('InvitationService - Unit Tests', () => {
 
       const publicSaved = mockDeps.messageDB.saveSpace.mock.calls[0][0];
       expect(publicSaved.inviteUrl).not.toContain('qm.one');
+      expect(publicSaved.inviteUrl).not.toContain('localhost');
+      expect(
+        publicSaved.inviteUrl.startsWith('https://app.quorummessenger.com/invite/')
+      ).toBe(true);
+    });
+  });
+
+  describe('9. Generating a public link tells existing members', () => {
+    // The POST to the server is read by joiners and device restores only.
+    // Nothing refetches a manifest for someone already in the Space, so the
+    // hub control message is the ONLY way an existing member ever learns the
+    // link exists. Before this, the URL stayed on the owner's device until
+    // they happened to rename the Space or change its icon.
+    //
+    // This failure is silent — no error, the link simply never appears —
+    // which is why it needs pinning here rather than being left to notice.
+    const setUpOwnerWithEvals = (spaceId: string) => {
+      mockDeps.messageDB.getSpace = vi.fn().mockResolvedValue({ spaceId, inviteUrl: null });
+      mockDeps.messageDB.getSpaceKey = vi.fn().mockImplementation((_id: string, keyId: string) => {
+        if (keyId === 'owner') return Promise.resolve({ keyId: 'owner', address: 'owner-addr', publicKey: 'op', privateKey: 'opriv' });
+        if (keyId === 'hub') return Promise.resolve({ keyId: 'hub', address: 'hub-addr', publicKey: 'hp', privateKey: 'hpriv' });
+        if (keyId === 'config') return Promise.resolve({ keyId: 'config', address: 'cfg-addr', publicKey: 'cp', privateKey: 'cpriv' });
+        return Promise.resolve({ keyId, publicKey: 'p', privateKey: 'p' });
+      });
+      mockDeps.messageDB.getEncryptionStates = vi.fn().mockResolvedValue([
+        {
+          state: JSON.stringify({
+            state: JSON.stringify({ root_key: 'rk', id_peer_map: {}, peer_id_map: {} }),
+            template: { dkg_ratchet: JSON.stringify({ id: 1 }), root_key: 'rk' },
+            evals: [[1, 2]],
+          }),
+          conversationId: spaceId + '/' + spaceId,
+        },
+      ]);
+    };
+
+    it('broadcasts, rather than only POSTing to the server', async () => {
+      const spaceId = 'space-broadcasts';
+      setUpOwnerWithEvals(spaceId);
+
+      await invitationService.generateNewInviteLink(spaceId, {} as any, {} as any, {} as any);
+
+      expect(mockDeps.apiClient.postSpaceManifest).toHaveBeenCalledTimes(1);
+      expect(broadcastSpaceManifest).toHaveBeenCalledTimes(1);
+    });
+
+    it('broadcasts the SAME manifest object it POSTed, not a rebuilt one', async () => {
+      // The invite path encrypts its manifest with the same ephemeral X448 key
+      // as the invite eval. A second manifest built here would carry a
+      // different ephemeral key and break that pairing — the defect class
+      // behind months of "expired or invalid invite link" reports.
+      //
+      // Reference equality is the assertion precisely because a structurally
+      // identical copy is NOT good enough: toEqual would pass for a rebuild
+      // that happened to look the same, which is the bug.
+      const spaceId = 'space-same-manifest';
+      setUpOwnerWithEvals(spaceId);
+
+      await invitationService.generateNewInviteLink(spaceId, {} as any, {} as any, {} as any);
+
+      const posted = (mockDeps.apiClient.postSpaceManifest as any).mock.calls[0][1];
+      const broadcast = (broadcastSpaceManifest as any).mock.calls[0][1];
+
+      expect(broadcast).toBe(posted);
+    });
+
+    it('publishes a manifest that actually carries the new invite URL', async () => {
+      // The snapshot a joiner fetches is built from the `space` object. If the
+      // URL were assigned after encryption, the published manifest would
+      // describe a Space with no invite link — which is the bug the mobile
+      // client had.
+      const spaceId = 'space-manifest-carries-url';
+      setUpOwnerWithEvals(spaceId);
+
+      await invitationService.generateNewInviteLink(spaceId, {} as any, {} as any, {} as any);
+
+      const encryptArg = JSON.parse(
+        (chRaw.js_encrypt_inbox_message as any).mock.calls.at(-1)[0]
+      );
+      const publishedSpace = JSON.parse(
+        Buffer.from(new Uint8Array(encryptArg.plaintext)).toString('utf-8')
+      );
+
+      expect(publishedSpace.inviteUrl).toContain('app.quorummessenger.com');
+      expect(publishedSpace.modifiedDate).toBeGreaterThan(0);
+    });
+
+    it('bumps modifiedDate to the manifest timestamp, so the record stays monotonic', async () => {
+      // The receiver applies a manifest whose timestamp beats its stored
+      // modifiedDate, then writes the record wholesale. Broadcasting a fresh
+      // timestamp next to a stale modifiedDate would push the receiver's
+      // replay watermark BACKWARDS.
+      const spaceId = 'space-monotonic';
+      setUpOwnerWithEvals(spaceId);
+
+      await invitationService.generateNewInviteLink(spaceId, {} as any, {} as any, {} as any);
+
+      const posted = (mockDeps.apiClient.postSpaceManifest as any).mock.calls[0][1];
+      const saved = mockDeps.messageDB.saveSpace.mock.calls[0][0];
+
+      expect(saved.modifiedDate).toBe(posted.timestamp);
     });
   });
 

--- a/src/services/InvitationService.ts
+++ b/src/services/InvitationService.ts
@@ -13,14 +13,7 @@ import type { Space } from '@quilibrium/quorum-shared';
 import { isQuorumApiError } from '../api/baseTypes';
 import type { Ref } from '../types/ref';
 import type { SpaceInfoMap } from '../types/spaceRefs';
-
-// Mobile generates invite URLs with the long prod domain (app.quorummessenger.com).
-// Shared's getInviteUrlBase still emits qm.one for the prod browser case; override
-// here so desktop matches mobile until shared is updated in a separate cross-repo PR.
-// Acceptance of qm.one links keeps working via getValidInvitePrefixes().
-function buildInviteBase(isPublic: boolean): string {
-  return getInviteUrlBase(isPublic).replace('://qm.one/', '://app.quorummessenger.com/');
-}
+import { broadcastSpaceManifest } from './spaceManifestBroadcast';
 
 const MAX_PUBLIC_EVALS = 1;
 
@@ -130,7 +123,7 @@ export class InvitationService {
       { ...response[0], state: JSON.stringify(sets[0]) },
       true
     );
-    const link = `${buildInviteBase(false)}#spaceId=${spaceId}&configKey=${config_key.privateKey}&template=${template}&secret=${secret}&hubKey=${hub_key.privateKey}`;
+    const link = `${getInviteUrlBase(false)}#spaceId=${spaceId}&configKey=${config_key.privateKey}&template=${template}&secret=${secret}&hubKey=${hub_key.privateKey}`;
     return link;
   }
 
@@ -359,8 +352,17 @@ export class InvitationService {
       // Build the new public invite URL using the EXISTING config private key.
       // The URL string is therefore deterministic per space — regenerating
       // produces the same URL, only the server-side eval and manifest change.
-      const inviteLink = `${buildInviteBase(true)}#spaceId=${spaceId}&configKey=${configKey.privateKey}`;
+      const inviteLink = `${getInviteUrlBase(true)}#spaceId=${spaceId}&configKey=${configKey.privateKey}`;
+
+      // Both fields are set BEFORE the manifest is encrypted below, so the
+      // published snapshot carries them. modifiedDate matters as much as the
+      // URL: the receiving client applies a manifest whose timestamp is newer
+      // than its stored modifiedDate and then writes the record wholesale, so
+      // broadcasting a fresh timestamp alongside a stale modifiedDate would
+      // write the receiver's replay watermark BACKWARDS.
+      const ts = Date.now();
       space.inviteUrl = inviteLink;
+      space.modifiedDate = ts;
 
       // Re-publish the manifest encrypted with the existing config key. This
       // is what gives new joiners a current snapshot (name, members, channels)
@@ -375,7 +377,6 @@ export class InvitationService {
         } as secureChannel.SealedInboxMessageEncryptRequest)
       );
 
-      const ts = Date.now();
       const manifestSignaturePayloadBase64 = Buffer.from(
         new Uint8Array([
           ...new Uint8Array(Buffer.from(manifestCiphertext, 'utf-8')),
@@ -407,7 +408,7 @@ export class InvitationService {
       });
 
       // Re-publish the manifest.
-      await this.apiClient.postSpaceManifest(spaceId, {
+      const manifest: secureChannel.SpaceManifest = {
         space_address: spaceId,
         space_manifest: manifestCiphertext,
         ephemeral_public_key: ephemeralPublicKeyHex,
@@ -417,7 +418,22 @@ export class InvitationService {
           manifestSignatureBase64,
           'base64'
         ).toString('hex'),
-      });
+      };
+      await this.apiClient.postSpaceManifest(spaceId, manifest);
+
+      // Tell EXISTING members. The POST above serves joiners and device
+      // restores only — nothing refetches the manifest for someone already in
+      // the Space — so without this the new inviteUrl stayed on the owner's
+      // device until they happened to edit the Space for an unrelated reason.
+      //
+      // The SAME manifest object goes out, deliberately. Rebuilding one, or
+      // routing this through a helper that mints its own ephemeral key, would
+      // break the alignment between the eval's ephemeral key and the
+      // manifest's.
+      broadcastSpaceManifest(
+        { messageDB: this.messageDB, enqueueOutbound: this.enqueueOutbound },
+        manifest
+      );
 
       // Persist the new inviteUrl locally.
       await this.messageDB.saveSpace(space);

--- a/src/services/SpaceService.ts
+++ b/src/services/SpaceService.ts
@@ -12,6 +12,7 @@ import { t } from '@lingui/core/macro';
 import { QuorumApiClient } from '../api/baseTypes';
 import type { Ref } from '../types/ref';
 import type { SpaceInfoMap } from '../types/spaceRefs';
+import { broadcastSpaceManifest } from './spaceManifestBroadcast';
 
 // Type definitions for the service
 export interface SpaceServiceDependencies {
@@ -81,44 +82,22 @@ export class SpaceService {
 
   /**
    * Submits space manifest update via hub.
+   *
+   * Thin wrapper over `broadcastSpaceManifest` so InvitationService, which has
+   * no SpaceService reference, can send an identical envelope.
    */
   async submitUpdateSpace(manifest: secureChannel.SpaceManifest) {
+    // The swallow is preserved from the original rather than tidied away. It
+    // only ever covered a synchronous throw from enqueueOutbound (the sealing
+    // below runs later, inside the queue), so it is almost certainly dead — but
+    // this method is on the rename, icon and role paths, and changing when
+    // those surface an error is not this change's business. New callers use
+    // broadcastSpaceManifest directly and get the un-swallowed behaviour.
     try {
-      this.enqueueOutbound(async () => {
-        const hubKey = await this.messageDB.getSpaceKey(
-          manifest.space_address,
-          'hub'
-        );
-        const configKey = await this.messageDB.getSpaceKey(
-          manifest.space_address,
-          'config'
-        );
-        const envelope = await secureChannel.SealHubEnvelope(
-          hubKey.address!,
-          {
-            type: 'ed448',
-            private_key: [
-              ...hexToSpreadArray(hubKey.privateKey),
-            ],
-            public_key: [
-              ...hexToSpreadArray(hubKey.publicKey),
-            ],
-          },
-          JSON.stringify({
-            type: 'control',
-            message: {
-              type: 'space-manifest',
-              manifest: manifest,
-            },
-          }),
-          configKey ? {
-            type: 'x448',
-            public_key: [...hexToSpreadArray(configKey.publicKey)],
-            private_key: [...hexToSpreadArray(configKey.privateKey)],
-          } : undefined
-        );
-        return [JSON.stringify({ type: 'group', ...envelope })];
-      });
+      broadcastSpaceManifest(
+        { messageDB: this.messageDB, enqueueOutbound: this.enqueueOutbound },
+        manifest
+      );
     } catch { /* ignore */ }
   }
 

--- a/src/services/spaceManifestBroadcast.ts
+++ b/src/services/spaceManifestBroadcast.ts
@@ -1,0 +1,74 @@
+// Sending a space-manifest control message on the hub, in one place.
+//
+// This is the ONLY channel by which an already-joined member learns that a
+// Space record changed. The manifest POSTed to the server is read exclusively
+// by joiners and by device restores — no code path anywhere refetches it for an
+// existing member — so a change that is POSTed but not broadcast reaches nobody
+// who is already in the Space.
+//
+// Extracted as a free function rather than left as a SpaceService method
+// because InvitationService needs it too and holds no SpaceService reference:
+// InvitationService is constructed before SpaceService in MessageDB.tsx, so
+// injecting one would need a reorder or a lazy getter. This mirrors mobile,
+// where the equivalent (`sendSpaceManifestMessage`) is likewise a free
+// function.
+
+import { channel as secureChannel } from '@quilibrium/quilibrium-js-sdk-channels';
+import { MessageDB } from '../db/messages';
+import { hexToSpreadArray } from '../utils/crypto';
+
+export interface BroadcastSpaceManifestDeps {
+  messageDB: MessageDB;
+  enqueueOutbound: (action: () => Promise<string[]>) => void;
+}
+
+/**
+ * Tell every existing member about a Space manifest.
+ *
+ * Pass the SAME manifest object that was POSTed to the server. Do not rebuild
+ * one here and do not route a manifest through a helper that mints its own
+ * ephemeral key: the invite path deliberately encrypts its manifest with the
+ * same ephemeral X448 key as the invite eval, and re-publishing under a
+ * different key breaks the legacy-server fallback. That exact mismatch caused
+ * months of "expired or invalid public invite link" reports.
+ *
+ * Sealing happens inside `enqueueOutbound` so the keys are read at send time
+ * rather than at call time.
+ */
+export function broadcastSpaceManifest(
+  { messageDB, enqueueOutbound }: BroadcastSpaceManifestDeps,
+  manifest: secureChannel.SpaceManifest
+): void {
+  enqueueOutbound(async () => {
+    const hubKey = await messageDB.getSpaceKey(manifest.space_address, 'hub');
+    const configKey = await messageDB.getSpaceKey(
+      manifest.space_address,
+      'config'
+    );
+
+    const envelope = await secureChannel.SealHubEnvelope(
+      hubKey.address!,
+      {
+        type: 'ed448',
+        private_key: [...hexToSpreadArray(hubKey.privateKey)],
+        public_key: [...hexToSpreadArray(hubKey.publicKey)],
+      },
+      JSON.stringify({
+        type: 'control',
+        message: {
+          type: 'space-manifest',
+          manifest: manifest,
+        },
+      }),
+      configKey
+        ? {
+            type: 'x448',
+            public_key: [...hexToSpreadArray(configKey.publicKey)],
+            private_key: [...hexToSpreadArray(configKey.privateKey)],
+          }
+        : undefined
+    );
+
+    return [JSON.stringify({ type: 'group', ...envelope })];
+  });
+}


### PR DESCRIPTION
Generating a public invite link told nobody. This is the desktop half of a cross-client fix; the mobile half shipped as quorum-mobile #259 and the invite-domain change as quorum-shared #84.

### The gap

`generateNewInviteLink` POSTed the manifest to the server, saved locally, and stopped.

That POSTed manifest is read only by joiners and by device restores. No code path anywhere refetches it for someone already in the Space, so the hub `space-manifest` control message is the only channel that reaches an existing member, and the invite path never sent one. The new `inviteUrl` stayed on the owner's device until they happened to edit the Space for an unrelated reason, which broadcasts the whole record.

It fails silently. Nothing errors; the link simply never appears, which is indistinguishable from no link existing yet.

Who it bites: members who were already in the Space **before** the link was created. Someone who joins *via* the public link is fine, because the manifest they fetch on the way in already carries it. But the normal lifecycle is create a Space, invite the first people directly, open it up later, and those founding members are exactly the ones you would want sharing it. This repo's own non-owner Invites view is built entirely on the field they never receive.

### The fix

The manifest is now built into a variable, POSTed, and broadcast. Deliberately the **same object**, not a rebuild: the invite path encrypts its manifest with the same ephemeral X448 key as the invite eval, and re-publishing under a different key breaks that pairing, which is the defect class behind months of "expired or invalid invite link" reports. The new test asserts reference equality for that reason, since a structurally identical copy would still be wrong.

`modifiedDate` is bumped alongside `inviteUrl`, both set before the manifest is encrypted so the published snapshot carries them. Without the bump the broadcast would pair a fresh manifest timestamp with a stale `modifiedDate`, and since the receiver applies the manifest and then writes the record whole, that would push its replay watermark backwards.

Sealing moves into a free function (`spaceManifestBroadcast.ts`) so `InvitationService` can reach it: it holds no `SpaceService` reference and is constructed before one exists. `SpaceService.submitUpdateSpace` now delegates to it and produces a byte-for-byte identical envelope. It keeps its `try/catch` swallow, dead as that looks, because it also serves the rename, icon and role paths, and changing when those surface an error is not this change's business.

### Also

- Drops the local `buildInviteBase` wrapper, now that shared generates the production host itself. Two call sites bypassed that wrapper, so the same client minted two different domains depending on the path taken.
- Corrects the comment claiming the URL reaches members "via the encrypted manifest", which was the written form of this bug.
- Rewrites the invite-domain doc sections, which still described environment-derived generation as current and as an intentional staging-isolation feature. That design was deliberate and sound; what invalidated it was `inviteUrl` becoming replicated. The doc now records both.
- Fixes a pre-existing test that asserted `enqueueOutbound` was never called. That became false here, and kept passing only because this PR mocks the broadcast module, so it was describing the mock rather than the code. It now asserts the invariant it was really guarding: one envelope, not one per member.

### Filed, not fixed

`.agents/issues/.open/2026-08-19-desktop-applies-any-space-manifest-with-no-staleness-guard.md` — desktop's receive handler applies any owner-signed manifest with no timestamp comparison, where mobile skips stale ones. Pre-existing and not worsened here, but this PR makes broadcasts more frequent, and a correct fix needs an audit of whether every desktop sender populates `modifiedDate` first.

### Verification

1527 tests passing across 166 files, typecheck clean, lint clean. Four new tests plus two strengthened assertions, each verified red-on-revert.

**What this does not prove:** all of it is unit-level. It shows the right object goes into the right envelope; it does not show the envelope arrives. That needs the cross-client test — owner generates on one client, a member already in the Space on the other sees the link appear without the owner touching settings, with a member of a different Space as the control arm. That test is only runnable now that all three repos have their half.
