### PR TITLE
fix(auth): verify a message's signature at every point its sender is resolved

### DIFF
--- a/src/dev/tests/services/MessageService.unit.test.tsx
+++ b/src/dev/tests/services/MessageService.unit.test.tsx
@@ -50,7 +50,14 @@ vi.mock('@quilibrium/quilibrium-js-sdk-channels', () => ({
   },
   channel_raw: {
     js_sign_ed448: vi.fn().mockReturnValue(JSON.stringify('mock-signature')),
-    js_verify_ed448: vi.fn().mockReturnValue(true),
+    // The WASM primitive returns the STRING 'true'/'false', and production
+    // compares `=== 'true'`. A boolean here silently fails EVERY signature
+    // check, which turns "the signer was verified" tests into "rejected for an
+    // unrelated reason" tests that still pass — and leaves the ones that need a
+    // valid signature depending on a `mockReturnValue('true')` leaking out of
+    // some earlier sibling, since `clearAllMocks` clears calls but not
+    // implementations. Default to valid; override to 'false' to reject.
+    js_verify_ed448: vi.fn().mockReturnValue('true'),
   },
 }));
 
@@ -452,13 +459,19 @@ describe('MessageService - Unit Tests', () => {
       expect(mockDeps.messageDB.deleteMessage).not.toHaveBeenCalled();
     });
 
-    it('DROPS a SIGNED space delete when the signer is not the author and has no role', async () => {
+    it('DROPS a SIGNED space delete whose signer claims to be someone else', async () => {
       // Signer resolves to 'mallory' (a real member) but claims senderId=original-sender.
+      //
+      // Mallory is deliberately given message:delete here. Without it the
+      // permission check denies this on its own and the test passes without
+      // ever reaching the senderId binding it exists to pin — which is what it
+      // used to do. With the role, the ONLY thing that can stop it is the
+      // verified-signer-vs-claimed-sender comparison.
       const publicKey = 'ffeeddccbbaa99887766554433221100';
       mockDeps.messageDB.getMessage = vi.fn().mockResolvedValue(spaceTarget);
       mockDeps.messageDB.getSpace = vi.fn().mockResolvedValue({
         spaceId: 'space',
-        roles: [],
+        roles: [{ roleId: 'r', members: ['mallory'], permissions: ['message:delete'] }],
         groups: [],
       });
       mockDeps.messageDB.getSpaceMembers = vi.fn().mockResolvedValue([
@@ -695,9 +708,19 @@ describe('MessageService - Unit Tests', () => {
       expect(mockDeps.messageDB.muteUser).not.toHaveBeenCalled();
     });
 
-    it('DROPS a SIGNED mute whose signer is not the claimed moderator', async () => {
+    it('DROPS a SIGNED mute whose signer claims to be the moderator', async () => {
       const publicKey = 'ff00ff00ff00ff00ff00ff00ff00ff00';
-      // Key belongs to 'mallory' (no mute role); payload claims 'mod'.
+      // Key belongs to 'mallory'; payload claims 'mod'. Mallory is given
+      // user:mute deliberately — without it the permission check denies this
+      // by itself and the test never reaches the senderId binding it names.
+      mockDeps.messageDB.getSpace = vi.fn().mockResolvedValue({
+        spaceId: 'space',
+        roles: [
+          { members: ['mod'], permissions: ['user:mute'] },
+          { members: ['mallory'], permissions: ['user:mute'] },
+        ],
+        groups: [],
+      });
       mockDeps.messageDB.getSpaceMembers = vi
         .fn()
         .mockResolvedValue([{ address: 'mallory', inbox_address: deriveInboxAddress(publicKey) }]);

--- a/src/dev/tests/services/MessageService.unit.test.tsx
+++ b/src/dev/tests/services/MessageService.unit.test.tsx
@@ -26,7 +26,12 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { MessageService, MessageServiceDependencies } from '@/services/MessageService';
-import { deriveInboxAddress, buildDeviceKeyStatementBytes } from '@quilibrium/quorum-shared';
+import {
+  deriveInboxAddress,
+  buildDeviceKeyStatementBytes,
+  buildMessageFingerprint,
+  computeMessageIdHex,
+} from '@quilibrium/quorum-shared';
 import { channel_raw } from '@quilibrium/quilibrium-js-sdk-channels';
 import { QueryClient } from '@tanstack/react-query';
 
@@ -48,6 +53,39 @@ vi.mock('@quilibrium/quilibrium-js-sdk-channels', () => ({
     js_verify_ed448: vi.fn().mockReturnValue(true),
   },
 }));
+
+/**
+ * Stamp the messageId a real client would produce: the hash of the message's
+ * own fingerprint. Auth paths recompute it and reject a mismatch, so a fixture
+ * carrying an arbitrary id is refused before any signature is looked at.
+ *
+ * These ids used to be arbitrary strings (or 64 zeros) and still passed,
+ * because `setup.ts` stubs `crypto.subtle.digest` to return 32 zero bytes for
+ * EVERY input — which made the recompute inert and let any id match. Sender
+ * verification now runs real SHA-256, so fixtures have to be well-formed to
+ * stand in for genuine traffic.
+ */
+const withRealMessageId = <
+  T extends {
+    nonce: string;
+    spaceId: string;
+    channelId: string;
+    content: { senderId: string };
+  },
+>(
+  msg: T
+): T => ({
+  ...msg,
+  messageId: computeMessageIdHex(
+    buildMessageFingerprint({
+      nonce: msg.nonce,
+      content: msg.content as never,
+      senderId: msg.content.senderId,
+      spaceId: msg.spaceId,
+      channelId: msg.channelId,
+    })
+  ),
+});
 
 describe('MessageService - Unit Tests', () => {
   let messageService: MessageService;
@@ -348,28 +386,30 @@ describe('MessageService - Unit Tests', () => {
       lastModifiedHash: 'hash',
       content: { senderId: 'original-sender', type: 'post', text: 'Message' },
     };
-    const spaceRemove = (over: Record<string, unknown> = {}) => ({
-      messageId: 'remove-123',
-      spaceId: 'space',
-      channelId: 'channel',
-      createdDate: Date.now(),
-      modifiedDate: Date.now(),
-      digestAlgorithm: 'sha256' as const,
-      nonce: 'nonce',
-      lastModifiedHash: 'hash',
-      content: {
-        senderId: 'original-sender',
-        type: 'remove-message',
-        removeMessageId: 'msg-to-remove',
-      },
-      ...over,
-    });
+    const spaceRemove = (over: Record<string, unknown> = {}) =>
+      withRealMessageId({
+        messageId: 'remove-123',
+        spaceId: 'space',
+        channelId: 'channel',
+        createdDate: Date.now(),
+        modifiedDate: Date.now(),
+        digestAlgorithm: 'sha256' as const,
+        nonce: 'nonce',
+        lastModifiedHash: 'hash',
+        content: {
+          senderId: 'original-sender',
+          type: 'remove-message',
+          removeMessageId: 'msg-to-remove',
+        },
+        ...over,
+      });
 
     it('honors a SIGNED space delete when the verified signer authored the target', async () => {
       // The verified sender is derived from the signing key, not the payload.
       // Register a member whose inbox_address matches this public key so the
       // reverse lookup resolves to 'original-sender'.
       const publicKey = 'aabbccddeeff00112233445566778899';
+      vi.mocked(channel_raw.js_verify_ed448).mockReturnValue('true');
       mockDeps.messageDB.getMessage = vi.fn().mockResolvedValue(spaceTarget);
       mockDeps.messageDB.getSpace = vi.fn().mockResolvedValue({
         spaceId: 'space',
@@ -603,7 +643,7 @@ describe('MessageService - Unit Tests', () => {
   // the spoofable payload senderId (same class as remove/edit).
   describe('3d. addMessage() - Space mute authorization (anti-spoofing)', () => {
     const muteMsg = (over: Record<string, unknown> = {}) =>
-      ({
+      withRealMessageId({
         messageId: 'mute-1',
         spaceId: 'space',
         channelId: 'channel',
@@ -629,6 +669,7 @@ describe('MessageService - Unit Tests', () => {
 
     it('honors a SIGNED mute from the verified user:mute role holder', async () => {
       const publicKey = '11223344556677889900aabbccddeeff';
+      vi.mocked(channel_raw.js_verify_ed448).mockReturnValue('true');
       mockDeps.messageDB.getSpaceMembers = vi
         .fn()
         .mockResolvedValue([{ address: 'mod', inbox_address: deriveInboxAddress(publicKey) }]);
@@ -702,11 +743,8 @@ describe('MessageService - Unit Tests', () => {
         content: { senderId: 'manager', type: 'post', text: 'announce' },
         ...over,
       }) as any;
-    // The test harness mocks crypto.subtle.digest to return 32 zero bytes, so
-    // the signed-post's messageId must match that (64 hex zeros) to pass the
-    // fingerprint recompute in isReadOnlyPostAuthorized.
     const signedManagerPost = () =>
-      roPost({ messageId: '0'.repeat(64), publicKey: mgrPub, signature: 'sig' });
+      withRealMessageId(roPost({ publicKey: mgrPub, signature: 'sig' }));
 
     beforeEach(() => {
       mockDeps.messageDB.getSpace = vi.fn().mockResolvedValue(roSpace);
@@ -777,12 +815,13 @@ describe('MessageService - Unit Tests', () => {
         queryClient,
         'space',
         RO,
-        roPost({
-          messageId: '0'.repeat(64),
-          publicKey: mgrPub,
-          signature: 'sig',
-          content: { senderId: 'manager', type: 'embed', imageUrl: 'x' },
-        })
+        withRealMessageId(
+          roPost({
+            publicKey: mgrPub,
+            signature: 'sig',
+            content: { senderId: 'manager', type: 'embed', imageUrl: 'x' },
+          })
+        )
       );
       expect(spy).toHaveBeenCalled();
     });
@@ -823,7 +862,9 @@ describe('MessageService - Unit Tests', () => {
         ...over,
       }) as any;
     const signedManagerPost = (over: Record<string, unknown> = {}) =>
-      roPost({ messageId: '0'.repeat(64), publicKey: mgrPub, signature: 'sig', ...over });
+      withRealMessageId(
+        roPost({ publicKey: mgrPub, signature: 'sig', ...over })
+      );
 
     const save = (msg: any) =>
       messageService.saveMessage(
@@ -907,7 +948,7 @@ describe('MessageService - Unit Tests', () => {
     const victimInbox = deriveInboxAddress(victimPub);
 
     const upMsg = (over: Record<string, unknown> = {}) =>
-      ({
+      withRealMessageId({
         messageId: 'up-1',
         spaceId: 'space',
         channelId: 'space',
@@ -933,6 +974,10 @@ describe('MessageService - Unit Tests', () => {
       );
 
     beforeEach(() => {
+      // The signature must actually check out for these cases to say anything
+      // about authorization: an invalid one is now rejected before the
+      // key->member lookup, which is what makes the lookup's answer meaningful.
+      vi.mocked(channel_raw.js_verify_ed448).mockReturnValue('true');
       mockDeps.messageDB.saveSpaceMember = vi.fn().mockResolvedValue(undefined);
       mockDeps.messageDB.getSpaceMember = vi.fn().mockResolvedValue(null);
       mockDeps.messageDB.getSpaceMembers = vi.fn().mockResolvedValue([]);
@@ -1546,11 +1591,15 @@ describe('MessageService - Unit Tests', () => {
       revoked: false,
     };
     // remove-message of Alice's own message, signed by her SECOND device key.
-    const removeOwn = {
+    const removeOwn = withRealMessageId({
+      messageId: '',
+      spaceId: SPACE,
+      channelId: CHANNEL,
+      nonce: 'n-pdk',
       publicKey: DEVICE_KEY_PUB,
       signature: 'sig',
       content: { type: 'remove-message', senderId: ALICE, removeMessageId: 'm1' },
-    } as any;
+    }) as any;
     const targetByAlice = { content: { senderId: ALICE, type: 'post' } } as any;
 
     beforeEach(() => {

--- a/src/dev/tests/services/verifiedSenderRequiresVerification.test.ts
+++ b/src/dev/tests/services/verifiedSenderRequiresVerification.test.ts
@@ -194,6 +194,98 @@ describe('a sender identity is never derived from an unverified key', () => {
       'no ed448 verification ran, so any sender this path resolved is unproven'
     ).toHaveBeenCalled();
   });
+
+  /**
+   * SCOPE BINDING. A control-message signature covers the space and channel it
+   * was signed for. The question is which scope the receiver checks against:
+   * the one the message CLAIMS (attacker-controlled) or the one the action will
+   * actually land in.
+   *
+   * Checking the claimed scope is self-defeating: the attacker picks both the
+   * claim and the signature, so they always agree, and the signature ends up
+   * attesting one place while the delete/pin/mute happens somewhere else.
+   * Mobile binds the context scope on purpose (`spaceMessageAuth.ts:70-73`);
+   * these tests hold desktop to the same rule.
+   */
+  describe('a control message acts only in the scope its signature names', () => {
+    const CHANNEL = 'chan-1';
+    const OTHER_SPACE = 'space-2';
+    const OTHER_CHANNEL = 'chan-2';
+
+    /** A remove-message genuinely signed for `spaceId`/`channelId`. */
+    const controlSignedFor = (spaceId: string, channelId: string) => {
+      const nonce = 'nonce-scope';
+      const content = {
+        type: 'remove-message' as const,
+        senderId: VICTIM,
+        removeMessageId: 'target-1',
+      };
+      return {
+        spaceId,
+        channelId,
+        nonce,
+        messageId: computeMessageIdHex(
+          buildMessageFingerprint({
+            nonce,
+            content: content as never,
+            senderId: VICTIM,
+            spaceId,
+            channelId,
+          })
+        ),
+        digestAlgorithm: 'SHA-256' as const,
+        createdDate: Date.now(),
+        modifiedDate: Date.now(),
+        lastModifiedHash: '',
+        content,
+        publicKey: VICTIM_PUB,
+        signature: 'ab'.repeat(114),
+      };
+    };
+
+    /** Their own message, so permissions never enter into the verdict. */
+    const target = { content: { senderId: VICTIM, type: 'post' } };
+
+    /** Always delivered into SPACE / CHANNEL, whatever the message claims. */
+    const authorizeHere = (msg: unknown) =>
+      (
+        messageService as unknown as {
+          isSpaceControlAuthorized: (
+            ...a: unknown[]
+          ) => Promise<boolean>;
+        }
+      ).isSpaceControlAuthorized(
+        msg,
+        mockDeps.messageDB,
+        SPACE,
+        CHANNEL,
+        target
+      );
+
+    it('CONTROL ARM: signed for THIS scope, and honoured', async () => {
+      verifyEd448.mockReturnValue('true');
+      expect(
+        await authorizeHere(controlSignedFor(SPACE, CHANNEL)),
+        'a correctly scoped control message stopped working'
+      ).toBe(true);
+    });
+
+    it('signed for ANOTHER space, so it must not act here', async () => {
+      verifyEd448.mockReturnValue('true');
+      expect(
+        await authorizeHere(controlSignedFor(OTHER_SPACE, CHANNEL)),
+        'a signature naming a different space authorized an action in this one'
+      ).toBe(false);
+    });
+
+    it('signed for ANOTHER channel, so it must not act here', async () => {
+      verifyEd448.mockReturnValue('true');
+      expect(
+        await authorizeHere(controlSignedFor(SPACE, OTHER_CHANNEL)),
+        'a signature naming a different channel authorized an action in this one'
+      ).toBe(false);
+    });
+  });
 });
 
 /**

--- a/src/dev/tests/services/verifiedSenderRequiresVerification.test.ts
+++ b/src/dev/tests/services/verifiedSenderRequiresVerification.test.ts
@@ -24,6 +24,8 @@
  * before trusting either result.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 
 /** Controllable ed448 verdict. The WASM primitive returns the STRING 'true'. */
 const verifyEd448 = vi.fn<(...args: string[]) => string>();
@@ -191,5 +193,46 @@ describe('a sender identity is never derived from an unverified key', () => {
       verifyEd448,
       'no ed448 verification ran, so any sender this path resolved is unproven'
     ).toHaveBeenCalled();
+  });
+});
+
+/**
+ * SOURCE GUARD. The behavioural tests above cover the paths a fixture can
+ * reach; this covers the ones it cannot, and it is the cheaper half of the
+ * defence. It matches text, so a reformat defeats it — what it can do is make
+ * reintroducing the unsafe shape loud instead of silent.
+ */
+describe('the unverified resolver cannot come back', () => {
+  const SOURCE = readFileSync(
+    resolve(process.cwd(), 'src/services/MessageService.ts'),
+    'utf8'
+  );
+
+  it('MessageService neither imports nor calls the raw reverse lookup', () => {
+    // `resolveVerifiedSender` runs no cryptography. Reaching it directly means
+    // some path can obtain an identity without a signature check — the defect
+    // the fused primitive exists to make unrepresentable.
+    //
+    // Matches an import entry or a call, NOT the name in prose: several
+    // comments legitimately explain what the reverse lookup is and why it must
+    // be fed a verified key, and those should stay.
+    expect(
+      /^\s*resolveVerifiedSender,\s*$/m.test(SOURCE),
+      'MessageService imported the no-crypto reverse lookup again; use verifySpaceSender'
+    ).toBe(false);
+    expect(
+      /\bresolveVerifiedSender\s*\(/.test(SOURCE),
+      'MessageService called the no-crypto reverse lookup again; use verifySpaceSender'
+    ).toBe(false);
+  });
+
+  it('every sender resolution goes through verifySpaceSender', () => {
+    // One definition, and at least the four auth paths consuming it: control
+    // messages, update-profile, read-only posts, and the @everyone gate.
+    const uses = SOURCE.match(/\bverifySpaceSender\b/g) ?? [];
+    expect(
+      uses.length,
+      'a sender-resolution call site was added or removed — re-check that each one verifies'
+    ).toBeGreaterThanOrEqual(5);
   });
 });

--- a/src/dev/tests/services/verifiedSenderRequiresVerification.test.ts
+++ b/src/dev/tests/services/verifiedSenderRequiresVerification.test.ts
@@ -1,0 +1,195 @@
+/**
+ * INSTRUMENT for the verify/resolve fusion.
+ *
+ * THE INVARIANT: a sender identity may only be derived from a signing key whose
+ * signature this client actually checked. `resolveVerifiedSender` is a REVERSE
+ * LOOKUP (key -> inbox address -> member) and runs no cryptography of its own —
+ * it trusts that its caller already verified. That trust is currently carried by
+ * a comment (`MessageService.ts`, above `resolveSpaceSender`) rather than by the
+ * types, so a handler that calls the lookup without satisfying the distant
+ * verify gate gets an identity that merely looks proven.
+ *
+ * WHY update-profile IS THE PROBE. The verify gate opens for non-repudiable
+ * spaces, for `CONTROL_MESSAGE_TYPES`, and for @everyone posts. `update-profile`
+ * is none of those, so in a REPUDIABLE space the gate never runs and
+ * `isUpdateProfileAuthorized` resolves a key nothing checked. Its blast radius is
+ * bounded today — the handler refuses to write `inbox_address`, so the residual
+ * is the cosmetic display-name spoof accepted in
+ * `.done/2026-07-19-update-profile-inbox-poisoning-control-msg-impersonation.md`
+ * — but the *shape* is the bug, and it is the shape that generalises.
+ *
+ * CONTROL ARM, ON PURPOSE. Two cases differing in exactly one variable: whether
+ * ed448 verification succeeds. A correct implementation separates them. If both
+ * arms move together the harness is measuring something else — fix the harness
+ * before trusting either result.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/** Controllable ed448 verdict. The WASM primitive returns the STRING 'true'. */
+const verifyEd448 = vi.fn<(...args: string[]) => string>();
+
+vi.mock('@quilibrium/quilibrium-js-sdk-channels', () => ({
+  channel: {
+    TripleRatchetEncrypt: vi.fn(),
+    DoubleRatchetInboxEncrypt: vi.fn().mockReturnValue([]),
+    DoubleRatchetInboxEncryptForceSenderInit: vi.fn().mockReturnValue([]),
+  },
+  channel_raw: {
+    js_sign_ed448: vi.fn().mockReturnValue(JSON.stringify('mock-signature')),
+    js_verify_ed448: (...args: string[]) => verifyEd448(...args),
+  },
+}));
+
+import {
+  MessageService,
+  type MessageServiceDependencies,
+} from '@/services/MessageService';
+import {
+  buildMessageFingerprint,
+  computeMessageIdHex,
+  deriveInboxAddress,
+} from '@quilibrium/quorum-shared';
+
+const SPACE = 'space-1';
+const VICTIM = 'victim-address';
+
+/**
+ * The victim's ed448 public key. Public by construction: it rides on every
+ * signed message they send, so possessing it proves nothing. Only a signature
+ * over this specific message does.
+ */
+const VICTIM_PUB =
+  '2222222222222222222222222222222222222222222222222222222222222222';
+const VICTIM_INBOX = deriveInboxAddress(VICTIM_PUB);
+
+/** An update-profile whose messageId genuinely matches its own fingerprint. */
+const buildProfileMessage = () => {
+  const nonce = 'nonce-probe';
+  const content = {
+    type: 'update-profile' as const,
+    senderId: VICTIM,
+    displayName: 'Name The Victim Did Not Choose',
+  };
+  return {
+    spaceId: SPACE,
+    channelId: SPACE,
+    nonce,
+    messageId: computeMessageIdHex(
+      buildMessageFingerprint({
+        nonce,
+        content: content as never,
+        senderId: VICTIM,
+        spaceId: SPACE,
+        channelId: SPACE,
+      })
+    ),
+    digestAlgorithm: 'SHA-256' as const,
+    createdDate: Date.now(),
+    modifiedDate: Date.now(),
+    lastModifiedHash: '',
+    content,
+    publicKey: VICTIM_PUB,
+    // Well-formed hex, wrong bytes: what an attacker without the private key
+    // can produce. Distinguishing this from a real signature is the whole job.
+    signature: 'ab'.repeat(114),
+  };
+};
+
+describe('a sender identity is never derived from an unverified key', () => {
+  let messageService: MessageService;
+  let mockDeps: MessageServiceDependencies;
+
+  beforeEach(() => {
+    verifyEd448.mockReset();
+    mockDeps = {
+      messageDB: {
+        saveMessage: vi.fn().mockResolvedValue(undefined),
+        getMessage: vi.fn().mockResolvedValue(null),
+        getSpace: vi.fn().mockResolvedValue({
+          spaceId: SPACE,
+          // The gate's blind spot: repudiable, so a non-control type is never
+          // routed through the verify block at all.
+          isRepudiable: true,
+          groups: [],
+          roles: [],
+        }),
+        getSpaceMember: vi.fn().mockResolvedValue({
+          user_address: VICTIM,
+          address: VICTIM,
+          inbox_address: VICTIM_INBOX,
+        }),
+        getSpaceMembers: vi.fn().mockResolvedValue([
+          { user_address: VICTIM, address: VICTIM, inbox_address: VICTIM_INBOX },
+        ]),
+        getSpaceMemberDevices: vi.fn().mockResolvedValue([]),
+        saveSpaceMember: vi.fn().mockResolvedValue(undefined),
+        isMessageDeleted: vi.fn().mockResolvedValue(false),
+        updateMessage: vi.fn().mockResolvedValue(undefined),
+      } as unknown as MessageServiceDependencies['messageDB'],
+      enqueueOutbound: vi.fn(),
+      addOrUpdateConversation: vi.fn(),
+      apiClient: {} as never,
+      deleteEncryptionStates: vi.fn().mockResolvedValue(undefined),
+      deleteInboxMessages: vi.fn().mockResolvedValue(undefined),
+      navigate: vi.fn(),
+      spaceInfo: { current: {} } as never,
+      syncInfo: { current: {} } as never,
+      synchronizeAll: vi.fn().mockResolvedValue(undefined),
+      informSyncData: vi.fn().mockResolvedValue(undefined),
+      initiateSync: vi.fn().mockResolvedValue(undefined),
+      requestSync: vi.fn().mockResolvedValue(undefined),
+      directSync: vi.fn().mockResolvedValue(undefined),
+      saveConfig: vi.fn().mockResolvedValue(undefined),
+      sendHubMessage: vi.fn().mockResolvedValue('message-id'),
+    } as unknown as MessageServiceDependencies;
+
+    messageService = new MessageService(mockDeps);
+  });
+
+  const receive = () =>
+    messageService.saveMessage(
+      buildProfileMessage() as never,
+      mockDeps.messageDB,
+      SPACE,
+      SPACE,
+      'group',
+      {},
+      null,
+      undefined
+    );
+
+  it('ATTACK ARM: a forged signature over a real member key is rejected', async () => {
+    verifyEd448.mockReturnValue('false');
+
+    await receive();
+
+    expect(
+      mockDeps.messageDB.saveSpaceMember,
+      'the victim profile was rewritten by a message carrying a signature nobody checked'
+    ).not.toHaveBeenCalled();
+  });
+
+  it('CONTROL ARM: a genuine signature over the same key is still accepted', async () => {
+    verifyEd448.mockReturnValue('true');
+
+    await receive();
+
+    expect(
+      mockDeps.messageDB.saveSpaceMember,
+      'the fix over-rejected: a legitimately signed profile update stopped applying'
+    ).toHaveBeenCalled();
+  });
+
+  it('the ed448 verifier is actually consulted on this path', async () => {
+    verifyEd448.mockReturnValue('true');
+
+    await receive();
+
+    // The directest statement of the invariant. Zero calls means the identity
+    // came from a reverse lookup over a key no cryptography ever touched.
+    expect(
+      verifyEd448,
+      'no ed448 verification ran, so any sender this path resolved is unproven'
+    ).toHaveBeenCalled();
+  });
+});

--- a/src/dev/tests/setup.ts
+++ b/src/dev/tests/setup.ts
@@ -39,6 +39,15 @@ beforeAll(() => {
         importKey: vi.fn(),
         encrypt: vi.fn(),
         decrypt: vi.fn(),
+        // ⚠️ Returns 32 ZERO BYTES for EVERY input, so any code that hashes
+        // here produces the same digest for all content. Every "recompute the
+        // fingerprint and compare the messageId" check thus compares a constant
+        // to a constant and cannot fail. That silently made nine signature-auth
+        // tests pass while verifying nothing (2026-08-20), and the inline
+        // verify blocks in MessageService.handleNewMessage still hash this way,
+        // so they remain untestable through this setup. If you are testing
+        // anything signature-related, either drive code that uses the shared
+        // primitive (noble SHA-256, not stubbed) or replace this stub locally.
         digest: vi.fn().mockResolvedValue(new ArrayBuffer(32)),
       },
     },

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -2020,24 +2020,27 @@ export class MessageService {
   private async verifySpaceSender(
     message: Message,
     messageDB: MessageDB,
-    lookupSpaceId: string,
+    // SCOPE — the space/channel the action will actually APPLY in, never the
+    // one the message claims. Control-type fingerprints bind these, so checking
+    // the claimed scope would be self-defeating: an attacker picks both the
+    // claim and the signature, so the two always agree, and the signature ends
+    // up attesting one place while the delete/pin/mute lands in another.
+    // Matches mobile, which binds the context scope for this reason
+    // (services/space/spaceMessageAuth.ts). Inert for non-control types, whose
+    // fingerprints carry no scope at all.
+    scopeSpaceId: string,
+    scopeChannelId: string,
     members?: SpaceMemberRow[]
   ): Promise<VerifiedSenderResult> {
     const [resolvedMembers, deviceKeys] = await Promise.all([
-      members ?? messageDB.getSpaceMembers(lookupSpaceId),
-      messageDB.getSpaceMemberDevices(lookupSpaceId),
+      members ?? messageDB.getSpaceMembers(scopeSpaceId),
+      messageDB.getSpaceMemberDevices(scopeSpaceId),
     ]);
     type Params = Parameters<typeof verifyAndResolveSender>[0];
     return verifyAndResolveSender({
       message,
-      // SCOPE: the WIRE spaceId/channelId, which is exactly what the receive
-      // path's verify blocks have always bound, so this stays a pure security
-      // change. Mobile deliberately binds the CONTEXT scope instead (see
-      // services/space/spaceMessageAuth.ts) so a signature can never attest one
-      // scope while the action lands in another. Aligning desktop is a real
-      // behaviour change and is tracked separately — do not switch it silently.
-      scopeSpaceId: message.spaceId,
-      scopeChannelId: message.channelId,
+      scopeSpaceId,
+      scopeChannelId,
       members: resolvedMembers as unknown as Params['members'],
       deviceKeys: deviceKeys as unknown as Params['deviceKeys'],
       provider: this.signingProvider,
@@ -2127,6 +2130,7 @@ export class MessageService {
       decryptedContent,
       messageDB,
       spaceId,
+      channelId,
       members
     );
     return authorizeControlMessage({
@@ -2304,13 +2308,15 @@ export class MessageService {
   private async isUpdateProfileAuthorized(
     decryptedContent: Message,
     messageDB: MessageDB,
-    spaceId: string
+    spaceId: string,
+    channelId: string
   ): Promise<boolean> {
     const members = await messageDB.getSpaceMembers(spaceId);
     const { signatureValid, sender } = await this.verifySpaceSender(
       decryptedContent,
       messageDB,
       spaceId,
+      channelId,
       members
     );
     // An unchecked signature proves nothing, so it must not buy the bootstrap
@@ -2346,6 +2352,7 @@ export class MessageService {
       decryptedContent,
       this.messageDB,
       space.spaceId,
+      channel.channelId,
       members
     );
     return (
@@ -2804,7 +2811,8 @@ export class MessageService {
         !(await this.isUpdateProfileAuthorized(
           decryptedContent,
           messageDB,
-          spaceId
+          spaceId,
+          channelId
         ))
       ) {
         return;
@@ -3360,7 +3368,8 @@ export class MessageService {
         !(await this.isUpdateProfileAuthorized(
           decryptedContent,
           this.messageDB,
-          spaceId
+          spaceId,
+          channelId
         ))
       ) {
         return;
@@ -7034,7 +7043,8 @@ export class MessageService {
             const { sender: everyoneSender } = await this.verifySpaceSender(
               decryptedContent,
               this.messageDB,
-              spaceId
+              spaceId,
+              channelId
             );
             const isMentioned =
               isMentionedWithSettings(decryptedContent, {

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -2020,14 +2020,24 @@ export class MessageService {
   private async verifySpaceSender(
     message: Message,
     messageDB: MessageDB,
-    // SCOPE — the space/channel the action will actually APPLY in, never the
-    // one the message claims. Control-type fingerprints bind these, so checking
-    // the claimed scope would be self-defeating: an attacker picks both the
-    // claim and the signature, so the two always agree, and the signature ends
-    // up attesting one place while the delete/pin/mute lands in another.
-    // Matches mobile, which binds the context scope for this reason
+    // SCOPE — the space/channel the action will actually APPLY in. Control-type
+    // fingerprints bind these, so verifying against the scope the message
+    // CLAIMS is self-defeating: the attacker picks the claim and the signature
+    // together, so they always agree, and the signature ends up attesting one
+    // place while the delete/pin/mute lands in another. Matches mobile
     // (services/space/spaceMessageAuth.ts). Inert for non-control types, whose
     // fingerprints carry no scope at all.
+    //
+    // HONEST LIMIT, worth knowing before relying on this: only the SPACE half
+    // is independently sourced. `spaceId` comes from the delivering session
+    // (`conversationId.split('/')[0]`), which an attacker cannot choose without
+    // actually being in that space. `channelId` has no such independent source
+    // — a space is one group-encryption scope and the channel is a plaintext
+    // label inside it, so the context channel IS the wire channel. It is safe
+    // today only because the same variable also drives every target lookup
+    // (`getMessage({spaceId, channelId, messageId})`), so verification and
+    // effect cannot be pointed at different channels. If channels ever gain
+    // their own keys or an independent source, re-check this.
     scopeSpaceId: string,
     scopeChannelId: string,
     members?: SpaceMemberRow[]
@@ -2135,7 +2145,10 @@ export class MessageService {
     );
     return authorizeControlMessage({
       content: decryptedContent.content as ControlMessageContent,
-      verifiedSender,
+      // `?? null` is the union collapsing, not a shortcut: an unverified result
+      // carries NO sender field at all, and both that and a verified-but-
+      // unresolvable key mean the same thing downstream — nobody proven.
+      verifiedSender: verifiedSender ?? null,
       space: space ?? undefined,
       channel,
       targetMessage,
@@ -5406,6 +5419,16 @@ export class MessageService {
             // Verify signatures for non-repudiable spaces (all types) AND for
             // control messages in ANY space — control auth must not depend on
             // repudiability, or a repudiable space would skip the gate.
+            //
+            // ⚠️ VESTIGIAL as an AUTHORIZATION gate. No auth decision depends on
+            // this block any more: every one re-verifies at its own call site
+            // via `verifySpaceSender`, which fails closed independently. What
+            // this still does is strip an unverifiable signature off the stored
+            // row (and drop update-profile below), which the display layer
+            // reads. Note it fingerprints the WIRE scope, the pattern the auth
+            // paths deliberately moved away from — harmless here because
+            // nothing authorizes on the result, but do not copy it, and do not
+            // assume auth is relying on it.
             if (
               space &&
               decryptedContent.publicKey &&
@@ -6508,6 +6531,12 @@ export class MessageService {
                 for (const message of envelope.message.messages) {
                   // Verify non-repudiable (all types) + control messages (any
                   // space) — control auth must not depend on repudiability.
+                  //
+                  // ⚠️ VESTIGIAL as an AUTHORIZATION gate — same as the live
+                  // path's block: auth re-verifies at its own call site via
+                  // `verifySpaceSender`. This only strips unverifiable
+                  // signatures off stored rows, and it fingerprints the WIRE
+                  // scope, which the auth paths deliberately no longer do.
                   if (
                     space &&
                     message.publicKey &&

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -16,7 +16,7 @@ import {
   SimpleRateLimiter,
   RATE_LIMITS,
   buildMessageFingerprint,
-  resolveVerifiedSender,
+  verifyAndResolveSender,
   authorizeControlMessage,
   isControlMessageType,
   shouldSignEdit,
@@ -28,6 +28,7 @@ import {
   applyEdit,
   getConversationSetting,
   type ControlMessageContent,
+  type VerifiedSenderResult,
   type DeviceKeyStatement,
   type AnnounceKeysStatement,
   type RevokeDeviceStatement,
@@ -1987,9 +1988,9 @@ export class MessageService {
    * fail closed) — never the spoofable payload senderId — and returns the
    * shared allow/drop verdict. Must be applied identically in both the DB
    * (saveMessage) and cache (addMessage) handlers so they can't disagree.
-   * `decryptedContent.publicKey` is non-null only after signature verification
-   * (see the verify blocks); unsigned/invalid control messages resolve to a
-   * null sender and are dropped (except the unsigned-edit-of-unsigned case).
+   * The signature is verified HERE (see verifySpaceSender) rather than assumed
+   * from the receive-path gate, so unsigned/invalid control messages resolve to
+   * a null sender and are dropped (except the unsigned-edit-of-unsigned case).
    */
   /**
    * Ed448 verifier in the shape shared's verifyDeviceKeyStatement expects,
@@ -2001,23 +2002,46 @@ export class MessageService {
   };
 
   /**
-   * Resolve a verified signer against BOTH the join-bound member table and the
-   * per-device signing keys admitted via master-signed statements. Every
-   * control/read-only/update-profile auth path funnels through here so the
-   * two lookup paths stay consistent.
+   * Verify a space message's ed448 signature AND resolve its signer, against
+   * both the join-bound member table and the per-device signing keys admitted
+   * via master-signed statements. Every control/read-only/update-profile/
+   * @everyone auth path funnels through here.
+   *
+   * Replaces the previous raw-publicKey resolver. That form took a key and
+   * returned an identity without checking anything, which was only safe while a
+   * distant gate in the receive path happened to have verified this message's
+   * type — a precondition carried by a comment, invisible to the type system,
+   * and silently absent for any type not on that gate's list. Verification is
+   * local now, so a new message type cannot inherit a false guarantee.
+   *
+   * `result.sender` is non-null only when `result.signatureValid`; callers that
+   * need proof of authorship must not read one without the other.
    */
-  private async resolveSpaceSender(
-    publicKey: string,
+  private async verifySpaceSender(
+    message: Message,
     messageDB: MessageDB,
-    spaceId: string,
-    members: SpaceMemberRow[]
-  ) {
-    const deviceKeys = await messageDB.getSpaceMemberDevices(spaceId);
-    return resolveVerifiedSender(
-      publicKey,
-      members as unknown as Parameters<typeof resolveVerifiedSender>[1],
-      deviceKeys as unknown as Parameters<typeof resolveVerifiedSender>[2]
-    );
+    lookupSpaceId: string,
+    members?: SpaceMemberRow[]
+  ): Promise<VerifiedSenderResult> {
+    const [resolvedMembers, deviceKeys] = await Promise.all([
+      members ?? messageDB.getSpaceMembers(lookupSpaceId),
+      messageDB.getSpaceMemberDevices(lookupSpaceId),
+    ]);
+    type Params = Parameters<typeof verifyAndResolveSender>[0];
+    return verifyAndResolveSender({
+      message,
+      // SCOPE: the WIRE spaceId/channelId, which is exactly what the receive
+      // path's verify blocks have always bound, so this stays a pure security
+      // change. Mobile deliberately binds the CONTEXT scope instead (see
+      // services/space/spaceMessageAuth.ts) so a signature can never attest one
+      // scope while the action lands in another. Aligning desktop is a real
+      // behaviour change and is tracked separately — do not switch it silently.
+      scopeSpaceId: message.spaceId,
+      scopeChannelId: message.channelId,
+      members: resolvedMembers as unknown as Params['members'],
+      deviceKeys: deviceKeys as unknown as Params['deviceKeys'],
+      provider: this.signingProvider,
+    });
   }
 
   /**
@@ -2099,14 +2123,12 @@ export class MessageService {
       ?.find((g) => g.channels.find((c) => c.channelId === channelId))
       ?.channels.find((c) => c.channelId === channelId);
     const members = await messageDB.getSpaceMembers(spaceId);
-    const verifiedSender = decryptedContent.publicKey
-      ? await this.resolveSpaceSender(
-          decryptedContent.publicKey,
-          messageDB,
-          spaceId,
-          members
-        )
-      : null;
+    const { sender: verifiedSender } = await this.verifySpaceSender(
+      decryptedContent,
+      messageDB,
+      spaceId,
+      members
+    );
     return authorizeControlMessage({
       content: decryptedContent.content as ControlMessageContent,
       verifiedSender,
@@ -2284,20 +2306,25 @@ export class MessageService {
     messageDB: MessageDB,
     spaceId: string
   ): Promise<boolean> {
-    if (!decryptedContent.publicKey || !decryptedContent.signature) {
-      return false;
-    }
     const members = await messageDB.getSpaceMembers(spaceId);
-    const verifiedSender = await this.resolveSpaceSender(
-      decryptedContent.publicKey,
+    const { signatureValid, sender } = await this.verifySpaceSender(
+      decryptedContent,
       messageDB,
       spaceId,
       members
     );
-    return (
-      verifiedSender === null ||
-      verifiedSender === decryptedContent.content.senderId
-    );
+    // An unchecked signature proves nothing, so it must not buy the bootstrap
+    // exemption below. This path used to resolve the key WITHOUT verifying:
+    // `update-profile` is not a control type, so in a repudiable space the
+    // receive-path gate never ran and a forged signature over a real member's
+    // (public) key resolved to that member.
+    if (!signatureValid) return false;
+    // A key already registered to a member may speak only for THAT member. A
+    // key registered to nobody is accepted as a rotation/bootstrap announcement
+    // so a member whose join broadcast never arrived can still surface a
+    // display name — the residual accepted in #243, bounded because the handler
+    // never writes the announced key onto the row.
+    return sender === null || sender === decryptedContent.content.senderId;
   }
 
   /**
@@ -2315,41 +2342,14 @@ export class MessageService {
     channel: Channel,
     members: SpaceMemberRow[]
   ): Promise<boolean> {
-    if (!decryptedContent.publicKey || !decryptedContent.signature) {
-      return false;
-    }
-    const messageId = await crypto.subtle.digest(
-      'SHA-256',
-      Buffer.from(
-        buildMessageFingerprint({
-          nonce: decryptedContent.nonce,
-          content: decryptedContent.content as any,
-          senderId: decryptedContent.content.senderId,
-          spaceId: decryptedContent.spaceId,
-          channelId: decryptedContent.channelId,
-        }),
-        'utf-8'
-      )
-    );
-    if (
-      decryptedContent.messageId !== Buffer.from(messageId).toString('hex') ||
-      ch.js_verify_ed448(
-        Buffer.from(decryptedContent.publicKey, 'hex').toString('base64'),
-        Buffer.from(messageId).toString('base64'),
-        Buffer.from(decryptedContent.signature, 'hex').toString('base64')
-      ) !== 'true'
-    ) {
-      return false;
-    }
-    const verifiedSender = await this.resolveSpaceSender(
-      decryptedContent.publicKey,
+    const { sender } = await this.verifySpaceSender(
+      decryptedContent,
       this.messageDB,
       space.spaceId,
       members
     );
     return (
-      !!verifiedSender &&
-      canManageReadOnlyChannel(verifiedSender, false, space, channel)
+      !!sender && canManageReadOnlyChannel(sender, false, space, channel)
     );
   }
 
@@ -7024,20 +7024,18 @@ export class MessageService {
               ?.map(role => role.roleId) ?? [];
 
             // @everyone gate: honor it only if the VERIFIED signer (not the
-            // spoofable payload senderId) held mention:everyone. The verify
-            // block above always verifies @everyone-bearing posts, so a present
-            // publicKey here is proven. We drop `space` from
+            // spoofable payload senderId) held mention:everyone. Verification
+            // happens here rather than being inherited from the receive-path
+            // gate, so this holds even if that gate stops covering @everyone
+            // posts. We drop `space` from
             // isMentionedWithSettings (disabling its payload-based @everyone
             // check) and do the @everyone check ourselves against the verified
             // signer; user/@role checks are unaffected (they don't use space).
-            const everyoneSender = decryptedContent.publicKey
-              ? await this.resolveSpaceSender(
-                  decryptedContent.publicKey,
-                  this.messageDB,
-                  spaceId,
-                  await this.messageDB.getSpaceMembers(spaceId)
-                )
-              : null;
+            const { sender: everyoneSender } = await this.verifySpaceSender(
+              decryptedContent,
+              this.messageDB,
+              spaceId
+            );
             const isMentioned =
               isMentionedWithSettings(decryptedContent, {
                 userAddress: self_address,


### PR DESCRIPTION
Routes every receive-side authorization path through the fused verify-and-resolve primitive added in QuilibriumNetwork/quorum-shared#86.

`resolveSpaceSender` took a raw public key and returned an identity without checking anything. That is only sound while a gate elsewhere in the receive path has already verified this message's type — a precondition held by a comment, invisible to the type system, and not inherited by anything added later.

`verifySpaceSender` replaces it and verifies locally. All four paths now use it: control messages, profile updates, read-only-channel posts, and the @everyone mention gate. `isReadOnlyPostAuthorized` was already self-contained and loses its hand-rolled copy of the same logic.

### Signature validity and identity are now separate questions

`isUpdateProfileAuthorized` rejects an invalid signature outright, while still accepting a valid signature from a key registered to no member — the bootstrap case that lets a member whose join broadcast never arrived surface a display name (#243's documented residual, unchanged).

### Scope binding follows the mobile client

A control signature is checked against the space and channel the action applies in, rather than the ones the message carries. For legitimate traffic these are the same value, so nothing changes; they differ only when a message names a scope other than the one delivering it.

Only the space half is independently sourced — the channel has no separate source in this architecture — and that limit is written down at the call site rather than implied.

The two inline verify blocks in `handleNewMessage` are deliberately untouched and are now annotated as vestigial for authorization purposes: every decision re-verifies at its own call site, and those blocks only strip unverifiable signatures off stored rows.

### Tests

1609 passing, plus 8/8 of the space harness scenarios against the live relay (including the kick path, which exercises key rotation and re-established group ratchets).

Each new check was verified by removing it and confirming a specific test fails.

Nine existing tests needed well-formed fixtures. They carried arbitrary `messageId`s and passed because `setup.ts` stubs `crypto.subtle.digest` to return 32 zero bytes for every input, which made the fingerprint comparison inert. All nine were "accept the legitimate signed message" cases; no rejection test changed. The stub now carries a warning, and two negative tests that were being satisfied by the permission check rather than the identity check were tightened so they exercise what their names claim.
