### PR TITLE
fix(threads): authorize thread actions against the verified signer

### DIFF
--- a/src/dev/tests/services/ThreadService.unit.test.ts
+++ b/src/dev/tests/services/ThreadService.unit.test.ts
@@ -30,58 +30,15 @@ describe('ThreadService', () => {
     threadService = new ThreadService(mockDB);
   });
 
-  describe('isThreadAuthorized', () => {
-    it('returns true when sender is thread creator', async () => {
-      const result = await threadService.isThreadAuthorized({
-        senderId: 'user-a',
-        createdBy: 'user-a',
-        spaceId: 'space-1',
-      });
-      expect(result).toBe(true);
-      // Should NOT call getSpace — short-circuits on author match
-      expect(mockDB.getSpace).not.toHaveBeenCalled();
-    });
-
-    it('returns true when sender has message:delete permission', async () => {
-      (mockDB.getSpace as any).mockResolvedValue({
-        roles: [{
-          members: ['user-mod'],
-          permissions: ['message:delete'],
-        }],
-      });
-      const result = await threadService.isThreadAuthorized({
-        senderId: 'user-mod',
-        createdBy: 'user-other',
-        spaceId: 'space-1',
-      });
-      expect(result).toBe(true);
-    });
-
-    it('returns false when sender is neither author nor has permission', async () => {
-      (mockDB.getSpace as any).mockResolvedValue({
-        roles: [{
-          members: ['user-mod'],
-          permissions: ['message:pin'],  // wrong permission
-        }],
-      });
-      const result = await threadService.isThreadAuthorized({
-        senderId: 'user-random',
-        createdBy: 'user-other',
-        spaceId: 'space-1',
-      });
-      expect(result).toBe(false);
-    });
-
-    it('returns false when space has no roles', async () => {
-      (mockDB.getSpace as any).mockResolvedValue({ roles: undefined });
-      const result = await threadService.isThreadAuthorized({
-        senderId: 'user-random',
-        createdBy: 'user-other',
-        spaceId: 'space-1',
-      });
-      expect(result).toBe(false);
-    });
-  });
+  // The `isThreadAuthorized` block that used to sit here was deleted with the
+  // method. It fed the helper raw `senderId` strings, so it passed identically
+  // whether callers supplied a verified sender or a payload claim — it could
+  // not have detected the bug that made this rewrite necessary.
+  //
+  // The rule itself now lives in shared `authorizeThreadAction` and is unit
+  // tested there. Whether callers reach it with a PROVEN identity is covered by
+  // threadActionsRequireVerifiedSender.test.ts, which is the part that has to
+  // be tested through the public API to mean anything.
 
   describe('handleThreadReceive', () => {
     it('rejects DMs (spaceId === channelId)', async () => {
@@ -122,6 +79,7 @@ describe('ThreadService', () => {
         threadMsg,
         spaceId: 'space-1',
         channelId: 'channel-1',
+        verifiedSender: threadMsg.senderId as any,
         currentUserAddress: 'user-a',
         conversationType: 'group',
         updatedUserProfile: { user_icon: '', display_name: '' },
@@ -150,6 +108,7 @@ describe('ThreadService', () => {
         threadMsg,
         spaceId: 'space-1',
         channelId: 'channel-1',
+        verifiedSender: threadMsg.senderId as any,
         currentUserAddress: 'user-a',
         conversationType: 'group',
         updatedUserProfile: { user_icon: '', display_name: '' },
@@ -177,6 +136,7 @@ describe('ThreadService', () => {
         threadMsg,
         spaceId: 'space-1',
         channelId: 'channel-1',
+        verifiedSender: threadMsg.senderId as any,
         currentUserAddress: 'user-a',
         conversationType: 'group',
         updatedUserProfile: { user_icon: '', display_name: '' },
@@ -206,6 +166,7 @@ describe('ThreadService', () => {
         threadMsg,
         spaceId: 'space-1',
         channelId: 'channel-1',
+        verifiedSender: threadMsg.senderId as any,
         currentUserAddress: 'user-a',
         conversationType: 'group',
         updatedUserProfile: { user_icon: '', display_name: '' },
@@ -238,6 +199,7 @@ describe('ThreadService', () => {
         threadMsg,
         spaceId: 'space-1',
         channelId: 'channel-1',
+        verifiedSender: threadMsg.senderId as any,
         currentUserAddress: 'user-a',
         conversationType: 'group',
         updatedUserProfile: { user_icon: '', display_name: '' },
@@ -268,6 +230,7 @@ describe('ThreadService', () => {
         threadMsg,
         spaceId: 'space-1',
         channelId: 'channel-1',
+        verifiedSender: threadMsg.senderId as any,
         currentUserAddress: 'user-a',
         conversationType: 'group',
         updatedUserProfile: { user_icon: '', display_name: '' },
@@ -297,6 +260,7 @@ describe('ThreadService', () => {
         threadMsg,
         spaceId: 'space-1',
         channelId: 'channel-1',
+        verifiedSender: threadMsg.senderId as any,
         currentUserAddress: 'user-a',
         conversationType: 'group',
         updatedUserProfile: { user_icon: '', display_name: '' },
@@ -329,6 +293,7 @@ describe('ThreadService', () => {
         threadMsg,
         spaceId: 'space-1',
         channelId: 'channel-1',
+        verifiedSender: threadMsg.senderId as any,
         currentUserAddress: 'user-a',
         conversationType: 'group',
         updatedUserProfile: { user_icon: '', display_name: '' },
@@ -353,6 +318,7 @@ describe('ThreadService', () => {
         threadMsg,
         spaceId: 'space-1',
         channelId: 'channel-1',
+        verifiedSender: threadMsg.senderId as any,
         currentUserAddress: 'user-a',
         conversationType: 'group',
         updatedUserProfile: { user_icon: '', display_name: '' },
@@ -382,6 +348,7 @@ describe('ThreadService', () => {
         threadMsg,
         spaceId: 'space-1',
         channelId: 'channel-1',
+        verifiedSender: threadMsg.senderId as any,
         currentUserAddress: 'user-a',
         conversationType: 'group',
         updatedUserProfile: { user_icon: '', display_name: '' },
@@ -412,6 +379,7 @@ describe('ThreadService', () => {
         threadMsg,
         spaceId: 'space-1',
         channelId: 'channel-1',
+        verifiedSender: threadMsg.senderId as any,
         currentUserAddress: 'user-a',
         conversationType: 'group',
         updatedUserProfile: { user_icon: '', display_name: '' },
@@ -509,6 +477,7 @@ describe('ThreadService', () => {
         threadMsg,
         spaceId: 'same',
         channelId: 'same',
+        verifiedSender: threadMsg.senderId as any,
         queryClient,
       });
       expect(result).toBe(false);
@@ -531,6 +500,7 @@ describe('ThreadService', () => {
         threadMsg,
         spaceId: 'space-1',
         channelId: 'channel-1',
+        verifiedSender: threadMsg.senderId as any,
         queryClient,
       });
       expect(result).toBe(false);
@@ -561,6 +531,7 @@ describe('ThreadService', () => {
         threadMsg,
         spaceId: 'space-1',
         channelId: 'channel-1',
+        verifiedSender: threadMsg.senderId as any,
         queryClient,
       });
       expect(result).toBe(true);

--- a/src/dev/tests/services/threadActionsRequireVerifiedSender.test.ts
+++ b/src/dev/tests/services/threadActionsRequireVerifiedSender.test.ts
@@ -13,6 +13,8 @@
  * `verifyAndResolveSender` tests and by MessageService.unit.test.tsx.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { QueryClient } from '@tanstack/react-query';
 import { ThreadService } from '@/services/ThreadService';
 import type { MessageDB } from '@/db/messages';
@@ -306,6 +308,46 @@ describe('thread actions are authorized against the verified signer', () => {
       expect(honored).toBe(false);
     });
 
+    it('ATTACK: a close frame cannot rewrite createdBy in the live cache', async () => {
+      // The DB path pins ownership; if the cache path does not, the attacker's
+      // chosen name is what every participant SEES as the thread creator, even
+      // though authorization keeps re-reading the correct value from storage.
+      (mockDB.getMessage as any).mockResolvedValue(aliceRootWithThread());
+      (mockDB.getSpace as any).mockResolvedValue({
+        roles: [{ members: [MODERATOR], permissions: ['message:delete'] }],
+      });
+      const queryClient = new QueryClient();
+      // Must match buildMessagesKeyPrefix (['Messages', spaceId, channelId])
+      // plus the variant segment, or setQueriesData writes nothing and this
+      // test passes while exercising none of the code it names.
+      const CACHE_KEY = ['Messages', 'space-1', 'channel-1', 'with-threads'];
+      queryClient.setQueryData(CACHE_KEY, {
+        pageParams: [undefined],
+        pages: [{ messages: [aliceRootWithThread()] }],
+      });
+
+      await threadService.handleThreadCache({
+        threadMsg: threadFrame({
+          senderId: MODERATOR,
+          action: 'close',
+          threadMeta: {
+            threadId: 'thread-1',
+            createdBy: MODERATOR,
+            isClosed: true,
+          },
+        }),
+        spaceId: 'space-1',
+        channelId: 'channel-1',
+        queryClient,
+        verifiedSender: MODERATOR,
+      });
+
+      const cached: any = queryClient.getQueryData(CACHE_KEY);
+      const root = cached.pages[0].messages[0];
+      expect(root.threadMeta.isClosed).toBe(true); // the action DID apply
+      expect(root.threadMeta.createdBy).toBe(ALICE); // ownership did NOT move
+    });
+
     it('CONTROL: the real creator still removes it from the cache', async () => {
       (mockDB.getMessage as any).mockResolvedValue(aliceRootWithThread());
 
@@ -319,5 +361,51 @@ describe('thread actions are authorized against the verified signer', () => {
 
       expect(honored).toBe(true);
     });
+  });
+});
+
+/**
+ * SOURCE GUARD — catches a failure the behavioural tests above structurally
+ * cannot see.
+ *
+ * The receive side refuses thread frames without a valid signature. The send
+ * side must therefore never honor the "send unsigned" toggle for one. The first
+ * attempt at that fix was placed in a branch thread messages never enter
+ * (`if (isPostMessage)`, which explicitly excludes them), so it compiled,
+ * type-checked, passed every test, and did nothing.
+ *
+ * Nothing above could have caught it: those tests inject `verifiedSender`
+ * directly and never exercise the send path's signing decision. The failure
+ * mode it leaves behind is the worst kind here — the sender's own client
+ * applies a thread deletion, every other client discards the frame, and no
+ * error is raised on either side.
+ *
+ * So this asserts the shape instead: no send branch may decide signing from the
+ * raw toggle. They must all route through the shared `shouldSignOutbound`,
+ * which derives the answer from the same list the receive side enforces.
+ */
+describe('the send path cannot silently emit an unsignable control frame', () => {
+  const source = readFileSync(
+    resolve(__dirname, '../../../services/MessageService.ts'),
+    'utf-8'
+  );
+
+  it('decides outbound signing only through the shared helper', () => {
+    // The pre-fix shape, verified present at HEAD~ before this guard existed.
+    expect(source).not.toMatch(/isRepudiable\s*&&\s*!skipSigning/);
+  });
+
+  it('routes the thread and pin send branches through it', () => {
+    const calls = source.match(/shouldSignOutbound\(\{/g) ?? [];
+    expect(calls.length).toBeGreaterThanOrEqual(3);
+    expect(source).toMatch(/contentType: 'thread'/);
+    expect(source).toMatch(/contentType: 'pin'/);
+  });
+
+  it('leaves edits on the inherit rule, which must NOT force-sign', () => {
+    // An edit of a deliberately-unsigned message must stay unsigned, or
+    // deniability is destroyed by the act of editing.
+    expect(source).toMatch(/shouldSignEdit\(originalMessage\)/);
+    expect(source).not.toMatch(/contentType: 'edit-message'/);
   });
 });

--- a/src/dev/tests/services/threadActionsRequireVerifiedSender.test.ts
+++ b/src/dev/tests/services/threadActionsRequireVerifiedSender.test.ts
@@ -1,0 +1,323 @@
+/**
+ * Thread control frames must be authorized against the ed448-VERIFIED signer,
+ * never against `threadMsg.senderId` — a plaintext field the sending client
+ * writes and any space member can set to anyone's address.
+ *
+ * Every ATTACK ARM here fails against the pre-fix code, and each is paired with
+ * a CONTROL ARM performing the same action as its legitimate owner. Without the
+ * pairing, deleting the feature outright would score as a fix.
+ *
+ * These are unit tests over ThreadService because that is where the decision is
+ * made. What feeds it — MessageService resolving the signer via
+ * `verifySpaceSender` before calling in — is covered by the shared
+ * `verifyAndResolveSender` tests and by MessageService.unit.test.tsx.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient } from '@tanstack/react-query';
+import { ThreadService } from '@/services/ThreadService';
+import type { MessageDB } from '@/db/messages';
+import type { Message, ThreadMessage } from '@quilibrium/quorum-shared';
+
+// Invented addresses. Never use a real account address in a fixture.
+const ALICE = 'QmAliceVictimAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+const MALLORY = 'QmMalloryAttackerMMMMMMMMMMMMMMMMMMMMMMMMMMMM';
+const MODERATOR = 'QmModeratorMoOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOO';
+
+/** Alice's post, carrying a thread Alice opened on it. */
+function aliceRootWithThread(): Message {
+  return {
+    messageId: 'msg-root',
+    content: { type: 'post', senderId: ALICE, text: 'a message worth keeping' },
+    threadMeta: { threadId: 'thread-1', createdBy: ALICE },
+  } as unknown as Message;
+}
+
+function threadFrame(overrides: Partial<ThreadMessage> = {}): ThreadMessage {
+  return {
+    type: 'thread',
+    senderId: ALICE,
+    targetMessageId: 'msg-root',
+    action: 'remove',
+    threadMeta: { threadId: 'thread-1', createdBy: ALICE },
+    ...overrides,
+  } as ThreadMessage;
+}
+
+function createMockMessageDB(overrides: Partial<MessageDB> = {}): MessageDB {
+  return {
+    getMessage: vi.fn().mockResolvedValue(null),
+    getSpace: vi.fn().mockResolvedValue({ roles: [] }),
+    getChannelThread: vi.fn().mockResolvedValue(null),
+    getChannelThreads: vi.fn().mockResolvedValue([]),
+    getThreadMessages: vi
+      .fn()
+      .mockResolvedValue({ messages: [], replyCount: 0 }),
+    saveMessage: vi.fn().mockResolvedValue(undefined),
+    saveChannelThread: vi.fn().mockResolvedValue(undefined),
+    deleteMessage: vi.fn().mockResolvedValue(undefined),
+    deleteChannelThread: vi.fn().mockResolvedValue(undefined),
+    getConversation: vi.fn().mockResolvedValue({ conversation: null }),
+    ...overrides,
+  } as unknown as MessageDB;
+}
+
+const RECEIVE_CONTEXT = {
+  spaceId: 'space-1',
+  channelId: 'channel-1',
+  currentUserAddress: 'QmLocalReaderRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRR',
+  conversationType: 'group',
+  updatedUserProfile: { user_icon: '', display_name: '' },
+};
+
+describe('thread actions are authorized against the verified signer', () => {
+  let threadService: ThreadService;
+  let mockDB: MessageDB;
+
+  beforeEach(() => {
+    mockDB = createMockMessageDB();
+    threadService = new ThreadService(mockDB);
+  });
+
+  describe('remove — the destructive one', () => {
+    it('ATTACK: a member claiming to be the creator cannot delete the root message', async () => {
+      (mockDB.getMessage as any).mockResolvedValue(aliceRootWithThread());
+
+      const honored = await threadService.handleThreadReceive({
+        ...RECEIVE_CONTEXT,
+        // Mallory writes ALICE into the payload. Free to do: the address is
+        // public, and pre-fix this field alone decided the outcome.
+        threadMsg: threadFrame({ senderId: ALICE, action: 'remove' }),
+        verifiedSender: MALLORY,
+      });
+
+      expect(honored).toBe(false);
+      expect(mockDB.deleteMessage).not.toHaveBeenCalled();
+      expect(mockDB.deleteChannelThread).not.toHaveBeenCalled();
+    });
+
+    it('CONTROL: the real creator still removes their own thread and root', async () => {
+      (mockDB.getMessage as any).mockResolvedValue(aliceRootWithThread());
+
+      const honored = await threadService.handleThreadReceive({
+        ...RECEIVE_CONTEXT,
+        threadMsg: threadFrame({ senderId: ALICE, action: 'remove' }),
+        verifiedSender: ALICE,
+      });
+
+      expect(honored).toBe(true);
+      expect(mockDB.deleteMessage).toHaveBeenCalledWith('msg-root');
+      expect(mockDB.deleteChannelThread).toHaveBeenCalledWith('thread-1');
+    });
+
+    it('CONTROL: a moderator removes the thread but does NOT hard-delete a message they did not write', async () => {
+      (mockDB.getMessage as any).mockResolvedValue(aliceRootWithThread());
+      (mockDB.getSpace as any).mockResolvedValue({
+        roles: [{ members: [MODERATOR], permissions: ['message:delete'] }],
+      });
+
+      const honored = await threadService.handleThreadReceive({
+        ...RECEIVE_CONTEXT,
+        threadMsg: threadFrame({ senderId: MODERATOR, action: 'remove' }),
+        verifiedSender: MODERATOR,
+      });
+
+      expect(honored).toBe(true);
+      // Alice's post survives with its threadMeta stripped.
+      expect(mockDB.deleteMessage).not.toHaveBeenCalled();
+      expect(mockDB.saveMessage).toHaveBeenCalled();
+      const saved = (mockDB.saveMessage as any).mock.calls[0][0] as Message;
+      expect(saved.threadMeta).toBeUndefined();
+    });
+
+    it('ATTACK: a moderator cannot hard-delete the root by claiming to be its author', async () => {
+      (mockDB.getMessage as any).mockResolvedValue(aliceRootWithThread());
+      (mockDB.getSpace as any).mockResolvedValue({
+        roles: [{ members: [MODERATOR], permissions: ['message:delete'] }],
+      });
+
+      // Authorized to act on the thread, but claims ALICE so the hard-delete
+      // branch (`isRootSender`) fires instead of the strip branch.
+      await threadService.handleThreadReceive({
+        ...RECEIVE_CONTEXT,
+        threadMsg: threadFrame({ senderId: ALICE, action: 'remove' }),
+        verifiedSender: MODERATOR,
+      });
+
+      expect(mockDB.deleteMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('close / updateTitle', () => {
+    it('ATTACK: a member claiming to be the creator cannot close the thread', async () => {
+      (mockDB.getMessage as any).mockResolvedValue(aliceRootWithThread());
+
+      const honored = await threadService.handleThreadReceive({
+        ...RECEIVE_CONTEXT,
+        threadMsg: threadFrame({
+          senderId: ALICE,
+          action: 'close',
+          threadMeta: { threadId: 'thread-1', createdBy: ALICE, isClosed: true },
+        }),
+        verifiedSender: MALLORY,
+      });
+
+      expect(honored).toBe(false);
+      expect(mockDB.saveMessage).not.toHaveBeenCalled();
+    });
+
+    it('CONTROL: the real creator closes their own thread', async () => {
+      (mockDB.getMessage as any).mockResolvedValue(aliceRootWithThread());
+
+      const honored = await threadService.handleThreadReceive({
+        ...RECEIVE_CONTEXT,
+        threadMsg: threadFrame({
+          senderId: ALICE,
+          action: 'close',
+          threadMeta: { threadId: 'thread-1', createdBy: ALICE, isClosed: true },
+        }),
+        verifiedSender: ALICE,
+      });
+
+      expect(honored).toBe(true);
+      expect(mockDB.saveMessage).toHaveBeenCalled();
+    });
+
+    it('ATTACK: a member claiming to be the creator cannot rename the thread', async () => {
+      (mockDB.getMessage as any).mockResolvedValue(aliceRootWithThread());
+
+      const honored = await threadService.handleThreadReceive({
+        ...RECEIVE_CONTEXT,
+        threadMsg: threadFrame({
+          senderId: ALICE,
+          action: 'updateTitle',
+          threadMeta: {
+            threadId: 'thread-1',
+            createdBy: ALICE,
+            customTitle: 'renamed by the attacker',
+          },
+        }),
+        verifiedSender: MALLORY,
+      });
+
+      expect(honored).toBe(false);
+      expect(mockDB.saveMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('createdBy is owned by the verifier, not by the wire', () => {
+    it('ATTACK: create cannot install someone else as the thread creator', async () => {
+      (mockDB.getMessage as any).mockResolvedValue({
+        messageId: 'msg-root',
+        content: { type: 'post', senderId: ALICE, text: 'a message' },
+        threadMeta: undefined,
+      } as unknown as Message);
+
+      await threadService.handleThreadReceive({
+        ...RECEIVE_CONTEXT,
+        threadMsg: threadFrame({
+          senderId: MALLORY,
+          action: 'create',
+          // Mallory names ALICE as creator, which pre-fix was copied verbatim
+          // and then became the anchor for every later authorization check.
+          threadMeta: { threadId: 'thread-1', createdBy: ALICE },
+        }),
+        verifiedSender: MALLORY,
+      });
+
+      expect(mockDB.saveChannelThread).toHaveBeenCalled();
+      const savedThread = (mockDB.saveChannelThread as any).mock.calls[0][0];
+      expect(savedThread.createdBy).toBe(MALLORY);
+
+      const savedMessage = (mockDB.saveMessage as any).mock
+        .calls[0][0] as Message;
+      expect(savedMessage.threadMeta?.createdBy).toBe(MALLORY);
+    });
+
+    it('ATTACK: a later frame cannot rewrite createdBy to seize the thread', async () => {
+      (mockDB.getMessage as any).mockResolvedValue(aliceRootWithThread());
+      (mockDB.getSpace as any).mockResolvedValue({
+        roles: [{ members: [MODERATOR], permissions: ['message:delete'] }],
+      });
+
+      // Legitimately authorized to close, but smuggles a new createdBy in the
+      // merged threadMeta — which would make them the permanent owner.
+      await threadService.handleThreadReceive({
+        ...RECEIVE_CONTEXT,
+        threadMsg: threadFrame({
+          senderId: MODERATOR,
+          action: 'close',
+          threadMeta: {
+            threadId: 'thread-1',
+            createdBy: MODERATOR,
+            isClosed: true,
+          },
+        }),
+        verifiedSender: MODERATOR,
+      });
+
+      expect(mockDB.saveMessage).toHaveBeenCalled();
+      const saved = (mockDB.saveMessage as any).mock.calls[0][0] as Message;
+      expect(saved.threadMeta?.createdBy).toBe(ALICE);
+    });
+  });
+
+  describe('an unverifiable frame is never honored', () => {
+    it.each(['remove', 'close', 'reopen', 'updateSettings', 'updateTitle', 'create'] as const)(
+      'drops %s when no sender could be verified',
+      async (action) => {
+        (mockDB.getMessage as any).mockResolvedValue(aliceRootWithThread());
+
+        const honored = await threadService.handleThreadReceive({
+          ...RECEIVE_CONTEXT,
+          threadMsg: threadFrame({
+            senderId: ALICE,
+            action,
+            // A NEW threadId for 'create', or the idempotency short-circuit
+            // returns false before authorization is ever consulted and the
+            // case passes without testing anything.
+            threadMeta: {
+              threadId: action === 'create' ? 'thread-2' : 'thread-1',
+              createdBy: ALICE,
+            },
+          }),
+          verifiedSender: null,
+        });
+
+        expect(honored).toBe(false);
+        expect(mockDB.deleteMessage).not.toHaveBeenCalled();
+        expect(mockDB.saveMessage).not.toHaveBeenCalled();
+        expect(mockDB.saveChannelThread).not.toHaveBeenCalled();
+      }
+    );
+  });
+
+  describe('the cache path enforces the same rule', () => {
+    it('ATTACK: a forged remove does not strip the thread from the cache', async () => {
+      (mockDB.getMessage as any).mockResolvedValue(aliceRootWithThread());
+
+      const honored = await threadService.handleThreadCache({
+        threadMsg: threadFrame({ senderId: ALICE, action: 'remove' }),
+        spaceId: 'space-1',
+        channelId: 'channel-1',
+        queryClient: new QueryClient(),
+        verifiedSender: MALLORY,
+      });
+
+      expect(honored).toBe(false);
+    });
+
+    it('CONTROL: the real creator still removes it from the cache', async () => {
+      (mockDB.getMessage as any).mockResolvedValue(aliceRootWithThread());
+
+      const honored = await threadService.handleThreadCache({
+        threadMsg: threadFrame({ senderId: ALICE, action: 'remove' }),
+        spaceId: 'space-1',
+        channelId: 'channel-1',
+        queryClient: new QueryClient(),
+        verifiedSender: ALICE,
+      });
+
+      expect(honored).toBe(true);
+    });
+  });
+});

--- a/src/dev/tests/services/verifiedSenderRequiresVerification.test.ts
+++ b/src/dev/tests/services/verifiedSenderRequiresVerification.test.ts
@@ -328,3 +328,168 @@ describe('the unverified resolver cannot come back', () => {
     ).toBeGreaterThanOrEqual(5);
   });
 });
+
+/**
+ * THE WIRING, not the rule.
+ *
+ * `ThreadService` decides correctly when handed a verified signer, and its own
+ * tests prove that. What they cannot see is whether MessageService actually
+ * hands it one — the two call sites that resolve the signer and pass it in.
+ *
+ * That gap was MEASURED, not hypothesised: reverting those two call sites to
+ * the forgeable `threadMsg.senderId` left all 506 service tests green. Every
+ * test was checking the rule; none was checking that the rule was wired up.
+ *
+ * So this drives a thread frame through `MessageService.saveMessage` end to
+ * end. The frame claims to be from the victim and is signed by a key belonging
+ * to someone else — the whole attack in one message.
+ */
+describe('a thread frame is authorized on its signer, end to end', () => {
+  const CHANNEL = 'chan-1';
+  const ATTACKER = 'attacker-address';
+  const ATTACKER_PUB =
+    '3333333333333333333333333333333333333333333333333333333333333333';
+  const ATTACKER_INBOX = deriveInboxAddress(ATTACKER_PUB);
+  const ROOT_ID = 'root-msg-1';
+
+  /**
+   * A `thread`/`remove` naming the VICTIM as sender, signed with the ATTACKER's
+   * key. The messageId is computed over the CLAIMED senderId, exactly as a real
+   * sender would — so nothing here is malformed; only the key betrays it.
+   */
+  const forgedThreadRemove = (signingKey: string) => {
+    const nonce = 'nonce-thread';
+    const content = {
+      type: 'thread' as const,
+      senderId: VICTIM,
+      targetMessageId: ROOT_ID,
+      action: 'remove' as const,
+      threadMeta: { threadId: 'thread-1', createdBy: VICTIM },
+    };
+    return {
+      spaceId: SPACE,
+      channelId: CHANNEL,
+      nonce,
+      messageId: computeMessageIdHex(
+        buildMessageFingerprint({
+          nonce,
+          content: content as never,
+          senderId: VICTIM,
+          spaceId: SPACE,
+          channelId: CHANNEL,
+        })
+      ),
+      digestAlgorithm: 'SHA-256' as const,
+      createdDate: Date.now(),
+      modifiedDate: Date.now(),
+      lastModifiedHash: '',
+      content,
+      publicKey: signingKey,
+      signature: 'ab'.repeat(114),
+    };
+  };
+
+  let messageService: MessageService;
+  let deps: MessageServiceDependencies;
+
+  beforeEach(() => {
+    verifyEd448.mockReset();
+    verifyEd448.mockReturnValue('true'); // the signature itself is genuine
+    deps = {
+      messageDB: {
+        // The victim's post, carrying a thread the victim opened.
+        getMessage: vi.fn().mockResolvedValue({
+          messageId: ROOT_ID,
+          content: { type: 'post', senderId: VICTIM, text: 'keep me' },
+          threadMeta: { threadId: 'thread-1', createdBy: VICTIM },
+        }),
+        getSpace: vi.fn().mockResolvedValue({
+          spaceId: SPACE,
+          isRepudiable: true,
+          groups: [{ channels: [{ channelId: CHANNEL }] }],
+          roles: [], // attacker holds no moderation role
+        }),
+        getChannelThread: vi.fn().mockResolvedValue(null),
+        getChannelThreads: vi.fn().mockResolvedValue([]),
+        getThreadMessages: vi
+          .fn()
+          .mockResolvedValue({ messages: [], replyCount: 0 }),
+        getSpaceMembers: vi.fn().mockResolvedValue([
+          { user_address: VICTIM, address: VICTIM, inbox_address: VICTIM_INBOX },
+          {
+            user_address: ATTACKER,
+            address: ATTACKER,
+            inbox_address: ATTACKER_INBOX,
+          },
+        ]),
+        getSpaceMemberDevices: vi.fn().mockResolvedValue([]),
+        getSpaceMember: vi.fn().mockResolvedValue(null),
+        saveMessage: vi.fn().mockResolvedValue(undefined),
+        saveChannelThread: vi.fn().mockResolvedValue(undefined),
+        deleteMessage: vi.fn().mockResolvedValue(undefined),
+        deleteChannelThread: vi.fn().mockResolvedValue(undefined),
+        isMessageDeleted: vi.fn().mockResolvedValue(false),
+        updateMessage: vi.fn().mockResolvedValue(undefined),
+        saveSpaceMember: vi.fn().mockResolvedValue(undefined),
+        getConversation: vi.fn().mockResolvedValue({ conversation: null }),
+      } as unknown as MessageServiceDependencies['messageDB'],
+      enqueueOutbound: vi.fn(),
+      addOrUpdateConversation: vi.fn(),
+      apiClient: {} as never,
+      deleteEncryptionStates: vi.fn().mockResolvedValue(undefined),
+      deleteInboxMessages: vi.fn().mockResolvedValue(undefined),
+      navigate: vi.fn(),
+      spaceInfo: { current: {} } as never,
+      syncInfo: { current: {} } as never,
+      synchronizeAll: vi.fn().mockResolvedValue(undefined),
+      informSyncData: vi.fn().mockResolvedValue(undefined),
+      initiateSync: vi.fn().mockResolvedValue(undefined),
+      requestSync: vi.fn().mockResolvedValue(undefined),
+      directSync: vi.fn().mockResolvedValue(undefined),
+      saveConfig: vi.fn().mockResolvedValue(undefined),
+      sendHubMessage: vi.fn().mockResolvedValue('message-id'),
+    } as unknown as MessageServiceDependencies;
+
+    messageService = new MessageService(deps);
+  });
+
+  const receive = (msg: unknown) =>
+    messageService.saveMessage(
+      msg as never,
+      deps.messageDB,
+      SPACE,
+      CHANNEL,
+      'group',
+      {},
+      null,
+      undefined
+    );
+
+  it('ATTACK ARM: signed by someone else, so the victim\'s message survives', async () => {
+    await receive(forgedThreadRemove(ATTACKER_PUB));
+
+    expect(
+      deps.messageDB.deleteMessage,
+      "the verified signer never reached ThreadService: a thread frame claiming " +
+        "the victim's address deleted the victim's message"
+    ).not.toHaveBeenCalled();
+  });
+
+  it('CONTROL ARM: signed by the thread creator, and still honoured', async () => {
+    await receive(forgedThreadRemove(VICTIM_PUB));
+
+    expect(
+      deps.messageDB.deleteMessage,
+      'the fix over-rejected: the real creator can no longer remove their own thread'
+    ).toHaveBeenCalledWith(ROOT_ID);
+  });
+
+  it('the ed448 verifier is consulted before any thread action', async () => {
+    await receive(forgedThreadRemove(ATTACKER_PUB));
+
+    expect(
+      verifyEd448,
+      'no signature check ran on the thread path, so its sender is unproven'
+    ).toHaveBeenCalled();
+  });
+});

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -19,7 +19,7 @@ import {
   verifyAndResolveSender,
   authorizeControlMessage,
   isControlMessageType,
-  requiresVerifiedSignature,
+  shouldSignOutbound,
   shouldSignEdit,
   canManageReadOnlyChannel,
   verifyDeviceKeyStatement,
@@ -7305,27 +7305,17 @@ export class MessageService {
       const nonce = crypto.randomUUID();
       const space = await this.messageDB.getSpace(spaceId);
 
-      // Read-only posts must always be signed (receive-side drops unsigned ones,
-      // including a manager's own), so force-sign regardless of the repudiable
-      // "send unsigned" toggle.
       const targetChannel = space
         ? this.findChannelInSpace(space, channelId)
         : undefined;
-      // Same reasoning, one class wider: every type on
-      // SIGNATURE_REQUIRED_MESSAGE_TYPES is refused unsigned by receivers, so
-      // honoring "send unsigned" for one would produce an action that appears
-      // to succeed locally and is silently discarded by everyone else.
-      //
-      // This does NOT touch deniability. That is a property of ordinary posts,
-      // which are absent from the list and still send unsigned at the user's
-      // choice. What is excluded is the small set of frames that moderate or
-      // destroy OTHER people's content, where "who did this" has to be provable
-      // for the receiver to act on it at all.
-      const signatureRequired = requiresVerifiedSignature(
-        (pendingMessage as { type?: string })?.type ?? ''
-      );
-      const effectiveSkipSigning =
-        targetChannel?.isReadOnly || signatureRequired ? false : skipSigning;
+      // Shared decision, so send-side and receive-side cannot drift. See
+      // shouldSignOutbound: deniability still applies to ordinary posts.
+      const effectiveSkipSigning = !shouldSignOutbound({
+        contentType: (pendingMessage as { type?: string })?.type ?? 'post',
+        isRepudiable: !!space?.isRepudiable,
+        isReadOnlyChannel: !!targetChannel?.isReadOnly,
+        skipSigning: !!skipSigning,
+      });
 
       // Calculate messageId (SHA-256 of the canonical fingerprint). Uses the
       // shared builder so the real content.type is hashed (control messages
@@ -7694,8 +7684,20 @@ export class MessageService {
           conversationId,
         });
 
-        // Enforce non-repudiability
-        if (!space?.isRepudiable || (space?.isRepudiable && !skipSigning)) {
+        // Enforce non-repudiability. 'pin' is refused unsigned by receivers
+        // (authorizeControlMessage denies a null sender), so honoring the
+        // "send unsigned" toggle here would pin the message locally and
+        // nowhere else, with nothing reporting the disagreement.
+        if (
+          shouldSignOutbound({
+            contentType: 'pin',
+            isRepudiable: !!space?.isRepudiable,
+            isReadOnlyChannel: !!(
+              space && this.findChannelInSpace(space, channelId)?.isReadOnly
+            ),
+            skipSigning: !!skipSigning,
+          })
+        ) {
           const inboxKey = await this.getSigningKey(spaceId);
           message.publicKey = inboxKey.publicKey;
           message.signature = Buffer.from(
@@ -7775,8 +7777,21 @@ export class MessageService {
           } as ThreadMessage,
         } as Message;
 
-        // Sign (same pattern as pin messages)
-        if (!space?.isRepudiable || (space?.isRepudiable && !skipSigning)) {
+        // Thread frames are refused unsigned by every receiver
+        // (authorizeThreadAction denies a null sender outright), so the
+        // "send unsigned" toggle must not reach this branch: an unsigned
+        // 'remove' would delete the thread on this device and nowhere else,
+        // which reads as a successful deletion and is not one.
+        if (
+          shouldSignOutbound({
+            contentType: 'thread',
+            isRepudiable: !!space?.isRepudiable,
+            isReadOnlyChannel: !!(
+              space && this.findChannelInSpace(space, channelId)?.isReadOnly
+            ),
+            skipSigning: !!skipSigning,
+          })
+        ) {
           const inboxKey = await this.getSigningKey(spaceId);
           message.publicKey = inboxKey.publicKey;
           message.signature = Buffer.from(

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -19,6 +19,7 @@ import {
   verifyAndResolveSender,
   authorizeControlMessage,
   isControlMessageType,
+  requiresVerifiedSignature,
   shouldSignEdit,
   canManageReadOnlyChannel,
   verifyDeviceKeyStatement,
@@ -2804,10 +2805,20 @@ export class MessageService {
       );
     } else if (decryptedContent.content.type === 'thread') {
       const threadMsg = decryptedContent.content as ThreadMessage;
+      // SECURITY: thread frames carry a second deletion primitive ('remove'
+      // hard-deletes the root and every reply). Authorize on the VERIFIED
+      // signer; the payload's senderId is a claim, not proof.
+      const { sender: threadSender } = await this.verifySpaceSender(
+        decryptedContent,
+        messageDB,
+        spaceId,
+        channelId
+      );
       await this.threadService.handleThreadReceive({
         threadMsg,
         spaceId,
         channelId,
+        verifiedSender: threadSender ?? null,
         currentUserAddress: currentUserAddress ?? '',
         conversationType,
         updatedUserProfile: {
@@ -3366,10 +3377,19 @@ export class MessageService {
       });
     } else if (decryptedContent.content.type === 'thread') {
       const threadMsg = decryptedContent.content as ThreadMessage;
+      // Same verdict inputs as the DB path above, or the cache and the store
+      // disagree about whether a thread action happened.
+      const { sender: threadSender } = await this.verifySpaceSender(
+        decryptedContent,
+        this.messageDB,
+        spaceId,
+        channelId
+      );
       await this.threadService.handleThreadCache({
         threadMsg,
         spaceId,
         channelId,
+        verifiedSender: threadSender ?? null,
         queryClient,
       });
     } else if (decryptedContent.content.type === 'update-profile') {
@@ -7291,9 +7311,21 @@ export class MessageService {
       const targetChannel = space
         ? this.findChannelInSpace(space, channelId)
         : undefined;
-      const effectiveSkipSigning = targetChannel?.isReadOnly
-        ? false
-        : skipSigning;
+      // Same reasoning, one class wider: every type on
+      // SIGNATURE_REQUIRED_MESSAGE_TYPES is refused unsigned by receivers, so
+      // honoring "send unsigned" for one would produce an action that appears
+      // to succeed locally and is silently discarded by everyone else.
+      //
+      // This does NOT touch deniability. That is a property of ordinary posts,
+      // which are absent from the list and still send unsigned at the user's
+      // choice. What is excluded is the small set of frames that moderate or
+      // destroy OTHER people's content, where "who did this" has to be provable
+      // for the receiver to act on it at all.
+      const signatureRequired = requiresVerifiedSignature(
+        (pendingMessage as { type?: string })?.type ?? ''
+      );
+      const effectiveSkipSigning =
+        targetChannel?.isReadOnly || signatureRequired ? false : skipSigning;
 
       // Calculate messageId (SHA-256 of the canonical fingerprint). Uses the
       // shared builder so the real content.type is hashed (control messages

--- a/src/services/ThreadService.ts
+++ b/src/services/ThreadService.ts
@@ -7,7 +7,7 @@ import type {
   ChannelThread,
   VerifiedSender,
 } from '@quilibrium/quorum-shared';
-import { authorizeThreadAction } from '@quilibrium/quorum-shared';
+import { authorizeThreadAction, logger } from '@quilibrium/quorum-shared';
 import {
   buildChannelThreadFromCreate,
   updateChannelThreadOnReply,
@@ -85,13 +85,30 @@ export class ThreadService {
       this.resolveThreadCreator(threadMsg, targetMessage),
     ]);
 
-    return authorizeThreadAction({
+    const verdict = authorizeThreadAction({
       action: threadMsg.action,
       verifiedSender,
       threadCreatedBy,
       space: space ?? undefined,
       channel,
-    }).allowed;
+    });
+
+    // A denial here is indistinguishable from "nothing happened" for the user,
+    // and several BENIGN causes land on this path: a join broadcast that has
+    // not arrived yet, a device key not yet admitted, a rotation in flight. The
+    // verdict already knows which case it is, so record it rather than
+    // discarding the one piece of information that makes this diagnosable.
+    // The reason names no key or address and tells an attacker nothing they
+    // did not already supply.
+    if (!verdict.allowed) {
+      logger.warn('thread action denied', {
+        action: threadMsg.action,
+        reason: verdict.reason,
+        threadId: threadMsg.threadMeta.threadId,
+      });
+    }
+
+    return verdict.allowed;
   }
 
   /**
@@ -145,7 +162,7 @@ export class ThreadService {
       return false;
     }
     // Past the gate, so a sender was proven; safe to treat as the actor.
-    const actor = verifiedSender as string;
+    const actor = verifiedSender as VerifiedSender;
 
     // --- Action routing ---
 
@@ -233,7 +250,7 @@ export class ThreadService {
     spaceId: string;
     channelId: string;
     /** Already authorized by the caller's gate; the proven signer. */
-    actor: string;
+    actor: VerifiedSender;
     currentUserAddress: string;
     conversationType: string;
     updatedUserProfile: { user_icon: string; display_name: string };
@@ -358,7 +375,7 @@ export class ThreadService {
     ) {
       return false;
     }
-    const actor = verifiedSender as string;
+    const actor = verifiedSender as VerifiedSender;
 
     if (threadMsg.action === 'remove') {
       return this.handleThreadRemoveCache({
@@ -377,7 +394,19 @@ export class ThreadService {
             ...page,
             messages: page.messages.map((m: Message) =>
               m.messageId === threadMsg.targetMessageId
-                ? { ...m, threadMeta: { ...m.threadMeta, ...threadMsg.threadMeta } }
+                ? {
+                    ...m,
+                    threadMeta: {
+                      ...m.threadMeta,
+                      ...threadMsg.threadMeta,
+                      // Same pin as the DB path. Authorization always re-reads
+                      // ownership from storage, so an unpinned value here could
+                      // not escalate — but it would still display the attacker's
+                      // chosen name as the thread's creator, and a rule the two
+                      // paths apply differently is the defect being fixed.
+                      createdBy: m.threadMeta?.createdBy ?? actor,
+                    },
+                  }
                 : m
             ),
           })),
@@ -402,7 +431,7 @@ export class ThreadService {
     spaceId: string;
     channelId: string;
     /** Already authorized by the caller's gate; the proven signer. */
-    actor: string;
+    actor: VerifiedSender;
     queryClient: QueryClient;
   }): Promise<boolean> {
     const { threadMsg, targetMessage, spaceId, channelId, actor, queryClient } = params;

--- a/src/services/ThreadService.ts
+++ b/src/services/ThreadService.ts
@@ -1,38 +1,97 @@
 import type { QueryClient, InfiniteData } from '@tanstack/react-query';
 import type { MessageDB } from '../db/messages';
 import type {
+  Channel,
   Message,
   ThreadMessage,
   ChannelThread,
+  VerifiedSender,
 } from '@quilibrium/quorum-shared';
+import { authorizeThreadAction } from '@quilibrium/quorum-shared';
 import {
   buildChannelThreadFromCreate,
   updateChannelThreadOnReply,
 } from './channelThreadHelpers';
 import { buildMessagesKeyPrefix } from '../hooks/queries/messages/buildMessagesKey';
 
+/**
+ * Thread control frames (`create` / `close` / `reopen` / `updateSettings` /
+ * `updateTitle` / `remove`) reach across to other users' content — `remove`
+ * hard-deletes the root message and every reply.
+ *
+ * Every authorization input here is therefore the VERIFIED signer, resolved by
+ * the receive path before it calls in. `threadMsg.senderId` is a plaintext field
+ * the sending client writes, and it is never consulted for a decision; it stayed
+ * usable as a display value only.
+ */
 export class ThreadService {
   constructor(private messageDB: MessageDB) {}
 
-  /**
-   * Unified thread authorization: thread creator OR message:delete permission.
-   * Replaces 6 duplicate auth checks across MessageService's three code paths.
-   */
-  async isThreadAuthorized(params: {
-    senderId: string;
-    createdBy: string | undefined;
-    spaceId: string;
-  }): Promise<boolean> {
-    if (params.senderId === params.createdBy) return true;
+  /** The channel row, needed so read-only channels keep their isolated rules. */
+  private async resolveChannel(
+    spaceId: string,
+    channelId: string
+  ): Promise<{ space: Awaited<ReturnType<MessageDB['getSpace']>>; channel: Channel | undefined }> {
+    const space = await this.messageDB.getSpace(spaceId);
+    const channel = space?.groups
+      ?.find((g: { channels: Channel[] }) =>
+        g.channels.find((c: Channel) => c.channelId === channelId)
+      )
+      ?.channels.find((c: Channel) => c.channelId === channelId);
+    return { space, channel };
+  }
 
-    const space = await this.messageDB.getSpace(params.spaceId);
-    return (
-      space?.roles?.some(
-        (role: { members: string[]; permissions: string[] }) =>
-          role.members.includes(params.senderId) &&
-          role.permissions.includes('message:delete')
-      ) ?? false
+  /**
+   * Who owns this thread, per STORED state — the root's `threadMeta`, or the
+   * registry when the root is already gone (a `remove` following a delete).
+   *
+   * Never the incoming frame. That value is only trustworthy because `create`
+   * pins it to the verified creator; reading it off the wire here would undo
+   * that in one line.
+   */
+  private async resolveThreadCreator(
+    threadMsg: ThreadMessage,
+    targetMessage: Message | undefined
+  ): Promise<string | undefined> {
+    if (targetMessage?.threadMeta?.createdBy) {
+      return targetMessage.threadMeta.createdBy;
+    }
+    if (threadMsg.action === 'create') return undefined;
+    const record = await this.messageDB.getChannelThread(
+      threadMsg.threadMeta.threadId
     );
+    return record?.createdBy;
+  }
+
+  /**
+   * The single authorization gate for an incoming thread frame. Both the DB and
+   * the cache path funnel through it so they cannot reach different verdicts
+   * about the same frame.
+   */
+  private async isThreadFrameAuthorized(params: {
+    threadMsg: ThreadMessage;
+    targetMessage: Message | undefined;
+    spaceId: string;
+    channelId: string;
+    verifiedSender: VerifiedSender | null;
+  }): Promise<boolean> {
+    const { threadMsg, targetMessage, spaceId, channelId, verifiedSender } =
+      params;
+    // Cheap denial first: an unverifiable frame needs no space lookup at all.
+    if (!verifiedSender) return false;
+
+    const [{ space, channel }, threadCreatedBy] = await Promise.all([
+      this.resolveChannel(spaceId, channelId),
+      this.resolveThreadCreator(threadMsg, targetMessage),
+    ]);
+
+    return authorizeThreadAction({
+      action: threadMsg.action,
+      verifiedSender,
+      threadCreatedBy,
+      space: space ?? undefined,
+      channel,
+    }).allowed;
   }
 
   /**
@@ -45,11 +104,13 @@ export class ThreadService {
     threadMsg: ThreadMessage;
     spaceId: string;
     channelId: string;
+    /** The ed448-proven signer, or null when nothing could be proven. */
+    verifiedSender: VerifiedSender | null;
     currentUserAddress: string;
     conversationType: string;
     updatedUserProfile: { user_icon: string; display_name: string };
   }): Promise<boolean> {
-    const { threadMsg, spaceId, channelId, currentUserAddress, conversationType, updatedUserProfile } = params;
+    const { threadMsg, spaceId, channelId, verifiedSender, currentUserAddress, conversationType, updatedUserProfile } = params;
 
     // Reject DMs
     if (spaceId === channelId) return false;
@@ -63,42 +124,54 @@ export class ThreadService {
     // For 'remove' action, allow proceeding even if root was already deleted
     if (!targetMessage && threadMsg.action !== 'remove') return false;
 
+    // Idempotency sits AHEAD of authorization on purpose: a duplicate create is
+    // a no-op we already applied, not an access decision to re-litigate.
+    if (
+      threadMsg.action === 'create' &&
+      targetMessage!.threadMeta?.threadId === threadMsg.threadMeta.threadId
+    ) {
+      return false;
+    }
+
+    if (
+      !(await this.isThreadFrameAuthorized({
+        threadMsg,
+        targetMessage,
+        spaceId,
+        channelId,
+        verifiedSender,
+      }))
+    ) {
+      return false;
+    }
+    // Past the gate, so a sender was proven; safe to treat as the actor.
+    const actor = verifiedSender as string;
+
     // --- Action routing ---
 
     if (threadMsg.action === 'create') {
-      // Idempotent — skip if threadId already set
-      if (targetMessage!.threadMeta?.threadId === threadMsg.threadMeta.threadId) return false;
-
       const rootText = (targetMessage!.content as { text?: string })?.text ?? '';
       const newThread = buildChannelThreadFromCreate({
         spaceId,
         channelId,
         rootMessageId: threadMsg.targetMessageId,
-        threadMeta: threadMsg.threadMeta,
+        // createdBy comes from the signature, not the payload. Pre-fix the wire
+        // value was copied verbatim and then became the anchor every later
+        // authorization check compared against — so naming a victim here was
+        // enough to hand them the blame and yourself the access.
+        threadMeta: { ...threadMsg.threadMeta, createdBy: actor },
         rootMessageText: typeof rootText === 'string' ? rootText : '',
         currentUserAddress: currentUserAddress ?? '',
         now: Date.now(),
       });
       await this.messageDB.saveChannelThread(newThread);
-    } else if (threadMsg.action === 'updateTitle') {
-      if (threadMsg.senderId !== targetMessage!.threadMeta?.createdBy) return false;
-    } else if (
-      threadMsg.action === 'close' ||
-      threadMsg.action === 'reopen' ||
-      threadMsg.action === 'updateSettings'
-    ) {
-      const authorized = await this.isThreadAuthorized({
-        senderId: threadMsg.senderId,
-        createdBy: targetMessage!.threadMeta?.createdBy,
-        spaceId,
-      });
-      if (!authorized) return false;
     } else if (threadMsg.action === 'remove') {
       return this.handleThreadRemoveReceive({
         threadMsg,
         targetMessage,
         spaceId,
         channelId,
+        actor,
         currentUserAddress,
         conversationType,
         updatedUserProfile,
@@ -111,7 +184,14 @@ export class ThreadService {
     // Merge threadMeta and save
     const updatedMessage: Message = {
       ...targetMessage,
-      threadMeta: { ...targetMessage.threadMeta, ...threadMsg.threadMeta },
+      threadMeta: {
+        ...targetMessage.threadMeta,
+        ...threadMsg.threadMeta,
+        // Ownership is set once, at create, and is not a field later frames may
+        // carry. Without this pin, anyone authorized to close a thread could
+        // also seize it by attaching a new createdBy to that same frame.
+        createdBy: targetMessage.threadMeta?.createdBy ?? actor,
+      },
     };
     await this.messageDB.saveMessage(
       updatedMessage, 0, spaceId, conversationType,
@@ -152,28 +232,20 @@ export class ThreadService {
     targetMessage: Message | undefined;
     spaceId: string;
     channelId: string;
+    /** Already authorized by the caller's gate; the proven signer. */
+    actor: string;
     currentUserAddress: string;
     conversationType: string;
     updatedUserProfile: { user_icon: string; display_name: string };
   }): Promise<boolean> {
-    const { threadMsg, targetMessage, spaceId, channelId, currentUserAddress, conversationType, updatedUserProfile } = params;
-
-    // Auth: fall back to channel_threads registry if root was already deleted
-    const threadRecord = !targetMessage
-      ? await this.messageDB.getChannelThread(threadMsg.threadMeta.threadId)
-      : undefined;
-    const createdBy = targetMessage?.threadMeta?.createdBy ?? threadRecord?.createdBy;
-
-    const authorized = await this.isThreadAuthorized({
-      senderId: threadMsg.senderId,
-      createdBy,
-      spaceId,
-    });
-    if (!authorized) return false;
+    const { threadMsg, targetMessage, spaceId, channelId, actor, currentUserAddress, conversationType, updatedUserProfile } = params;
 
     // Handle root message
     if (targetMessage) {
-      const isRootSender = threadMsg.senderId === targetMessage.content.senderId;
+      // Deciding hard-delete vs strip, so it must be the proven signer: this is
+      // the branch that destroys someone else's message outright, and pre-fix
+      // both sides of the comparison were attacker-writable.
+      const isRootSender = actor === targetMessage.content.senderId;
       const rootText = (targetMessage.content as { text?: string })?.text;
       const isSoftDeleted = !rootText || (Array.isArray(rootText) && (rootText as string[]).every(s => !s));
 
@@ -256,9 +328,11 @@ export class ThreadService {
     threadMsg: ThreadMessage;
     spaceId: string;
     channelId: string;
+    /** The ed448-proven signer, or null when nothing could be proven. */
+    verifiedSender: VerifiedSender | null;
     queryClient: QueryClient;
   }): Promise<boolean> {
-    const { threadMsg, spaceId, channelId, queryClient } = params;
+    const { threadMsg, spaceId, channelId, verifiedSender, queryClient } = params;
 
     if (spaceId === channelId) return false;
 
@@ -266,24 +340,29 @@ export class ThreadService {
       spaceId, channelId, messageId: threadMsg.targetMessageId,
     });
 
-    // Auth checks per action
-    if (threadMsg.action === 'updateTitle') {
-      if (!targetMessage || threadMsg.senderId !== targetMessage.threadMeta?.createdBy) return false;
-    }
+    // Every action except 'remove' needs the root present to act on. The DB
+    // path has always required this; the cache path did not, so a 'create'
+    // could update the view where the store refused it. Matching them is the
+    // point — a decision that differs between the two is the bug class here.
+    if (!targetMessage && threadMsg.action !== 'remove') return false;
 
-    if (threadMsg.action === 'close' || threadMsg.action === 'reopen' || threadMsg.action === 'updateSettings') {
-      if (!targetMessage) return false;
-      const authorized = await this.isThreadAuthorized({
-        senderId: threadMsg.senderId,
-        createdBy: targetMessage.threadMeta?.createdBy,
+    // Same gate as the DB path — one verdict, so the two views cannot diverge.
+    if (
+      !(await this.isThreadFrameAuthorized({
+        threadMsg,
+        targetMessage,
         spaceId,
-      });
-      if (!authorized) return false;
+        channelId,
+        verifiedSender,
+      }))
+    ) {
+      return false;
     }
+    const actor = verifiedSender as string;
 
     if (threadMsg.action === 'remove') {
       return this.handleThreadRemoveCache({
-        threadMsg, targetMessage, spaceId, channelId, queryClient,
+        threadMsg, targetMessage, spaceId, channelId, actor, queryClient,
       });
     }
 
@@ -322,23 +401,17 @@ export class ThreadService {
     targetMessage: Message | undefined;
     spaceId: string;
     channelId: string;
+    /** Already authorized by the caller's gate; the proven signer. */
+    actor: string;
     queryClient: QueryClient;
   }): Promise<boolean> {
-    const { threadMsg, targetMessage, spaceId, channelId, queryClient } = params;
+    const { threadMsg, targetMessage, spaceId, channelId, actor, queryClient } = params;
     const threadId = threadMsg.threadMeta.threadId;
 
-    // Auth
-    const threadRecord = !targetMessage
-      ? await this.messageDB.getChannelThread(threadId)
-      : undefined;
-    const createdBy = targetMessage?.threadMeta?.createdBy ?? threadRecord?.createdBy;
-    const authorized = await this.isThreadAuthorized({
-      senderId: threadMsg.senderId, createdBy, spaceId,
-    });
-    if (!authorized) return false;
-
+    // Mirrors handleThreadRemoveReceive: the proven signer decides whether the
+    // root disappears or merely loses its threadMeta.
     const isRootSender = targetMessage
-      ? threadMsg.senderId === targetMessage.content.senderId
+      ? actor === targetMessage.content.senderId
       : false;
 
     // Update main feed cache
@@ -468,7 +541,7 @@ export class ThreadService {
     queryClient: QueryClient;
     currentUserAddress: string;
   }): Promise<{ shouldProceed: boolean; targetMessage?: Message }> {
-    const { threadMsg, spaceId, channelId } = params;
+    const { threadMsg, spaceId, channelId, currentUserAddress } = params;
 
     if (spaceId === channelId) return { shouldProceed: false };
 
@@ -482,8 +555,10 @@ export class ThreadService {
       return { shouldProceed: false };
     }
 
-    // updateTitle: only creator
-    if (threadMsg.action === 'updateTitle' && threadMsg.senderId !== targetMessage.threadMeta?.createdBy) {
+    // updateTitle: only creator. Send-side, so the actor is simply us — reading
+    // it off the outgoing payload would be checking our own claim about
+    // ourselves, which proves nothing and drifts from the receive-side rule.
+    if (threadMsg.action === 'updateTitle' && currentUserAddress !== targetMessage.threadMeta?.createdBy) {
       return { shouldProceed: false };
     }
 
@@ -513,7 +588,8 @@ export class ThreadService {
 
     // Remove action: full cleanup
     if (threadMsg.action === 'remove') {
-      const isRootSender = threadMsg.senderId === targetMessage.content.senderId;
+      // Send-side: the actor is the local user, not whatever the payload says.
+      const isRootSender = currentUserAddress === targetMessage.content.senderId;
       const rootText = (targetMessage.content as { text?: string })?.text;
       const isSoftDeleted = !rootText || (Array.isArray(rootText) && (rootText as string[]).every(s => !s));
 


### PR DESCRIPTION
## Why

Thread control frames were authorized against `senderId` taken from the decrypted
payload. Every other control frame is authorized against the signer resolved by
`verifyAndResolveSender`. Threads were the odd one out, so a thread frame's
authorization did not depend on who actually signed it.

This makes threads consistent with the rest of the control surface.

## What

**`ThreadService`**

- `handleThreadReceive` and `handleThreadCache` now take a
  `verifiedSender: VerifiedSender | null` and pass it through a single gate,
  `isThreadFrameAuthorized`. The old public `isThreadAuthorized` is gone; the
  branded type means an authorization check no longer compiles against a raw
  payload field.
- Thread ownership (`threadMeta.createdBy`) is pinned to the verified signer at
  creation and preserved on every later merge, on **both** the database and the
  cache path. Previously only the database path pinned it, so the two paths could
  show different creators for the same thread.
- `isRootSender` is derived from the verified signer.
- Denials are logged with their reason. Several innocent cases land on the deny
  path (a join broadcast that has not arrived, a device not yet admitted, a key
  rotation in flight); the code already knew which case it was and was discarding it.
- Non-creator management of an existing thread requires `message:delete` via
  `hasChannelPermission`, which has no own-message shortcut. Using
  `canDeleteMessage` here would have let a thread's root author manage the whole
  thread without holding any role.

**`MessageService`**

- Both thread receive branches resolve the signer via `verifySpaceSender` and pass
  it down. Previously they did not, and no test covered the wiring.
- Post, pin and thread send branches now derive signing from `shouldSignOutbound`
  instead of reading the repudiability toggle directly. The thread branch sits
  outside `isPostMessage`, so a signing rule written inside that branch never
  applied to threads: in a repudiable space with unsigned sending on, thread
  actions went out unsigned, every recipient refused them, and the sender's own
  screen showed the action as done.
- The edit branch is deliberately untouched and keeps `shouldSignEdit`. An edit is
  signed iff the message it edits was signed. Routing edits through the same helper
  would attach a signature when editing an unsigned message.

## Deniability

Unchanged for message content. In a repudiable space, thread and pin **control**
actions now carry a signature. They always needed one to be accepted; before this
change they were sent without one and silently discarded by every recipient. The
choice was never signed-or-private, it was signed-or-broken.

## Tests

`1629 passed` (174 files), `tsc` clean, `yarn lint` 0 errors.

New: `threadActionsRequireVerifiedSender.test.ts` (21 tests) covering both the
database and cache paths, ownership pinning, every thread action against an
unauthenticated frame, and source guards pinning the two send-side rules above.
Extended: `verifiedSenderRequiresVerification.test.ts` drives a real signed frame
end to end, which is what the missing wiring coverage needed.

Every guard was mutation-tested: each was confirmed to fail against the pre-fix
code and pass after. Reverting the `MessageService` wiring alone reddens the
end-to-end test while the `ThreadService` suite stays green, which is the gap that
let the wiring go uncovered in the first place.

## Depends on

QuilibriumNetwork/quorum-shared#87 (merged). `authorizeThreadAction`,
`shouldSignOutbound`, `requiresVerifiedSignature` and `hasChannelPermission` come
from there.