### PR TITLE
test(harness): two-arm relay scenario for thread authorization

### DIFF
--- a/src/dev/tests/harness/README.md
+++ b/src/dev/tests/harness/README.md
@@ -170,11 +170,24 @@ Log analyzers stay in `.agents/tools/dm-debug/` (`dr-ablate`, `dr-replay`,
 |---|---|
 | `yarn harness space-create` | S0: a bot creates a real space on production and reads its manifest back through the joiner's own decode path |
 | `yarn harness space-basic` | S1: B joins A's space by invite and must receive **both** A's post and A's member row. `HARNESS_SPACE_WINDOW_MS` / `HARNESS_SPACE_SAMPLE_MS` tune the wait |
+| `yarn harness space-thread-forgery` | can an ordinary member DESTROY your message by opening a thread on it? Two arms: an attacker forges the thread's `createdBy`, then forges authorship of a `remove`; a control arm does the same removal honestly. **The control arm is what makes the run meaningful** — its stripped `threadMeta` proves removes are arriving and being applied, so the attack arm cannot pass by everything being broken. See the caveat below |
 | `yarn harness space-wipe-restore` | what logging back in restores after a storage eviction. Two accounts of identical shape, one variable — `allowSync`. Sync on: Space, keys and profile return, DMs do not. Sync off (the DEFAULT): nothing returns, so the eviction takes the Spaces too. The sync-off arm is also the control — if both restored, something other than the published config would be doing it |
 
 `space-basic` asserts the ROSTER as well as the message, because the roster half
 is the thing under investigation. B writes only its own member row locally, so a
 second row can only have come off the wire.
+
+> ⚠️ **`space-thread-forgery` was green against the vulnerable code on its first
+> draft**, and the reason generalises to any security scenario written here.
+> That draft opened the thread honestly and forged only the `remove`. The claimed
+> sender was then neither the thread's creator nor a role-holder, so the old
+> check denied it — for a reason with nothing to do with the fix. A test that
+> cannot fail is worse than none, because it manufactures confidence.
+>
+> **Any arm asserting "the attack failed" must be run against code where the
+> attack WORKS**, and seen to go red. `git checkout <pre-fix-sha> -- <files>`,
+> run, confirm red, restore. If it stays green, the scenario is not expressing
+> the attack — it is expressing something the code rejects anyway.
 
 > ⚠️ **A green `space-basic` is not evidence the roster bug is absent.** It runs
 > at N=2 members; the reported failure is at N≈79 and is intermittent. Quoting a
@@ -286,4 +299,4 @@ See `2026-07-27-headless-dm-harness.md` under .agents/issues/ for the DM slice p
 `.agents/issues/transport/2026-07-27-headless-space-harness.md` for the space one,
 and `.agents/issues/transport/2026-07-26-dm-desktop-to-desktop-resurfaced.md` §1 for the DM
 findings.
-*Last updated: 2026-08-17*
+*Last updated: 2026-08-21*

--- a/src/dev/tests/harness/space-thread-forgery.scenario.test.ts
+++ b/src/dev/tests/harness/space-thread-forgery.scenario.test.ts
@@ -1,0 +1,391 @@
+// NETWORKED. Can a stranger DESTROY your messages by opening a thread on them?
+//
+//   yarn harness space-thread-forgery
+//
+// ── The attack ─────────────────────────────────────────────────────────────
+//
+// Thread actions used to be authorized against `content.senderId` — PLAINTEXT
+// the sending client writes — rather than against the sender the crypto layer
+// authenticated. `remove` is the destructive one: it chooses between
+// hard-deleting the thread's ROOT message and merely stripping that root's
+// `threadMeta`, and it made that choice by comparing two payload fields to each
+// other.
+//
+// A single forged frame is not enough, and the reason is the whole point of
+// this scenario. Authorization asks two questions in order:
+//
+//   1. is the sender the thread's creator?          → allowed
+//   2. otherwise, does the sender hold message:delete? → allowed
+//
+// Claiming to be the victim gets you nothing on its own: the victim is not the
+// creator either, so you land on question 2 and need a role you cannot grant
+// yourself. The chain works by making question 1 answer yes:
+//
+//   1. A posts a message.
+//   2. B opens a thread on it, and writes `threadMeta.createdBy: <A>`. Thread
+//      creation was unauthenticated and the registry copied `createdBy` straight
+//      off the wire, so the thread now records A as its own creator.
+//   3. B sends `remove` claiming `senderId: <A>`. Now sender == creator, so
+//      question 1 says yes with no role involved — and "am I the root's author?"
+//      compares two payload fields that both say A, so it says yes too.
+//
+// A's message is gone. B never held a role, the space owner was never involved,
+// and every frame decrypted perfectly.
+//
+// ⚠️ Step 2 is what makes this reachable. An earlier version of this scenario
+// created the thread honestly (`createdBy: <B>`) and forged only the remove.
+// That version passed against PRE-FIX code — the claimed sender A was neither
+// creator nor role-holder, so the pre-fix check denied it for reasons having
+// nothing to do with the fix. It was a green test that could not fail. If you
+// are tempted to simplify this file by dropping the forged `createdBy`, that is
+// the trap you are walking back into.
+//
+// ── The two arms, and why the control one is not optional ──────────────────
+//
+// ATTACK ARM   B forges `createdBy: <A>` then `senderId: <A>`. A's root must SURVIVE.
+// CONTROL ARM  B opens and removes a thread honestly, as itself. A's root must
+//              also survive, but its `threadMeta` must be STRIPPED.
+//
+// The control arm distinguishes "the fix works" from "threads are broken".
+// Without it, a build that ignored every thread frame — or one where the frames
+// never arrived at all — would pass the attack arm perfectly. Its stripped
+// `threadMeta` is the positive evidence that removes are being received,
+// decrypted, authorized and applied.
+//
+// ── Why this scenario builds its own envelopes ─────────────────────────────
+//
+// A well-behaved client cannot express either forged frame: `submitChannelMessage`
+// overwrites `content.senderId` with the sender's own address, and the fix pins
+// `threadMeta.createdBy` to the verified signer. A real attacker is not running
+// our client, so the scenario does what a modified one would — it builds the
+// exact bytes and hands them to the REAL sealing call (`encryptAndSendToSpace`),
+// each with a genuine ed448 signature from B's own space signing key. Only the
+// send side is synthetic; everything from the wire onward is A's production
+// receive path.
+//
+// Signing them for real matters. A garbage-signed frame would be refused for a
+// reason that has nothing to do with authorization, and the scenario would pass
+// while testing nothing. Note the two forged frames differ here on purpose:
+// the CREATE claims B's own authorship, so its signature verifies and survives
+// intact; only the REMOVE claims A, which is the claim under test.
+//
+// ⚠️ Talks to the PRODUCTION relay with throwaway accounts. See identity.ts.
+import { test, expect } from 'vitest';
+import { channel_raw as ch } from '@quilibrium/quilibrium-js-sdk-channels';
+import {
+  canonicalize,
+  type Message,
+  type ThreadMessage,
+} from '@quilibrium/quorum-shared';
+import { createSpaceBot, type HarnessSpaceBot } from './spaceBot';
+import { RunLog } from './log';
+
+const WINDOW_MS = Number(process.env.HARNESS_SPACE_WINDOW_MS ?? 120_000);
+const SAMPLE_MS = Number(process.env.HARNESS_SPACE_SAMPLE_MS ?? 2000);
+const SETTLE_MS = Number(process.env.HARNESS_SETTLE_MS ?? 20_000);
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/** The thread id the app derives from a root message — see Channel.tsx. */
+async function threadIdFor(messageId: string): Promise<string> {
+  const buf = await crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(messageId + ':thread')
+  );
+  return Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+/** Poll until `check` returns a value, or the window closes. */
+async function until<T>(
+  check: () => Promise<T | undefined>,
+  windowMs = WINDOW_MS
+): Promise<T | undefined> {
+  const deadline = Date.now() + windowMs;
+  for (;;) {
+    const got = await check();
+    if (got !== undefined) return got;
+    if (Date.now() >= deadline) return undefined;
+    await sleep(SAMPLE_MS);
+  }
+}
+
+/** The messageId of the post carrying `text`, as this bot persisted it. */
+function postIdByText(bot: HarnessSpaceBot, text: string): string | undefined {
+  return bot.captured.find(
+    (m) =>
+      m.content?.type === 'post' &&
+      (m.content as { text?: string }).text === text
+  )?.messageId;
+}
+
+/**
+ * Build a space `Message` around a thread payload exactly as the honest send
+ * path builds it, then sign it with `signing`.
+ *
+ * The fingerprint uses `content.senderId` because that is what the RECEIVER
+ * feeds to `buildMessageFingerprint`. Keeping them equal is what makes a forged
+ * frame internally consistent rather than merely malformed — a malformed frame
+ * would be dropped early and would prove nothing.
+ */
+async function sealThreadFrame(params: {
+  spaceId: string;
+  channelId: string;
+  thread: ThreadMessage;
+  signing: { publicKey: string; privateKey: string };
+}): Promise<Message> {
+  const { spaceId, channelId, thread, signing } = params;
+  const nonce = crypto.randomUUID();
+  const digest = await crypto.subtle.digest(
+    'SHA-256',
+    Buffer.from(
+      nonce + 'thread' + thread.senderId + canonicalize(thread as never),
+      'utf-8'
+    )
+  );
+  return {
+    spaceId,
+    channelId,
+    messageId: Buffer.from(digest).toString('hex'),
+    digestAlgorithm: 'SHA-256',
+    nonce,
+    createdDate: Date.now(),
+    modifiedDate: Date.now(),
+    lastModifiedHash: '',
+    content: thread,
+    publicKey: signing.publicKey,
+    signature: Buffer.from(
+      JSON.parse(
+        ch.js_sign_ed448(
+          Buffer.from(signing.privateKey, 'hex').toString('base64'),
+          Buffer.from(digest).toString('base64')
+        )
+      ),
+      'base64'
+    ).toString('hex'),
+    reactions: [],
+  } as unknown as Message;
+}
+
+test(
+  'space-thread-forgery: opening a thread on someone else’s message must not confer the power to destroy it',
+  async () => {
+    const startedAt = Date.now();
+    const stamp = String(startedAt).slice(-6);
+    const log = new RunLog('space-thread-forgery', startedAt);
+    const say = (msg: string, fields: Record<string, unknown> = {}) => {
+      console.log(`[thread-forgery] ${msg}`);
+      log.add(Date.now(), 'harness', 'note', { msg, ...fields });
+    };
+
+    // Fresh throwaways: a reused bot would already hold the roots and threads
+    // from a previous run and could "pass" with no exchange having happened.
+    const [a, b] = await Promise.all([
+      createSpaceBot(`thr-victim-${stamp}`),
+      createSpaceBot(`thr-attacker-${stamp}`),
+    ]);
+    await Promise.all([a.start(), b.start()]);
+
+    try {
+      say(
+        `victim=${a.identity.address.slice(0, 12)} attacker=${b.identity.address.slice(0, 12)}`
+      );
+
+      // ── Setup: A owns a space with two posts; B joins ────────────────────
+      const { spaceId, channelId } = await a.createSpace(`thr-${stamp}`);
+      const attackText = `A root under attack ${stamp}`;
+      const controlText = `A root as control ${stamp}`;
+      await a.post(spaceId, channelId, attackText);
+      await a.post(spaceId, channelId, controlText);
+
+      const link = await a.inviteLink(spaceId);
+      const joined = await b.join(link);
+      expect(joined.spaceId).toBe(spaceId);
+
+      // B must actually SEE both roots before it can thread them. This is the
+      // real sync exchange, so it is polled rather than slept through.
+      const seen = await until(async () => {
+        const atk = postIdByText(b, attackText);
+        const ctl = postIdByText(b, controlText);
+        return atk && ctl ? { atk, ctl } : undefined;
+      });
+      expect(
+        seen,
+        'attacker never received the victim’s posts — nothing was tested'
+      ).toBeTruthy();
+      const { atk: attackRootId, ctl: controlRootId } = seen!;
+      say(
+        `roots: attack=${attackRootId.slice(0, 10)} control=${controlRootId.slice(0, 10)}`
+      );
+
+      const signing = await b.signingKey(spaceId);
+      expect(
+        signing,
+        'attacker holds no space signing key — no frame could be signed'
+      ).toBeTruthy();
+
+      const attackThreadId = await threadIdFor(attackRootId);
+      const controlThreadId = await threadIdFor(controlRootId);
+
+      // ── ATTACK, step 2: open a thread that CLAIMS THE VICTIM CREATED IT ──
+      // Sent as B (so the signature verifies and survives the receive gate);
+      // only `threadMeta.createdBy` lies. This is the step that makes the
+      // remove below reachable without any role.
+      await b.forgeSend(
+        spaceId,
+        await sealThreadFrame({
+          spaceId,
+          channelId,
+          signing: signing!,
+          thread: {
+            type: 'thread',
+            senderId: b.identity.address,
+            targetMessageId: attackRootId,
+            action: 'create',
+            threadMeta: {
+              threadId: attackThreadId,
+              // ⚠️ THE FIRST LIE: B is creating this thread, not A.
+              createdBy: a.identity.address,
+              lastActivityAt: Date.now(),
+            },
+          },
+        })
+      );
+
+      // ── CONTROL: an ordinary thread, opened honestly by B ────────────────
+      await b.sendControl(spaceId, channelId, {
+        type: 'thread',
+        senderId: b.identity.address,
+        targetMessageId: controlRootId,
+        action: 'create',
+        threadMeta: {
+          threadId: controlThreadId,
+          createdBy: b.identity.address,
+          lastActivityAt: Date.now(),
+        },
+      } satisfies ThreadMessage);
+
+      // Both threads must have landed on A's device, or the removes below have
+      // nothing to act on and the whole run is vacuous.
+      const threaded = await until(async () => {
+        const atk = await a.getMessage(spaceId, channelId, attackRootId);
+        const ctl = await a.getMessage(spaceId, channelId, controlRootId);
+        return atk?.threadMeta && ctl?.threadMeta ? { atk, ctl } : undefined;
+      });
+      expect(
+        threaded,
+        'the threads never reached the victim — nothing was tested'
+      ).toBeTruthy();
+      // Report, do not assert. Post-fix this reads as the ATTACKER (the forged
+      // createdBy was overwritten with the verified signer); pre-fix it reads as
+      // the VICTIM. Asserting either way would pin the scenario to one side of
+      // the fix, and its job is to run meaningfully against both.
+      say(
+        `victim's view of attacked thread: createdBy=${threaded!.atk.threadMeta?.createdBy?.slice(0, 10)} ` +
+          `(attacker=${b.identity.address.slice(0, 10)} victim=${a.identity.address.slice(0, 10)})`
+      );
+
+      // ── ATTACK, step 3: `remove`, claiming to be A ──────────────────────
+      await b.forgeSend(
+        spaceId,
+        await sealThreadFrame({
+          spaceId,
+          channelId,
+          signing: signing!,
+          thread: {
+            type: 'thread',
+            // ⚠️ THE SECOND LIE: the victim's address, on a frame B sealed.
+            senderId: a.identity.address,
+            targetMessageId: attackRootId,
+            action: 'remove',
+            threadMeta: {
+              threadId: attackThreadId,
+              createdBy: a.identity.address,
+              lastActivityAt: Date.now(),
+            },
+          },
+        })
+      );
+      say('forged remove sent (claims victim authorship over victim-owned thread)');
+
+      // ── CONTROL: the same remove, sent honestly as B ────────────────────
+      await b.sendControl(spaceId, channelId, {
+        type: 'thread',
+        senderId: b.identity.address,
+        targetMessageId: controlRootId,
+        action: 'remove',
+        threadMeta: {
+          threadId: controlThreadId,
+          createdBy: b.identity.address,
+          lastActivityAt: Date.now(),
+        },
+      } satisfies ThreadMessage);
+      say('honest remove sent (control arm)');
+
+      // The control arm is the one with a positive outcome to wait for, so it
+      // doubles as the settle signal: once A has applied it, A has had at least
+      // as long to apply the forged frame that was sent first.
+      await until(async () => {
+        const ctl = await a.getMessage(spaceId, channelId, controlRootId);
+        return ctl && !ctl.threadMeta ? true : undefined;
+      });
+      await sleep(SETTLE_MS);
+
+      // ── RESULT ───────────────────────────────────────────────────────────
+      const attackRootAfter = await a.getMessage(
+        spaceId,
+        channelId,
+        attackRootId
+      );
+      const controlRootAfter = await a.getMessage(
+        spaceId,
+        channelId,
+        controlRootId
+      );
+
+      say('');
+      say('==== RESULT ====');
+      say(
+        `attack  root: ${attackRootAfter ? 'ALIVE' : 'DELETED'}  threadMeta=${!!attackRootAfter?.threadMeta}`
+      );
+      say(
+        `control root: ${controlRootAfter ? 'ALIVE' : 'DELETED'}  threadMeta=${!!controlRootAfter?.threadMeta}`
+      );
+      say(
+        `receive failures: NOVEL victim=${a.novelErrors().length} attacker=${b.novelErrors().length}`
+      );
+      for (const e of a.novelErrors().slice(0, 5)) say(`   ! ${e.message}`);
+      say(`log: ${log.file}`);
+
+      // ── CONTROL ARM assertions — the feature still works ────────────────
+      //
+      // These run FIRST deliberately. If threads are broken, or nothing
+      // arrived, this is the arm that says so, and it says so before the
+      // security assertion can pass for the wrong reason.
+      expect(
+        controlRootAfter,
+        'CONTROL ARM: an honest thread remove hard-deleted a root the remover did not write — ' +
+          'thread removal is over-reaching'
+      ).toBeTruthy();
+      expect(
+        controlRootAfter?.threadMeta,
+        'CONTROL ARM: the honest remove was never applied, so this run proves nothing about the ' +
+          'forged one — threads may be broken, or no frame arrived'
+      ).toBeFalsy();
+
+      // ── ATTACK ARM assertion — the security property ────────────────────
+      expect(
+        attackRootAfter,
+        'ATTACK: opening a thread on someone’s message, claiming they created it, then claiming ' +
+          'to be them, DESTROYED their message'
+      ).toBeTruthy();
+
+      say('PASS — a forged authorship claim carried no authority over the root');
+    } finally {
+      a.stop();
+      b.stop();
+    }
+  },
+  15 * 60 * 1000
+);

--- a/src/dev/tests/harness/spaceBot.ts
+++ b/src/dev/tests/harness/spaceBot.ts
@@ -73,6 +73,46 @@ export interface HarnessSpaceBot {
   /** Post a text message to a channel via the real submitChannelMessage path. */
   post(spaceId: string, channelId: string, text: string): Promise<void>;
   /**
+   * Send a structured control payload (thread / pin / edit-message / …) through
+   * the same real `submitChannelMessage` path `post` uses.
+   *
+   * Separate from `post` only because `post` takes a string and the string
+   * branch builds a `PostMessage` around it. Everything downstream — signing,
+   * sealing, the drain discipline — is identical, which is the point: an
+   * honestly-sent control frame in a scenario must not travel a shortcut its
+   * production counterpart does not.
+   */
+  sendControl(
+    spaceId: string,
+    channelId: string,
+    payload: object
+  ): Promise<void>;
+  /**
+   * Seal and broadcast a `Message` this bot built itself, bypassing
+   * `submitChannelMessage`.
+   *
+   * ⚠️ This exists to express frames a well-behaved client CANNOT produce.
+   * `submitChannelMessage` overwrites `content.senderId` with the sender's own
+   * address, so no honest path can claim someone else's authorship — but an
+   * attacker is not running our client. This is the same move
+   * `dm-selfdelete-forgery` makes for DMs: build the exact bytes, then hand them
+   * to the REAL sealing call (`encryptAndSendToSpace`) so everything from the
+   * wire onward is production code.
+   *
+   * Only the send side is synthetic. The receiver's path is untouched.
+   */
+  forgeSend(spaceId: string, message: Message): Promise<void>;
+  /** Read one message straight off this bot's disk, or undefined if gone. */
+  getMessage(
+    spaceId: string,
+    channelId: string,
+    messageId: string
+  ): Promise<Message | undefined>;
+  /** The per-space key this bot signs with — `signing`, falling back to `inbox`. */
+  signingKey(
+    spaceId: string
+  ): Promise<{ publicKey: string; privateKey: string } | undefined>;
+  /**
    * Post `count` messages, draining ONCE at the end rather than per message.
    *
    * Same real path as `post`; only the waiting differs. Used to build a relay
@@ -329,6 +369,41 @@ export async function createSpaceBot(
       await mustDrain(drainActionQueue(), 'post action queue');
       await mustDrain(graph.outbound.flush(), 'post outbound');
     },
+
+    sendControl: async (
+      spaceId: string,
+      channelId: string,
+      payload: object
+    ) => {
+      await graph.messageService.submitChannelMessage(
+        spaceId,
+        channelId,
+        payload,
+        queryClient,
+        passkeyInfo
+      );
+      // Same two-stage drain as `post`, and for the same reason: the call
+      // returning means "queued", not "sent".
+      await mustDrain(drainActionQueue(), 'sendControl action queue');
+      await mustDrain(graph.outbound.flush(), 'sendControl outbound');
+    },
+
+    forgeSend: async (spaceId: string, message: Message) => {
+      await graph.messageService.encryptAndSendToSpace(spaceId, message);
+      await mustDrain(graph.outbound.flush(), 'forgeSend outbound');
+    },
+
+    getMessage: (spaceId: string, channelId: string, messageId: string) =>
+      messageDB
+        .getMessage({ spaceId, channelId, messageId })
+        .then((m) => m ?? undefined)
+        .catch(() => undefined),
+
+    signingKey: async (spaceId: string) =>
+      ((await messageDB.getSpaceKey(spaceId, 'signing')) ??
+        (await messageDB.getSpaceKey(spaceId, 'inbox'))) as
+        | { publicKey: string; privateKey: string }
+        | undefined,
 
     postMany: async (
       spaceId: string,


### PR DESCRIPTION
## Why

The thread authorization fix (#359) shipped with unit coverage only. This adds the
relay-level scenario the work was missing: the real client, two bots, the
production relay, and the composed sequence rather than one frame at a time.

## What it does

`yarn harness space-thread-forgery`

Two arms, both driven through the real receive path:

- **Attack arm** — an ordinary member opens a thread on someone else's message,
  then claims that person's authorship of the removal. The victim's message must
  survive.
- **Control arm** — the same removal, sent honestly. The victim's message must
  also survive, but its `threadMeta` must be **stripped**.

The control arm is not decoration. Its stripped `threadMeta` is the positive
evidence that thread frames are arriving, decrypting, authorizing and applying.
Without it, a build that ignored every thread frame would pass the attack arm
perfectly.

## Mutation-checked in both directions

| | pre-fix services | current services |
|---|---|---|
| attack root | **DELETED** (red) | ALIVE (green) |
| control root | ALIVE, `threadMeta` stripped | ALIVE, `threadMeta` stripped |

Verified by `git checkout <pre-fix-sha> -- src/services/{ThreadService,MessageService}.ts`,
running, confirming red, and restoring.

## The trap this scenario walked into first

The first draft forged only the removal, matching how the chain had been described
in prose. **It passed against the vulnerable code**, because the claimed sender was
neither the thread's creator nor a role-holder, so the old check denied it for
reasons unrelated to the defect.

The chain needs a second forgery: `threadMeta.createdBy` at creation time, which
the pre-fix registry copied straight off the wire. Only then does sender == creator
and the authorization question answer yes with no role involved.

Reading the code could not have found this. Running it against reverted services did.

The harness README now records the rule: any arm asserting "the attack failed" must
be seen red against code where the attack works, or it is not evidence.

## Also added

- `spaceBot.sendControl` — send a structured control payload through the same real
  `submitChannelMessage` path `post` uses, with the same two-stage drain.
- `spaceBot.forgeSend` — seal and broadcast a self-built `Message` via the real
  `encryptAndSendToSpace`, for frames a well-behaved client cannot express. Same
  move `dm-selfdelete-forgery` already makes for DMs.
- `spaceBot.getMessage` / `signingKey` — read seams for assertions.

No production code is touched.