### PR TITLE
fix(sync): scope a sync-delta's message changes to its delivering space

### DIFF
--- a/src/dev/tests/harness/space-sync-delta-launder.scenario.test.ts
+++ b/src/dev/tests/harness/space-sync-delta-launder.scenario.test.ts
@@ -1,0 +1,241 @@
+// NETWORKED. A sync delta cannot reach another space's message by first
+// overwriting that message's own row to claim the delivering space.
+//
+//   yarn harness space-sync-delta-launder
+//
+// Scoping the delete alone is not enough: the same delta's `newMessages` arm can
+// overwrite a target row (keyed by bare messageId) and stamp it with the
+// delivering space, after which the delete check passes on the laundered row.
+// The fix guards all three arms with the same "already belongs to another
+// space?" test on the same stored row, so the save arm cannot launder what the
+// delete arm consumes.
+//
+//   m2    victim's message in S2  → laundered via newMessages, then named for delete
+//   bOwn  sender's own message S1 → named for delete (positive control: frame ran)
+//   m3    victim's message in S1  → never named (bystander: not a store wipe)
+//
+// The sender only ever deletes its OWN message. Send side is production crypto
+// (`SpaceService.sendHubMessage` with the sender's real shared keys); the
+// receiver's path is untouched. PRODUCTION relay, throwaway accounts. See
+// identity.ts.
+import { test, expect } from 'vitest';
+import { type Message } from '@quilibrium/quorum-shared';
+import { createSpaceBot, type HarnessSpaceBot } from './spaceBot';
+import { RunLog } from './log';
+
+const WINDOW_MS = Number(process.env.HARNESS_SPACE_WINDOW_MS ?? 120_000);
+const SAMPLE_MS = Number(process.env.HARNESS_SPACE_SAMPLE_MS ?? 2000);
+const SETTLE_MS = Number(process.env.HARNESS_SETTLE_MS ?? 20_000);
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+async function until<T>(
+  check: () => Promise<T | undefined>,
+  windowMs = WINDOW_MS
+): Promise<T | undefined> {
+  const deadline = Date.now() + windowMs;
+  for (;;) {
+    const got = await check();
+    if (got !== undefined) return got;
+    if (Date.now() >= deadline) return undefined;
+    await sleep(SAMPLE_MS);
+  }
+}
+
+function postIdByText(bot: HarnessSpaceBot, text: string): string | undefined {
+  return bot.captured.find(
+    (m) =>
+      m.content?.type === 'post' &&
+      (m.content as { text?: string }).text === text
+  )?.messageId;
+}
+
+/** A minimal post-shaped `Message` reusing `messageId` — the laundering payload. */
+function launderMessage(
+  messageId: string,
+  spaceId: string,
+  channelId: string,
+  senderId: string,
+  text: string
+): Message {
+  return {
+    spaceId,
+    channelId,
+    messageId,
+    digestAlgorithm: 'SHA-256',
+    nonce: crypto.randomUUID(),
+    createdDate: Date.now(),
+    modifiedDate: Date.now(),
+    lastModifiedHash: '',
+    content: { type: 'post', senderId, text },
+    publicKey: '',
+    signature: '',
+    reactions: [],
+  } as unknown as Message;
+}
+
+/** Seal a `sync-delta` with chosen newMessages + deletedMessageIds and send it. */
+async function sendSyncDelta(
+  bot: HarnessSpaceBot,
+  spaceId: string,
+  channelId: string,
+  delta: { newMessages?: Message[]; deletedMessageIds?: string[] }
+): Promise<void> {
+  const frame = await bot.graph.spaceService.sendHubMessage(
+    spaceId,
+    JSON.stringify({
+      type: 'control',
+      message: {
+        type: 'sync-delta',
+        messageDelta: {
+          spaceId,
+          channelId,
+          newMessages: delta.newMessages ?? [],
+          updatedMessages: [],
+          deletedMessageIds: delta.deletedMessageIds ?? [],
+        },
+        isFinal: true,
+      },
+    })
+  );
+  bot.graph.outbound.enqueue(async () => [frame]);
+  await bot.flush();
+}
+
+test(
+  'space-sync-delta-launder: laundering a row’s spaceId via newMessages must not enable an out-of-space delete',
+  async () => {
+    const startedAt = Date.now();
+    const stamp = String(startedAt).slice(-6);
+    const log = new RunLog('space-sync-delta-launder', startedAt);
+    const say = (msg: string, fields: Record<string, unknown> = {}) => {
+      console.log(`[sync-delta-launder] ${msg}`);
+      log.add(Date.now(), 'harness', 'note', { msg, ...fields });
+    };
+
+    const [a, b] = await Promise.all([
+      createSpaceBot(`sdl-victim-${stamp}`),
+      createSpaceBot(`sdl-sender-${stamp}`),
+    ]);
+    await Promise.all([a.start(), b.start()]);
+
+    try {
+      say(
+        `victim=${a.identity.address.slice(0, 12)} sender=${b.identity.address.slice(0, 12)}`
+      );
+
+      const s1 = await a.createSpace(`sdl-s1-${stamp}`);
+      const s2 = await a.createSpace(`sdl-s2-${stamp}`);
+      say(`S1=${s1.spaceId.slice(0, 12)} S2=${s2.spaceId.slice(0, 12)}`);
+
+      const m2Text = `A in S2 — launder+delete target ${stamp}`;
+      const m3Text = `A in S1 — the bystander ${stamp}`;
+      await a.post(s2.spaceId, s2.channelId, m2Text);
+      await a.post(s1.spaceId, s1.channelId, m3Text);
+
+      const m2 = postIdByText(a, m2Text);
+      const m3 = postIdByText(a, m3Text);
+      expect(m2, 'M2 (S2 message) was never persisted — nothing to test').toBeTruthy();
+      expect(m3, 'M3 (bystander) was never persisted — control is void').toBeTruthy();
+      expect(await a.getMessage(s2.spaceId, s2.channelId, m2!)).toBeTruthy();
+
+      const link = await a.inviteLink(s1.spaceId);
+      const joined = await b.join(link);
+      expect(joined.spaceId).toBe(s1.spaceId);
+
+      const bOwnText = `B’s own post in S1 ${stamp}`;
+      await b.post(s1.spaceId, s1.channelId, bOwnText);
+      const bOwn = await until(async () => {
+        const id = postIdByText(a, bOwnText);
+        return id && (await a.getMessage(s1.spaceId, s1.channelId, id))
+          ? id
+          : undefined;
+      });
+      expect(
+        bOwn,
+        'the victim never received the sender’s own S1 post — no positive control'
+      ).toBeTruthy();
+      say('sender joined S1; victim holds the positive-control target');
+
+      // ── ATTACK: launder m2 into S1 via newMessages, then delete it ────────
+      await sendSyncDelta(b, s1.spaceId, s1.channelId, {
+        newMessages: [
+          launderMessage(m2!, s1.spaceId, s1.channelId, b.identity.address, 'x'),
+        ],
+        deletedMessageIds: [bOwn!, m2!],
+      });
+      say(
+        'ATTACK: sync-delta into S1 — newMessages reuses m2’s id, deletedMessageIds=[bOwn, m2]'
+      );
+
+      await until(async () => {
+        const still = await a.getMessage(s1.spaceId, s1.channelId, bOwn!);
+        return still === undefined ? true : undefined;
+      });
+      await sleep(SETTLE_MS);
+
+      // ── RESULT ───────────────────────────────────────────────────────────
+      const bOwnAfter = await a.getMessage(s1.spaceId, s1.channelId, bOwn!);
+      // m2 is read WITHOUT its space scope, so that a successful launder (which
+      // would have moved the row to S1) is still detected as "row present" and
+      // never mistaken for a survival. If the row exists under ANY space, the
+      // message was not destroyed.
+      const m2After = await a.messageDB.getMessageById(m2!);
+      const m3After = await a.getMessage(s1.spaceId, s1.channelId, m3!);
+
+      say('');
+      say('==== RESULT ====');
+      say(`POSITIVE  bOwn in S1 (named)       : ${bOwnAfter ? 'ALIVE' : 'DELETED'}`);
+      say(
+        `PROPERTY  m2 (laundered + named)   : ${
+          m2After ? `PRESENT (space=${m2After.spaceId.slice(0, 8)})` : 'DESTROYED'
+        }`
+      );
+      say(`BYSTANDER m3 in S1 (unnamed)       : ${m3After ? 'ALIVE' : 'DELETED'}`);
+      say(
+        `receive failures: NOVEL victim=${a.novelErrors().length} sender=${b.novelErrors().length}`
+      );
+      for (const e of a.novelErrors().slice(0, 5)) say(`   ! ${e.message}`);
+      say(`log: ${log.file}`);
+
+      // ── POSITIVE CONTROL — the frame was processed ───────────────────────
+      expect(
+        bOwnAfter,
+        'POSITIVE CONTROL: the in-space delete was not applied, so this run ' +
+          'proves nothing about the laundered one'
+      ).toBeFalsy();
+      expect(
+        a.novelErrors().length,
+        'the victim raised a novel receive error — the forged frame may have ' +
+          'been rejected before the handler ran'
+      ).toBe(0);
+
+      // ── BYSTANDER ────────────────────────────────────────────────────────
+      expect(
+        m3After,
+        'BYSTANDER: an unnamed message was deleted — result is not isolated'
+      ).toBeTruthy();
+
+      // ── SECURITY PROPERTY — no launder-then-delete ───────────────────────
+      // m2 must still exist AND still belong to S2. Either "destroyed" or
+      // "relocated to S1" is a failure: relocation alone is the cross-space
+      // overwrite, and it is the step that would have unlocked the delete.
+      expect(
+        m2After,
+        'SECURITY: the victim’s S2 message was destroyed — the newMessages arm ' +
+          'laundered its spaceId and the delete arm then consumed it'
+      ).toBeTruthy();
+      expect(
+        m2After?.spaceId,
+        'SECURITY: the victim’s S2 message was relocated into S1 by a laundering ' +
+          'newMessages entry — spaceId must be immutable across a sync-delta'
+      ).toBe(s2.spaceId);
+
+      say('PASS — a sync-delta could not launder a row across the space boundary');
+    } finally {
+      a.stop();
+      b.stop();
+    }
+  },
+  20 * 60 * 1000
+);

--- a/src/dev/tests/harness/space-sync-delta-scope.scenario.test.ts
+++ b/src/dev/tests/harness/space-sync-delta-scope.scenario.test.ts
@@ -1,0 +1,217 @@
+// NETWORKED. A sync delta may only delete messages belonging to the space that
+// delivered it.
+//
+//   yarn harness space-sync-delta-scope
+//
+// `sync-delta` carries `deletedMessageIds`, applied against a `messages` store
+// keyed by bare messageId — so without a scope check a delta into one space
+// could delete a message stored for a DIFFERENT space, one the sender may have
+// no relationship to. The handler skips any id whose stored row belongs to
+// another space.
+//
+//   bOwn  sender's message in S1 → named for delete (positive control: frame ran)
+//   m2    victim's message in S2 → named for delete (must survive: out of scope)
+//   m3    victim's message in S1 → never named (bystander: not a store wipe)
+//
+// The sender only ever deletes its OWN message. Send side is production crypto
+// (`SpaceService.sendHubMessage` with the sender's real shared keys); the
+// receiver's path is untouched. PRODUCTION relay, throwaway accounts. See
+// identity.ts.
+import { test, expect } from 'vitest';
+import { createSpaceBot, type HarnessSpaceBot } from './spaceBot';
+import { RunLog } from './log';
+
+const WINDOW_MS = Number(process.env.HARNESS_SPACE_WINDOW_MS ?? 120_000);
+const SAMPLE_MS = Number(process.env.HARNESS_SPACE_SAMPLE_MS ?? 2000);
+const SETTLE_MS = Number(process.env.HARNESS_SETTLE_MS ?? 20_000);
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/** Poll `check` until it returns a defined value or the window expires. */
+async function until<T>(
+  check: () => Promise<T | undefined>,
+  windowMs = WINDOW_MS
+): Promise<T | undefined> {
+  const deadline = Date.now() + windowMs;
+  for (;;) {
+    const got = await check();
+    if (got !== undefined) return got;
+    if (Date.now() >= deadline) return undefined;
+    await sleep(SAMPLE_MS);
+  }
+}
+
+function postIdByText(bot: HarnessSpaceBot, text: string): string | undefined {
+  return bot.captured.find(
+    (m) =>
+      m.content?.type === 'post' &&
+      (m.content as { text?: string }).text === text
+  )?.messageId;
+}
+
+/**
+ * Seal a `sync-delta` hub-control frame with `bot`'s real space keys and put it
+ * on the wire, exactly as a hub broadcast travels.
+ *
+ * `SpaceService.sendHubMessage` is the SAME call the app uses for every hub
+ * control frame: it fetches this bot's `hub` + `config` keys and returns a
+ * `{type:'group',...}` frame. Only the payload is chosen here. Enqueuing on the
+ * bot's own outbound queue is how the frame reaches the relay and fans out to
+ * the space's listeners.
+ */
+async function sendSyncDeltaDelete(
+  bot: HarnessSpaceBot,
+  spaceId: string,
+  channelId: string,
+  deletedMessageIds: string[]
+): Promise<void> {
+  const frame = await bot.graph.spaceService.sendHubMessage(
+    spaceId,
+    JSON.stringify({
+      type: 'control',
+      message: {
+        type: 'sync-delta',
+        messageDelta: {
+          spaceId,
+          channelId,
+          newMessages: [],
+          updatedMessages: [],
+          deletedMessageIds,
+        },
+        isFinal: true,
+      },
+    })
+  );
+  bot.graph.outbound.enqueue(async () => [frame]);
+  await bot.flush();
+}
+
+test(
+  'space-sync-delta-scope: a sync-delta must not delete a message outside its delivering space',
+  async () => {
+    const startedAt = Date.now();
+    const stamp = String(startedAt).slice(-6);
+    const log = new RunLog('space-sync-delta-scope', startedAt);
+    const say = (msg: string, fields: Record<string, unknown> = {}) => {
+      console.log(`[sync-delta-scope] ${msg}`);
+      log.add(Date.now(), 'harness', 'note', { msg, ...fields });
+    };
+
+    const [a, b] = await Promise.all([
+      createSpaceBot(`sds-victim-${stamp}`),
+      createSpaceBot(`sds-sender-${stamp}`),
+    ]);
+    await Promise.all([a.start(), b.start()]);
+
+    try {
+      say(
+        `victim=${a.identity.address.slice(0, 12)} sender=${b.identity.address.slice(0, 12)}`
+      );
+
+      // ── Setup ────────────────────────────────────────────────────────────
+      // A owns two spaces on ONE device (one IndexedDB). B joins only S1. A's
+      // message in S2 is reachable from an S1 frame iff the delete ignores scope.
+      const s1 = await a.createSpace(`sds-s1-${stamp}`);
+      const s2 = await a.createSpace(`sds-s2-${stamp}`);
+      say(`S1=${s1.spaceId.slice(0, 12)} S2=${s2.spaceId.slice(0, 12)}`);
+
+      const m2Text = `A in S2 — out of the delta’s scope ${stamp}`;
+      const m3Text = `A in S1 — the bystander ${stamp}`;
+      await a.post(s2.spaceId, s2.channelId, m2Text);
+      await a.post(s1.spaceId, s1.channelId, m3Text);
+
+      const m2 = postIdByText(a, m2Text);
+      const m3 = postIdByText(a, m3Text);
+      expect(m2, 'M2 (S2 message) was never persisted — nothing to test').toBeTruthy();
+      expect(m3, 'M3 (bystander) was never persisted — control is void').toBeTruthy();
+      expect(await a.getMessage(s2.spaceId, s2.channelId, m2!)).toBeTruthy();
+      expect(await a.getMessage(s1.spaceId, s1.channelId, m3!)).toBeTruthy();
+
+      const link = await a.inviteLink(s1.spaceId);
+      const joined = await b.join(link);
+      expect(joined.spaceId).toBe(s1.spaceId);
+      say('sender joined S1 (and nothing else)');
+
+      // B posts its OWN message in S1. This is the message B is entitled to
+      // delete, and its deletion is the positive control.
+      const bOwnText = `B’s own post in S1 ${stamp}`;
+      await b.post(s1.spaceId, s1.channelId, bOwnText);
+      const bOwn = await until(async () => {
+        const id = postIdByText(a, bOwnText);
+        return id && (await a.getMessage(s1.spaceId, s1.channelId, id))
+          ? id
+          : undefined;
+      });
+      expect(
+        bOwn,
+        'the victim never received the sender’s own S1 post — the positive ' +
+          'control cannot run, so a surviving M2 would prove nothing'
+      ).toBeTruthy();
+      say('victim holds the sender’s own S1 post (positive-control target)');
+
+      // ── The delta: names an in-space message (bOwn) and an out-of-space one (m2)
+      await sendSyncDeltaDelete(b, s1.spaceId, s1.channelId, [bOwn!, m2!]);
+      say('sync-delta sent into S1, deletedMessageIds = [bOwn(S1), m2(S2)]');
+
+      // Wait for the positive control to land, then settle. Waiting on the
+      // in-space delete gives the out-of-space one at least as long to be applied
+      // if the scope check were absent — so a surviving M2 is a real refusal.
+      await until(async () => {
+        const still = await a.getMessage(s1.spaceId, s1.channelId, bOwn!);
+        return still === undefined ? true : undefined;
+      });
+      await sleep(SETTLE_MS);
+
+      // ── RESULT ───────────────────────────────────────────────────────────
+      const bOwnAfter = await a.getMessage(s1.spaceId, s1.channelId, bOwn!);
+      const m2After = await a.getMessage(s2.spaceId, s2.channelId, m2!);
+      const m3After = await a.getMessage(s1.spaceId, s1.channelId, m3!);
+
+      say('');
+      say('==== RESULT ====');
+      say(`POSITIVE  bOwn in S1 (named)   : ${bOwnAfter ? 'ALIVE' : 'DELETED'}`);
+      say(`PROPERTY  m2   in S2 (named)   : ${m2After ? 'ALIVE' : 'DELETED'}`);
+      say(`BYSTANDER m3   in S1 (unnamed) : ${m3After ? 'ALIVE' : 'DELETED'}`);
+      say(
+        `receive failures: NOVEL victim=${a.novelErrors().length} sender=${b.novelErrors().length}`
+      );
+      for (const e of a.novelErrors().slice(0, 5)) say(`   ! ${e.message}`);
+      say(`log: ${log.file}`);
+
+      // ── POSITIVE CONTROL first — the delete path is live ─────────────────
+      expect(
+        bOwnAfter,
+        'POSITIVE CONTROL: the in-space delete was NOT applied, so this run ' +
+          'proves nothing about the out-of-space one — sync-delta delete may be ' +
+          'broken, or no frame arrived'
+      ).toBeFalsy();
+
+      expect(
+        a.novelErrors().length,
+        'the victim raised a novel receive error — the forged frame may have ' +
+          'been rejected before the handler ran, making a surviving M2 a false ' +
+          'positive'
+      ).toBe(0);
+
+      // ── BYSTANDER — the delete was targeted ──────────────────────────────
+      expect(
+        m3After,
+        'BYSTANDER: an unnamed message was deleted — the delete is untargeted ' +
+          '(or the store was wiped), so the property below is not isolated'
+      ).toBeTruthy();
+
+      // ── SECURITY PROPERTY — the scope boundary held ──────────────────────
+      expect(
+        m2After,
+        'SECURITY: a sync-delta delivered on S1 deleted a message in S2. A ' +
+          'delete must be refused when the stored row belongs to another space.'
+      ).toBeTruthy();
+
+      say('PASS — the delta deleted only within its delivering space');
+    } finally {
+      a.stop();
+      b.stop();
+    }
+  },
+  20 * 60 * 1000
+);

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -6697,7 +6697,32 @@ export class MessageService {
               // Collect unique channelIds that need to be refetched
               const channelIdsToRefetch = new Set<string>();
 
+              // A sync delta may only touch messages already stored under the
+              // delivering space. `messages` is keyed by bare messageId, so every
+              // arm must guard, not just delete: otherwise `newMessages` could
+              // overwrite a target's row to claim this space, and the delete arm
+              // would then pass its own check on the laundered row. Both arms read
+              // the same stored row, closing that ordering trick. An id not yet
+              // stored falls through and is created/deleted as before.
+              const wouldCrossSpaceBoundary = async (
+                messageId: string
+              ): Promise<boolean> => {
+                const stored = await this.messageDB.getMessageById(messageId);
+                if (stored && stored.spaceId !== spaceId) {
+                  logger.warn(
+                    `[MessageService] sync-delta: refusing out-of-space write/delete of ` +
+                      `${messageId.substring(0, 12)} — belongs to ${stored.spaceId.substring(
+                        0,
+                        12
+                      )}, delta delivered on ${spaceId.substring(0, 12)}`
+                  );
+                  return true;
+                }
+                return false;
+              };
+
               for (const msg of msgDelta.newMessages || []) {
+                if (await wouldCrossSpaceBoundary(msg.messageId)) continue;
                 const channelId = msg.channelId || msgDelta.channelId;
                 await this.saveMessage(
                   msg,
@@ -6715,6 +6740,7 @@ export class MessageService {
               }
 
               for (const msg of msgDelta.updatedMessages || []) {
+                if (await wouldCrossSpaceBoundary(msg.messageId)) continue;
                 const channelId = msg.channelId || msgDelta.channelId;
                 await this.saveMessage(
                   msg,
@@ -6732,6 +6758,7 @@ export class MessageService {
               }
 
               for (const msgId of msgDelta.deletedMessageIds || []) {
+                if (await wouldCrossSpaceBoundary(msgId)) continue;
                 await this.messageDB.deleteMessage(msgId);
               }
 


### PR DESCRIPTION
## What

The message-delta arms of a `sync-delta` — new, updated and deleted messages — act on the `messages` store, which is keyed by bare `messageId`. This scopes all three arms to the space the delta was delivered on:

- a delete only removes a stored row belonging to the delivering space;
- a new or updated message only overwrites a stored row belonging to the delivering space;
- an id not yet stored is created or deleted as before, and a stored row belonging to another space is left untouched.

All three arms resolve the same stored row, so the guard is consistent across them.

## Tests

Two networked harness scenarios — `yarn harness space-sync-delta-scope` and `yarn harness space-sync-delta-launder` — each with a positive control (an in-space operation still applies), a bystander control (an unnamed message is untouched), and the boundary assertion. Both were verified to fail with the guard reverted.
