### PR TITLE
fix(notifications): stop a partial settings record crashing the channel route

### DIFF
--- a/.agents/issues/2026-08-22-partial-notification-record-crashes-channel-route.md
+++ b/.agents/issues/2026-08-22-partial-notification-record-crashes-channel-route.md
@@ -1,0 +1,238 @@
+---
+type: bug
+title: "A partial notificationSettings record written by mobile crashes the whole channel route on desktop"
+status: in-progress
+priority: high
+created: 2026-08-22
+updated: 2026-08-22
+area: Notifications / cross-client config sync
+repos: quorum-desktop, quorum-shared, quorum-mobile
+related:
+  - "issues/.done/2026-06-23-notification-settings-stale-read-and-clobber.md (the previous bug in the same hook; its clobber guard interacts with this fix)"
+  - "docs/features/mention-notification-system.md"
+  - "docs/features/channel-space-mute-system.md"
+---
+
+## Symptom
+
+On production (`app.quorummessenger.com`, release build `index-DTb_hj0K.js`), opening
+one specific space showed **"the channel could not be loaded"**. The channel never
+rendered; the route error boundary caught the failure.
+
+Console, in order:
+
+```
+GET .../users/<address>/public-profile 404 (Not Found)        <- unrelated noise
+TypeError: Cannot read properties of undefined (reading 'filter')
+    at vY (index-DTb_hj0K.js:126:10333)
+Route error boundary caught: TypeError: ... (reading 'filter')
+[ReplyCounts] Error calculating reply counts: TypeError: Cannot read properties of undefined (reading 'includes')
+    at tRi (EmojiPicker-dQQMB-6f.js:56:333)
+[SpaceReplyCounts] Error calculating reply counts: TypeError: ... (reading 'includes')
+```
+
+Only one space and one account were affected. A second account on the same build
+was fine, which is why it looked like it might already be fixed in dev — it was
+not. The code at both crash sites is byte-identical between the release tag and
+`main`.
+
+## Cause
+
+`UserConfig.notificationSettings[spaceId]` **existed but had no
+`enabledNotificationTypes` array**.
+
+`SpaceNotificationSettings` declares that field as **required**, so every reader
+treated it as guaranteed. The value does not come from TypeScript, though — it
+comes from an untyped, cross-device synced config blob. The type is a claim about
+what should be there, not a guarantee.
+
+The producer is quorum-mobile, `services/config/configService.ts` → `setSpaceMuted`:
+
+```ts
+[spaceId]: { ...(prevSettings[spaceId] ?? {}), isMuted: muted } as any,
+```
+
+For a space with **no prior settings**, `?? {}` makes this write a bare
+`{ isMuted }` — no `spaceId`, no `enabledNotificationTypes`. That record then
+syncs to every other device. Its sibling `setNotificationTypes` was always
+correct; only the mute path was lossy.
+
+Desktop could not recover from it, because the guard was a null-check, not a
+shape-check:
+
+```ts
+config?.notificationSettings?.[spaceId] ?? getDefaultNotificationSettings(spaceId)
+```
+
+The record is **truthy**, so `??` never fires and the missing array survives.
+
+### Why it took down the entire route
+
+```
+mobile: first mute/unmute of a space  ──►  { isMuted: false }
+                                              │  syncs
+desktop useMentionNotificationSettings ───────┴──►  settings.enabledNotificationTypes === undefined
+                                                        │
+                                    selectedTypes = useState(undefined)
+                                                        │
+                    NotificationPanel.tsx:66  selectedTypes.filter(...)  ✗ THROWS IN RENDER
+```
+
+`NotificationPanel` is mounted **unconditionally** in `Channel.tsx:1696` — `isOpen`
+is only a prop, so the component and its hooks run even while the panel is closed.
+The user never had to click the bell. A render-phase throw there is not
+recoverable, so the route error boundary swallowed the whole channel.
+
+The `.includes` errors are the same root cause on a non-fatal path:
+`isNotificationTypeEnabled` had `if (!settings) return true;` then
+`settings.enabledNotificationTypes.includes(...)`. Both reply-count hooks wrap it
+in try/catch, so it degraded to zero counts plus console noise.
+
+`isMuted` must have been **false** on the affected account: the reply-count hooks
+return early when a space is muted, so reaching the `.includes` proves the space
+was muted and then unmuted on mobile.
+
+### Method note
+
+The two crash sites were identified by downloading the deployed bundles and
+reading the minified functions directly, rather than by guessing from source:
+
+- `tRi` = `function tRi(e,t){return e?e.enabledNotificationTypes.includes(t):!0}`
+  → `isNotificationTypeEnabled`
+- `vY` = the `NotificationPanel` component, crashing on
+  `g.filter(e=>e.startsWith("mention-"))`, and mounted in the deployed build with
+  a real `spaceId` in the channel header
+
+## Fix
+
+Three layers. **A is the one that unbreaks affected accounts** — C alone does
+nothing for data already written and synced.
+
+| Layer | Repo | Change |
+|-------|------|--------|
+| **A** | quorum-desktop | `useMentionNotificationSettings` normalizes the record on read instead of `??`-ing it |
+| **B** | quorum-shared | new `normalizeSpaceNotificationSettings`; `isNotificationTypeEnabled` and `hasEnabledNotificationTypes` now shape-check instead of null-check |
+| **C** | quorum-mobile | `setSpaceMuted` writes a complete record even on first write |
+
+The fix is **read-side only on desktop**. No desktop write path was changed.
+
+### Rejected: repairing the stored record (implemented, then reverted)
+
+Read-normalization makes a partial record harmless but does not **converge** it —
+the selection derived from it equals the normalized default, so `saveSettings`'
+clobber guard matches and returns early, and the malformed shape survives on the
+server.
+
+A repair path was built for this: a `needsSpaceNotificationSettingsRepair`
+predicate that let Save bypass the clobber guard when the raw stored record was
+malformed, plus the same normalization applied to `useChannelMute`'s mute/unmute
+writes. **It was reverted.** The safety argument behind it — "a record missing its
+array carries no user selection to clobber, so writing the default fills a blank"
+— is wrong:
+
+- The repair writes the all-enabled **default**, which is not a selection the user
+  made.
+- Config sync is **last-write-wins over the whole blob** (`ConfigService.ts:72`
+  compares timestamps; there is no per-field merge). So the repair does not fill a
+  blank quietly — it publishes an assertion with a fresh timestamp that competes
+  with every other device.
+- A partial record is a **transient** state, not a terminal one. Mobile's flow is
+  mute-first-then-refine-types, so "partial" is a normal step on the way to a real
+  value that has not synced down yet.
+- The trigger is far wider than notification editing: `saveSettings` runs on
+  **every** Account-tab Save (`SpaceSettingsModal.handleAccountSave`), including a
+  save where the user only changed a nickname.
+
+Together those give a concrete data-loss path: mobile writes a real
+`['mention-roles']`; before it syncs down, desktop's unrelated Save repairs the
+still-partial record to all-four with a newer timestamp; the user's choice is
+silently reverted. That is exactly the class of bug the 2026-06-23 clobber guard
+exists to prevent.
+
+`useChannelMute` had the same defect once normalized: pre-change it spread a
+partial record forward and asserted only `isMuted`, inventing nothing. Normalizing
+made it assert the default array too. Reverted for the same reason.
+
+**Accepted instead:** a partial record is inert while every reader normalizes, and
+it converges by itself the first time the user genuinely changes a selection on
+any device, because that write goes out complete. Convergence is traded for never
+writing a value the user did not choose.
+
+This decision is pinned by tests in all three repos; reintroducing a repair write
+turns them red.
+
+Normalization is deliberately conservative: a stored `enabledNotificationTypes: []`
+means "notify me about nothing" and is preserved, not mistaken for missing data.
+`isMuted` is preserved in every path — healing the shape must never silently
+unmute a space the user muted on their phone.
+
+## Verification
+
+Every test below was **mutation-proven**: the fix was reverted and the tests were
+confirmed to go red, then restored.
+
+| Suite | New tests | Red without the fix |
+|-------|-----------|---------------------|
+| quorum-shared `src/utils/notificationSettingsUtils.test.ts` | 14 | 7 fail |
+| quorum-desktop `src/dev/tests/hooks/notificationSettingsPartialRecord.unit.test.tsx` | 14 | 8 fail |
+| quorum-mobile `__tests__/spaceMuteWritesCompleteRecord.test.ts` | 6 | 3 fail |
+
+The desktop suite is mutation-tested in **both** directions, because the two
+failure modes here are opposites and a one-sided check would miss one of them:
+
+| Mutation | Expected | Result |
+|----------|----------|--------|
+| Revert read-normalization to `??` (the original crash) | crash tests red | 8 red |
+| Reintroduce a repair write on Save | **no-write tests red** | 2 red |
+
+The second direction is what defends the rejected-design decision above. Without
+it, a future change could re-add the repair path and the suite would stay green.
+
+The desktop test reproduces the production error verbatim
+(`Cannot read properties of undefined (reading 'length')` and the `.filter`)
+against the **real** hook and the **real** shared normalizer. The pre-existing
+`NotificationPanel.test.tsx` mocks `useMentionNotificationSettings` wholesale, so
+it could never have caught this.
+
+Full suites after the change: quorum-shared 756 passed, quorum-desktop 1663
+passed, quorum-mobile 1208 passed. Desktop `tsc --noEmit` clean.
+
+Two independent adversarial reviews ran. The first swept all three repos for remaining unguarded
+reads of `enabledNotificationTypes` / `notificationSettings[...]` and found none.
+It confirmed the other readers (`fetchSpaceMentions`, `useSpaceMentionCounts`,
+`useChannelMentionCounts`, `MessageService`, and mobile's own getters) were
+already safe, because they read at the **property** level with a `||`/`??`
+fallback — `settings?.enabledNotificationTypes` is `undefined` on a partial record
+whether or not the object is truthy, so those fallbacks always fired. Only the
+object-level `??` in `useMentionNotificationSettings` and the null-check in
+`isNotificationTypeEnabled` were vulnerable.
+
+The second review was scoped to the repair-on-Save mechanism and is what killed
+it. It confirmed the trigger was any Account-tab Save rather than a notification
+edit, confirmed the whole-blob last-write-wins sync, and constructed the
+interleaving above. It also independently re-ran the claimed mutation results in
+both directions rather than trusting them. Its one finding that did NOT drive the
+revert: the predicate also fired for a record with a valid array but a missing
+`spaceId` — a real selection — though no current writer produces that shape.
+
+## Status
+
+Implemented across all three repos on branch
+`fix/partial-notification-settings-record`. Not yet shipped.
+
+Stored records are deliberately not repaired (see the rejected design above), so
+an affected account keeps its partial record until the user next changes a
+notification selection on any device. That is inert. Mobile's fix prevents new
+corruption but heals nothing retroactively.
+
+## Known debt, not fixed here
+
+quorum-mobile declares its own local `SpaceNotificationTypeId` union in
+`services/config/configService.ts` instead of importing quorum-shared's identical
+type. The lists match today and nothing keeps them in step, so a change in shared
+would leave mobile silently stale with no compiler error. Pre-existing (it carries
+its own `TODO: drop the as any once the shared type is published + pinned`), and
+this change extends reliance on it. Worth its own task.
+
+---
+*Last updated: 2026-08-22*

--- a/src/dev/tests/hooks/notificationSettingsPartialRecord.unit.test.tsx
+++ b/src/dev/tests/hooks/notificationSettingsPartialRecord.unit.test.tsx
@@ -1,0 +1,298 @@
+/**
+ * A PARTIALLY-WRITTEN per-space notification record must not crash the channel.
+ *
+ * Production symptom (app.quorummessenger.com, 2026-08-21): opening one
+ * specific space showed "the channel could not be loaded", with
+ * `TypeError: Cannot read properties of undefined (reading 'filter')` caught by
+ * the route error boundary, plus repeated
+ * `[ReplyCounts]/[SpaceReplyCounts] ... (reading 'includes')` in the console.
+ *
+ * Cause: `UserConfig.notificationSettings[spaceId]` existed but had no
+ * `enabledNotificationTypes`. quorum-mobile's `setSpaceMuted` persists
+ * `{ ...(prev[spaceId] ?? {}), isMuted }`, so for a space with no prior settings
+ * it writes a bare `{ isMuted }` — which then syncs to desktop. The old
+ * `config?.notificationSettings?.[spaceId] ?? getDefaultNotificationSettings()`
+ * could not catch that: the record is truthy, so the fallback never fired and
+ * `selectedTypes` came out `undefined`. NotificationPanel then did
+ * `selectedTypes.filter(...)` during render and took the whole route down. The
+ * panel is mounted unconditionally in Channel.tsx (`isOpen` is only a prop), so
+ * the user never had to open it.
+ *
+ * This exercises the REAL hook against the REAL shared normalizer. The existing
+ * NotificationPanel test mocks `useMentionNotificationSettings` wholesale, so it
+ * could never have caught this.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import * as React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const SPACE_ID = 'space-1';
+const ADDR = 'QmPeerAEgVKpYZKYuFu2J49zHXnA8vZtEqHMtpB4imzzzz';
+const ALL_TYPES = ['mention-you', 'mention-everyone', 'mention-roles', 'reply'];
+
+const mocks = vi.hoisted(() => ({
+  config: undefined as unknown,
+  enqueue: vi.fn(),
+  getUserConfig: vi.fn(),
+}));
+
+vi.mock('@quilibrium/quilibrium-js-sdk-channels', () => ({
+  usePasskeysContext: () => ({ currentPasskeyInfo: { address: ADDR } }),
+}));
+
+vi.mock('@/components/context/useMessageDB', () => ({
+  useMessageDB: () => ({
+    messageDB: { getUserConfig: (...a: unknown[]) => mocks.getUserConfig(...a) },
+    actionQueueService: { enqueue: (...a: unknown[]) => mocks.enqueue(...a) },
+    keyset: {},
+  }),
+}));
+
+vi.mock('@/hooks/queries/config', () => ({
+  useConfig: () => ({ data: mocks.config }),
+  buildConfigKey: ({ userAddress }: { userAddress: string }) => ['config', userAddress],
+}));
+
+vi.mock('@/utils/toast', () => ({ showError: vi.fn() }));
+
+import { useMentionNotificationSettings } from '@/hooks/business/mentions/useMentionNotificationSettings';
+
+const wrapper = ({ children }: { children: React.ReactNode }) => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return React.createElement(QueryClientProvider, { client }, children);
+};
+
+const renderWithConfig = (config: unknown) => {
+  mocks.config = config;
+  // saveSettings re-reads the config cache-first and falls back to
+  // messageDB.getUserConfig. The mocked useConfig doesn't populate the query
+  // cache, so the fallback is the leg that runs here — it must return the same
+  // config the hook rendered from, or Save sees `undefined` and no-ops for
+  // reasons that have nothing to do with the behaviour under test.
+  mocks.getUserConfig.mockResolvedValue(config);
+  return renderHook(() => useMentionNotificationSettings({ spaceId: SPACE_ID }), {
+    wrapper,
+  });
+};
+
+/** Exactly what quorum-mobile's setSpaceMuted writes for a fresh space. */
+const mobileMuteOnlyConfig = (isMuted: boolean) => ({
+  address: ADDR,
+  spaceIds: [SPACE_ID],
+  notificationSettings: { [SPACE_ID]: { isMuted } },
+});
+
+beforeEach(() => {
+  mocks.config = undefined;
+  mocks.enqueue.mockReset().mockResolvedValue(undefined);
+  mocks.getUserConfig.mockReset().mockResolvedValue(undefined);
+});
+
+/** The per-space record a Save actually enqueued, or undefined if it no-opped. */
+const enqueuedRecord = () => {
+  if (mocks.enqueue.mock.calls.length === 0) return undefined;
+  const [, payload] = mocks.enqueue.mock.calls[0] as [
+    string,
+    { config: { notificationSettings: Record<string, unknown> } },
+  ];
+  return payload.config.notificationSettings[SPACE_ID] as
+    | { spaceId?: string; enabledNotificationTypes?: string[]; isMuted?: boolean }
+    | undefined;
+};
+
+describe('useMentionNotificationSettings with a partial stored record', () => {
+  it('yields an ARRAY of selected types, never undefined', () => {
+    // The load-bearing assertion. `undefined` here is what reached
+    // NotificationPanel's `selectedTypes.filter(...)` and killed the route.
+    const { result } = renderWithConfig(mobileMuteOnlyConfig(false));
+
+    expect(Array.isArray(result.current.selectedTypes)).toBe(true);
+    expect(result.current.selectedTypes).toEqual(ALL_TYPES);
+  });
+
+  it('survives the render + re-sync effect without throwing', () => {
+    // The effect calls sameTypes(prev, persistedTypes), which read `.length`
+    // off the missing array — a second crash site behind the first.
+    expect(() => renderWithConfig(mobileMuteOnlyConfig(false))).not.toThrow();
+  });
+
+  it('reproduces the exact NotificationPanel expression that crashed', () => {
+    const { result } = renderWithConfig(mobileMuteOnlyConfig(false));
+    const selected = result.current.selectedTypes;
+
+    // Verbatim from NotificationPanel.tsx: the .filter and the .includes.
+    expect(() => selected.filter((t) => t.startsWith('mention-'))).not.toThrow();
+    expect(selected.filter((t) => t.startsWith('mention-'))).toEqual([
+      'mention-you',
+      'mention-everyone',
+      'mention-roles',
+    ]);
+    expect(selected.includes('reply')).toBe(true);
+  });
+
+  it('keeps the space muted while healing the missing array', () => {
+    // Filling in defaults must not quietly unmute a space the user muted on
+    // their phone. isMuted is the whole reason the partial record exists.
+    const { result } = renderWithConfig(mobileMuteOnlyConfig(true));
+
+    expect(result.current.settings.isMuted).toBe(true);
+    expect(result.current.settings.enabledNotificationTypes).toEqual(ALL_TYPES);
+  });
+
+  it('backfills spaceId onto the partial record', () => {
+    const { result } = renderWithConfig(mobileMuteOnlyConfig(false));
+    expect(result.current.settings.spaceId).toBe(SPACE_ID);
+  });
+});
+
+describe('useMentionNotificationSettings with well-formed input (non-regression)', () => {
+  // These already passed before the fix. They are here so the fix cannot be
+  // the thing that started making them pass, and so normalization cannot
+  // silently override a real stored choice.
+  it('respects an explicit stored selection', () => {
+    const { result } = renderWithConfig({
+      address: ADDR,
+      spaceIds: [SPACE_ID],
+      notificationSettings: {
+        [SPACE_ID]: { spaceId: SPACE_ID, enabledNotificationTypes: ['reply'] },
+      },
+    });
+    expect(result.current.selectedTypes).toEqual(['reply']);
+  });
+
+  it('respects an explicitly empty selection rather than resetting it', () => {
+    // "Notify me about nothing" is a real choice and must not be mistaken for
+    // missing data.
+    const { result } = renderWithConfig({
+      address: ADDR,
+      spaceIds: [SPACE_ID],
+      notificationSettings: {
+        [SPACE_ID]: { spaceId: SPACE_ID, enabledNotificationTypes: [] },
+      },
+    });
+    expect(result.current.selectedTypes).toEqual([]);
+  });
+
+  it('falls back to all-enabled defaults when the space has no record', () => {
+    const { result } = renderWithConfig({
+      address: ADDR,
+      spaceIds: [SPACE_ID],
+      notificationSettings: {},
+    });
+    expect(result.current.selectedTypes).toEqual(ALL_TYPES);
+  });
+});
+
+describe('saveSettings never invents a selection the user did not make', () => {
+  // Normalizing on READ fixes the crash but does not converge the stored record.
+  // Writing the normalized value back to converge it was implemented and then
+  // REVERTED, because the value written is the all-enabled DEFAULT — not a user
+  // choice — and config sync is last-write-wins over the whole blob
+  // (ConfigService compares timestamps; no per-field merge). A repair write
+  // therefore races a real selection made on another device that hasn't synced
+  // down yet and silently reverts it, reopening the exact data-loss class the
+  // 2026-06-23 clobber guard exists to close. See that issue.
+  //
+  // These tests pin the reverted behaviour. If a future change reintroduces a
+  // repair write, the first three go red.
+
+  it('does NOT write on a no-op Save when the stored record is partial', async () => {
+    // The tempting case: the record is visibly broken and Save is right there.
+    // Writing here would assert ALL_TYPES over a selection the user may have
+    // just made on their phone.
+    const { result } = renderWithConfig(mobileMuteOnlyConfig(false));
+
+    await act(async () => {
+      await result.current.saveSettings();
+    });
+
+    expect(mocks.enqueue).not.toHaveBeenCalled();
+  });
+
+  it('does NOT write on a no-op Save for a healthy record', async () => {
+    const { result } = renderWithConfig({
+      address: ADDR,
+      spaceIds: [SPACE_ID],
+      notificationSettings: {
+        [SPACE_ID]: { spaceId: SPACE_ID, enabledNotificationTypes: ALL_TYPES },
+      },
+    });
+
+    await act(async () => {
+      await result.current.saveSettings();
+    });
+
+    expect(mocks.enqueue).not.toHaveBeenCalled();
+  });
+
+  it('does NOT write when a healthy record holds a narrowed selection', async () => {
+    // The exact shape the June bug was about: another device set
+    // ['mention-roles'] and desktop must not POST its own default over it.
+    const { result } = renderWithConfig({
+      address: ADDR,
+      spaceIds: [SPACE_ID],
+      notificationSettings: {
+        [SPACE_ID]: { spaceId: SPACE_ID, enabledNotificationTypes: ['mention-roles'] },
+      },
+    });
+
+    await act(async () => {
+      await result.current.saveSettings();
+    });
+
+    expect(mocks.enqueue).not.toHaveBeenCalled();
+  });
+
+  it('does NOT write for a space that has no record at all', async () => {
+    const { result } = renderWithConfig({
+      address: ADDR,
+      spaceIds: [SPACE_ID],
+      notificationSettings: {},
+    });
+
+    await act(async () => {
+      await result.current.saveSettings();
+    });
+
+    expect(mocks.enqueue).not.toHaveBeenCalled();
+  });
+});
+
+describe('a genuine edit still converges a partial record', () => {
+  // This is why declining to repair is acceptable rather than merely cheap: the
+  // record heals itself the first time the user actually chooses something,
+  // because that write goes out complete. No separate repair path is needed.
+
+  it('writes a COMPLETE record when the user changes the selection', async () => {
+    const { result } = renderWithConfig(mobileMuteOnlyConfig(false));
+
+    act(() => {
+      result.current.setSelectedTypes(['reply']);
+    });
+    await act(async () => {
+      await result.current.saveSettings();
+    });
+
+    expect(mocks.enqueue).toHaveBeenCalledTimes(1);
+    const written = enqueuedRecord()!;
+    expect(written.enabledNotificationTypes).toEqual(['reply']);
+    expect(written.spaceId).toBe(SPACE_ID);
+  });
+
+  it('carries isMuted through that convergence write', async () => {
+    // Healing on a real edit must not unmute a space muted on another device.
+    const { result } = renderWithConfig(mobileMuteOnlyConfig(true));
+
+    act(() => {
+      result.current.setSelectedTypes(['mention-you']);
+    });
+    await act(async () => {
+      await result.current.saveSettings();
+    });
+
+    expect(enqueuedRecord()!.isMuted).toBe(true);
+  });
+});

--- a/src/hooks/business/channels/useChannelMute.ts
+++ b/src/hooks/business/channels/useChannelMute.ts
@@ -317,7 +317,16 @@ export function useChannelMute({
           buildConfigKey({ userAddress })
         ) ?? (await messageDB.getUserConfig({ address: userAddress }));
 
-      // Get current notification settings for this space
+      // Get current notification settings for this space.
+      //
+      // Deliberately NOT normalized. A partial record (mobile's setSpaceMuted
+      // used to write a bare `{ isMuted }`) is spread forward as-is, so this
+      // write asserts only the mute flag the user just toggled. Completing it
+      // here was tried and reverted: the completion asserts the all-enabled
+      // DEFAULT, which is not a value the user chose, and config sync is
+      // last-write-wins over the whole blob — so it could silently revert a real
+      // selection made on another device that has not synced down yet. Every
+      // READER normalizes instead, which fixes the crash without inventing data.
       const currentSettings = currentConfig?.notificationSettings?.[spaceId] ||
         getDefaultNotificationSettings(spaceId);
 
@@ -377,7 +386,9 @@ export function useChannelMute({
           buildConfigKey({ userAddress })
         ) ?? (await messageDB.getUserConfig({ address: userAddress }));
 
-      // Get current notification settings for this space
+      // Get current notification settings for this space. Deliberately NOT
+      // normalized, for the same reason as muteSpace above — this write must
+      // assert only the mute flag, never an invented type selection.
       const currentSettings = currentConfig?.notificationSettings?.[spaceId] ||
         getDefaultNotificationSettings(spaceId);
 

--- a/src/hooks/business/mentions/useMentionNotificationSettings.ts
+++ b/src/hooks/business/mentions/useMentionNotificationSettings.ts
@@ -15,7 +15,7 @@ import { t } from '@lingui/core/macro';
 import { useMessageDB } from '../../../components/context/useMessageDB';
 import { usePasskeysContext } from '@quilibrium/quilibrium-js-sdk-channels';
 import type { SpaceNotificationSettings, SpaceNotificationTypeId } from '../../../types/notifications';
-import { getDefaultNotificationSettings, logger } from '@quilibrium/quorum-shared';
+import { normalizeSpaceNotificationSettings, logger } from '@quilibrium/quorum-shared';
 import { useConfig, buildConfigKey } from '../../queries/config';
 import { showError } from '../../../utils/toast';
 
@@ -88,10 +88,19 @@ export function useMentionNotificationSettings({
 
   // The persisted settings for this space, derived from the live config.
   // Falls back to all-types-enabled defaults for a space with no stored value.
+  //
+  // `normalize` rather than `??`: a record can EXIST but omit
+  // enabledNotificationTypes (quorum-mobile's setSpaceMuted writes a bare
+  // `{ isMuted }` for a space with no prior settings, which then syncs here).
+  // `??` does not fire on that truthy record, so the missing array used to
+  // reach `selectedTypes` as undefined and kill the channel route at
+  // NotificationPanel's `selectedTypes.filter(...)`.
   const settings = useMemo<SpaceNotificationSettings>(
     () =>
-      config?.notificationSettings?.[spaceId] ??
-      getDefaultNotificationSettings(spaceId),
+      normalizeSpaceNotificationSettings(
+        spaceId,
+        config?.notificationSettings?.[spaceId]
+      ),
     [config?.notificationSettings, spaceId]
   );
 
@@ -143,15 +152,35 @@ export function useMentionNotificationSettings({
 
       // Preserve any other fields already in notificationSettings[spaceId]
       // (most importantly isMuted, written by useChannelMute.muteSpace).
-      const currentSettings =
-        currentConfig?.notificationSettings?.[spaceId] ||
-        getDefaultNotificationSettings(spaceId);
+      // Normalized so a partial record can't reach the sameTypes() guard below
+      // with an undefined array — that threw on `.length` and made Save fail.
+      const currentSettings = normalizeSpaceNotificationSettings(
+        spaceId,
+        currentConfig?.notificationSettings?.[spaceId]
+      );
 
       // Clobber guard: if the selection matches what's already persisted, there
       // is nothing to write. This protects against the no-op Save that would
       // otherwise POST the current (now always-fresh) value back. Combined with
       // the reactive read above, a Save can no longer overwrite a value set on
       // another device with a stale desktop default.
+      //
+      // A malformed stored record deliberately does NOT bypass this guard, even
+      // though that means the broken shape survives on the server. Bypassing was
+      // tried and reverted: the repair write asserts the all-enabled DEFAULT,
+      // which is not a value the user chose, and config sync is last-write-wins
+      // over the whole blob (ConfigService compares timestamps; there is no
+      // per-field merge). So a repair racing a real selection made on another
+      // device and not yet synced down here would silently revert it. That window
+      // is not exotic — mobile's flow is mute-first-then-refine, so a partial
+      // record is a normal transient state on the way to a real value, and this
+      // Save runs on EVERY Account-tab save (SpaceSettingsModal.handleAccountSave),
+      // including ones where the user never touched the notification selector.
+      //
+      // Reading through normalizeSpaceNotificationSettings already makes a
+      // partial record harmless everywhere. It converges on its own the moment
+      // the user genuinely changes a selection on any device, because that write
+      // goes out through this same path below and lands complete.
       if (sameTypes(selectedTypes, currentSettings.enabledNotificationTypes)) {
         isDirtyRef.current = false;
         return;


### PR DESCRIPTION
Opening one specific space showed **"the channel could not be loaded"**. The route error boundary caught `TypeError: Cannot read properties of undefined (reading 'filter')`, alongside repeated `[ReplyCounts]` / `[SpaceReplyCounts] ... (reading 'includes')` in the console.

## Cause

`UserConfig.notificationSettings[spaceId]` existed but had no `enabledNotificationTypes`. Older quorum-mobile builds' `setSpaceMuted` wrote a bare `{ isMuted }` for a space with no prior settings, and that record syncs here.

`record ?? getDefaultNotificationSettings()` could not recover from it: the record is **truthy**, so the fallback never fired. `selectedTypes` came out `undefined` and `NotificationPanel` did `selectedTypes.filter(...)` during render. That panel is mounted unconditionally in `Channel.tsx` (`isOpen` is only a prop), so the user never had to open it for the route to die.

The two crash sites were identified by reading the minified functions out of the deployed bundle and matching them to source, rather than inferred.

## Fix

Normalize on read in `useMentionNotificationSettings`. That is the whole change: **no desktop write path is modified.**

## Repairing the stored record was implemented, then reverted

Read-normalization does not converge the stored data, so a repair path was built and then removed. Both the code comments and the issue file record why:

- The repair asserts the all-enabled **default**, which is not a value the user chose.
- Config sync is last-write-wins over the whole blob (`ConfigService.ts:72`), so the repair publishes a competing assertion with a fresh timestamp.
- A partial record is **transient**, not terminal: mobile's flow is mute-first-then-refine-types.
- `saveSettings` runs on **every** Account-tab save, including one that only changed a nickname.

Together: mobile writes a real `['mention-roles']`; before it syncs down, an unrelated desktop Save repairs the record to all-four with a newer timestamp; the user's choice is silently reverted. That is the data-loss class the 2026-06-23 clobber guard exists to prevent. `useChannelMute` had the same defect once normalized, and is likewise left alone.

A partial record is inert while readers normalize, and converges on its own the first time the user genuinely changes a selection anywhere.

## Tests

Drive the real hook and the real shared normalizer, unlike the existing `NotificationPanel.test.tsx` which mocks this hook wholesale — which is why this shipped in the first place.

Mutation-proven in both directions:

| Mutation | Result |
|---|---|
| Revert read-normalization | 8 red, reproducing the production error |
| Reintroduce a repair write | 2 red |

Full suite 1663 passing, `tsc --noEmit` clean.

## Related

Depends on quorum-shared #88 (consumed via the local link, no publish required). Producer fixed in quorum-mobile.
