### PR TITLE
fix(sync): verify a sync frame against a key the space has bound to a member

### DIFF
--- a/src/dev/tests/harness/space-sync-owner-key-forgery.scenario.test.ts
+++ b/src/dev/tests/harness/space-sync-owner-key-forgery.scenario.test.ts
@@ -1,0 +1,637 @@
+// NETWORKED. A sync frame is only honoured when its signature verifies against a
+// key the SPACE already bound to an identity — never against a key the frame
+// itself introduced.
+//
+//   yarn harness space-sync-owner-key-forgery
+//
+// `sync-peer-map`, `sync-members` and `sync-messages` share one gate
+// (`MessageService.ts:5787`, `:6519`, `:6648`):
+//
+//   reg.owner_public_keys.includes(exteriorEnvelope.owner_public_key)
+//     || this.syncInfo.current[spaceId]
+//
+// The second disjunct is a truthiness test on an object this client writes when
+// IT requests a sync, and which production code never deletes. Past the gate the
+// handler verifies `owner_signature` against `owner_public_key` — both fields
+// supplied by the sender, out of the same envelope. So once this page has asked
+// for a sync even once, a frame signed by a key the attacker generated moments
+// earlier verifies against itself and is applied as though the space owner had
+// sent it.
+//
+// The forge sends a frame no honest client can produce. Every legitimate sender
+// signs with a key the space knows: `synchronizeAll` with the registered owner
+// key (`SyncService.ts:92`), `directSync` / `handleSyncInitiateV2` /
+// `handleSyncManifest` with the sender's own space `inbox` key (`:348`, `:837`,
+// `:968`). None of them can sign with a throwaway. Only the sealing call's
+// signing keypair is chosen here; `SealSyncEnvelope` is the real one, and the
+// receiver's path is untouched.
+//
+//   NOSYNC   fresh-key frame, delivered BEFORE the victim ever asked for a sync
+//            → must be REFUSED (isolates the fallback as the cause: the owner
+//              check is present and does work, it is the disjunct that opens)
+//   ATTACK   fresh-key frame, delivered AFTER one sync request
+//            → the victim must NOT store the forged roster row (PROPERTY)
+//   PEER     the IDENTICAL frame signed with the sender's REAL per-space `inbox`
+//            key — what every genuine peer sender uses
+//            → must still be APPLIED. Without this arm a fix that refused ALL
+//              peer sync would pass every other assertion here AND `space-basic`
+//              (a fresh joiner also gets its roster via the ungated `sync-delta`),
+//              so silent death of peer sync would look exactly like success.
+//   BADSIG   fresh-key frame, signature corrupted, sync flag still set
+//            → nothing must be written. ⚠️ MEASURED 2026-08-22: the production
+//              relay REFUSES TO CARRY this frame — it never reaches the victim
+//              socket at all — so this arm demonstrates relay-side filtering and
+//              does NOT exercise the client's own ed448 call. Kept because a
+//              relay that stopped filtering would make it a real client-side
+//              control, and the arm reports which of the two happened.
+//
+// That relay behaviour also sharpens the diagnosis: the relay accepts the ATTACK
+// frame for exactly the reason the client does — the envelope really is
+// internally consistent. The defect was never a missing signature check. It is
+// that the check is run against a key the frame chose.
+//
+// ⚠️ Each arm asserts a NEGATIVE ("the row was not written"), which is what a
+// frame that never arrived also looks like. So every arm is paired with an
+// arrival check that matches THAT ARM'S OWN throwaway signing key in
+// `transport.arrived` — the raw socket log, upstream of any application
+// dispatch. Without it a wholly broken transport would render this file green.
+// MEASURED on the first run: the ATTACK arm is self-proving (the row appears,
+// so the frame plainly arrived), but both control arms are not, and an earlier
+// draft of this check read a log line that never fired — it would have reported
+// "0 envelopes seen" while the attack was demonstrably landing.
+//
+// Each arm targets a DIFFERENT fabricated member row, so no two frames ever
+// write the same key — the concurrency trap in the harness README bites well
+// before "two frames, one row", and batches here are one frame deep for that
+// reason.
+//
+// PRODUCTION relay, throwaway accounts. See identity.ts.
+import { test, expect } from 'vitest';
+import {
+  channel as secureChannel,
+  channel_raw as ch,
+} from '@quilibrium/quilibrium-js-sdk-channels';
+import { hexToSpreadArray } from '../../../utils/crypto';
+import { createSpaceBot, type HarnessSpaceBot } from './spaceBot';
+import { RunLog } from './log';
+
+const WINDOW_MS = Number(process.env.HARNESS_SPACE_WINDOW_MS ?? 120_000);
+const SAMPLE_MS = Number(process.env.HARNESS_SPACE_SAMPLE_MS ?? 2000);
+const SETTLE_MS = Number(process.env.HARNESS_SETTLE_MS ?? 20_000);
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/** Poll `check` until it returns a defined value or the window expires. */
+async function until<T>(
+  check: () => Promise<T | undefined>,
+  windowMs = WINDOW_MS
+): Promise<T | undefined> {
+  const deadline = Date.now() + windowMs;
+  for (;;) {
+    const got = await check();
+    if (got !== undefined) return got;
+    if (Date.now() >= deadline) return undefined;
+    await sleep(SAMPLE_MS);
+  }
+}
+
+/**
+ * Force the relay to re-push everything queued for this bot.
+ *
+ * ⚠️ The sleep is not politeness. `reconnect` resolves once the socket has been
+ * asked to open, but the CLOSING socket's own handler schedules a second
+ * `open()` a second later, so the transport can end up pointing at a socket in
+ * readyState CONNECTING while `connected` is still true. A send issued in that
+ * window is recorded in `outbound.failures` and RESOLVES ANYWAY. Copied from
+ * space-message-id-derivation, where that window silently ate two frames of six
+ * and read exactly like the gate under test dropping them.
+ */
+async function forceDelivery(bot: HarnessSpaceBot): Promise<void> {
+  // Drain first. Anything still queued when the socket churns is attempted
+  // against a CONNECTING socket and lands in `outbound.failures`, which is
+  // noise this scenario would otherwise have to explain away. MEASURED on the
+  // first run of this file: three such failures on the victim, all from its own
+  // sync-info / sync-request traffic, none related to any arm.
+  await bot.graph.outbound.flush();
+  bot.disconnect();
+  await bot.reconnect();
+  await until(async () => (bot.transport.connected ? true : undefined), 30_000);
+  await sleep(3000);
+  await until(async () => (bot.transport.connected ? true : undefined), 30_000);
+}
+
+/**
+ * Did this bot's SOCKET receive the directed sync envelope signed by this exact
+ * key?
+ *
+ * `transport.arrived` is appended in the raw ws 'message' handler, upstream of
+ * any application dispatch (`transport.ts:314`), so it answers "did the frame
+ * reach the client" independently of whether the client then accepted it,
+ * refused it, or threw on it. That independence is the whole point: every
+ * control arm here asserts a NEGATIVE, and a frame that never arrived is
+ * indistinguishable from one that was refused.
+ *
+ * Matching the arm's own throwaway signing key makes it SPECIFIC to that arm. A
+ * frame counter would not: the relay redelivers backlog on every `listen`, so a
+ * counter rises for traffic that has nothing to do with the arm — the exact
+ * false-green the harness README calls out (`space-manifest-scope`'s review
+ * caught one).
+ */
+function forgedFrameArrived(
+  bot: HarnessSpaceBot,
+  signingKeyHex: string
+): boolean {
+  // Deliberately a substring search over the whole frame rather than a parse of
+  // `encryptedContent`. An earlier version parsed the frame and matched
+  // `outer.owner_public_key`; it reported "never arrived" for all three arms in
+  // a run where the ATTACK arm had demonstrably arrived and written its row, so
+  // an assumption about the relay's delivered shape was wrong. The needle is a
+  // 114-hex-char ed448 public key generated for this arm alone — it cannot
+  // collide with anything, and matching it needs no assumption about how the
+  // relay wraps what it delivers.
+  const needle = signingKeyHex.toLowerCase();
+  return bot.transport.arrived.some((frame) => {
+    try {
+      return JSON.stringify(frame).toLowerCase().includes(needle);
+    } catch {
+      return false;
+    }
+  });
+}
+
+/** Top-level shape of a delivered frame — recorded so the next reader need not guess. */
+function describeArrivedShape(bot: HarnessSpaceBot): string {
+  const sample = bot.transport.arrived[bot.transport.arrived.length - 1];
+  if (!sample) return 'none';
+  const keys = Object.keys(sample).join(',');
+  const raw = (sample as { encryptedContent?: unknown }).encryptedContent;
+  let innerKeys = 'n/a';
+  if (typeof raw === 'string') {
+    try {
+      innerKeys = Object.keys(JSON.parse(raw) as object).join(',');
+    } catch {
+      innerKeys = 'unparseable';
+    }
+  }
+  return `frame{${keys}} encryptedContent{${innerKeys}}`;
+}
+
+/**
+ * Seal a `sync-members` frame addressed to `victimInbox`, signed by a keypair
+ * generated here rather than by any key the space registered.
+ *
+ * This is the whole forgery: `SealSyncEnvelope`'s FOURTH argument becomes the
+ * envelope's `owner_public_key` / `owner_signature` pair
+ * (`quilibrium-js-sdk-channels`, `SealSyncEnvelope`), and the receiver verifies
+ * the signature against that same self-declared key. Passing a throwaway
+ * keypair there is something no send path in the app can express — all four
+ * real senders pass either the space `owner` keyset or their own `inbox` keyset.
+ *
+ * The hub and config keys are the attacker's REAL ones: they are shared per
+ * space, so holding them is just membership, which is the bar this whole class
+ * of finding already assumes.
+ */
+async function forgeSyncMembersFrame(params: {
+  bot: HarnessSpaceBot;
+  spaceId: string;
+  victimInbox: string;
+  members: unknown[];
+  corruptSignature?: boolean;
+  /**
+   * Which key signs the envelope.
+   *
+   * `fresh` — a throwaway the space has never seen: the forgery.
+   * `spaceInbox` — the sender's REAL per-space `inbox` key, which is exactly
+   *   what `directSync` / `handleSyncInitiateV2` / `handleSyncManifest` sign
+   *   with. This is the honest peer control, and it is the arm that keeps the
+   *   fix from silently refusing all peer sync.
+   */
+  signWith?: 'fresh' | 'spaceInbox';
+}): Promise<{ frame: string; signingKeyHex: string }> {
+  const {
+    bot,
+    spaceId,
+    victimInbox,
+    members,
+    corruptSignature,
+    signWith = 'fresh',
+  } = params;
+
+  const hubKey = await bot.messageDB.getSpaceKey(spaceId, 'hub');
+  const configKey = await bot.messageDB.getSpaceKey(spaceId, 'config');
+  if (!hubKey?.address) {
+    throw new Error(
+      `[harness] no hub key/address for ${spaceId} — the attacker is not a member, ` +
+        'so the forge cannot even be sealed and the run would prove nothing'
+    );
+  }
+
+  let fresh: { public_key: number[]; private_key: number[] };
+  if (signWith === 'spaceInbox') {
+    const inboxKey = await bot.messageDB.getSpaceKey(spaceId, 'inbox');
+    if (!inboxKey?.publicKey) {
+      throw new Error(
+        `[harness] no space inbox key for ${spaceId} — the honest peer control ` +
+          'cannot be signed, so a green run would not prove peer sync still works'
+      );
+    }
+    fresh = {
+      public_key: hexToSpreadArray(inboxKey.publicKey),
+      private_key: hexToSpreadArray(inboxKey.privateKey),
+    };
+  } else {
+    // A keypair the space has never seen and never will.
+    fresh = JSON.parse(ch.js_generate_ed448()) as {
+      public_key: number[];
+      private_key: number[];
+    };
+  }
+
+  const envelope = await secureChannel.SealSyncEnvelope(
+    victimInbox,
+    hubKey.address,
+    {
+      type: 'ed448',
+      private_key: hexToSpreadArray(hubKey.privateKey),
+      public_key: hexToSpreadArray(hubKey.publicKey),
+    },
+    { type: 'ed448', ...fresh },
+    JSON.stringify({
+      type: 'control',
+      message: { type: 'sync-members', members },
+    }),
+    configKey
+      ? {
+          type: 'x448' as const,
+          public_key: hexToSpreadArray(configKey.publicKey),
+          private_key: hexToSpreadArray(configKey.privateKey),
+        }
+      : undefined
+  );
+
+  if (corruptSignature) {
+    // Flip one hex nibble. The envelope still parses and still opens — only the
+    // ed448 check can tell the difference, which is precisely what this arm is
+    // asking about.
+    const sig = envelope.owner_signature;
+    const flipped = sig[0] === '0' ? '1' : '0';
+    envelope.owner_signature = flipped + sig.slice(1);
+  }
+
+  return {
+    frame: JSON.stringify({ type: 'sync', ...envelope }),
+    signingKeyHex: Buffer.from(new Uint8Array(fresh.public_key)).toString('hex'),
+  };
+}
+
+/** Put a raw frame on the wire through the attacker's own serialized queue. */
+async function send(bot: HarnessSpaceBot, frame: string): Promise<void> {
+  bot.graph.outbound.enqueue(async () => [frame]);
+  const drained = await bot.graph.outbound.flush();
+  if (!drained) {
+    throw new Error(
+      '[harness] the attacker outbound queue did not drain — the frame was never ' +
+        'sent, so any "refused" result below would be an artifact'
+    );
+  }
+}
+
+/** A fabricated roster row. The address is invented and belongs to nobody. */
+function forgedRow(tag: string, stamp: string) {
+  return {
+    user_address: `QmForgedMember${tag}${stamp}`,
+    inbox_address: `QmForgedInbox${tag}${stamp}`,
+    display_name: `ATTACKER-INJECTED-${tag}-${stamp}`,
+    user_icon: '',
+  };
+}
+
+test(
+  'space-sync-owner-key-forgery: a sync frame signed by a self-declared key must not be applied',
+  async () => {
+    const startedAt = Date.now();
+    const stamp = String(startedAt).slice(-6);
+    const log = new RunLog('space-sync-owner-key-forgery', startedAt);
+    const say = (msg: string, fields: Record<string, unknown> = {}) => {
+      console.log(`[sync-owner-forgery] ${msg}`);
+      log.add(Date.now(), 'harness', 'note', { msg, ...fields });
+    };
+
+    const [v, x] = await Promise.all([
+      createSpaceBot(`sokf-victim-${stamp}`),
+      createSpaceBot(`sokf-attacker-${stamp}`),
+    ]);
+    await Promise.all([v.start(), x.start()]);
+
+    try {
+      say(
+        `victim=${v.identity.address.slice(0, 12)} attacker=${x.identity.address.slice(0, 12)}`
+      );
+
+      // ── Setup ────────────────────────────────────────────────────────────
+      // V owns the space; X is an ordinary member. X holding the hub and config
+      // keys is exactly what membership means here — no privilege beyond that.
+      const s = await v.createSpace(`sokf-${stamp}`);
+      say(`space=${s.spaceId.slice(0, 12)}`);
+
+      const link = await v.inviteLink(s.spaceId);
+      const joined = await x.join(link);
+      expect(joined.spaceId).toBe(s.spaceId);
+      say('attacker joined as an ordinary member');
+
+      const victimInbox = (await v.messageDB.getSpaceKey(s.spaceId, 'inbox'))
+        ?.address;
+      expect(
+        victimInbox,
+        'the victim has no space inbox address — nothing can be addressed to it'
+      ).toBeTruthy();
+
+      // Let the join settle so the roster/keys are in place on both sides and
+      // the join traffic is not still in flight when the arms start.
+      await forceDelivery(v);
+      await sleep(SETTLE_MS);
+
+      const rowNoSync = forgedRow('NOSYNC', stamp);
+      const rowAttack = forgedRow('ATTACK', stamp);
+      const rowBadSig = forgedRow('BADSIG', stamp);
+
+      // ── ARM 1 — NOSYNC: the fallback is not yet open ─────────────────────
+      // The victim has never called requestSync for this space, so
+      // syncInfo.current[spaceId] should be unset and ONLY the owner-key
+      // disjunct can admit a frame. A fresh key is not a registered owner key,
+      // so this must be refused — which is what proves the owner check exists
+      // and is doing work, making ARM 2 attributable to the fallback rather
+      // than to there being no check at all.
+      const syncFlagBefore = v.graph.syncInfo.current[s.spaceId];
+      if (syncFlagBefore) {
+        // Not expected — nothing in the harness calls requestSync implicitly —
+        // but if some path armed it, say so rather than silently testing a
+        // different thing, and clear it so the arm still means what it claims.
+        say('⚠️ victim already had a sync session before ARM 1 — clearing it');
+        delete v.graph.syncInfo.current[s.spaceId];
+      }
+      say(`ARM 1 NOSYNC — sync flag set: ${!!syncFlagBefore} (expected false)`);
+
+      const f1 = await forgeSyncMembersFrame({
+        bot: x,
+        spaceId: s.spaceId,
+        victimInbox: victimInbox!,
+        members: [rowNoSync],
+      });
+      say(`ARM 1 signed by throwaway key ${f1.signingKeyHex.slice(0, 16)}…`);
+      await send(x, f1.frame);
+      await forceDelivery(v);
+      await until(
+        async () => (forgedFrameArrived(v, f1.signingKeyHex) ? true : undefined),
+        WINDOW_MS
+      );
+      await sleep(SETTLE_MS);
+      const arrived1 = forgedFrameArrived(v, f1.signingKeyHex);
+      const noSyncRow = await v.messageDB.getSpaceMember(
+        s.spaceId,
+        rowNoSync.user_address
+      );
+
+      // ── ARM 2 — ATTACK: one sync request opens the fallback ──────────────
+      const asked = await v.requestSync(s.spaceId);
+      expect(asked, 'requestSync did not even queue — the precondition is unmet').toBe(
+        true
+      );
+      await until(
+        async () =>
+          v.graph.syncInfo.current[s.spaceId] !== undefined ? true : undefined,
+        30_000
+      );
+      const syncFlagArmed = !!v.graph.syncInfo.current[s.spaceId];
+      expect(
+        syncFlagArmed,
+        'PRECONDITION: the victim requested a sync but syncInfo was never ' +
+          'populated, so the fallback this scenario exercises is not open and ' +
+          'a refused ATTACK arm would prove nothing'
+      ).toBe(true);
+      say('ARM 2 ATTACK — sync flag now armed (the fallback is open)');
+
+      const f2 = await forgeSyncMembersFrame({
+        bot: x,
+        spaceId: s.spaceId,
+        victimInbox: victimInbox!,
+        members: [rowAttack],
+      });
+      say(`ARM 2 signed by throwaway key ${f2.signingKeyHex.slice(0, 16)}…`);
+      await send(x, f2.frame);
+      await forceDelivery(v);
+      await until(
+        async () => (forgedFrameArrived(v, f2.signingKeyHex) ? true : undefined),
+        WINDOW_MS
+      );
+      await sleep(SETTLE_MS);
+      const arrived2 = forgedFrameArrived(v, f2.signingKeyHex);
+      const attackRow = await v.messageDB.getSpaceMember(
+        s.spaceId,
+        rowAttack.user_address
+      );
+
+      // ── ARM 3 — BADSIG: the same frame with a broken signature ───────────
+      // Still inside an armed sync session, so the gate opens exactly as it did
+      // for ARM 2 and only the ed448 result differs.
+      const f3 = await forgeSyncMembersFrame({
+        bot: x,
+        spaceId: s.spaceId,
+        victimInbox: victimInbox!,
+        members: [rowBadSig],
+        corruptSignature: true,
+      });
+      say(`ARM 3 signed by throwaway key ${f3.signingKeyHex.slice(0, 16)}… (signature corrupted)`);
+      await send(x, f3.frame);
+      await forceDelivery(v);
+      // Short window on purpose: non-arrival is the MEASURED expectation here
+      // (the relay filters it), so spending the full delivery window waiting for
+      // something that is not coming just makes every run four minutes longer.
+      await until(
+        async () => (forgedFrameArrived(v, f3.signingKeyHex) ? true : undefined),
+        30_000
+      );
+      await sleep(SETTLE_MS);
+      const arrived3 = forgedFrameArrived(v, f3.signingKeyHex);
+      const badSigRow = await v.messageDB.getSpaceMember(
+        s.spaceId,
+        rowBadSig.user_address
+      );
+
+      // ── ARM 4 — PEER: the identical frame signed with a REAL space key ───
+      // THE MOST IMPORTANT ARM IN THIS FILE, and the reason is worth stating.
+      // Every other arm asserts something was refused. A fix that refused ALL
+      // peer sync would satisfy every one of them, and `space-basic` would still
+      // pass too, because a fresh joiner also gets its roster through the
+      // UNGATED `sync-delta` — so nothing else here would notice that peer-signed
+      // sync had been killed outright. This arm isolates the single variable
+      // under test: same sender, same payload, same envelope, only the signing
+      // key differs. `spaceInbox` is precisely what the three real peer senders
+      // sign with (`SyncService.ts:348`, `:837`, `:968`).
+      const rowPeer = forgedRow('PEERKEY', stamp);
+      const f4 = await forgeSyncMembersFrame({
+        bot: x,
+        spaceId: s.spaceId,
+        victimInbox: victimInbox!,
+        members: [rowPeer],
+        signWith: 'spaceInbox',
+      });
+      say(`ARM 4 signed by the sender's REAL space key ${f4.signingKeyHex.slice(0, 16)}…`);
+      await send(x, f4.frame);
+      await forceDelivery(v);
+      await until(
+        async () => (forgedFrameArrived(v, f4.signingKeyHex) ? true : undefined),
+        WINDOW_MS
+      );
+      await until(
+        async () =>
+          (await v.messageDB.getSpaceMember(s.spaceId, rowPeer.user_address))
+            ? true
+            : undefined,
+        WINDOW_MS
+      );
+      await sleep(SETTLE_MS);
+      const arrived4 = forgedFrameArrived(v, f4.signingKeyHex);
+      const peerRow = await v.messageDB.getSpaceMember(
+        s.spaceId,
+        rowPeer.user_address
+      );
+
+      // ── DIAGNOSTICS BEFORE VERDICTS ──────────────────────────────────────
+      // Order matters. A wedged send pipeline or a novel receive error makes
+      // every "refused" result below meaningless, so those are reported and
+      // asserted first — otherwise the run quietly indicts the code under test.
+      say('');
+      say('==== DIAG ====');
+      say(
+        `outbound failures  victim/attacker : ${v.graph.outbound.failures.length} / ${x.graph.outbound.failures.length}`
+      );
+      for (const f of [
+        ...v.graph.outbound.failures,
+        ...x.graph.outbound.failures,
+      ].slice(0, 5)) {
+        say(`   ! outbound: ${f.error}`);
+      }
+      say(
+        `novel receive errors victim/attacker : ${v.novelErrors().length} / ${x.novelErrors().length}`
+      );
+      for (const e of v.novelErrors().slice(0, 5)) say(`   ! victim: ${e.message}`);
+      say(
+        `forged frame reached victim socket : arm1 ${arrived1}, arm2 ${arrived2}, ` +
+          `arm3 ${arrived3}, arm4 ${arrived4}`
+      );
+      say(`frames arrived at victim socket (all traffic) : ${v.transport.arrived.length}`);
+      say(`delivered frame shape : ${describeArrivedShape(v)}`);
+
+      say('');
+      say('==== RESULT ====');
+      say(`NOSYNC  forged row stored : ${noSyncRow ? 'YES' : 'no'}  (want: no)`);
+      say(`ATTACK  forged row stored : ${attackRow ? 'YES' : 'no'}  (want: no)`);
+      say(`BADSIG  forged row stored : ${badSigRow ? 'YES' : 'no'}  (want: no)`);
+      say(`PEER    real-key row stored : ${peerRow ? 'YES' : 'no'}  (want: YES)`);
+      say(`log: ${log.file}`);
+
+      // The ATTACKER's queue is asserted strictly: those are the frames every
+      // verdict below is about, and one that never left is a refusal that never
+      // happened.
+      //
+      // The VICTIM's queue is reported but deliberately NOT asserted empty. It
+      // only ever carries the victim's own `sync-info` / `sync-request` traffic,
+      // none of which any verdict here depends on, and `forceDelivery`'s
+      // reconnect churn puts occasional sends against a CONNECTING socket
+      // (MEASURED: 3 on the first run of this file, all that shape). The one
+      // victim-side precondition — that a sync session is armed — is asserted
+      // directly against `syncInfo` rather than inferred from a successful send,
+      // so a dropped victim frame cannot manufacture a false refusal.
+      expect(
+        x.graph.outbound.failures.map((f) => f.error),
+        'an attacker outbound action failed — a forged frame may never have ' +
+          'reached the relay, so a refused arm cannot be attributed to the gate'
+      ).toEqual([]);
+
+      expect(
+        v.novelErrors().length,
+        'the victim raised a novel receive error — a forged frame may have been ' +
+          'rejected before the gate ran, making every refusal below a false positive'
+      ).toBe(0);
+
+      // ── ARRIVAL — the negatives below are about refusal, not absence ──────
+      expect(
+        arrived1,
+        'ARM 1 arrival: the NOSYNC frame never reached the victim socket, so ' +
+          '"not stored" means "never delivered" and the arm proves nothing'
+      ).toBe(true);
+      expect(
+        arrived2,
+        'ARM 2 arrival: the ATTACK frame never reached the victim socket'
+      ).toBe(true);
+      // ARM 3 is NOT asserted to arrive. MEASURED 2026-08-22: the relay drops a
+      // sync envelope whose owner_signature does not verify against its
+      // owner_public_key, so the frame never reaches the victim. Asserting
+      // arrival here would encode relay behaviour as a requirement; asserting
+      // non-arrival would equally freeze it. Both outcomes are reported instead,
+      // and only the outcome that matters either way — nothing was written — is
+      // asserted below.
+      say(
+        arrived3
+          ? 'ARM 3 note: the relay CARRIED the corrupted-signature frame, so its ' +
+              'refusal below IS a client-side ed448 result'
+          : 'ARM 3 note: the relay FILTERED the corrupted-signature frame — it ' +
+              'never reached the victim, so this arm does not exercise the ' +
+              "client's own ed448 check"
+      );
+
+      // ── DELIVERY — peer sync still works ─────────────────────────────────
+      // Asserted BEFORE the security property on purpose. If peer-signed sync is
+      // broken, the security result below is worthless: everything is refused,
+      // including everything legitimate, and the "PASS" would be measuring a
+      // client that has stopped syncing rather than one that has stopped being
+      // forgeable.
+      expect(
+        arrived4,
+        'ARM 4 arrival: the honest peer frame never reached the victim socket, so ' +
+          'this run cannot show that peer sync survives the fix'
+      ).toBe(true);
+      expect(
+        peerRow,
+        'DELIVERY: a sync frame signed with the sender’s REAL per-space key was ' +
+          'REFUSED. This is the silent-breakage failure mode — every peer sync ' +
+          '(directSync, handleSyncInitiateV2, handleSyncManifest) signs with that ' +
+          'key, so the fix has killed syncing rather than narrowing it.'
+      ).toBeTruthy();
+
+      // ── CONTROL 1 — the owner check exists and refuses a stranger ────────
+      expect(
+        noSyncRow,
+        'CONTROL (NOSYNC): a fresh-key frame was applied even with NO sync ' +
+          'session open. Then the owner-key check is not doing anything at all, ' +
+          'and the ATTACK arm cannot be attributed to the syncInfo fallback.'
+      ).toBeFalsy();
+
+      // ── CONTROL 2 — a broken signature is honoured by nobody ─────────────
+      // True whether the relay filtered it or the client refused it; the note
+      // above records which. Either way, a frame whose signature does not verify
+      // must never reach storage.
+      expect(
+        badSigRow,
+        'CONTROL (BADSIG): a frame with a corrupted signature was applied. Some ' +
+          'layer that must reject an unverifiable envelope did not.'
+      ).toBeFalsy();
+
+      // ── SECURITY PROPERTY ────────────────────────────────────────────────
+      expect(
+        attackRow,
+        'SECURITY: an ordinary member signed a sync frame with a key it generated ' +
+          'itself, and the victim applied it as owner-authored roster state. A ' +
+          'signature must be verified against a key the space already bound to an ' +
+          'identity, never against one the frame supplied.'
+      ).toBeFalsy();
+
+      say('PASS — a self-declared signing key is not accepted as space authority');
+    } finally {
+      v.stop();
+      x.stop();
+    }
+  },
+  20 * 60 * 1000
+);

--- a/src/dev/tests/services/syncFrameAuth.unit.test.ts
+++ b/src/dev/tests/services/syncFrameAuth.unit.test.ts
@@ -1,0 +1,196 @@
+// The sync gate's membership predicate.
+//
+// These cases are here rather than in the networked harness because two bots on
+// a live relay cannot cheaply produce a revoked device admission, a malformed
+// member row, or a roster that has been kicked down to nothing — and those are
+// exactly the states where a membership rule fails open or fails silently.
+//
+// The harness proves the gate works end to end
+// (`space-sync-owner-key-forgery`); this proves the rule underneath it is the
+// rule we think it is.
+import { describe, it, expect } from 'vitest';
+import { deriveInboxAddress } from '@quilibrium/quorum-shared';
+import type { SpaceMember, SpaceMemberDevice } from '@quilibrium/quorum-shared';
+import { classifySyncFrameSigner } from '../../../services/syncFrameAuth';
+
+const SELF = 'QmSelfMemberAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+const PEER = 'QmPeerMemberBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
+
+/** Any hex string works — the derivation is a hash, not a key operation. */
+const PEER_KEY = 'aa'.repeat(57);
+const STRANGER_KEY = 'bb'.repeat(57);
+const DEVICE_KEY = 'cc'.repeat(57);
+
+const member = (over: Partial<SpaceMember> = {}): SpaceMember =>
+  ({
+    user_address: PEER,
+    address: PEER,
+    inbox_address: deriveInboxAddress(PEER_KEY),
+    ...over,
+  }) as unknown as SpaceMember;
+
+const self = (over: Partial<SpaceMember> = {}): SpaceMember =>
+  ({
+    user_address: SELF,
+    address: SELF,
+    inbox_address: 'QmSelfInboxCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+    ...over,
+  }) as unknown as SpaceMember;
+
+const classify = (
+  publicKeyHex: string,
+  members: SpaceMember[],
+  deviceKeys: SpaceMemberDevice[] = []
+) =>
+  classifySyncFrameSigner({
+    publicKeyHex,
+    members,
+    deviceKeys,
+    selfAddress: SELF,
+  });
+
+describe('classifySyncFrameSigner', () => {
+  it("accepts a current member's own signing key", () => {
+    expect(classify(PEER_KEY, [self(), member()])).toBe('member');
+  });
+
+  it('refuses a key belonging to nobody in the space', () => {
+    expect(classify(STRANGER_KEY, [self(), member()])).toBe('unbound');
+  });
+
+  it('refuses an empty key rather than treating it as unknown-but-fine', () => {
+    expect(classify('', [self(), member()])).toBe('unbound');
+  });
+
+  describe('a kicked member stops being able to sign for the space', () => {
+    // Two representations exist locally and BOTH must exclude. `verify-kicked`
+    // sets isKicked (MessageService.ts, verify-kicked handler); the `kick`
+    // handler instead clears inbox_address. A rule that only knew about one of
+    // them would keep honouring a removed member's frames.
+    it('when the kick was recorded as isKicked', () => {
+      expect(classify(PEER_KEY, [self(), member({ isKicked: true } as never)])).toBe(
+        'unbound'
+      );
+    });
+
+    it('when the kick was recorded by clearing inbox_address', () => {
+      expect(classify(PEER_KEY, [self(), member({ inbox_address: '' } as never)])).toBe(
+        'unbound'
+      );
+    });
+  });
+
+  describe('per-device admissions', () => {
+    const device = (over: Partial<SpaceMemberDevice> = {}): SpaceMemberDevice =>
+      ({
+        inboxAddress: deriveInboxAddress(DEVICE_KEY),
+        userAddress: PEER,
+        revoked: false,
+        ...over,
+      }) as unknown as SpaceMemberDevice;
+
+    it("accepts a second device's key once its admission has been stored", () => {
+      expect(classify(DEVICE_KEY, [self(), member()], [device()])).toBe('member');
+    });
+
+    it('refuses a revoked device', () => {
+      expect(
+        classify(DEVICE_KEY, [self(), member()], [device({ revoked: true })])
+      ).toBe('unbound');
+    });
+
+    it('refuses an admission whose owning member has been kicked (isKicked)', () => {
+      expect(
+        classify(
+          DEVICE_KEY,
+          [self(), member({ isKicked: true } as never)],
+          [device()]
+        )
+      ).toBe('unbound');
+    });
+
+    it('refuses an admission whose owner was kicked by CLEARING inbox_address', () => {
+      // THE CASE THAT WAS MISSED, found by independent review.
+      //
+      // The earlier version of these tests checked both kick spellings against
+      // the join-bound path only, and this combination — kicked the way the LIVE
+      // `kick` handler actually records it (`MessageService.ts:6468-6471`, which
+      // clears `inbox_address` and never sets `isKicked`), plus an admitted second
+      // device — slipped through every one of them. Shared's device path screens
+      // the owning row with `!m.isKicked` alone (`messageAuth.ts:190-193`), so it
+      // resolved the kicked member as current.
+      //
+      // A removed member could therefore have gone on signing `sync-peer-map`
+      // frames, which overwrite the space's ratchet state.
+      expect(
+        classify(
+          DEVICE_KEY,
+          [self(), member({ inbox_address: '' } as never)],
+          [device()]
+        )
+      ).toBe('unbound');
+    });
+
+    it('refuses when the owning row is a bare kick tombstone', () => {
+      // `verify-kicked` upserts `{user_address, inbox_address: '', isKicked: true}`
+      // for a member it never had a row for. Belt and braces: neither spelling
+      // alone should be load-bearing.
+      expect(
+        classify(
+          DEVICE_KEY,
+          [
+            self(),
+            {
+              user_address: PEER,
+              inbox_address: '',
+              isKicked: true,
+            } as unknown as SpaceMember,
+          ],
+          [device()]
+        )
+      ).toBe('unbound');
+    });
+
+    it('falls through to bootstrap — not to member — when the owning row is absent', () => {
+      // Documented rather than asserted as a security property: with only our own
+      // row present the bootstrap window is open anyway, so the admission is not
+      // what admits this frame. Worth pinning so a future change that makes an
+      // ownerless admission resolve to `member` is visible.
+      expect(classify(DEVICE_KEY, [self()], [device()])).toBe('bootstrap');
+    });
+  });
+
+  describe('the bootstrap window', () => {
+    it('is OPEN while we know of no member but ourselves', () => {
+      expect(classify(STRANGER_KEY, [self()])).toBe('bootstrap');
+    });
+
+    it('is OPEN on a completely empty roster', () => {
+      expect(classify(STRANGER_KEY, [])).toBe('bootstrap');
+    });
+
+    it('is CLOSED as soon as one other member is known', () => {
+      expect(classify(STRANGER_KEY, [self(), member()])).toBe('unbound');
+    });
+
+    it('is CLOSED by a kicked other member too — a kick does not reopen it', () => {
+      // Otherwise removing the last other member would hand an ex-member a fresh
+      // window in which any key is accepted.
+      expect(
+        classify(STRANGER_KEY, [self(), member({ isKicked: true } as never)])
+      ).toBe('unbound');
+    });
+
+    it('is NOT closed by a row carrying no address at all', () => {
+      // A malformed/partial row must not count as "another member we know".
+      // Counting it would slam the window shut on a client that genuinely still
+      // needs it, and the symptom would be a join that never receives anything.
+      expect(
+        classify(STRANGER_KEY, [
+          self(),
+          { inbox_address: '' } as unknown as SpaceMember,
+        ])
+      ).toBe('bootstrap');
+    });
+  });
+});

--- a/src/dev/tests/services/verifiedSenderRequiresVerification.test.ts
+++ b/src/dev/tests/services/verifiedSenderRequiresVerification.test.ts
@@ -318,6 +318,66 @@ describe('the unverified resolver cannot come back', () => {
     ).toBe(false);
   });
 
+  it('the sync gate asks a membership question and never keeps the identity', () => {
+    // `syncFrameAuth.ts` is the ONE place outside the fused primitive allowed to
+    // touch the raw reverse lookup, and this test is the price of that. It is an
+    // EXTENSION of the guard above, not an exemption from it: the invariant being
+    // protected is "no sender identity without a signature check", and that holds
+    // here only because the resolved identity is discarded on the spot.
+    //
+    // The sync gate genuinely needs a different question from the auth paths —
+    // "is this signing key one the space already knows", answered as a boolean,
+    // with the ed448 check run against the same key immediately afterwards. If a
+    // future edit starts returning, storing or passing on what the lookup
+    // returns, that question quietly becomes "who is this", and this fails.
+    const SYNC_AUTH = readFileSync(
+      resolve(process.cwd(), 'src/services/syncFrameAuth.ts'),
+      'utf8'
+    );
+
+    const calls = SYNC_AUTH.match(/\bresolveVerifiedSender\s*\(/g) ?? [];
+    expect(
+      calls.length,
+      'syncFrameAuth should call the reverse lookup exactly once'
+    ).toBe(1);
+
+    // THE STRUCTURAL ASSERTION, and it is the only one here with real teeth.
+    //
+    // Used ONLY as an `if` condition, the resolved identity never becomes a
+    // value in that module — so there is nothing to leak, by construction. That
+    // is what makes the guarantee hold rather than merely be policed.
+    //
+    // ⚠️ This was briefly replaced with softer checks (count the exports, match
+    // the declared return type) when the implementation needed a local to
+    // re-screen the resolved row. An independent review then demonstrated TWO
+    // low-effort constructions that leaked the identity — via `globalThis`, and
+    // via a separate `export { … }` statement the export regex never matches —
+    // while passing every one of those checks. A regex cannot follow data flow;
+    // it can only observe shape. So the implementation was restructured to
+    // filter kicked rows BEFORE the lookup, which removed the need for the local
+    // and let this assertion come back. Do not trade it away again: if a change
+    // needs the resolved value, the right move is to find a shape that does not.
+    //
+    // MEASURED after restoring it — five constructions that genuinely move the
+    // resolver's return value somewhere observable were run against these
+    // assertions, and all five are caught: assign to a local; assign inside the
+    // condition; pass it to a function; store it in a module-level variable that
+    // is exported; call the resolver a second time. The only shape that passes is
+    // the one where the value is never bound to anything.
+    expect(
+      /\bif\s*\(\s*resolveVerifiedSender\s*\(/.test(SYNC_AUTH),
+      'the reverse lookup is no longer used purely as an `if` condition, so the ' +
+        'resolved identity now exists as a value that could escape the module. ' +
+        'Restructure so it does not, rather than relaxing this check.'
+    ).toBe(true);
+
+    expect(
+      /(?:return|=)\s*resolveVerifiedSender\s*\(/.test(SYNC_AUTH),
+      'syncFrameAuth returned or stored the resolved identity; it must only ever ' +
+        'answer a membership question'
+    ).toBe(false);
+  });
+
   it('every sender resolution goes through verifySpaceSender', () => {
     // One definition, and at least the four auth paths consuming it: control
     // messages, update-profile, read-only posts, and the @everyone gate.

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -35,6 +35,7 @@ import {
   type AnnounceKeysStatement,
   type RevokeDeviceStatement,
 } from '@quilibrium/quorum-shared';
+import { classifySyncFrameSigner } from './syncFrameAuth';
 import { MessageDB, EncryptionState, EncryptedMessage } from '../db/messages';
 import type { SpaceMemberRow } from '../db/messages';
 import type {
@@ -2057,6 +2058,92 @@ export class MessageService {
       deviceKeys: deviceKeys as unknown as Params['deviceKeys'],
       provider: this.signingProvider,
     });
+  }
+
+  /**
+   * May this signing key speak for the space on a directed sync frame?
+   *
+   * `sync-peer-map`, `sync-members` and `sync-messages` share one gate, and its
+   * second disjunct used to admit ANY key once this client had requested a sync
+   * — after which the handler verified `owner_signature` against
+   * `owner_public_key`, both taken from the SAME envelope. A signature checked
+   * against a key the frame supplied proves only that the frame is internally
+   * consistent with itself; it says nothing about authority. This binds the key
+   * to an identity the space already knows BEFORE the signature is checked,
+   * which is what makes checking it mean anything.
+   *
+   * ⚠️ It deliberately does NOT require the registered owner key, and that is
+   * the whole difficulty of this gate. Only `synchronizeAll` signs with the
+   * owner key (`SyncService.ts:92`, and it only runs on a client that holds one
+   * at all). `directSync`, `handleSyncInitiateV2` and `handleSyncManifest` all
+   * sign with the SENDER'S OWN space `inbox` key (`SyncService.ts:348`, `:837`,
+   * `:968`), so an owner-only rule would refuse every peer-to-peer sync and
+   * break syncing silently — the failure mode this codebase can least afford.
+   *
+   * The membership question itself lives in `syncFrameAuth.ts`, deliberately
+   * NOT here: answering it needs the shared reverse lookup, which runs no
+   * cryptography, and a source guard forbids this file from touching that
+   * directly (see that module's header, and
+   * `dev/tests/services/verifiedSenderRequiresVerification.test.ts`). What
+   * crosses back is a verdict, never an identity.
+   *
+   * A storage failure fails CLOSED here rather than propagating. Letting it
+   * throw would abandon the whole hub/sync branch for this frame in the terminal
+   * catch — losing any LATER handler work the same frame would have done — and
+   * report it as a generic "Error processing hub/sync message" with no hint that
+   * a roster read was the cause. Refusing this one frame is recoverable: the next
+   * sync round re-sends it.
+   *
+   * (An earlier version of this comment claimed a throw would get the frame
+   * RETAINED for redelivery as unopenable. That was wrong — `opened` is already
+   * true by the time any of these handlers run (`:5473`), so the retain branch
+   * cannot fire here. Corrected after independent review rather than left as a
+   * plausible-sounding justification for the right code.)
+   */
+  private async syncFrameSignerIsBoundToSpace(
+    spaceId: string,
+    publicKeyHex: string,
+    selfAddress: string
+  ): Promise<boolean> {
+    let members: Awaited<ReturnType<MessageDB['getSpaceMembers']>>;
+    let deviceKeys: Awaited<ReturnType<MessageDB['getSpaceMemberDevices']>>;
+    try {
+      [members, deviceKeys] = await Promise.all([
+        this.messageDB.getSpaceMembers(spaceId),
+        this.messageDB.getSpaceMemberDevices(spaceId),
+      ]);
+    } catch (err) {
+      logger.warn(
+        `[MessageService] sync-auth: refusing a sync frame for ${spaceId.substring(0, 12)} — ` +
+          `could not read the roster to check its signing key`,
+        err
+      );
+      return false;
+    }
+
+    type ClassifyParams = Parameters<typeof classifySyncFrameSigner>[0];
+    const verdict = classifySyncFrameSigner({
+      publicKeyHex,
+      members: members as unknown as ClassifyParams['members'],
+      deviceKeys: deviceKeys as unknown as ClassifyParams['deviceKeys'],
+      selfAddress,
+    });
+
+    if (verdict === 'member') return true;
+
+    if (verdict === 'bootstrap') {
+      logger.warn(
+        `[MessageService] sync-auth: accepting a signing key bound to no member of ` +
+          `${spaceId.substring(0, 12)} — roster bootstrap, we know of no other member yet`
+      );
+      return true;
+    }
+
+    logger.warn(
+      `[MessageService] sync-auth: refusing a sync frame for ${spaceId.substring(0, 12)} — ` +
+        `its signing key ${publicKeyHex.substring(0, 16)} is bound to no member of this space`
+    );
+    return false;
   }
 
   /**
@@ -5784,11 +5871,23 @@ export class MessageService {
               this.spaceInfo.current[conversationId.split('/')[0]] = reg;
             }
 
+            // The second disjunct used to be the bare truthiness of
+            // `syncInfo.current[spaceId]`, which let ANY key through once this
+            // client had ever requested a sync — and the verify below then
+            // checked that key against its own signature. Requiring the signer
+            // to be bound to this space first is what gives the verify meaning.
+            // See syncFrameSignerIsBoundToSpace for why an owner-only rule is
+            // NOT the fix here.
             if (
               reg.owner_public_keys.includes(
                 exteriorEnvelope.owner_public_key
               ) ||
-              this.syncInfo.current[conversationId.split('/')[0]]
+              (!!this.syncInfo.current[conversationId.split('/')[0]] &&
+                (await this.syncFrameSignerIsBoundToSpace(
+                  conversationId.split('/')[0],
+                  exteriorEnvelope.owner_public_key,
+                  self_address
+                )))
             ) {
               const verify = JSON.parse(
                 ch.js_verify_ed448(
@@ -6516,11 +6615,23 @@ export class MessageService {
               this.spaceInfo.current[conversationId.split('/')[0]] = reg;
             }
 
+            // The second disjunct used to be the bare truthiness of
+            // `syncInfo.current[spaceId]`, which let ANY key through once this
+            // client had ever requested a sync — and the verify below then
+            // checked that key against its own signature. Requiring the signer
+            // to be bound to this space first is what gives the verify meaning.
+            // See syncFrameSignerIsBoundToSpace for why an owner-only rule is
+            // NOT the fix here.
             if (
               reg.owner_public_keys.includes(
                 exteriorEnvelope.owner_public_key
               ) ||
-              this.syncInfo.current[conversationId.split('/')[0]]
+              (!!this.syncInfo.current[conversationId.split('/')[0]] &&
+                (await this.syncFrameSignerIsBoundToSpace(
+                  conversationId.split('/')[0],
+                  exteriorEnvelope.owner_public_key,
+                  self_address
+                )))
             ) {
               const verify = JSON.parse(
                 ch.js_verify_ed448(
@@ -6645,11 +6756,23 @@ export class MessageService {
               this.spaceInfo.current[conversationId.split('/')[0]] = reg;
             }
 
+            // The second disjunct used to be the bare truthiness of
+            // `syncInfo.current[spaceId]`, which let ANY key through once this
+            // client had ever requested a sync — and the verify below then
+            // checked that key against its own signature. Requiring the signer
+            // to be bound to this space first is what gives the verify meaning.
+            // See syncFrameSignerIsBoundToSpace for why an owner-only rule is
+            // NOT the fix here.
             if (
               reg.owner_public_keys.includes(
                 exteriorEnvelope.owner_public_key
               ) ||
-              this.syncInfo.current[conversationId.split('/')[0]]
+              (!!this.syncInfo.current[conversationId.split('/')[0]] &&
+                (await this.syncFrameSignerIsBoundToSpace(
+                  conversationId.split('/')[0],
+                  exteriorEnvelope.owner_public_key,
+                  self_address
+                )))
             ) {
               const verify = JSON.parse(
                 ch.js_verify_ed448(

--- a/src/services/syncFrameAuth.ts
+++ b/src/services/syncFrameAuth.ts
@@ -1,0 +1,155 @@
+// Is the key that signed a directed sync envelope bound to this space?
+//
+// WHY THIS IS ITS OWN MODULE, AND NOT INLINE IN MessageService.
+//
+// `resolveVerifiedSender` runs no cryptography — it is a reverse lookup
+// (key → inbox address → member row) that assumes its caller already verified.
+// A source guard (`src/dev/tests/services/verifiedSenderRequiresVerification.test.ts`)
+// forbids MessageService from importing or calling it at all, because inside
+// that 3000-line receive handler a raw identity is one careless line away from
+// being treated as proof of authorship. That guard is load-bearing and must not
+// be relaxed to accommodate a new caller.
+//
+// The sync gate needs a genuinely different question: not "WHO signed this",
+// but "is this signing key one the space already knows". The answer is a
+// BOOLEAN, the identity is deliberately discarded, and the ed448 check runs
+// immediately afterwards against the same key. No identity escapes this file —
+// which is what makes the guard's invariant ("no sender identity without
+// crypto") still hold, and why the guard was EXTENDED to cover this module
+// rather than loosened for it.
+//
+// Reusing the shared matcher rather than re-deriving it here is deliberate too.
+// Hand-rolling `deriveInboxAddress` + a member scan would duplicate security
+// logic that is expected to evolve (the per-device admission path is recent).
+// If shared ever admits a key by some further route, a local copy would silently
+// stop recognising legitimate senders — a silent delivery loss, which is the
+// failure mode this codebase can least afford.
+import { resolveVerifiedSender } from '@quilibrium/quorum-shared';
+import type { SpaceMember, SpaceMemberDevice } from '@quilibrium/quorum-shared';
+
+export type SyncSignerVerdict =
+  /** The key belongs to a current member (or an admitted device of one). */
+  | 'member'
+  /** We know of no member but ourselves yet — see the bootstrap note below. */
+  | 'bootstrap'
+  /** Bound to nobody in this space. Refuse. */
+  | 'unbound';
+
+/**
+ * Decide whether a sync envelope's signing key may speak for this space.
+ *
+ * Pure: all state is passed in, so this is unit-testable without a database and
+ * without the network. The caller supplies the roster and admitted device keys
+ * for the DELIVERING space — never a space named by the frame.
+ *
+ * ⚠️ This does NOT check a signature, and must never be treated as if it did.
+ * It answers a membership question only. The caller verifies the ed448
+ * signature against the same key afterwards; both are required.
+ */
+export function classifySyncFrameSigner(params: {
+  publicKeyHex: string;
+  members: SpaceMember[];
+  deviceKeys: SpaceMemberDevice[];
+  selfAddress: string;
+}): SyncSignerVerdict {
+  const { publicKeyHex, members, deviceKeys, selfAddress } = params;
+  if (!publicKeyHex) return 'unbound';
+
+  // ⚠️ The shared lookup is NOT sufficient on its own, and an earlier version of
+  // this file wrongly claimed it was. Found by independent review, then confirmed
+  // by reading both sites:
+  //
+  //  - its join-bound path matches on `inbox_address`, so a member whose kick was
+  //    recorded by CLEARING that field can never match — safe;
+  //  - but its per-device path (`messageAuth.ts:189-196`) resolves through
+  //    `device.userAddress` and screens the owning row with `!m.isKicked` ALONE.
+  //
+  // Those two facts collide, because the live `kick` receive handler records a
+  // kick by clearing `inbox_address` and does NOT set `isKicked`
+  // (`MessageService.ts:6468-6471`); only the separate `verify-kicked`
+  // reconciliation sets that flag. And nothing revokes a kicked member's device
+  // admissions — a `revoke-device` statement must be signed by that user's own
+  // master key, so no one else can mint one for them.
+  //
+  // So a member who had a second device admitted before being kicked would keep
+  // authorizing sync frames, including `sync-peer-map`, which overwrites the
+  // space's ratchet state. The same gap is reachable from the control-message
+  // paths and is filed separately — it wants fixing in shared, for every caller.
+  //
+  // Closed here by never OFFERING a kicked row as a candidate, rather than by
+  // resolving and re-screening afterwards. That ordering is deliberate and is
+  // the safer of the two: the resolved identity never exists as a value in this
+  // module at all, so there is nothing that could later escape it — the property
+  // the source guard is trying to protect. An earlier version did resolve first
+  // and re-check, and an independent review demonstrated two working
+  // constructions that leaked the identity while still passing that guard.
+  // Filtering removes the possibility instead of policing it.
+  //
+  // Note the filter is applied to the LOOKUP only. The bootstrap count below
+  // deliberately uses the FULL roster: a kicked member's row still means we know
+  // of somebody else, so a kick must not reopen the bootstrap window.
+  const activeMembers = members.filter(isActiveMemberRow);
+  if (resolveVerifiedSender(publicKeyHex, activeMembers, deviceKeys))
+    return 'member';
+
+  // BOOTSTRAP — and the point of it is that it closes itself.
+  //
+  // A client that has just joined holds exactly ONE member row, its own
+  // (`InvitationService.ts:799-805`), and then immediately requests a sync
+  // (`:903`). Its roster is precisely what the frames it is waiting for will
+  // populate, so requiring the sender to be in that roster already is circular
+  // and would deadlock every join.
+  //
+  // Scoped to "we know of no member but ourselves" rather than to "we asked for
+  // a sync": the latter stays true for the whole session, which is the defect
+  // being repaired, while this shuts permanently the moment one real member row
+  // lands. Nothing a peer can send SHRINKS a roster, so it cannot be reopened.
+  //
+  // HONEST RESIDUAL: in a space whose only member is us, it never closes.
+  const knowsAnotherMember = members.some(
+    (m) => memberAddress(m) !== undefined && memberAddress(m) !== selfAddress
+  );
+  return knowsAnotherMember ? 'unbound' : 'bootstrap';
+}
+
+/**
+ * A member row's own address.
+ *
+ * Both spellings exist on these rows and neither is reliably present: shared's
+ * `SpaceMember` carries `address`, desktop's stored rows carry `user_address`,
+ * and the adapter fills whichever it can (`adapters/indexedDbAdapter.ts:153-158`).
+ * Returning `undefined` for a row with neither matters: an addressless row must
+ * not be counted as "another member we know", or a single malformed row would
+ * silently close the bootstrap window for a client that genuinely needs it.
+ *
+ * `||` rather than `??`, to match `resolveVerifiedSender`'s own precedence
+ * (`messageAuth.ts:180`, `:194`) exactly. With `??` an `address: ''` would stop
+ * the fallback to `user_address` while the shared function still took it, and
+ * the two would disagree about who a row belongs to.
+ */
+function memberAddress(m: SpaceMember): string | undefined {
+  const candidate =
+    (m as { address?: string }).address ||
+    (m as { user_address?: string }).user_address;
+  return candidate || undefined;
+}
+
+/**
+ * Is this row a member we should still honour as a signer?
+ *
+ * Screens BOTH local spellings of a kick, because the two receive paths that
+ * record one disagree: `verify-kicked` sets `isKicked`
+ * (`MessageService.ts:6714-6731`), while the live `kick` handler clears
+ * `inbox_address` (`:6468-6471`) and never sets that flag. Shared's join-bound
+ * lookup is safe from the second because it matches ON `inbox_address`; its
+ * per-device lookup is not, because it reaches the row through
+ * `device.userAddress` instead.
+ *
+ * Fails CLOSED on a row with no inbox address. The asymmetry is deliberate:
+ * wrongly accepting lets a removed member rewrite the space's ratchet state,
+ * while wrongly refusing costs one sync frame that the next sync round re-sends.
+ */
+function isActiveMemberRow(row: SpaceMember): boolean {
+  if ((row as { isKicked?: boolean }).isKicked) return false;
+  return !!(row as { inbox_address?: string }).inbox_address;
+}


### PR DESCRIPTION
A directed sync frame (`sync-peer-map`, `sync-members`, `sync-messages`) is now
honoured only when its signing key is one the space already knows — the
registered owner key, or the registered signing key of a current, non-kicked
member. The signature is checked against a key bound to an identity, rather
than against whatever key the frame itself names.

### Why the owner key alone is not the rule

Only `synchronizeAll` signs with the space's registered owner key, and it only
runs on a client that holds one. `directSync`, `handleSyncInitiateV2` and
`handleSyncManifest` all sign with the **sender's own per-space `inbox` key**,
so an owner-only rule would silently refuse every peer-to-peer sync. Peer
authorization, not owner authorization, is what this path actually needs.

### Bootstrap

A client that has just joined holds exactly one member row — its own — and then
immediately requests a sync, so requiring the sender to already be in that
roster is circular. While the roster holds nobody but ourselves, an unbound key
is accepted. That window closes permanently as soon as any other member row
arrives, and nothing a peer can send shrinks a roster, so it cannot be reopened.

Known residual, recorded rather than left implicit: in a space whose only member
is you, the window does not close.

### Structure

The membership question lives in `src/services/syncFrameAuth.ts` rather than in
the receive handler, which must not reach the no-crypto reverse lookup directly.
Kicked rows are filtered out *before* the lookup instead of screened after it, so
the resolved identity never becomes a value in that module and cannot escape it.
The existing source guard is extended to cover the new module.

Both local spellings of a kick are handled: `verify-kicked` sets `isKicked`,
while the live `kick` handler clears `inbox_address` and does not set that flag.

### Verification

- New networked harness scenario, `yarn harness space-sync-owner-key-forgery`,
  with four arms. The delivery arm — an identical frame signed with the sender's
  **real** per-space key — must still be applied, which is what distinguishes
  "narrowed" from "broken".
- Mutation-proven: red before the change, green after, and red again on revert
  with the final test file, failing on exactly the security assertion.
- `space-basic` (fresh join receives roster + message) and `space-kick` pass.
- 14 unit tests for the membership rule, covering both kick spellings, admitted
  and revoked device keys, an addressless member row, and the bootstrap window
  opening and closing.
- `tsc --noEmit` clean, `yarn lint` no new errors, `yarn test:run` 1680 passing
  across 177 files.

Desktop only: the mobile client no longer participates in this sync protocol in
either direction.
