### PR TITLE
fix(dm): keep the session an init envelope re-announces, and release the cross-client arm

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,8 +229,7 @@ of them** — ask it rather than guessing from the list below:
 ```
   ROUTED     mobile
   TIER       fast + live
-  LIVE ARMS  config-cross
-  HELD BACK  cross-dm  (run `yarn verify --all`)
+  LIVE ARMS  cross-dm, config-cross
              (only quorum-mobile changed — running the cross-client arms; the
               four same-client arms load no mobile code and cannot observe it)
 ```
@@ -241,10 +240,10 @@ of them** — ask it rather than guessing from the list below:
   not run. Changing the colour of a button falls here, as does editing
   `src/i18n/<locale>/messages.po` — but not `src/i18n/i18n.ts`, which is code.
 - **A quorum-mobile-only change**: the fast tier plus **only the cross-client
-  arms**, which today means `config-cross` alone (`cross-dm` is held back, see
-  below). The four same-client arms are desktop vitest scenarios that never
-  load mobile code, so they cannot observe the change; running them would be
-  six minutes of real-relay traffic that could not have gone red.
+  arms**, `cross-dm` and `config-cross`. The four same-client arms are desktop
+  vitest scenarios that never load mobile code, so they cannot observe the
+  change; running them would be six minutes of real-relay traffic that could
+  not have gone red.
 - **Services, sync, storage, crypto, or any path nobody has classified**: the
   fast tier plus the live tier, about **6.5 minutes measured**. Real bots send
   real messages over a real relay.
@@ -253,21 +252,18 @@ of them** — ask it rather than guessing from the list below:
   change to it is exactly the change a live run has to check. Every other
   directory under `src/dev/tests/` stays on the fast tier, which already runs
   those tests.
-- **Two arms are HELD BACK from every per-change run**, for unrelated reasons.
-  `yarn verify --all` runs both, and every run that leaves one out says so on
-  its own `HELD BACK` line, quoting why — so this can never quietly become
-  "nobody ran it".
+- **One arm is HELD BACK from every per-change run.** `yarn verify --all` runs
+  it, and every run that leaves it out says so on its own `HELD BACK` line,
+  quoting why — so this can never quietly become "nobody ran it".
   - **`space-basic`** creates a permanent, undeletable Space each time it runs,
     and unlike `space-delivery` it cannot reuse one, because creating a space
     is its subject.
-  - **`cross-dm`** reports a reproducible cross-client message loss (5 of 6
-    runs, always the first echo desktop sends) whose cause is not yet known,
-    tracked in
-    `.agents/issues/.open/2026-08-24-cross-client-dm-loses-the-first-desktop-to-mobile-message.md`.
-    It is held back rather than removed because an arm that is red in most runs
-    for a reason unrelated to the change under test would block every piece of
-    work. Release it — two lines in `scripts/verify/steps.mjs` — once that issue
-    is resolved either way.
+  - **`cross-dm` was released on 2026-08-24** and now runs on every change that
+    routes to the live tier. It was held back while it reported a reproducible
+    cross-client message loss; that loss is now measured, fixed on both sides,
+    and the arm is green in five consecutive runs. It is the only cross-client
+    DM coverage there is, and the bug it found survived for months precisely
+    because nothing measured that cell.
 - `yarn verify --fast` skips the live tier on request, for a quick check
   mid-work; it is not a substitute for the full run before reporting done.
 - `space-delivery` is retried once if it fails, because it is load-sensitive
@@ -293,4 +289,4 @@ behalf.
 
 ---
 
-_Last updated: 2026-08-23_
+_Last updated: 2026-08-24_

--- a/scripts/verify/steps.mjs
+++ b/scripts/verify/steps.mjs
@@ -156,29 +156,25 @@ export function stepsFor(repoName, repoPath, tier) {
         heldBackWhy: 'it creates a permanent, undeletable Space every run',
       },
       mk('space-delivery', 'space-delivery', ['harness', 'space-delivery'], harnessDetail),
-      // `exhaustiveOnly` for a different reason than `space-basic`: not cost,
-      // but trust. This arm could not run at all until 2026-08-24 (it resolved
-      // quorum-mobile wrong from a worktree), and the first thing it did once
-      // fixed was report a reproducible message loss — 5 of 6 runs, always the
-      // FIRST echo desktop sends, while the opposite direction stayed 20/20.
+      // RELEASED 2026-08-24, after being held back for two weeks.
       //
-      // That loss is real as far as it has been measured: desktop's own log
-      // says `sent=20/20 received=20 novel decrypt failures=0`, and mobile's
-      // counting half is the same instrument that measured mobile↔mobile at
-      // 80/80. But the cause is not yet known, and an arm that goes red in
-      // most runs for a reason unrelated to the change under test would block
-      // every piece of work behind a bug nobody is fixing this week.
+      // This arm could not run at all until then (it resolved quorum-mobile
+      // wrong from a worktree), and the first thing it did once fixed was
+      // report a reproducible message loss — 5 of 6 runs, always the FIRST
+      // echo desktop sends, while the opposite direction stayed 20/20. It was
+      // held back on trust rather than cost: an arm red in most runs for a
+      // reason unrelated to the change under test blocks every piece of work.
       //
-      // So it is held back rather than removed, and the report names it on
-      // every run that skips it. Release it — delete these two lines — as soon
-      // as the tracked issue is resolved either way.
-      {
-        ...mk('cross-dm', 'cross-dm', ['harness:cross'], harnessDetail),
-        exhaustiveOnly: true,
-        heldBackWhy:
-          'it reports a reproducible cross-client message loss whose cause is not yet known — ' +
-          '.agents/issues/.open/2026-08-24-cross-client-dm-loses-the-first-desktop-to-mobile-message.md',
-      },
+      // The cause is now measured and fixed on both sides, and the arm is
+      // green in 5 consecutive runs. Holding it back any longer would mean the
+      // ONLY cross-client coverage never runs — and this bug existed for
+      // months precisely because nothing measured that cell.
+      //
+      // If it turns out to be flaky INSIDE the gate (it has a known
+      // collect-time flake in back-to-back vitest runs, see the issue's
+      // "traps" section), re-add `exhaustiveOnly: true` with a fresh reason
+      // rather than deleting the arm.
+      mk('cross-dm', 'cross-dm', ['harness:cross'], harnessDetail),
       mk('config-cross', 'config-cross', ['harness:config-cross'], harnessDetail),
     ];
   }

--- a/src/dev/tests/harness/setup.harness.ts
+++ b/src/dev/tests/harness/setup.harness.ts
@@ -4,10 +4,55 @@
 // Order matters: the shim must apply before the SDK bundle evaluates, so it is a
 // separate side-effect module imported first.
 import './shim';
-import { readFileSync, existsSync } from 'node:fs';
+import { appendFileSync, mkdirSync, readFileSync, existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { i18n } from '@lingui/core';
 import { channel_raw } from '@quilibrium/quilibrium-js-sdk-channels';
+
+// HARNESS_CONSOLE_FILE=1 mirrors every console call to a file.
+//
+// Vitest SWALLOWS this side's console output entirely when its stdout is piped,
+// which is exactly how the cross-client orchestrator runs it (run-cross.mjs
+// spawns it and tags each line). MEASURED 2026-08-24: a run in which the
+// scenario's own `console.log('[dm-cross b] …')` produced ZERO lines in the
+// piped output while the identical strings appeared in the RunLog jsonl.
+//
+// The practical cost was that the desktop half of the cross-client arm could
+// only ever be observed through whatever the scenario deliberately wrote to its
+// RunLog — every `logger.warn` from the service layer, including the one that
+// announces a session being REPLACED, was invisible. A blind side of an
+// instrument reads as "nothing happened", which is worse than no instrument.
+//
+// A file append bypasses the capture; stderr does not, because vitest hooks
+// that too. Off by default: it is a diagnostic, not a normal cost.
+if (process.env.HARNESS_CONSOLE_FILE === '1') {
+  const dir = resolve(process.cwd(), 'src/dev/tests/harness/logs');
+  mkdirSync(dir, { recursive: true });
+  const role = process.env.HARNESS_ROLE ?? 'x';
+  const runId = process.env.HARNESS_RUN_ID ?? 'local';
+  const file = resolve(dir, `${runId}-${role}-console.log`);
+  for (const level of ['debug', 'log', 'info', 'warn', 'error'] as const) {
+    const original = console[level].bind(console);
+    console[level] = (...args: unknown[]) => {
+      try {
+        const line = args
+          .map((a) => {
+            if (typeof a === 'string') return a;
+            try {
+              return JSON.stringify(a);
+            } catch {
+              return String(a);
+            }
+          })
+          .join(' ');
+        appendFileSync(file, `[${level}] ${line}\n`);
+      } catch {
+        // Never let the diagnostic break the run it is observing.
+      }
+      original(...args);
+    };
+  }
+}
 
 // The service layer calls lingui `t` macros; without an active locale they throw
 // ("Attempted to call a translation function without setting a locale"). The

--- a/src/dev/tests/harness/spaceState.ts
+++ b/src/dev/tests/harness/spaceState.ts
@@ -295,8 +295,17 @@ export function loadSpaceState(name: string): SpaceStateSnapshot | undefined {
  * and it is plain `.mjs` executed by node, so it cannot import this TypeScript
  * module. Owning the rule in a `.mjs` both sides can import is what stops the
  * two answers drifting apart; see that function's header in `routing.mjs`.
+ *
+ * ⚠️ IMPORTED, then re-exported — NOT `export { x } from '…'`. That form
+ * forwards the binding without introducing it into this module's scope, so
+ * `restoreSharedSpace` below threw `ReferenceError: wantsFreshSpace is not
+ * defined` on its first line, failing `space-delivery` in every run. It is a
+ * static scoping mistake, so it fails deterministically and identically for
+ * everyone; do not "simplify" it back.
  */
-export { wantsFreshSpace } from '../../../../scripts/verify/routing.mjs';
+import { wantsFreshSpace } from '../../../../scripts/verify/routing.mjs';
+
+export { wantsFreshSpace };
 
 /**
  * Restore a space shared by several bots, or report that one must be created.

--- a/src/dev/tests/services/MessageService.initReannounce.unit.test.ts
+++ b/src/dev/tests/services/MessageService.initReannounce.unit.test.ts
@@ -1,0 +1,292 @@
+/**
+ * An init envelope for a session we ALREADY hold must not replace it.
+ *
+ * ── Why this test exists ────────────────────────────────────────────────────
+ *
+ * Both clients re-announce an existing, still-advancing DM session by wrapping
+ * it in a fresh InitializationEnvelope, on EVERY send, until the peer's reply
+ * confirms it (desktop: `DoubleRatchetInboxEncryptForceSenderInit`; mobile:
+ * `buildReinitEnvelopeSend`). The device-inbox receive path could not tell that
+ * apart from a genuinely new session, so it tore the session down and rebuilt it
+ * every time — minting a new receiving inbox the peer had never been told about
+ * and deleting the row the peer was still writing to.
+ *
+ * MEASURED 2026-08-24, one 3-round cross-client run: 8 replacements, 7 distinct
+ * receiving inboxes, and the peer's next message logged as
+ * "DM frame for unknown inbox — no encryption state, retained unread".
+ *
+ * The discriminator is the X3DH ephemeral, and it is exact rather than
+ * heuristic: the same ephemeral necessarily derives the same session key.
+ *
+ * ⚠️ THE CONTROL ARM IS THE POINT. A test that only proves "we kept the
+ * session" would also pass if the code kept EVERY session, which would break a
+ * peer reinstall — the failure mode a whole separate issue exists about. So the
+ * different-ephemeral case is asserted just as hard as the same-ephemeral one.
+ *
+ * See `.agents/issues/.open/2026-08-24-cross-client-dm-loses-the-first-desktop-to-mobile-message.md`
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const sdk = vi.hoisted(() => ({
+  unseal: vi.fn(),
+  recipientSession: vi.fn(),
+  newInboxKeyset: vi.fn(),
+}));
+
+vi.mock('@quilibrium/quilibrium-js-sdk-channels', async (importOriginal) => {
+  const actual = await importOriginal<any>();
+  return {
+    ...actual,
+    channel: {
+      ...actual.channel,
+      UnsealInitializationEnvelope: (...a: unknown[]) => sdk.unseal(...a),
+      NewDoubleRatchetRecipientSession: (...a: unknown[]) =>
+        sdk.recipientSession(...a),
+      NewInboxKeyset: (...a: unknown[]) => sdk.newInboxKeyset(...a),
+    },
+  };
+});
+
+const { MessageService } = await import('../../../services/MessageService');
+
+const SELF = 'QmSelfAddressCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC';
+const PARTNER = 'QmPeerAEgVKpYZKYuFu2J49zHXnA8vZtEqHMtpB4imAAAA';
+const CONVERSATION = `${PARTNER}/${PARTNER}`;
+const OUR_DEVICE_INBOX = 'QmOurDeviceInboxAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+/** The peer's device inbox — the `tag` every row for this peer is keyed by. */
+const PEER_TAG = 'QmPeerDeviceInboxBBBBBBBBBBBBBBBBBBBBBBBBBBB';
+/** The receiving inbox we already advertised, and the peer is writing to. */
+const ADVERTISED_INBOX = 'QmAdvertisedInboxDDDDDDDDDDDDDDDDDDDDDDDDDD';
+/** What a rebuild would mint instead. */
+const FRESH_INBOX = 'QmFreshlyMintedInboxEEEEEEEEEEEEEEEEEEEEEEEE';
+
+const EPHEMERAL_A = 'aa11bb22cc33dd44ee55ff66';
+const EPHEMERAL_B = '9988776655443322110099aa';
+
+const keyset = {
+  deviceKeyset: {
+    inbox_keyset: {
+      inbox_address: OUR_DEVICE_INBOX,
+      inbox_key: { public_key: [1, 2, 3], private_key: [4, 5, 6] },
+    },
+    identity_key: { public_key: [7, 8, 9] },
+  },
+} as any;
+
+const existingRow = (timestamp: number) => ({
+  state: JSON.stringify({
+    ratchet_state: 'RATCHET-WE-ALREADY-HOLD',
+    receiving_inbox: {
+      inbox_address: ADVERTISED_INBOX,
+      inbox_key: { public_key: [11], private_key: [12] },
+    },
+    tag: PEER_TAG,
+    sending_inbox: {
+      inbox_address: 'QmPeerConversationInboxFFFFFFFFFFFFFFFFFFFFF',
+      inbox_encryption_key: 'enc',
+      inbox_public_key: 'peer-pub',
+      inbox_private_key: 'peer-priv',
+    },
+  }),
+  timestamp,
+  inboxId: ADVERTISED_INBOX,
+  conversationId: CONVERSATION,
+  sentAccept: true,
+});
+
+describe('handleNewMessage — init envelope on our device inbox', () => {
+  let messageService: any;
+  let mockDeps: any;
+  let now: number;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    now = Date.now();
+
+    sdk.newInboxKeyset.mockResolvedValue({
+      inbox_address: FRESH_INBOX,
+      inbox_key: { public_key: [21], private_key: [22] },
+    });
+
+    mockDeps = {
+      messageDB: {
+        getEncryptionStates: vi.fn().mockResolvedValue([existingRow(now - 5_000)]),
+        getAllEncryptionStates: vi
+          .fn()
+          .mockResolvedValue([existingRow(now - 5_000)]),
+        saveEncryptionState: vi.fn().mockResolvedValue(undefined),
+        deleteEncryptionState: vi.fn().mockResolvedValue(undefined),
+        saveMessage: vi.fn().mockResolvedValue(undefined),
+        getMessage: vi.fn().mockResolvedValue(null),
+        getMessages: vi.fn().mockResolvedValue({ messages: [], hasMore: false }),
+        isMessageDeleted: vi.fn().mockResolvedValue(false),
+        getConversation: vi.fn().mockResolvedValue({ conversation: null }),
+        getUserConfig: vi.fn().mockResolvedValue({}),
+        updateMessage: vi.fn().mockResolvedValue(undefined),
+      } as any,
+      enqueueOutbound: vi.fn(),
+      addOrUpdateConversation: vi.fn(),
+      apiClient: {} as any,
+      deleteEncryptionStates: vi.fn().mockResolvedValue(undefined),
+      deleteInboxMessages: vi.fn().mockResolvedValue(undefined),
+      navigate: vi.fn(),
+      spaceInfo: { current: {} } as any,
+      syncInfo: { current: {} } as any,
+      synchronizeAll: vi.fn().mockResolvedValue(undefined),
+      informSyncData: vi.fn().mockResolvedValue(undefined),
+      initiateSync: vi.fn().mockResolvedValue(undefined),
+      requestSync: vi.fn().mockResolvedValue(undefined),
+      directSync: vi.fn().mockResolvedValue(undefined),
+      saveConfig: vi.fn().mockResolvedValue(undefined),
+      sendHubMessage: vi.fn().mockResolvedValue('message-id'),
+    };
+    messageService = new MessageService(mockDeps);
+  });
+
+  /** Drive one init-wrapped frame in, sealed with `ephemeral`. */
+  const deliverInitEnvelope = async (ephemeral: string, timestamp: number) => {
+    sdk.unseal.mockReturnValue({
+      user_address: PARTNER,
+      display_name: undefined,
+      user_icon: undefined,
+      return_inbox_address: 'QmPeerConversationInboxFFFFFFFFFFFFFFFFFFFFF',
+      return_inbox_encryption_key: 'enc',
+      return_inbox_public_key: 'peer-pub',
+      return_inbox_private_key: 'peer-priv',
+      identity_public_key: 'peer-identity',
+      tag: PEER_TAG,
+      message: 'inner-ciphertext',
+      type: 'direct',
+      ephemeral_public_key: ephemeral,
+    });
+    sdk.recipientSession.mockResolvedValue({
+      state: 'REBUILT-RATCHET',
+      message: JSON.stringify({
+        messageId: `msg-${timestamp}`,
+        channelId: PARTNER,
+        createdDate: timestamp,
+        content: { type: 'post', text: 'hello', senderId: PARTNER },
+      }),
+      tag: PEER_TAG,
+      return_inbox_address: 'QmPeerConversationInboxFFFFFFFFFFFFFFFFFFFFF',
+      return_inbox_encryption_key: 'enc',
+      return_inbox_public_key: 'peer-pub',
+      return_inbox_private_key: 'peer-priv',
+      user_address: PARTNER,
+      identity_public_key: 'peer-identity',
+    });
+
+    await messageService.handleNewMessage(
+      SELF,
+      keyset,
+      {
+        inboxAddress: OUR_DEVICE_INBOX,
+        encryptedContent: JSON.stringify({ envelope: 'sealed' }),
+        timestamp,
+      } as any,
+      undefined as any
+    );
+  };
+
+  /** Every inbox address this run asked the relay to listen on. */
+  const listenedAddresses = async (): Promise<string[]> => {
+    const out: string[] = [];
+    for (const [action] of mockDeps.enqueueOutbound.mock.calls) {
+      const frames: string[] = await action();
+      for (const f of frames) {
+        const parsed = JSON.parse(f);
+        if (parsed.type === 'listen') out.push(...parsed.inbox_addresses);
+      }
+    }
+    return out;
+  };
+
+  describe('a genuinely new session (ephemeral we have never seen)', () => {
+    it('replaces the session, mints a receiving inbox and listens on it', async () => {
+      await deliverInitEnvelope(EPHEMERAL_B, now);
+
+      expect(sdk.newInboxKeyset).toHaveBeenCalledTimes(1);
+      expect(mockDeps.messageDB.deleteEncryptionState).toHaveBeenCalledTimes(1);
+      const saved = mockDeps.messageDB.saveEncryptionState.mock.calls.at(-1)[0];
+      expect(saved.inboxId).toBe(FRESH_INBOX);
+      expect(JSON.parse(saved.state).ratchet_state).toBe('REBUILT-RATCHET');
+      expect(await listenedAddresses()).toContain(FRESH_INBOX);
+    });
+
+    it('still delivers the message', async () => {
+      await deliverInitEnvelope(EPHEMERAL_B, now);
+      expect(mockDeps.messageDB.saveMessage).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('a re-announcement of the session we already hold', () => {
+    beforeEach(async () => {
+      // The first envelope installs the session and records its ephemeral.
+      await deliverInitEnvelope(EPHEMERAL_A, now - 2_000);
+      // From here the row IS the one that first envelope installed.
+      mockDeps.messageDB.getEncryptionStates.mockResolvedValue([
+        {
+          ...existingRow(now - 2_000),
+          inboxId: FRESH_INBOX,
+          state: JSON.stringify({
+            ...JSON.parse(existingRow(now - 2_000).state),
+            receiving_inbox: {
+              inbox_address: FRESH_INBOX,
+              inbox_key: { public_key: [21], private_key: [22] },
+            },
+          }),
+        },
+      ]);
+      vi.clearAllMocks();
+      sdk.newInboxKeyset.mockResolvedValue({
+        inbox_address: 'QmShouldNeverBeMintedGGGGGGGGGGGGGGGGGGGGGG',
+        inbox_key: { public_key: [31], private_key: [32] },
+      });
+    });
+
+    it('does NOT mint a new receiving inbox', async () => {
+      await deliverInitEnvelope(EPHEMERAL_A, now);
+      expect(sdk.newInboxKeyset).not.toHaveBeenCalled();
+    });
+
+    it('does NOT delete the row the peer is writing to', async () => {
+      await deliverInitEnvelope(EPHEMERAL_A, now);
+      expect(mockDeps.messageDB.deleteEncryptionState).not.toHaveBeenCalled();
+    });
+
+    it('does NOT overwrite the ratchet our own replies are encrypted with', async () => {
+      await deliverInitEnvelope(EPHEMERAL_A, now);
+      // Rebuilding discards the sending chain the peer has already confirmed.
+      for (const [row] of mockDeps.messageDB.saveEncryptionState.mock.calls) {
+        expect(JSON.parse(row.state).ratchet_state).not.toBe('REBUILT-RATCHET');
+      }
+    });
+
+    it('keeps listening on the address it already advertised', async () => {
+      await deliverInitEnvelope(EPHEMERAL_A, now);
+      expect(await listenedAddresses()).toEqual([FRESH_INBOX]);
+    });
+
+    it('still delivers the message the re-announcement carried', async () => {
+      await deliverInitEnvelope(EPHEMERAL_A, now);
+      expect(mockDeps.messageDB.saveMessage).toHaveBeenCalledTimes(1);
+    });
+
+    it('survives a burst of them without churning the session', async () => {
+      // The measured shape: one re-announcement per send until confirmation.
+      for (let i = 1; i <= 5; i++) {
+        await deliverInitEnvelope(EPHEMERAL_A, now + i * 100);
+      }
+      expect(sdk.newInboxKeyset).not.toHaveBeenCalled();
+      expect(mockDeps.messageDB.deleteEncryptionState).not.toHaveBeenCalled();
+      expect(mockDeps.messageDB.saveMessage).toHaveBeenCalledTimes(5);
+    });
+
+    it('a DIFFERENT ephemeral still replaces it — a peer reinstall must work', async () => {
+      await deliverInitEnvelope(EPHEMERAL_B, now);
+      expect(sdk.newInboxKeyset).toHaveBeenCalledTimes(1);
+      expect(mockDeps.messageDB.deleteEncryptionState).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/dev/tests/services/MessageService.initReannounce.unit.test.ts
+++ b/src/dev/tests/services/MessageService.initReannounce.unit.test.ts
@@ -224,8 +224,12 @@ describe('handleNewMessage — init envelope on our device inbox', () => {
     beforeEach(async () => {
       // The first envelope installs the session and records its ephemeral.
       await deliverInitEnvelope(EPHEMERAL_A, now - 2_000);
-      // From here the row IS the one that first envelope installed.
-      mockDeps.messageDB.getEncryptionStates.mockResolvedValue([
+
+      // From here the row IS the one that first envelope installed — and the
+      // store is STATEFUL, so a save the code performs is visible to the next
+      // delivery. A fixed mock would hide exactly the behaviour the replay test
+      // below depends on.
+      const rows = [
         {
           ...existingRow(now - 2_000),
           inboxId: FRESH_INBOX,
@@ -237,7 +241,17 @@ describe('handleNewMessage — init envelope on our device inbox', () => {
             },
           }),
         },
+      ];
+      mockDeps.messageDB.getEncryptionStates.mockImplementation(async () => [
+        ...rows,
       ]);
+      mockDeps.messageDB.saveEncryptionState.mockImplementation(
+        async (row: any) => {
+          const i = rows.findIndex((r) => r.inboxId === row.inboxId);
+          if (i >= 0) rows[i] = { ...rows[i], ...row };
+          else rows.push(row);
+        }
+      );
       vi.clearAllMocks();
       sdk.newInboxKeyset.mockResolvedValue({
         inbox_address: 'QmShouldNeverBeMintedGGGGGGGGGGGGGGGGGGGGGG',
@@ -281,6 +295,37 @@ describe('handleNewMessage — init envelope on our device inbox', () => {
       expect(sdk.newInboxKeyset).not.toHaveBeenCalled();
       expect(mockDeps.messageDB.deleteEncryptionState).not.toHaveBeenCalled();
       expect(mockDeps.messageDB.saveMessage).toHaveBeenCalledTimes(5);
+    });
+
+    it('refuses an exact replay of a re-announcement it already accepted', async () => {
+      // The relay redelivers any frame whose ack-by-delete failed, so a
+      // re-announcement can arrive twice. `isStaleInitEnvelope` rule 2 catches
+      // that by exact timestamp match against a row we hold — which only works
+      // because the keep branch advances the row's timestamp. Without that, the
+      // replay is accepted forever: a duplicate notification and a redundant
+      // X3DH every time.
+      const ts = now + 1_000;
+      await deliverInitEnvelope(EPHEMERAL_A, ts);
+      expect(mockDeps.messageDB.saveMessage).toHaveBeenCalledTimes(1);
+      // The accept advanced the row's timestamp to this envelope's, which is
+      // what arms rule 2 against the replay below.
+      expect(mockDeps.messageDB.saveEncryptionState).toHaveBeenCalledTimes(1);
+      expect(
+        mockDeps.messageDB.saveEncryptionState.mock.calls[0][0].timestamp
+      ).toBe(ts);
+
+      vi.clearAllMocks();
+      await deliverInitEnvelope(EPHEMERAL_A, ts); // byte-identical replay
+
+      // ⚠️ The discriminating assertion. `saveEncryptionState` alone would NOT
+      // discriminate: the stale path and an unbumped keep path both leave it
+      // uncalled, so asserting on it passes whether or not the fix is present.
+      // Only the stale path returns BEFORE re-subscribing, so the absence of a
+      // listen frame is what distinguishes "refused" from "accepted again".
+      expect(mockDeps.enqueueOutbound).not.toHaveBeenCalled();
+      expect(mockDeps.messageDB.saveEncryptionState).not.toHaveBeenCalled();
+      expect(sdk.newInboxKeyset).not.toHaveBeenCalled();
+      expect(mockDeps.messageDB.deleteEncryptionState).not.toHaveBeenCalled();
     });
 
     it('a DIFFERENT ephemeral still replaces it — a peer reinstall must work', async () => {

--- a/src/dev/tests/utils/dmInitSessionLedger.unit.test.ts
+++ b/src/dev/tests/utils/dmInitSessionLedger.unit.test.ts
@@ -1,0 +1,134 @@
+/**
+ * The DM init-session ledger.
+ *
+ * The property under test is WHICH WAY IT FAILS. Every uncertain path must
+ * answer "not the same session", because the opposite answer keeps a session
+ * the peer has abandoned and kills the conversation in one direction with no
+ * error anyone can see.
+ *
+ * ⚠️ The fail-safe tests here make `localStorage` GENUINELY THROW, via a spy on
+ * `Storage.prototype` — the same technique `dmRevealLedger.unit.test.ts` uses,
+ * and for the same reason: a fake store that cannot throw leaves the safety
+ * branch unreachable from any test while appearing covered.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  recordInitSession,
+  isSameInitSession,
+  forgetInitSessions,
+} from '@/utils/dmInitSessionLedger';
+
+const CONV = 'QmPeerAEgVKpYZKYuFu2J49zHXnA8vZtEqHMtpB4imAAAA/QmPeerAEgVKpYZKYuFu2J49zHXnA8vZtEqHMtpB4imAAAA';
+const OTHER_CONV = 'QmThemThemKpYZKYuFu2J49zHXnA8vZtEqHMtpB4imCCCC/QmThemThemKpYZKYuFu2J49zHXnA8vZtEqHMtpB4imCCCC';
+const TAG = 'QmDeviceOneKpYZKYuFu2J49zHXnA8vZtEqHMtpB4im1111';
+const OTHER_TAG = 'QmDeviceTwoKpYZKYuFu2J49zHXnA8vZtEqHMtpB4im2222';
+const EPH_A = 'aa11bb22cc33dd44';
+const EPH_B = 'ff99ee88dd77cc66';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+  localStorage.clear();
+});
+
+describe('dmInitSessionLedger', () => {
+  it('recognises a re-announcement of the session it recorded', () => {
+    recordInitSession(CONV, TAG, EPH_A);
+    expect(isSameInitSession(CONV, TAG, EPH_A)).toBe(true);
+  });
+
+  it('does NOT recognise a different ephemeral — that is a genuinely new session', () => {
+    recordInitSession(CONV, TAG, EPH_A);
+    expect(isSameInitSession(CONV, TAG, EPH_B)).toBe(false);
+  });
+
+  it('answers false when nothing was ever recorded', () => {
+    expect(isSameInitSession(CONV, TAG, EPH_A)).toBe(false);
+  });
+
+  it('scopes records per peer device, not per conversation', () => {
+    recordInitSession(CONV, TAG, EPH_A);
+    expect(isSameInitSession(CONV, OTHER_TAG, EPH_A)).toBe(false);
+  });
+
+  it('scopes records per conversation', () => {
+    recordInitSession(CONV, TAG, EPH_A);
+    expect(isSameInitSession(OTHER_CONV, TAG, EPH_A)).toBe(false);
+  });
+
+  it('a later install replaces the recorded ephemeral', () => {
+    recordInitSession(CONV, TAG, EPH_A);
+    recordInitSession(CONV, TAG, EPH_B);
+    expect(isSameInitSession(CONV, TAG, EPH_B)).toBe(true);
+    // The old one must stop matching, or a redelivered envelope from the
+    // session we just replaced would be treated as a re-announcement of the
+    // one we now hold.
+    expect(isSameInitSession(CONV, TAG, EPH_A)).toBe(false);
+  });
+
+  it('forgetInitSessions clears every device of one conversation and nothing else', () => {
+    recordInitSession(CONV, TAG, EPH_A);
+    recordInitSession(CONV, OTHER_TAG, EPH_B);
+    recordInitSession(OTHER_CONV, TAG, EPH_A);
+
+    forgetInitSessions(CONV);
+
+    expect(isSameInitSession(CONV, TAG, EPH_A)).toBe(false);
+    expect(isSameInitSession(CONV, OTHER_TAG, EPH_B)).toBe(false);
+    expect(isSameInitSession(OTHER_CONV, TAG, EPH_A)).toBe(true);
+  });
+
+  describe('fail direction', () => {
+    it.each([
+      ['empty conversationId', '', TAG, EPH_A],
+      ['empty tag', CONV, '', EPH_A],
+      ['empty ephemeral', CONV, TAG, ''],
+    ])('refuses to record or match with an %s', (_label, conv, tag, eph) => {
+      recordInitSession(conv, tag, eph);
+      expect(isSameInitSession(conv, tag, eph)).toBe(false);
+    });
+
+    it('a read that throws answers "not the same session"', () => {
+      recordInitSession(CONV, TAG, EPH_A);
+      expect(isSameInitSession(CONV, TAG, EPH_A)).toBe(true); // control
+
+      vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+        throw new Error('storage unavailable');
+      });
+      expect(isSameInitSession(CONV, TAG, EPH_A)).toBe(false);
+    });
+
+    it('a write that throws does not throw out of recordInitSession', () => {
+      vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        throw new Error('quota exceeded');
+      });
+      expect(() => recordInitSession(CONV, TAG, EPH_A)).not.toThrow();
+      // Nothing stored, so the next envelope takes the replace-the-session
+      // path — the behaviour that shipped before this ledger existed.
+      vi.restoreAllMocks();
+      expect(isSameInitSession(CONV, TAG, EPH_A)).toBe(false);
+    });
+
+    it('a failing sweep does not throw out of forgetInitSessions', () => {
+      recordInitSession(CONV, TAG, EPH_A);
+      vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => {
+        throw new Error('storage unavailable');
+      });
+      expect(() => forgetInitSessions(CONV)).not.toThrow();
+    });
+  });
+
+  describe('key injectivity', () => {
+    /**
+     * A hand-rolled `${conversationId}:${tag}` key is NOT injective: the pair
+     * below collides under it, and a collision would report one peer device's
+     * session as another's. The JSON-array encoding cannot produce it.
+     */
+    it('two different (conversation, tag) pairs cannot collide', () => {
+      recordInitSession('A', 'B:C', EPH_A);
+      expect(isSameInitSession('A:B', 'C', EPH_A)).toBe(false);
+    });
+  });
+});

--- a/src/dev/tests/utils/dmInitSessionLedger.unit.test.ts
+++ b/src/dev/tests/utils/dmInitSessionLedger.unit.test.ts
@@ -12,10 +12,12 @@
  * branch unreachable from any test while appearing covered.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { logger } from '@quilibrium/quorum-shared';
 import {
   recordInitSession,
   isSameInitSession,
   forgetInitSessions,
+  __resetInitSessionLedgerWarnForTests,
 } from '@/utils/dmInitSessionLedger';
 
 const CONV = 'QmPeerAEgVKpYZKYuFu2J49zHXnA8vZtEqHMtpB4imAAAA/QmPeerAEgVKpYZKYuFu2J49zHXnA8vZtEqHMtpB4imAAAA';
@@ -27,10 +29,12 @@ const EPH_B = 'ff99ee88dd77cc66';
 
 beforeEach(() => {
   localStorage.clear();
+  __resetInitSessionLedgerWarnForTests();
 });
 afterEach(() => {
   vi.restoreAllMocks();
   localStorage.clear();
+  __resetInitSessionLedgerWarnForTests();
 });
 
 describe('dmInitSessionLedger', () => {
@@ -109,6 +113,19 @@ describe('dmInitSessionLedger', () => {
       // path — the behaviour that shipped before this ledger existed.
       vi.restoreAllMocks();
       expect(isSameInitSession(CONV, TAG, EPH_A)).toBe(false);
+    });
+
+    it('reports a storage failure once, not once per envelope', () => {
+      // The point of the throttle: a broken store makes this ledger answer
+      // "different session" forever, which silently restores the old bug. That
+      // must be visible — but `isSameInitSession` runs on every init envelope,
+      // so an unthrottled warn would bury its own signal.
+      const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+      vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+        throw new Error('storage unavailable');
+      });
+      for (let i = 0; i < 20; i++) isSameInitSession(CONV, TAG, EPH_A);
+      expect(warn).toHaveBeenCalledTimes(1);
     });
 
     it('a failing sweep does not throw out of forgetInitSessions', () => {

--- a/src/dev/tests/verify/routing.test.ts
+++ b/src/dev/tests/verify/routing.test.ts
@@ -208,10 +208,10 @@ const LIVE_STEPS = [
 ].map((label) => ({
   id: `desktop:${label}`,
   label,
-  // Mirrors steps.mjs. Two arms run on `--all` rather than on every code
-  // change, for unrelated reasons: space-basic creates a permanent Space, and
-  // cross-dm reports a reproducible loss whose cause is still open.
-  ...(label === 'space-basic' || label === 'cross-dm' ? { exhaustiveOnly: true } : {}),
+  // Mirrors steps.mjs. ONE arm now runs on `--all` rather than on every code
+  // change: space-basic, because it creates a permanent, undeletable Space.
+  // cross-dm was released 2026-08-24 once the loss it reported was fixed.
+  ...(label === 'space-basic' ? { exhaustiveOnly: true } : {}),
 }));
 
 describe('liveArmsFor', () => {
@@ -222,22 +222,25 @@ describe('liveArmsFor', () => {
     expect(labels(planFromPaths(['desktop/README.md']))).toEqual([]);
   });
 
-  // space-basic and cross-dm are absent: both wait for --all, for unrelated
-  // reasons (a permanent Space, and an open loss finding).
+  // space-basic is absent: it waits for --all, because it mints a permanent
+  // Space. cross-dm IS here — it is a cross-client arm, and a desktop service
+  // change is exactly what it exists to observe.
   it('runs every per-change arm for a desktop change', () => {
     expect(labels(planFromPaths(['desktop/src/services/MessageService.ts']))).toEqual([
       'dm-basic',
       'dm-delivery',
       'space-delivery',
+      'cross-dm',
       'config-cross',
     ]);
   });
 
-  // Reduced to one arm while cross-dm is held back. That is a real narrowing
-  // of mobile-only coverage and it is stated on the run, not absorbed quietly:
-  // config-cross is the only arm left that loads mobile code.
-  it('runs only the in-scope cross-client arm for a mobile-only change', () => {
+  // Both cross-client arms, and only those: the four same-client arms are
+  // desktop vitest scenarios that never load mobile code, so they cannot
+  // observe a mobile-only change.
+  it('runs only the cross-client arms for a mobile-only change', () => {
     expect(labels(planFromPaths(['mobile/services/space/SpaceService.ts']))).toEqual([
+      'cross-dm',
       'config-cross',
     ]);
   });
@@ -245,16 +248,14 @@ describe('liveArmsFor', () => {
   // Defensive: a plan built before liveScope existed, or hand-made by a test,
   // must fail toward running MORE — the same direction as the allowlist.
   it('treats a missing liveScope as every arm', () => {
-    expect(labels({ live: true })).toHaveLength(4);
+    expect(labels({ live: true })).toHaveLength(5);
   });
 
-  it('releases the held-back arms only when the plan is exhaustive', () => {
+  it('releases the held-back arm only when the plan is exhaustive', () => {
     const perChange = planFromPaths(['desktop/src/services/MessageService.ts']);
     expect(labels(perChange)).not.toContain('space-basic');
-    expect(labels(perChange)).not.toContain('cross-dm');
     const exhaustive = labels({ ...perChange, exhaustive: true });
     expect(exhaustive).toContain('space-basic');
-    expect(exhaustive).toContain('cross-dm');
   });
 });
 
@@ -266,7 +267,6 @@ describe('heldBackArms', () => {
   it('names the arms a per-change run left out', () => {
     expect(labels(planFromPaths(['desktop/src/services/MessageService.ts']))).toEqual([
       'space-basic',
-      'cross-dm',
     ]);
   });
 
@@ -281,10 +281,9 @@ describe('heldBackArms', () => {
 
   // A mobile-only run never reaches space-basic in the first place, so it is
   // out of scope rather than held back — reporting it would be misleading.
-  // cross-dm IS in scope for such a run (it loads mobile code), so it is
-  // genuinely held back and must be named.
-  it('names only the in-scope arm for a mobile-only run', () => {
-    expect(labels(planFromPaths(['mobile/services/space/SpaceService.ts']))).toEqual(['cross-dm']);
+  // With cross-dm released there is nothing left to name for such a run.
+  it('names nothing for a mobile-only run, because nothing in scope is held back', () => {
+    expect(labels(planFromPaths(['mobile/services/space/SpaceService.ts']))).toEqual([]);
   });
 
   it('identifies exactly the two arms that spawn quorum-mobile', () => {
@@ -482,7 +481,12 @@ describe('LIVE_STEPS matches the real step catalogue', () => {
     // Stated as a value, not just a comparison: if BOTH sides lost the flag,
     // the equality above would still pass and space-basic would quietly start
     // creating a Space on every code change again.
-    expect(heldFor(real)).toEqual(['space-basic', 'cross-dm']);
+    //
+    // `cross-dm` was here until 2026-08-24 and is deliberately NOT any more.
+    // Adding an arm back to this list is a decision that costs every future
+    // run some coverage, so it has to be written down twice — here and in
+    // `steps.mjs` — and this assertion is what forces the second edit.
+    expect(heldFor(real)).toEqual(['space-basic']);
   });
 
   it('gives every held-back arm a reason to print', () => {

--- a/src/services/EncryptionService.ts
+++ b/src/services/EncryptionService.ts
@@ -5,6 +5,7 @@ import { MessageDB, EncryptionState } from '../db/messages';
 import { int64ToBytes } from '@quilibrium/quorum-shared';
 import type { Space } from '@quilibrium/quorum-shared';
 import { sha256, base58btc, hexToSpreadArray } from '../utils/crypto';
+import { forgetInitSessions } from '../utils/dmInitSessionLedger';
 import { QueryClient } from '@tanstack/react-query';
 import { buildSpacesKey, buildConfigKey } from '../hooks';
 import { channel as secureChannel, channel_raw as ch } from '@quilibrium/quilibrium-js-sdk-channels';
@@ -78,6 +79,12 @@ export class EncryptionService {
       try {
         await this.messageDB.deleteLatestState(conversationId);
       } catch { /* ignore */ }
+      // The rows this ledger describes are gone, so its records describe
+      // nothing. Harmless to leave today (the re-announcement branch also
+      // requires a surviving row), but a ledger that outlives what it describes
+      // is a trap for the next change — and this is the USER-INITIATED reset,
+      // the one place a stale record would be most surprising.
+      forgetInitSessions(conversationId);
     } catch { /* ignore */ }
   }
 

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -4779,20 +4779,26 @@ export class MessageService {
           // address we keep listening on is the address we are advertising.
           // Reading any other row could pin us to an inbox we never told the
           // peer about, which is the bug this branch exists to prevent.
-          const priorRow = existing.length
-            ? (existing.find(
-                (e) =>
-                  e.inboxId ===
-                  (orderSessionsForSend(existing)[0]?.receiving_inbox as
-                    | secureChannel.InboxKeyset
-                    | undefined)?.inbox_address
-              ) ?? null)
-            : null;
-          const priorReceivingInbox = priorRow
-            ? (JSON.parse(priorRow.state).receiving_inbox as
-                | secureChannel.InboxKeyset
-                | undefined)
-            : undefined;
+          const sendOrdered = orderSessionsForSend(existing);
+          const sendRowInbox = (
+            sendOrdered[0]?.receiving_inbox as secureChannel.InboxKeyset | undefined
+          )?.inbox_address;
+          const priorRow =
+            (sendRowInbox && existing.find((e) => e.inboxId === sendRowInbox)) ||
+            null;
+          let priorReceivingInbox: secureChannel.InboxKeyset | undefined;
+          try {
+            // Guarded for the same reason `orderSessionsForSend` guards its own
+            // parse: a corrupted row must degrade to "no prior session" (and so
+            // to the replace path), never take the whole receive loop down.
+            priorReceivingInbox = priorRow
+              ? (JSON.parse(priorRow.state).receiving_inbox as
+                  | secureChannel.InboxKeyset
+                  | undefined)
+              : undefined;
+          } catch {
+            priorReceivingInbox = undefined;
+          }
           if (
             priorRow &&
             priorReceivingInbox?.inbox_address &&
@@ -4802,10 +4808,23 @@ export class MessageService {
               envelope.ephemeral_public_key
             )
           ) {
-            // Keep the row, the ratchet and the address exactly as they are.
-            // The payload has already been decrypted out of the envelope
-            // above, so the message is processed normally below.
+            // Keep the ratchet and the address exactly as they are, and take
+            // the message — it was already decrypted out of the envelope above.
+            //
+            // The row IS still written, with its state byte-identical and only
+            // its timestamp advanced to this envelope's. That is not
+            // bookkeeping: `isStaleInitEnvelope` rule 2 refuses an envelope
+            // whose timestamp exactly matches a row we hold, and it is the only
+            // defence against the relay replaying a frame whose ack-by-delete
+            // failed. Leaving the timestamp pinned at the first install would
+            // mean every LATER re-announcement stayed replayable for as long as
+            // the session was unconfirmed — each replay costing a duplicate
+            // notification and a redundant X3DH.
             newState = priorRow.state;
+            await this.messageDB.saveEncryptionState(
+              { ...priorRow, timestamp: message.timestamp },
+              true
+            );
             logger.debug(
               '[MessageService] init envelope is a re-announcement of the session we already hold — keeping it',
               {

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -105,6 +105,11 @@ import {
   recordReveal,
 } from '../utils/dmRevealLedger';
 import {
+  forgetInitSessions,
+  isSameInitSession,
+  recordInitSession,
+} from '../utils/dmInitSessionLedger';
+import {
   claimSpaceProfileAnnounce,
   recordSpaceProfileAnnounce,
   releaseSpaceProfileAnnounce,
@@ -4643,6 +4648,10 @@ export class MessageService {
             }
           );
           await this.deleteEncryptionStates({ conversationId });
+          // The rows are gone, so the record of which X3DH ephemeral produced
+          // them describes nothing. Cleared here rather than left to expire
+          // (see utils/dmInitSessionLedger.ts).
+          forgetInitSessions(conversationId);
           this.dispatchInboxDelete(
             keyset.deviceKeyset.inbox_keyset,
             [envelope.timestamp],
@@ -4691,11 +4700,18 @@ export class MessageService {
           return;
         }
 
-        const inbox_key = await secureChannel.NewInboxKeyset();
         // Ratchet critical section: replacing the session rows for this tag
         // and persisting the new session must be atomic vs concurrent sends
         // on the same conversation (see dmRatchetMutex).
-        const installed = await dmRatchetMutex.runExclusive(conversationId, async () => {
+        //
+        // Returns the inbox we are listening on for this session, or null when
+        // nothing was installed. It is RETURNED rather than assigned to a
+        // captured variable so the compiler can see it is set on every path
+        // that claims success — the receiving inbox is now minted on only one
+        // of three branches, and "which address did we end up on" must not be
+        // answerable by reading a variable that might still hold its initial
+        // value.
+        const inbox_key = await dmRatchetMutex.runExclusive(conversationId, async () => {
           const encryptionStates = await this.messageDB.getEncryptionStates({
             conversationId,
           });
@@ -4735,8 +4751,73 @@ export class MessageService {
                   : null,
               }
             );
-            return false;
+            return null;
           }
+
+          // ── RE-ANNOUNCEMENT, NOT A NEW SESSION ──────────────────────────
+          //
+          // Both clients re-wrap an EXISTING, still-advancing session in a
+          // fresh init envelope on every send until the peer's reply confirms
+          // it (desktop: DoubleRatchetInboxEncryptForceSenderInit; mobile:
+          // buildReinitEnvelopeSend). Treating those as new sessions is what
+          // this branch stops, and the cost of not having it was measured:
+          // a 3-round cross-client run replaced the session EIGHT times,
+          // minting seven receiving inboxes, and the peer's next message
+          // landed on an address whose row had just been deleted.
+          //
+          // Rebuilding is not merely wasteful, it is destructive in both
+          // directions: it mints a receiving inbox the peer has never been
+          // told about, AND it discards the sending chain our own replies are
+          // encrypted with — the chain the peer has already confirmed.
+          //
+          // The ephemeral is a sound identity for the session, not a guess:
+          // the same X3DH ephemeral necessarily derives the same session key.
+          // See utils/dmInitSessionLedger.ts for why it is kept off the row.
+          //
+          // The row consulted is the one `orderSessionsForSend` puts first —
+          // i.e. the exact row our own SEND path uses for this tag, so the
+          // address we keep listening on is the address we are advertising.
+          // Reading any other row could pin us to an inbox we never told the
+          // peer about, which is the bug this branch exists to prevent.
+          const priorRow = existing.length
+            ? (existing.find(
+                (e) =>
+                  e.inboxId ===
+                  (orderSessionsForSend(existing)[0]?.receiving_inbox as
+                    | secureChannel.InboxKeyset
+                    | undefined)?.inbox_address
+              ) ?? null)
+            : null;
+          const priorReceivingInbox = priorRow
+            ? (JSON.parse(priorRow.state).receiving_inbox as
+                | secureChannel.InboxKeyset
+                | undefined)
+            : undefined;
+          if (
+            priorRow &&
+            priorReceivingInbox?.inbox_address &&
+            isSameInitSession(
+              conversationId,
+              session.tag,
+              envelope.ephemeral_public_key
+            )
+          ) {
+            // Keep the row, the ratchet and the address exactly as they are.
+            // The payload has already been decrypted out of the envelope
+            // above, so the message is processed normally below.
+            newState = priorRow.state;
+            logger.debug(
+              '[MessageService] init envelope is a re-announcement of the session we already hold — keeping it',
+              {
+                conversationId: conversationId?.slice(0, 16),
+                inboxId: priorReceivingInbox.inbox_address?.slice(0, 12),
+                rowCount: existing.length,
+              }
+            );
+            return priorReceivingInbox;
+          }
+
+          const freshInbox = await secureChannel.NewInboxKeyset();
           logger.warn(
             '[MessageService] ⚠️ SESSION REPLACED by init envelope',
             {
@@ -4758,7 +4839,7 @@ export class MessageService {
 
           newState = JSON.stringify({
             ratchet_state: session.state,
-            receiving_inbox: inbox_key,
+            receiving_inbox: freshInbox,
             tag: session.tag,
             sending_inbox: {
               inbox_address: session.return_inbox_address,
@@ -4771,14 +4852,22 @@ export class MessageService {
             {
               state: newState,
               timestamp: message.timestamp,
-              inboxId: inbox_key.inbox_address,
+              inboxId: freshInbox.inbox_address,
               conversationId: conversationId,
             },
             true
           );
-          return true;
+          // Written LAST, and only after the row it describes is persisted: a
+          // record naming an ephemeral whose session failed to save would make
+          // the next re-announcement of it look like one we already hold.
+          recordInitSession(
+            conversationId,
+            session.tag,
+            envelope.ephemeral_public_key
+          );
+          return freshInbox;
         });
-        if (!installed) {
+        if (!inbox_key) {
           // Stale envelope refused: keep the current session and delete the
           // frame so it cannot redeliver. SALVAGE the payload first: a frame
           // retained after a persist failure re-enters here on redelivery
@@ -4853,6 +4942,9 @@ export class MessageService {
         // `session.user_address` is the address the crypto layer authenticated,
         // not the `envelope.user_address` field the sender wrote themselves.
         this.maybeAutoRevealToPartner(self_address, session.user_address, keyset);
+        // Re-subscribing to an inbox we are already listening on is a no-op, so
+        // the re-announcement branch sends this too rather than guessing whether
+        // the subscription survived the last reconnect.
         this.enqueueOutbound(async () => {
           return [
             JSON.stringify({
@@ -4863,7 +4955,8 @@ export class MessageService {
         });
 
         if (decryptedContent && newState) {
-          // Encryption state already persisted inside the locked section above.
+          // A session is in place for this frame — either persisted inside the
+          // locked section above, or the one the re-announcement branch kept.
           // The frame's payload is now the only copy of the message, so the
           // non-essential steps are isolated: a settings/notification/UI-cache
           // failure must never abort the save. (A throw anywhere in this block
@@ -5180,6 +5273,10 @@ export class MessageService {
                 }
               );
               await this.deleteEncryptionStates({ conversationId });
+              // The rows are gone, so the record of which X3DH ephemeral
+              // produced them describes nothing. Cleared here rather than left
+              // to expire (see utils/dmInitSessionLedger.ts).
+              forgetInitSessions(conversationId);
               // NOT awaited — dispatched after the state wipe above. This used to
               // rethrow; it no longer can, so its .catch is the only signal.
               this.dispatchInboxDelete(
@@ -5319,6 +5416,10 @@ export class MessageService {
                 }
               );
               await this.deleteEncryptionStates({ conversationId });
+              // The rows are gone, so the record of which X3DH ephemeral
+              // produced them describes nothing. Cleared here rather than left
+              // to expire (see utils/dmInitSessionLedger.ts).
+              forgetInitSessions(conversationId);
               // NOT awaited — dispatched after the state wipe above. This used to
               // rethrow; it no longer can, so its .catch is the only signal.
               this.dispatchInboxDelete(

--- a/src/utils/dmInitSessionLedger.ts
+++ b/src/utils/dmInitSessionLedger.ts
@@ -68,6 +68,30 @@ function isUsableIdentifier(value: unknown): value is string {
 }
 
 /**
+ * Storage failures are reported ONCE per session, not once per frame.
+ *
+ * They have to be reported at all: a systematically unreadable store makes this
+ * ledger answer "different session" forever, which silently restores the exact
+ * bug it was written to remove. But `isSameInitSession` runs on every init
+ * envelope, so an unconditional warn would bury the log it is trying to make
+ * visible.
+ */
+let storageFailureReported = false;
+function reportStorageFailure(what: string, conversationId: string, err: unknown): void {
+  if (storageFailureReported) return;
+  storageFailureReported = true;
+  logger.warn(
+    `[DMInitSessionLedger] ${what} failed — re-announcements will replace the session until storage recovers (reported once)`,
+    { conversation: conversationId.slice(0, 16), err }
+  );
+}
+
+/** Test seam: let a test observe the once-per-session warn more than once. */
+export function __resetInitSessionLedgerWarnForTests(): void {
+  storageFailureReported = false;
+}
+
+/**
  * INVARIANT: key(conversationId, tag) must be INJECTIVE, for the same reason
  * `dmRevealLedger` spells out at length — a hand-rolled `${a}:${b}` template is
  * not injective over arbitrary strings, and a collision here would report one
@@ -105,12 +129,8 @@ export function recordInitSession(
   } catch (err) {
     // Quota, private mode, storage disabled. Not fatal: the NEXT init envelope
     // simply fails to match and takes the old replace-the-session path, which
-    // is what shipped before this ledger existed. Logged because a systematic
-    // failure would silently restore the old bug with no signal at all.
-    logger.warn(
-      '[DMInitSessionLedger] write failed — re-announcements will replace the session this session',
-      { conversation: conversationId.slice(0, 16), err }
-    );
+    // is what shipped before this ledger existed.
+    reportStorageFailure('write', conversationId, err);
   }
 }
 
@@ -134,7 +154,12 @@ export function isSameInitSession(
   }
   try {
     return localStorage.getItem(key(conversationId, tag)) === ephemeralPublicKey;
-  } catch {
+  } catch (err) {
+    // Reported, not silent. An unreadable store answers "different session" for
+    // every envelope from here on, which is precisely the pre-fix behaviour —
+    // and a degradation back into a fixed bug must never be inferable only from
+    // the absence of a log line.
+    reportStorageFailure('read', conversationId, err);
     return false;
   }
 }
@@ -160,7 +185,10 @@ export function forgetInitSessions(conversationId: string): void {
       if (k && k.startsWith(prefix)) doomed.push(k);
     }
     for (const k of doomed) localStorage.removeItem(k);
-  } catch {
-    // Storage unreachable. Nothing to do: reads from it already fail closed.
+  } catch (err) {
+    // Storage unreachable. Reads already fail safe, so nothing is left in a
+    // wrong state — but it is still the same underlying fault, and reporting it
+    // here means a clear-only failure cannot pass unnoticed.
+    reportStorageFailure('clear', conversationId, err);
   }
 }

--- a/src/utils/dmInitSessionLedger.ts
+++ b/src/utils/dmInitSessionLedger.ts
@@ -1,0 +1,166 @@
+// "Which X3DH session is the one we currently hold for this peer device?"
+//
+// An InitializationEnvelope arriving on our DEVICE inbox is not necessarily a
+// NEW session. Both clients RE-ANNOUNCE an existing session by wrapping its
+// still-advancing ratchet in a fresh init envelope, and they do it on EVERY
+// send until the peer's reply confirms the session:
+//
+//   - desktop, via `DoubleRatchetInboxEncryptForceSenderInit` (same
+//     receiving_inbox, same tag, advancing ratchet — no new X3DH);
+//   - mobile, via `buildReinitEnvelopeSend` (quorum-mobile
+//     hooks/chat/useSendDirectMessage.ts), which reuses the session's STORED
+//     X3DH ephemeral for exactly this reason.
+//
+// The receiver could not tell those apart from a genuinely new session, so it
+// tore its session down and rebuilt it on every one. MEASURED 2026-08-24 over a
+// 3-round cross-client run: 8 replacements, 7 distinct receiving inboxes, and
+// the peer's next message stranded on an address whose row had just been
+// deleted ("DM frame for unknown inbox — no encryption state, retained
+// unread").
+//
+// ## Why the ephemeral public key is a SOUND discriminator, not a heuristic
+//
+// X3DH derives the session key from (sender ephemeral private, sender identity,
+// our identity, our signed pre-key). Three of those four are fixed for a given
+// pair of devices, so the ephemeral is the only thing that varies: the SAME
+// ephemeral necessarily yields the SAME session key, and therefore the same
+// session. A genuinely new session — a reinstall, a reset, a second device —
+// runs `generateX448()` again and cannot collide.
+//
+// So this is an equality test on a value that already fully determines the
+// answer. It is not "these look similar, probably the same".
+//
+// ## Why a separate ledger rather than a field on the encryption-state row
+//
+// Because the row is REWRITTEN, whole, by four other paths that know nothing
+// about init envelopes — the send path (MessageService `submitMessage`), both
+// conversation-inbox receive branches, and the offline action queue. Any field
+// added to the row is silently erased the first time we reply, which is exactly
+// when we most need it. This ledger is touched only by the init path, so
+// nothing can wipe it by accident.
+//
+// ## Fail direction: UNKNOWN means "not the same session"
+//
+// Deliberately asymmetric, because the two errors are not equally bad:
+//
+//   - saying "different" when it was the same  -> we replace the session, which
+//     is precisely the behaviour that shipped for months. Costs a message.
+//   - saying "same" when it was different      -> we KEEP a session the peer has
+//     abandoned, and the conversation goes dead in one direction until someone
+//     resets it. Costs everything after it.
+//
+// So every uncertainty (no record, storage unreachable, malformed input) reads
+// as "different" and takes the old replace-the-session path.
+//
+// Desktop-only: mobile stores its own ephemeral on the row itself, where its
+// row-writing paths preserve it.
+
+import { logger } from '@quilibrium/quorum-shared';
+
+/**
+ * localStorage namespace. Sits beside `quorum:dm-reveal` — same mechanism,
+ * separate namespace, because the two answer unrelated questions.
+ */
+const STORAGE_PREFIX = 'quorum:dm-init-session';
+
+function isUsableIdentifier(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+/**
+ * INVARIANT: key(conversationId, tag) must be INJECTIVE, for the same reason
+ * `dmRevealLedger` spells out at length — a hand-rolled `${a}:${b}` template is
+ * not injective over arbitrary strings, and a collision here would report one
+ * peer device's session as another's. JSON-array encoding is injective by
+ * construction from the JSON grammar.
+ */
+const key = (conversationId: string, tag: string): string =>
+  `${STORAGE_PREFIX}:${JSON.stringify([conversationId, tag])}`;
+
+/** The structural prefix of every key(conversationId, <anything>). */
+const conversationPrefix = (conversationId: string): string =>
+  `${STORAGE_PREFIX}:[${JSON.stringify(conversationId)},`;
+
+/**
+ * Remember that the session we just installed for this peer device was derived
+ * from this X3DH ephemeral.
+ *
+ * Call ONLY where a session is actually installed. Recording an ephemeral we
+ * did not install would make the next re-announcement of it look like ours.
+ */
+export function recordInitSession(
+  conversationId: string,
+  tag: string,
+  ephemeralPublicKey: string
+): void {
+  if (
+    !isUsableIdentifier(conversationId) ||
+    !isUsableIdentifier(tag) ||
+    !isUsableIdentifier(ephemeralPublicKey)
+  ) {
+    return;
+  }
+  try {
+    localStorage.setItem(key(conversationId, tag), ephemeralPublicKey);
+  } catch (err) {
+    // Quota, private mode, storage disabled. Not fatal: the NEXT init envelope
+    // simply fails to match and takes the old replace-the-session path, which
+    // is what shipped before this ledger existed. Logged because a systematic
+    // failure would silently restore the old bug with no signal at all.
+    logger.warn(
+      '[DMInitSessionLedger] write failed — re-announcements will replace the session this session',
+      { conversation: conversationId.slice(0, 16), err }
+    );
+  }
+}
+
+/**
+ * Is this init envelope a re-announcement of the session we already hold for
+ * this peer device?
+ *
+ * `false` on anything unknown — see the fail-direction note at the top.
+ */
+export function isSameInitSession(
+  conversationId: string,
+  tag: string,
+  ephemeralPublicKey: string
+): boolean {
+  if (
+    !isUsableIdentifier(conversationId) ||
+    !isUsableIdentifier(tag) ||
+    !isUsableIdentifier(ephemeralPublicKey)
+  ) {
+    return false;
+  }
+  try {
+    return localStorage.getItem(key(conversationId, tag)) === ephemeralPublicKey;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Forget every recorded session for a conversation.
+ *
+ * Called wherever the encryption states themselves are wiped (a
+ * `delete-conversation` reset). Leaving a record behind after the rows are gone
+ * would not cause a wrong answer today — the re-announcement branch also
+ * requires a surviving row — but a ledger that outlives what it describes is a
+ * trap for the next change, so it is cleared at the same moment.
+ */
+export function forgetInitSessions(conversationId: string): void {
+  if (!isUsableIdentifier(conversationId)) return;
+  try {
+    const prefix = conversationPrefix(conversationId);
+    // Collect first, then remove: removing during iteration reindexes
+    // localStorage and silently skips entries.
+    const doomed: string[] = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const k = localStorage.key(i);
+      if (k && k.startsWith(prefix)) doomed.push(k);
+    }
+    for (const k of doomed) localStorage.removeItem(k);
+  } catch {
+    // Storage unreachable. Nothing to do: reads from it already fail closed.
+  }
+}


### PR DESCRIPTION
Ships with the quorum-mobile PR of the same branch name. That one carries the
behavioural fix for the cross-client DM loss; this one fixes a defect on the
same theme on the desktop receive path, repairs a verify-gate bug found on the
way, and puts the arm that proves all of it back into the per-change gate.

## 1. An init envelope for a session we already hold must not replace it

Both clients **re-announce** an existing, still-advancing session by wrapping it
in a fresh InitializationEnvelope, on every send, until the peer's reply
confirms it (desktop: `DoubleRatchetInboxEncryptForceSenderInit`; mobile:
`buildReinitEnvelopeSend`). The device-inbox receive path could not tell that
apart from a genuinely new session, so on every one of them it minted a new
receiving inbox, deleted every row for the tag, and installed a rebuilt ratchet.

That is destructive in both directions: it mints an address the peer has never
been told about, **and** it discards the sending chain our own replies are
encrypted with, which the peer has already confirmed. MEASURED over one 3-round
cross-client run: 8 replacements, 7 distinct receiving inboxes, and the peer's
next message logged as `DM frame for unknown inbox — no encryption state,
retained unread`.

The discriminator is the X3DH ephemeral, and it is exact rather than heuristic:
three of X3DH's four inputs are fixed for a device pair, so the same ephemeral
necessarily derives the same session key. A reinstall, a reset or a second
device generates a new one and cannot collide.

It lives in its own ledger (`src/utils/dmInitSessionLedger.ts`, localStorage)
rather than on the encryption-state row, because that row is rewritten **whole**
by four paths that know nothing about init envelopes: the send path, both
conversation-inbox receive branches, and the offline action queue. A field added
to the row is erased the first time we reply, which is exactly when it is
needed. Unknown reads as "different session", so every uncertainty takes the old
replace-the-session path and a peer reinstall keeps working.

**Honest scope.** This is not what turned the cross-client arm green — the
mobile PR is. This branch logged zero hits in the green run. It ships on its own
merits and its own tests. What it buys, INFERRED and not yet measured, is the
redelivery case in `2026-07-29-session-replacement-strands-in-flight-frames.md`
§1: once we reply, the send path rewrites the row's timestamp, so guard rule 2
stops matching that envelope and a redelivery inside the 120s tolerance is
accepted and destroys the session. Now harmless. Building a harness arm that
redelivers an init envelope would move this to MEASURED, and is filed.

## 2. A replay window that review caught, and a test that proved nothing

The keep branch initially persisted nothing, so the row's timestamp stayed
pinned at first install. `isStaleInitEnvelope` rule 2 refuses an envelope whose
timestamp exactly matches a row we hold, and it is the only defence against the
relay replaying a frame whose ack-by-delete failed — so **every later
re-announcement stayed replayable** for as long as the session was unconfirmed,
each replay costing a duplicate notification and a redundant X3DH.

The row is now written back byte-identical with only its timestamp advanced.

Worth stating because it is the more useful half: the first test written for
this **passed with the fix removed**. It asserted on `saveEncryptionState`,
which both the stale path and an unbumped keep path leave uncalled. It now
asserts on the absence of a `listen` frame, which genuinely differs, and is red
without the fix.

## 3. `space-delivery` has been failing in every run since the gate landed

Unrelated to the rest, repaired here only because `yarn verify` could not report
a clean run without it.

`src/dev/tests/harness/spaceState.ts:299` used `export { x } from '...'`, which
forwards a binding **without** introducing it into the module's scope, so
`restoreSharedSpace` threw `ReferenceError: wantsFreshSpace is not defined` on
its own first line. A static scoping mistake, so it failed deterministically for
everyone, and the arm's documented retry could not help because the failure is
not load-related. Measured: fails in 589ms before, passes in 90s after.

## 4. `cross-dm` released from held-back

It was held back on 2026-08-24 because it reported a reproducible loss whose
cause was unknown, and an arm red in most runs for a reason unrelated to the
change under test blocks every piece of work. That cause is now measured and
fixed on both sides and the arm is green in five consecutive runs.

Released rather than left out because it is the **only cross-client DM coverage
there is**, and the bug it found survived months precisely because nothing
measured that cell. `routing.test.ts` asserts the held-back set by value, so
releasing an arm (or holding one back again) costs two edits in two files and
cannot be done quietly.

## 5. The desktop half of a cross-client run was blind

Vitest swallows that side's console entirely when its stdout is piped, which is
exactly how `run-cross.mjs` drives it. Proof: a run whose scenario emitted
`console.log('[dm-cross b] ...')` produced **zero** such lines in the piped
output while the identical strings appeared in its RunLog jsonl. Every
`logger.warn` from the service layer was invisible, so "no session replacement
logged" read as "no session replacement happened", which was false.
`HARNESS_CONSOLE_FILE=1` mirrors it to a file the capture does not intercept.

## Gate

```
  desktop  typecheck      PASS  |  desktop  dm-basic        PASS
  desktop  lint           PASS  |  desktop  dm-delivery     PASS
  desktop  unit           PASS  |  desktop  space-delivery  PASS
  desktop  build          PASS  |  desktop  cross-dm        PASS  369s
  mobile   unit           PASS  |  desktop  config-cross    PASS
  VERDICT  PASS
```

`mobile lint` and `mobile typecheck` are KNOWN-RED at their recorded baselines
(302 / 11), unchanged by this branch.

New tests: 25, across the ledger and the receive path, including control arms
for genuinely-new-session, message-still-delivered and peer-reinstall-still-
works. Neutralising the discriminator turns 9 of them red while every control
stays green.
